### PR TITLE
Import pysvn and mercurial modules only there where they are needed.

### DIFF
--- a/pontoon/administration/views.py
+++ b/pontoon/administration/views.py
@@ -7,7 +7,6 @@ import fnmatch
 import json
 import os
 import polib
-import pysvn
 import silme.core, silme.format.properties
 import urllib2
 
@@ -22,7 +21,6 @@ from django.utils.datastructures import MultiValueDictKeyError
 from pontoon.base.models import Locale, Project, Subpage, Entity, Translation, ProjectForm, UserProfile
 from pontoon.base.views import _request
 
-from mercurial import commands, hg, ui, error
 from mobility.decorators import mobile_template
 
 
@@ -217,6 +215,7 @@ def update_from_repository(request, template=None):
 
     elif url_repository.find('://hg') > 0:
         """ Mercurial """
+        from mercurial import commands, hg, ui, error
         software = 'hg'
         locales = [Locale.objects.get(code="en-US")]
         locales.extend(p.locales.all())
@@ -282,6 +281,7 @@ def update_from_repository(request, template=None):
 
     elif url_repository.find('://svn') > 0:
         """ Subversion """
+        import pysvn
         software = 'svn'
         path = os.path.join(settings.MEDIA_ROOT, software, p.name)
         client = pysvn.Client()

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -6,7 +6,6 @@ import fnmatch
 import json
 import os
 import polib
-import pysvn
 import requests
 import silme.core, silme.format.properties
 import traceback
@@ -526,6 +525,7 @@ def download(request, template=None):
 @login_required(redirect_field_name='', login_url='/404')
 def commit_to_svn(request, template=None):
     """Commit translations to SVN."""
+    import pysvn
     log.debug("Commit translations to SVN.")
 
     if request.method != 'POST':


### PR DESCRIPTION
This imports pysvn and mercurial modules only for the code segments where they are needed.

This helps running rest of pontoon without them installed and gives it a more plug-n-play feel :)
