### PR TITLE
Use SSH Keys for VCS auth on Heroku/Docker

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,4 @@
+https://github.com/ddollar/heroku-buildpack-apt
+https://github.com/Osmose/heroku-buildpack-ssh
 https://github.com/heroku/heroku-buildpack-nodejs
 https://github.com/heroku/heroku-buildpack-python

--- a/Aptfile
+++ b/Aptfile
@@ -1,0 +1,2 @@
+subversion
+mercurial

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ web:
     - "8000:8000"
   volumes:
     - .:/pontoon
+    - ~/.ssh:/root/.ssh:ro
   links:
     - db
   dns:

--- a/pontoon/administration/vcs.py
+++ b/pontoon/administration/vcs.py
@@ -1,12 +1,8 @@
 # -*- coding: utf8 -*-
 from __future__ import absolute_import
-import base64
 import logging
 import os
 import subprocess
-import urlparse
-
-from django.conf import settings
 
 
 log = logging.getLogger('pontoon')
@@ -144,12 +140,6 @@ class CommitToGit(CommitToRepository):
     def commit(self, path=None, message=None, user=None):
         log.debug("Git: Commit to repository.")
 
-        # Bail early if we lack credentials.
-        if not settings.GIT_USERNAME or not settings.GIT_PASSWORD:
-            raise CommitToRepositoryException(
-                'GIT_USERNAME and GIT_PASSWORD settings are not defined and '
-                'are required for committing to git repositories.')
-
         path = path or self.path
         message = message or self.message
         user = user or self.user
@@ -168,15 +158,8 @@ class CommitToGit(CommitToRepository):
         if code != 0 and len(error):
             raise CommitToRepositoryException(unicode(error))
 
-        # Add auth credentials to URL for push.
-        url_parts = urlparse.urlparse(self.url)
-        netloc = '{username}:{password}@{netloc}'.format(
-            username=settings.GIT_USERNAME, password=settings.GIT_PASSWORD,
-            netloc=url_parts.netloc)
-        url = url_parts._replace(netloc=netloc).geturl()
-
         # Push
-        push = ["git", "push", url]
+        push = ["git", "push", self.url]
         code, output, error = execute(push, path)
         if code != 0:
             raise CommitToRepositoryException(unicode(error))

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -63,10 +63,6 @@ MOZILLIANS_API_KEY = os.environ.get('MOZILLIANS_API_KEY', '')
 # Raygun.io API Key
 RAYGUN4PY_API_KEY = os.environ.get('RAYGUN_APIKEY', '')
 
-# Git(hub) Credentials
-GIT_USERNAME = os.environ.get('GIT_USERNAME', '')
-GIT_PASSWORD = os.environ.get('GIT_PASSWORD', '')
-
 # Email settings
 EMAIL_HOST_USER = os.environ.get('SENDGRID_USERNAME', '')
 EMAIL_HOST = 'smtp.sendgrid.net'


### PR DESCRIPTION
This removes some of the git-specific auth code I added and instead configures Docker to use the SSH keys of the system it runs on and Heroku to load an SSH key from the environment. This also adds a buildpack to install Subversion and Mercurial onto the Heroku dynos since they don't come with it pre-installed.

Testing the Heroku SVN/HG bits is blocked by [bug 1166010](https://bugzilla.mozilla.org/show_bug.cgi?id=1166010), but while we're waiting this could use a second pair of eyes.