### PR TITLE
Handle errors during loading a website for translation

### DIFF
--- a/pontoon/base/static/js/script.js
+++ b/pontoon/base/static/js/script.js
@@ -117,12 +117,12 @@
             } else {
               clearInterval(interval);
               var lang = $('html').attr('lang'),
-                  errorLink = (lang ? '/' + lang : '') + '/locale/' + escapedLocale + '/site/' + url + (url[url.length-1] !== '/' ? '/' : '') + 'oops/';
+                  errorLink = (lang ? '/' + lang : '') + '/translate/error/?locale=' + escapedLocale + '&url=' + url + (url[url.length-1] !== '/' ? '/' : '');
               if (projectWindow) {
-                window.location = errorLink + 'support/';
+                window.location = errorLink + '&error=' + "Oops, website is not supported by Pontoon.";
                 projectWindow.close();
               } else {
-                window.location = errorLink + 'popup/';
+                window.location = errorLink + '&error=' + 'Oops, looks like pop-ups are blocked.';
               }
             }
           }, 100);

--- a/pontoon/base/urls.py
+++ b/pontoon/base/urls.py
@@ -5,7 +5,7 @@ import views
 
 urlpatterns = patterns('',
     url(r'^$', views.home, name='pontoon.home'),
-    
+    url('^translate/error/$', views.handle_error, name='pontoon.handle_error'),
     url(r'^locale/(?P<locale>[A-Za-z0-9\-\@\.]+)/site/(?P<url>.+)/$',
         views.translate_site,
         name='pontoon.translate.site'),

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -58,6 +58,23 @@ def home(request, template=None):
 
     return render(request, template, data)
 
+
+def handle_error(request):
+    """
+    A view to handle errors during loading a website for translation
+    by Pontoon. This view is bound with a generic URL which can
+    be called from Pontoon's javascript with appropriate GET parameters
+    and the page will get redirected to the home page showing proper
+    error messages, url and locale.
+    """
+    messages.error(request, request.GET.get('error', ''))
+    request.session['translate_error'] = {
+        'locale': request.GET.get('locale'),
+        'url': request.GET.get('url')
+    }
+    return HttpResponseRedirect(reverse('pontoon.home'))
+
+
 @mobile_template('{mobile/}translate.html')
 def translate_site(request, locale, url, template=None):
     """Translate view: site."""


### PR DESCRIPTION
Handle errors during loading a website for translation and redirect to Pontoon's home page with proper error messages, locale
and url values.

@mathjazz This fixes the issue discussed here https://github.com/mathjazz/pontoon/issues/6#issuecomment-12052870
