### PR TITLE
Pin buildpacks

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,4 +1,4 @@
-https://github.com/ddollar/heroku-buildpack-apt
-https://github.com/Osmose/heroku-buildpack-ssh
-https://github.com/heroku/heroku-buildpack-nodejs
-https://github.com/heroku/heroku-buildpack-python
+https://github.com/ddollar/heroku-buildpack-apt#7954acd0aa932201377187402d8a0794f535c738
+https://github.com/Osmose/heroku-buildpack-ssh#680ac1a231af5ec6441f88fdac4fb8f4dc78c319
+https://github.com/heroku/heroku-buildpack-nodejs#e14c33b6f56691016e76ef57278c4147070d6fe6
+https://github.com/heroku/heroku-buildpack-python#ded2c5156aa41143e2236a77776083232c9dc366

--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -8,6 +8,17 @@ below assume you've already created an app and have installed the
 
 .. _Heroku Toolbelt: https://toolbelt.heroku.com/
 
+Buildpack
+---------
+Pontoon uses `heroku-buildpack-multi`_ as its buildpack. You can set this (and
+pin it to the correct version) with the following toolbelt command:
+
+.. code-block:: bash
+
+   heroku buildpacks:set https://github.com/heroku/heroku-buildpack-multi.git#26fa21ac7156e63d3d36df1627329aa57f8f137c
+
+.. _heroku-buildpack-multi: https://github.com/heroku/heroku-buildpack-multi
+
 Environment Variables
 ---------------------
 The following is a list of environment variables you'll want to set on the app


### PR DESCRIPTION
Pins our buildpacks to specific commits that we know work for deploying Pontoon. Also documents the process of pinning the multi-buildpack that combines them together.

This has been tested and works on staging, including pinning the multi-buildpack.

@mathjazz r?