### PR TITLE
Re-enable minification via yuglify.

### DIFF
--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -30,6 +30,15 @@ you create:
 ``HMAC_KEY``
    Required. Secret key used for hashing passwords.
 
+``PIPELINE_YUGLIFY_BINARY``
+   Required. Command for executing Yuglify_ during the build process.
+
+   The Heroku Python buildpack moves the project's code around during the build
+   process, so specifying this is important as you can't rely on yuglify or node
+   to be in your ``PATH``. Set this to
+   ``./.heroku/node/bin/node ./node_modules/yuglify/bin/yuglify`` to get
+   minification working properly on Heroku.
+
 ``SECRET_KEY``
    Required. Secret key used for sessions, cryptographic signing, etc.
 
@@ -66,6 +75,8 @@ you create:
    .. code-block:: bash
 
       heroku config:set SSH_KEY="`cat /path/to/key_rsa`"
+
+.. _Yuglify: https://github.com/yui/yuglify
 
 Add-ons
 -------

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -51,6 +51,9 @@ HMAC_KEYS = {
 SITE_URL = os.environ.get('SITE_URL', 'http://localhost:8000')
 BROWSERID_AUDIENCES = [SITE_URL]
 
+# Path to Yuglify binary.
+PIPELINE_YUGLIFY_BINARY = os.environ.get('PIPELINE_YUGLIFY_BINARY', 'yuglify')
+
 # Custom LD_LIBRARY_PATH environment variable for SVN
 SVN_LD_LIBRARY_PATH = os.environ.get('SVN_LD_LIBRARY_PATH', '')
 
@@ -169,11 +172,6 @@ AUTHENTICATION_BACKENDS = [
     'django_browserid.auth.BrowserIDBackend',
     'django.contrib.auth.backends.ModelBackend',
 ]
-
-# Temporarily do not compress CSS or JS until we figure out the issue
-# with Heroku failing to compress static files.
-PIPELINE_CSS_COMPRESSOR = 'pipeline.compressors.NoopCompressor'
-PIPELINE_JS_COMPRESSOR = 'pipeline.compressors.NoopCompressor'
 
 PIPELINE_DISABLE_WRAPPER = True
 PIPELINE_CSS = {


### PR DESCRIPTION
On Heroku, we'll have to provide a relative path to the binary since the app directory moves around during the Python build process.

This has been tested on the staging server and appears to work with the properly set environment variable.