### PR TITLE
Fix bug 1188929: Build assets in post_compile.

### DIFF
--- a/bin/post_compile
+++ b/bin/post_compile
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+export PATH=/app/.heroku/node/bin:$PATH
+./manage.py migrate --noinput
+./manage.py collectstatic --noinput

--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -19,6 +19,15 @@ you create:
 ``ADMIN_NAME``
    Optional. Name for the ``ADMINS`` setting.
 
+``DISABLE_COLLECTSTATIC``
+   Disables running ``./manage.py collectstatic`` during the build. Should be
+   set to ``1``.
+
+   Heroku's Python buildpack has a bug that causes issues when running node
+   binaries during the compile step of the buildpack. To get around this, we run
+   the command in our post-compile step (see ``bin/post_compile``) when the
+   issue doesn't occur.
+
 ``DJANGO_DEBUG``
    Controls ``DEBUG`` mode for the site. Should be set to `False` in
    production.
@@ -29,19 +38,6 @@ you create:
 
 ``HMAC_KEY``
    Required. Secret key used for hashing passwords.
-
-``PIPELINE_BABEL_BINARY``
-   Required. Command for executing Babel_ during the build process.
-
-   The Heroku Python buildpack moves the project's code around during the build
-   process, so specifying this is important as you can't rely on babel or node
-   to be in your ``PATH``. Set this to
-   ``./.heroku/node/bin/node ./node_modules/babel/bin/babel/index.js`` to get
-   minification working properly on Heroku.
-
-``PIPELINE_YUGLIFY_BINARY``
-   Required. Command for executing Yuglify_ during the build process. Set this
-   to ``./.heroku/node/bin/node ./node_modules/yuglify/bin/yuglify``.
 
 ``SECRET_KEY``
    Required. Secret key used for sessions, cryptographic signing, etc.
@@ -145,7 +141,7 @@ you'll have to use the Django shell to mark your user account as an admin:
 Gotchas
 -------
 - Changing the ``SSH_KEY`` or ``SSH_CONFIG`` environment variables *requires*
-  a rebuild of the site, as these settings are only using at build time. Simply
+  a rebuild of the site, as these settings are only used at build time. Simply
   changing them will not actually update the site until the next build.
 
   The `Heroku Repo`_ plugin includes a rebuild command that is handy for

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -51,10 +51,6 @@ HMAC_KEYS = {
 SITE_URL = os.environ.get('SITE_URL', 'http://localhost:8000')
 BROWSERID_AUDIENCES = [SITE_URL]
 
-# Path to binaries for django-pipeline.
-PIPELINE_YUGLIFY_BINARY = os.environ.get('PIPELINE_YUGLIFY_BINARY', 'yuglify')
-PIPELINE_BABEL_BINARY = os.environ.get('PIPELINE_BABEL_BINARY', 'babel')
-
 # Custom LD_LIBRARY_PATH environment variable for SVN
 SVN_LD_LIBRARY_PATH = os.environ.get('SVN_LD_LIBRARY_PATH', '')
 
@@ -94,6 +90,7 @@ INSTALLED_APPS = (
     'pontoon.base',
     'pontoon.administration',
     'pontoon.intro',
+    'pontoon.translate',
 
     # Django contrib apps
     'django.contrib.admin',
@@ -178,6 +175,8 @@ PIPELINE_COMPILERS = (
     'pipeline.compilers.es6.ES6Compiler',
 )
 
+PIPELINE_YUGLIFY_BINARY = path('node_modules/.bin/yuglify')
+PIPELINE_BABEL_BINARY = path('node_modules/.bin/babel')
 PIPELINE_BABEL_ARGUMENTS = '--modules ignore'
 
 PIPELINE_DISABLE_WRAPPER = True
@@ -212,6 +211,12 @@ PIPELINE_CSS = {
             'css/translate.css',
         ),
         'output_filename': 'css/translate.min.css',
+    },
+    'translate_new': {
+        'source_filenames': (
+            'css/translate_new.css',
+        ),
+        'output_filename': 'css/translate_new.min.css',
     },
     'user': {
         'source_filenames': (
@@ -253,6 +258,21 @@ PIPELINE_JS = {
             'js/jquery.timeago.js',
         ),
         'output_filename': 'js/translate.min.js',
+    },
+    'translate_new': {
+        'source_filenames': (
+            ('js/lib/react-with-addons-0.13.3.js' if DEBUG else
+             'js/lib/react-with-addons-0.13.3.min.js'),
+            'js/lib/classnames.js',
+            'browserid/api.js',
+            'js/translate/models.es6',
+            'js/translate/utils.es6',
+            'js/translate/TranslationEditor.es6',
+            'js/translate/TranslationSelector.es6',
+            'js/translate/TranslateView.es6',
+            'js/translate/bootstrap.es6',
+        ),
+        'output_filename': 'js/translate_new.min.js',
     },
     'user': {
         'source_filenames': (


### PR DESCRIPTION
Since collectstatic has trouble building the assets during the normal build, we build them during post_compile, when the path issues that cause collectstatic to fail don't exist anymore.

This commit also reverts the previous removal of the translate app as that was a temporary fix.

This has been tested on staging and seems to work fine. Before deploying to production we'll want to set the `DISABLE_COLLECTSTATIC` environment variable on prod to get rid of annoying non-error messages during the build.

@mathjazz r?