### PR TITLE
Remove en-GB as possible source locale directory

### DIFF
--- a/pontoon/administration/files.py
+++ b/pontoon/administration/files.py
@@ -229,7 +229,7 @@ def get_source_directory(path):
         # Ignore hidden folders
         dirnames[:] = [d for d in dirnames if not d[0] == '.']
 
-        for directory in ('templates', 'en-US', 'en-GB', 'en'):
+        for directory in ('templates', 'en-US', 'en'):
             for dirname in fnmatch.filter(dirnames, directory):
                 source_directory_path = os.path.join(root, dirname)
                 if detect_format(source_directory_path):
@@ -761,7 +761,7 @@ def update_from_repository(project):
     repository_url_master = False
     ending = os.path.basename(os.path.normpath(repository_url))
 
-    if ending in ('templates', 'en-US', 'en-GB', 'en'):
+    if ending in ('templates', 'en-US', 'en'):
         repository_url_master = repository_url.rsplit(ending, 1)[0]
         repository_path = os.path.join(repository_path_master, ending)
 

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -176,7 +176,7 @@ class Project(models.Model):
         """Path to the directory where source strings are stored."""
         for root, dirnames, filenames in os.walk(self.checkout_path):
             for dirname in dirnames:
-                if dirname in ('templates', 'en-US', 'en-GB', 'en'):
+                if dirname in ('templates', 'en-US', 'en'):
                     return os.path.join(root, dirname)
 
         raise Exception('No source directory found for project {0}'.format(self.slug))


### PR DESCRIPTION
This is a relic from the past, which we no longer use at Mozilla. We treat en-GB as a separate locale we localize into.

@Osmose, r?