### PR TITLE
Enable Mozilla product localization

### DIFF
--- a/bin/mozilla-en-US.py
+++ b/bin/mozilla-en-US.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+"""This script creates or updates en-US repository from Mozilla source
+   code to use for Mozilla product localization."""
+
+import os
+import shutil
+import subprocess
+
+
+CONFIG = {
+    'sources': ['comm-aurora', 'mozilla-aurora'],
+    'target': 'mozilla-aurora',
+    'folders': [
+        'browser', 'browser/branding/official', 'dom', 'netwerk',
+        'security/manager', 'services/sync', 'toolkit', 'webapprt',
+        'mobile', 'mobile/android', 'mobile/android/base',
+        'chat', 'editor/ui', 'mail', 'other-licenses/branding/thunderbird',
+        'calendar',
+        'suite',
+    ],
+}
+
+
+def execute(command, cwd=None):
+
+    try:
+        st = subprocess.PIPE
+        proc = subprocess.Popen(
+            args=command, stdout=st, stderr=st, stdin=st, cwd=cwd)
+
+        (output, error) = proc.communicate()
+        code = proc.returncode
+        return code, output, error
+
+    except OSError as error:
+        return -1, '', error
+
+
+def pull(url, target):
+
+    # Undo local changes
+    execute(['hg', 'revert', '--all', '--no-backup'], target)
+
+    code, output, error = execute(['hg', 'pull', '-u'], target)
+    if code == 0:
+        print('Repository at ' + url + ' updated.')
+
+    else:
+        print(unicode(error))
+        print('Clone instead.')
+
+        code, output, error = execute(['hg', 'clone', url, target])
+        if code == 0:
+            print('Repository at ' + url + ' cloned.')
+        else:
+            print(unicode(error))
+
+
+def push(path):
+
+    # Add
+    execute(['hg', 'add'], path)
+
+    # Commit
+    code, output, error = execute(['hg', 'commit', '-m', 'Update'], path)
+    if code != 0 and len(error):
+        print(unicode(error))
+
+    # Push
+    code, output, error = execute(['hg', 'push'], path)
+    if code == 0:
+        print('Repository at ' + path + ' pushed.')
+    elif len(error):
+        print(unicode(error))
+
+
+# Change working directory to where script is located
+abspath = os.path.abspath(__file__)
+dname = os.path.dirname(abspath)
+os.chdir(dname)
+
+
+# Clone or update source repositories
+for repo in CONFIG['sources']:
+    base = 'ssh://hg.mozilla.org/releases/'
+    url = os.path.join(base, repo)
+    target = os.path.join('source', repo)
+    pull(url, target)
+
+# Clone or update target repository
+repo = CONFIG['target']
+base = 'ssh://hg.mozilla.org/users/m_owca.info/'
+url = os.path.join(base, repo)
+target = os.path.join('target', repo)
+pull(url, target)
+
+# Copy folders from source to target
+for folder in CONFIG['folders']:
+    for source in CONFIG['sources']:
+        origin = os.path.join('source', source, folder, 'locales/en-US')
+        destination = os.path.join('target', repo, folder)
+
+        if os.path.exists(origin):
+            if os.path.exists(destination):
+                shutil.rmtree(destination)
+
+            shutil.copytree(origin, destination)
+
+# Commit and push target repository
+push(target)

--- a/bin/mozilla-en-US.py
+++ b/bin/mozilla-en-US.py
@@ -58,10 +58,12 @@ def pull(url, target):
     # Undo local changes
     execute(['hg', 'revert', '--all', '--no-backup'], target)
 
+    # Pull
     code, output, error = execute(['hg', 'pull', '-u'], target)
     if code == 0:
         print('Repository at ' + url + ' updated.')
 
+    # Clone
     else:
         print(unicode(error))
         print('Clone instead.')

--- a/bin/mozilla-en-US.py
+++ b/bin/mozilla-en-US.py
@@ -2,10 +2,11 @@
 """This script creates or updates en-US repositories from Mozilla source
    code to use for Mozilla product localization."""
 
+from __future__ import print_function
+
 import os
 import shutil
 import subprocess
