### PR TITLE
Bug 1190754: Do not allow newlines in .lang files translations

### DIFF
--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -659,6 +659,9 @@ def update_translation(request, template=None):
     translations = Translation.objects.filter(
         entity=e, locale=l, plural_form=plural_form)
 
+    if e.resource.format == 'lang' and '\n' in string:
+        return HttpResponse("Newline characters are not allowed.")
+
     # Translations exist
     if len(translations) > 0:
 

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -659,8 +659,9 @@ def update_translation(request, template=None):
     translations = Translation.objects.filter(
         entity=e, locale=l, plural_form=plural_form)
 
+    # Newlines are not allowed in .lang files (bug 1190754)
     if e.resource.format == 'lang' and '\n' in string:
-        return HttpResponse("Newline characters are not allowed.")
+        return HttpResponse('Newline characters are not allowed.')
 
     # Translations exist
     if len(translations) > 0:


### PR DESCRIPTION
Do not allow newlines in .lang files translations:
https://bugzilla.mozilla.org/show_bug.cgi?id=1190754

@Osmose, r?