### PR TITLE
Bug 1178874: Fall back to string when entity key is empty.

### DIFF
--- a/pontoon/administration/management/commands/sync_projects.py
+++ b/pontoon/administration/management/commands/sync_projects.py
@@ -151,7 +151,8 @@ class Command(BaseCommand):
         Generate a key for the given entity that is unique within the
         project.
         """
-        return ':'.join([entity.resource.path, entity.key])
+        key = entity.key or entity.string
+        return ':'.join([entity.resource.path, key])
 
     def commit_changes(self, db_project, changeset):
         """Commit the changes we've made back to the VCS."""


### PR DESCRIPTION
When constructing a unique key for entities during sync, if Entity.key is blank,
we should use Entity.string as the key value instead.

@mathjazz r? Found this while testing Mozilla.org sync locally. sync_projects used to do this but it got lost during some refactoring, so we need it again.

Without this fix, the langfile parser will create VCSEntities that have a key set to their string value, while database Entities will have a blank key. The code that matches up VCSEntities and database Entities for comparison will not match them up correctly since they will have different keys.