### PR TITLE
Bugfix: Retain order of entities in generated PO files.

### DIFF
--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -30,20 +30,30 @@ var Pontoon = (function () {
                 'username': self.user.name,
                 'user_email': self.user.email
             },
-            translations: {}
+            translations: []
         }
+
+        var msgid_index_dict = {};
 
         $(self.project.entities).each(function () {
           var msgid = this.original;
-          po.translations[msgid] = {
+          var index = msgid_index_dict.msgid;
+          if (index == undefined){
+            var data = {
+              msgid: msgid,
               fuzzy: false,
-              msgstr: this.translation,
+              msgstr: this.translation || "",
               occurrence: self.project.url,
-          };
+            }
+            msgid_index_dict[msgid] = po.translations.push(data) - 1;
+          }
+          else {
+            var data = po.translations[index];
+          }
 
           if (this.suggestions && !msgstr) {
-            po.translations[msgid].fuzzy = true,
-            po.translations[msgid].msgstr = this.suggestions[0].translation;
+            data.fuzzy = true,
+            data.msgstr = this.suggestions[0].translation;
           }
         });
 

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -494,7 +494,7 @@ def _generate_po_content(data):
     po = polib.POFile()
     current_time = datetime.datetime.now()
     metadata = json_dict.get('metadata', {})
-    translations = json_dict.get('translations', {})
+    translations = json_dict.get('translations', [])
 
     # Add PO metadata
     po.metadata = {
@@ -523,13 +523,13 @@ def _generate_po_content(data):
     )
 
     # Append PO entries
-    for msgid in translations.keys():
+    for trans in translations:
         po_entry = polib.POEntry(
-                msgid=msgid,
-                msgstr=translations[msgid].get('msgstr', ''),
-                occurrences = [(translations[msgid].get('occurrence', ''), '')]
+                msgid=trans['msgid'],
+                msgstr=trans.get('msgstr', ''),
+                occurrences = [(trans.get('occurrence', ''), '')]
         )
-        if translations[msgid].get('fuzzy'):
+        if trans.get('fuzzy'):
             po_entry.flags.append('fuzzy')
         po.append(po_entry)
     return unicode(po).encode('utf-8')


### PR DESCRIPTION
Generated PO file now retains order of entities as in the HTML file. The bug occurred because we previously used dictionaries/objects in JS to store translation values mapped to it's msgid (key). We all know that dictionary like objects always get auto sorted based on it's key values. So, we were not able to retain the original order of entities in the generated PO file. The solution was to simply use an array to hold the translation data.
