### PR TITLE
Fix sorting

### DIFF
--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -479,25 +479,19 @@ $(function() {
 
   // Menu sort
   $('.menu .sort span').click(function (e) {
-    function val(index, el, type) {
-      // Sort by alphabetical order
-      if (index !== 2) {
-        return $(el).find('span:eq(' + index + ')').html();
+    function getString(el) {
+      return $(el).find('span:eq(' + index + ')').html();
+    }
 
-      // Sort by approved, then by unapproved percentage
-      } else {
-        if (!$(el).find('.chart').length) {
-          return 0;
-        }
-        var chart = $(el).find('.chart').data('chart'),
-            data = JSON.parse(chart.replace(/'/g, "\""));
-
-        if (type !== "unapproved") {
-          return data.approved/data.total;
-        } else {
-          return data.translated/data.total;
-        }
+    function get(el, type) {
+      if (!$(el).find('.chart').length) {
+        return 0;
       }
+
+      var chart = $(el).find('.chart').data('chart'),
+          data = JSON.parse(chart.replace(/'/g, "\""));
+
+      return data[type]/data.total;
     }
 
     var index = $(this).index(),
@@ -511,10 +505,15 @@ $(function() {
     $(this).addClass(cls);
 
     listitems.sort(function(a, b) {
-      return (val(index, a) < val(index, b)) ? -dir :
-        (val(index, a) > val(index, b)) ? dir :
-        (val(index, a, "unapproved") < val(index, b, "unapproved")) ? -dir :
-        (val(index, a, "unapproved") > val(index, b, "unapproved")) ? dir : 0;
+      if (index !== 2) {
+        // Sort by alphabetical order
+        return getString(a).localeCompare(getString(b)) * dir;
+
+      } else {
+        // Sort by approved, then by unapproved percentage
+        return (get(a, "approved") - get(b, "approved")) * dir ||
+          (get(a, "translated") - get(b, "translated")) * dir;
+      }
     });
 
     ul.append(listitems);

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -479,17 +479,24 @@ $(function() {
 
   // Menu sort
   $('.menu .sort span').click(function (e) {
-    function val(index, el) {
+    function val(index, el, type) {
+      // Sort by alphabetical order
       if (index !== 2) {
         return $(el).find('span:eq(' + index + ')').html();
 
+      // Sort by approved, then by unapproved percentage
       } else {
         if (!$(el).find('.chart').length) {
           return 0;
         }
         var chart = $(el).find('.chart').data('chart'),
             data = JSON.parse(chart.replace(/'/g, "\""));
-        return data.approved/data.total;
+
+        if (type !== "unapproved") {
+          return data.approved/data.total;
+        } else {
+          return data.translated/data.total;
+        }
       }
     }
 
@@ -505,7 +512,9 @@ $(function() {
 
     listitems.sort(function(a, b) {
       return (val(index, a) < val(index, b)) ? -dir :
-        (val(index, a) > val(index, b)) ? dir : 0;
+        (val(index, a) > val(index, b)) ? dir :
+        (val(index, a, "unapproved") < val(index, b, "unapproved")) ? -dir :
+        (val(index, a, "unapproved") > val(index, b, "unapproved")) ? dir : 0;
     });
 
     ul.append(listitems);

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -483,11 +483,14 @@ $(function() {
       return $(el).find('span:eq(' + index + ')').html();
     }
 
-    function get(el, type) {
+    function getChart(el) {
       var chartData = $(el).find('.chart').data('chart');
       if (chartData) {
         var data = JSON.parse(chartData.replace(/'/g, "\""));
-        return data[type]/data.total;
+        return {
+          "approved": data.approved/data.total,
+          "translated": data.translated/data.total
+        };
       } else {
         return 0;
       }
@@ -510,8 +513,11 @@ $(function() {
 
       } else {
         // Sort by approved, then by unapproved percentage
-        return (get(a, "approved") - get(b, "approved")) * dir ||
-          (get(a, "translated") - get(b, "translated")) * dir;
+        var chartA = getChart(a),
+            chartB = getChart(b);
+
+        return (chartA.approved - chartB.approved) * dir ||
+          (chartA.translated - chartB.translated) * dir;
       }
     });
 

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -425,7 +425,7 @@ $(function() {
           '</aside>');
       }
 
-      var data = JSON.parse(chart.data('chart').replace(/'/g, "\"")),
+      var data = chart.data('chart'),
           untranslated = data.total - data.approved - data.translated - data.fuzzy,
           rect = chart[0].getBoundingClientRect(),
           height = $('.tooltip').outerHeight() + 15,

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -484,9 +484,8 @@ $(function() {
     }
 
     function getChart(el) {
-      var chartData = $(el).find('.chart').data('chart');
-      if (chartData) {
-        var data = JSON.parse(chartData.replace(/'/g, "\""));
+      var data = $(el).find('.chart').data('chart');
+      if (data) {
         return {
           "approved": data.approved/data.total,
           "translated": data.translated/data.total

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -484,14 +484,13 @@ $(function() {
     }
 
     function get(el, type) {
-      if (!$(el).find('.chart').length) {
+      var chartData = $(el).find('.chart').data('chart');
+      if (chartData) {
+        var data = JSON.parse(chartData.replace(/'/g, "\""));
+        return data[type]/data.total;
+      } else {
         return 0;
       }
-
-      var chart = $(el).find('.chart').data('chart'),
-          data = JSON.parse(chart.replace(/'/g, "\""));
-
-      return data[type]/data.total;
     }
 
     var index = $(this).index(),

--- a/pontoon/base/templates/locale_selector.html
+++ b/pontoon/base/templates/locale_selector.html
@@ -24,7 +24,7 @@
     </div>
     {% endif %}
     <ul>
-      {% for l in locales %}
+      {% for l in locales.order_by("name") %}
       <li class="clearfix{% if locale and locale == l %} current{% endif %}{% if l and l.chart %} filter{% endif %}">
         {% if l and l.chart %}
         <a href="/{{ l.code|lower }}/{{ project.slug }}/" class="clearfix">

--- a/pontoon/base/templates/project_selector.html
+++ b/pontoon/base/templates/project_selector.html
@@ -30,7 +30,7 @@
           <span class="url">{{ p.url }}</span>
           {% if p and p.chart and p.chart.total %}
           <span class="chart-wrapper">
-            <span class="chart" data-chart="{{ p.chart }}">
+            <span class="chart" data-chart="{{ p.chart|to_json }}">
               <span class="approved" style="width:{{ p.chart.approved / p.chart.total * 100 }}%;"></span>
               <span class="translated" style="width:{{ p.chart.translated / p.chart.total * 100 }}%;"></span>
               <span class="fuzzy" style="width:{{ p.chart.fuzzy / p.chart.total * 100 }}%;"></span>

--- a/pontoon/base/templates/project_selector.html
+++ b/pontoon/base/templates/project_selector.html
@@ -26,7 +26,7 @@
         {% endif %}
           <span class="name"
             data-slug="{{ p.slug }}"
-            data-details="{{ p.details }}">{{ p.name }}</span>
+            {% if p.details %}data-details="{{ p.details }}"{% endif %}>{{ p.name }}</span>
           <span class="url">{{ p.url }}</span>
           {% if p and p.chart and p.chart.total %}
           <span class="chart-wrapper">

--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import urllib
 import urlparse
 
@@ -63,3 +64,8 @@ def urlencode(txt):
 @library.global_function
 def static(path):
     return staticfiles_storage.url(path)
+
+
+@library.filter
+def to_json(value):
+    return json.dumps(value)


### PR DESCRIPTION
* If two projects/locales have equal share of approved strings, we sort them by comparing unapproved.
* In locale selector, sort locales by alphabetic order.
* Remove project.details from project selector when data not available.