### PR TITLE
Fix project admin links for non-imported projects

### DIFF
--- a/pontoon/base/templates/project_selector.html
+++ b/pontoon/base/templates/project_selector.html
@@ -21,7 +21,7 @@
     <ul>
       {% for p in projects %}
       <li class="clearfix{% if project and project == p %} current{% endif %}">
-        {% if p and p.chart and p.chart.total %}
+        {% if url_prefix %}
         <a href="/{{ url_prefix }}/{{ p.slug }}/" class="clearfix">
         {% endif %}
           <span class="name"
@@ -36,8 +36,10 @@
               <span class="fuzzy" style="width:{{ p.chart.fuzzy / p.chart.total * 100 }}%;"></span>
             </span>
           </span>
-        </a>
           {% endif %}
+        {% if url_prefix %}
+        </a>
+        {% endif %}
       </li>
       {% endfor %}
       <li class="no-match">No results</li>


### PR DESCRIPTION
If project was created but not imported, it was impossible to open it from the admin project list, because it wasn't linked to. Because we relied on stats to check if we should create the link or not.

@Osmose, r?