### PR TITLE
Set EXCLUDES setting via environment

### DIFF
--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -461,4 +461,4 @@ MICROSOFT_TERMINOLOGY_LOCALES = [
 ]
 
 # Contributors to exclude from Top Contributors list
-EXCLUDE = []
+EXCLUDE = os.environ.get('EXCLUDE', '').split(',')


### PR DESCRIPTION
@Osmose, quick r?

This enables EXCLUDES list again, which removes me from the top contributors list. I've been using Pontoon since day 1 and it's not fair I'm on that list.

While this fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1179956, I'm leaving it open in case we want to explore solutions for reading lists from environment variables. Which is less urgent than removing my name from the list.