### PR TITLE
Properly select default resources and subpages

### DIFF
--- a/pontoon/base/static/js/pontoon.js
+++ b/pontoon/base/static/js/pontoon.js
@@ -99,25 +99,6 @@
               hideToolbar(target);
               return false;
             }
-
-            if (key === 9) { // Tab: status quo + move around entities
-              // Disabled.
-              // TODO: re-number entities and re-enable
-              return false;
-              // If on last entity, jump to the first
-              if (next > entities.length) {
-                $.each(entities, function() {
-                  if (this.body) {
-                    next = this.id;
-                  }
-                });
-              }
-              cancel.click();
-              $(target).removeClass('pontoon-hovered');
-              postMessage("HOVER", id);
-              entities[next].hover();
-              $('.pontoon-editable-toolbar > .edit').click();
-            }
           }
         });
       }

--- a/pontoon/base/static/js/translate_old.js
+++ b/pontoon/base/static/js/translate_old.js
@@ -1262,33 +1262,9 @@ var Pontoon = (function (my) {
               locale = accept;
             }
           }
-
-          menu.find('.language.' + locale).click();
         }
 
-        // Fallback if selected part not available for the selected project
-        if (details[locale].length > 0) {
-          var detail = details[locale][0],
-              isPath = Object.keys(detail).indexOf("name") === -1,
-              type = isPath ? 'resource__path' : 'name';
-              part = $('.part .selector').attr('title');
-
-          // Selected part available
-          for (var d in details[locale]) {
-            if (details[locale][d][type] === part) {
-              return;
-            }
-          }
-
-          var defaultPart = detail[type];
-          $('header .part').removeClass("hidden")
-            .find('.selector')
-              .attr('title', defaultPart)
-              .find('.title')
-                .html(defaultPart.replace(/^.*[\\\/]/, ''));
-        } else {
-          $('header .part').addClass("hidden");
-        }
+        menu.find('.language.' + locale).click();
       });
 
       // Show only parts available for the selected project
@@ -1370,6 +1346,37 @@ var Pontoon = (function (my) {
         // Select locale
         } else {
           $('.locale .selector').html(language);
+        }
+
+        var details = Pontoon.getProjectDetails(),
+            locales = Object.keys(details),
+            menu = $('.locale .menu'),
+            locale = menu.siblings('.selector')
+              .find('.code').html().toLowerCase();
+
+        // Fallback if selected part not available for the selected project
+        if (details[locale].length > 0) {
+          var detail = details[locale][0],
+              isPath = Object.keys(detail).indexOf("name") === -1,
+              type = isPath ? 'resource__path' : 'name';
+              part = $('.part .selector').attr('title');
+
+          // Selected part available
+          for (var d in details[locale]) {
+            if (details[locale][d][type] === part) {
+              $('header .part').removeClass("hidden");
+              return;
+            }
+          }
+
+          var defaultPart = detail[type];
+          $('header .part').removeClass("hidden")
+            .find('.selector')
+              .attr('title', defaultPart)
+              .find('.title')
+                .html(defaultPart.replace(/^.*[\\\/]/, ''));
+        } else {
+          $('header .part').addClass("hidden");
         }
       });
 

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -266,7 +266,8 @@ def translate(request, locale, slug, part=None, template='translate.html'):
         try:
             page = pages.get(name=part)
         except Subpage.DoesNotExist:
-            page = pages[0]  # If page not specified or doesn't exist
+            # If page not specified or doesn't exist
+            page = pages.filter(resource__stats__locale=l)[0]
 
         data['page_url'] = page.url
         data['part'] = page.name


### PR DESCRIPTION
This PR does two things:
1. If no resource or subpage is requested in URL, it selects the first one available **for locale**.
2. In translate view, if selected locale doesn't support selected resource or subpage, fallback to the first option available.

Also removes "unreachable code after return statement" JS warning (should be a separate branch).

@Osmose, r?