### PR TITLE
Filter by locale when checking if translation changed.

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -342,7 +342,10 @@ class Entity(models.Model):
         if recently_approved.exists():
             return True
 
-        approved = self.translation_set.filter(approved=True)
+        approved = self.translation_set.filter(
+            approved=True,
+            locale__code=locale_code
+        )
         recently_deleted = Translation.deleted_objects.filter(
             entity=self,
             deleted__gt=project.last_synced,


### PR DESCRIPTION
This fixes an issue with deletion where approved translations for other locales would cause Entity.has_changed to return False when no approved translations exist for the given locale.

@mathjazz r?