### PR TITLE
Bug 1183013: Make Sign in warning more visible

### DIFF
--- a/pontoon/base/static/js/translate_old.js
+++ b/pontoon/base/static/js/translate_old.js
@@ -1235,6 +1235,10 @@ var Pontoon = (function (my) {
             name = project.html(),
             slug = project.data('slug');
 
+        if (slug !== 'pontoon-intro' && !self.user.email) {
+          return self.endLoader('Sign in to access more projects.', 'error', true);
+        }
+
         $('.project .selector .title')
           .html(name)
           .data('slug', slug);


### PR DESCRIPTION
Show Sign in warning to non-authenticated users right after projects get selected. Make it persistent.
https://bugzilla.mozilla.org/show_bug.cgi?id=1183013

@Osmose, r?