-
 
 TARGET_REPOS = {
     'firefox-aurora': {
@@ -35,7 +36,6 @@ TARGET_REPOS = {
         'repository': 'comm-aurora',
     },
 }
-
 
 SOURCE_REPOS = set(v["repository"] for v in TARGET_REPOS.values())
 
@@ -92,12 +92,10 @@ def push(path):
     elif len(error):
         print(unicode(error))
 
-
 # Change working directory to where script is located
 abspath = os.path.abspath(__file__)
 dname = os.path.dirname(abspath)
 os.chdir(dname)
-
 
 # Clone or update source repositories
 for repo in SOURCE_REPOS:

--- a/bin/mozilla-en-US.py
+++ b/bin/mozilla-en-US.py
@@ -41,7 +41,6 @@ SOURCE_REPOS = set(v["repository"] for v in TARGET_REPOS.values())
 
 
 def execute(command, cwd=None):
-
     try:
         st = subprocess.PIPE
         proc = subprocess.Popen(
@@ -56,7 +55,6 @@ def execute(command, cwd=None):
 
 
 def pull(url, target):
-
     # Undo local changes
     execute(['hg', 'revert', '--all', '--no-backup'], target)
 
@@ -76,7 +74,6 @@ def pull(url, target):
 
 
 def push(path):
-
     # Add
     execute(['hg', 'add'], path)
 

--- a/pontoon/administration/files.py
+++ b/pontoon/administration/files.py
@@ -131,21 +131,18 @@ Structure.modify_entity = modify_entity_mine
 """ End monkeypatching """
 
 
-def get_locale_paths(project, locale):
+def get_locale_paths(project, locale, source_paths, source_directory):
     """Get paths to locale files."""
 
     locale_paths = []
-    path = get_locale_directory(project, locale)["path"]
-    formats = Resource.objects.filter(project=project).values_list(
-        'format', flat=True).distinct()
+    locale_directory = get_locale_directory(project, locale)["name"]
 
-    for root, dirnames, filenames in os.walk(path):
-        # Ignore hidden files
-        filenames = [f for f in filenames if not f[0] == '.']
+    for path in source_paths:
+        locale_path = path.replace(
+            '/' + source_directory + '/', '/' + locale_directory + '/')
 
-        for format in formats:
-            for filename in fnmatch.filter(filenames, '*.' + format):
-                locale_paths.append(os.path.join(root, filename))
+        if os.path.exists(locale_path):
+            locale_paths.append(locale_path)
 
     return locale_paths
 
@@ -740,7 +737,7 @@ def extract_to_database(project, locales=None):
             paths = source_paths
             entities = True
         else:
-            paths = get_locale_paths(project, locale)
+            paths = get_locale_paths(project, locale, source_paths, source_directory['name'])
             entities = isFile
 
         for path in paths:

--- a/pontoon/administration/vcs.py
+++ b/pontoon/administration/vcs.py
@@ -45,7 +45,7 @@ class PullFromGit(PullFromRepository):
         else:
             log.debug("Git: " + unicode(error))
             log.debug("Git: Clone instead.")
-            command = ["git", "clone", source, target]
+            command = ["git", "clone", "--depth", "1", source, target]
             code, output, error = execute(command)
 
             if code == 0:


### PR DESCRIPTION
Mozilla product localization involves Firefox, Firefox for Android, Thunderbird, Lightning and Mozilla Suite. Instead of having 5 different repositories with l10n resources like all other projects do, we are dealing with just 2 repositories, one for Firefox and Firefox for Android, and one for Thunderbird, Lightning and Mozilla Suite. Both of these epositories are huge, because they contain the entire codebase of these products.

That means we have to move folders around to create fake per-project repositories, because this is what Pontoon expects. Depending on how long will it take to clone 2,5 GB of repositories on each sync cycle on staging, we might need to adapt sync to do it only every 2 hours for these projects.

@Osmose, r? It was convenient to simply add 3 blocks of code to existing methods. But it's also ugly. We should probably use separate methods to do these project-specific tasks. Any recommendations on what approach to use here?

**Note**: This PR is *very* important, because once it lands, we will be able to use one tool (Pontoon) to localize everything we localize at Mozila for the very first time.