### PR TITLE
Use jinja to render commit messages.

### DIFF
--- a/pontoon/administration/templates/commit_message.jinja
+++ b/pontoon/administration/templates/commit_message.jinja
@@ -1,0 +1,8 @@
+Pontoon: Updated {{ locale.name }} ({{ locale.code }}) localization of {{ project.name }}
+{%- if authors %}
+
+Translation authors:
+{% for author in authors -%}
+- {{ author.display_name|safe }}
+{%- endfor %}
+{% endif -%}


### PR DESCRIPTION
This lets us put some slightly more complex logic in the commit message
template, like hiding the list of authors if none are available.

@mathjazz r?