### PR TITLE
Fix sorting on project landing page

### DIFF
--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -484,15 +484,14 @@ $(function() {
     }
 
     function getChart(el) {
-      var data = $(el).find('.chart').data('chart');
-      if (data) {
-        return {
-          "approved": data.approved/data.total,
-          "translated": data.translated/data.total
-        };
-      } else {
-        return 0;
-      }
+      var data = $(el).find('.chart').data('chart'),
+          approved = data ? data.approved/data.total : 0,
+          translated = data ? data.translated/data.total : 0;
+
+      return {
+        "approved": approved,
+        "translated": translated
+      };
     }
 
     var index = $(this).index(),


### PR DESCRIPTION
We returned 0 instead of dict with values set to 0 if data wasn't
available. It didn't break on other landing pages but project page,
because data is always available.

@Osmose, r?