### PR TITLE
Bug 1178874: Handle paths properly in Project path methods.

### DIFF
--- a/pontoon/base/vcs_models.py
+++ b/pontoon/base/vcs_models.py
@@ -46,8 +46,7 @@ class VCSResource(object):
         db_project = vcs_project.db_project
         for locale in db_project.locales.all():
             resource_path = os.path.join(
-                db_project.checkout_path,
-                db_project.locale_directory_name(locale.code),
+                db_project.locale_directory_path(locale.code),
                 self.path
             )
             try:


### PR DESCRIPTION
A subtle bug in the path methods on the Project model caused paths to be
incorrect for projects that do not have locale directories at the root of their
repo. We fix this bug and also simplify the path methods based on how they're
used.

@mathjazz r? This is the bug that was causing issues with the Firefox 3.6 Start project on staging, since it has all it's locales underneath a top-level directory named `locale`.