### PR TITLE
Bug 1191133: Support using Memcached as a cache backend.

### DIFF
--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -100,9 +100,39 @@ Pontoon is designed to run with the following add-ons enabled:
 - Error Tracking: Raygun.io
 - Email: Sendgrid
 - Scheduled Jobs: Heroku Scheduler
+- Cache: Memcached Cloud
 
 It's possible to run with the free tiers of all of these add-ons, but it is
 recommended that, at a minimum, you run the "Standard 0" tier of Postgres.
+
+Cache Add-ons
+~~~~~~~~~~~~~
+Pontoon uses `django-pylibmc`_, which expects the following environment
+variables from the cache add-on:
+
+``MEMCACHE_SERVERS``
+   Semi-colon separated list of memcache server addresses.
+``MEMCACHE_USERNAME``
+   Username to use for authentication.
+``MEMCACHE_PASSWORD``
+   Password to use for authentication.
+
+.. note::
+
+   By default, the environment variables added by Memcached Cloud are prefixed
+   with ``MEMCACHEDCLOUD`` instead of ``MEMCACHE``. You can "attach" the
+   configuration variables with the correct prefix using the ``addons:attach``
+   command:
+
+   .. code-block:: bash
+
+      heroku addons:attach resource_name --as MEMCACHE
+
+   Replace ``resource_name`` with the name of the resource provided by the cache
+   addon you wish to use, such as ``memcachedcloud:30``. Use the
+   ``heroku addons`` command to see a list of resource names that are available.
+
+.. _django-pylibmc: https://github.com/django-pylibmc/django-pylibmc/
 
 Scheduled Jobs
 --------------

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -289,12 +289,25 @@ PIPELINE_JS = {
 }
 
 # Cache config
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-        'LOCATION': 'pontoon'
+# If the environment contains configuration data for Memcached, use
+# PyLibMC for the cache backend. Otherwise, default to an in-memory
+# cache.
+if os.environ.get('MEMCACHE_SERVERS') is not None:
+    CACHES = {
+        'default': {
+            'BACKEND': 'django_pylibmc.memcached.PyLibMCCache',
+            'TIMEOUT': 500,
+            'BINARY': True,
+            'OPTIONS': {}
+        }
     }
-}
+else:
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'pontoon'
+        }
+    }
 
 # Site ID is used by Django's Sites framework.
 SITE_ID = 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -176,3 +176,8 @@ django-bulk-update==1.1.4
 parsimonious==0.6.2
 # sha256: fn9zpnXFGHErrdeDJ54m0WQUDz_C7XoyECw9CKaipKc
 jsonfield==1.0.3
+# sha256: FiVVlWFqbXjNeGpVzGQx2lt6zPRlEt-FRxKgzbs6z6o
+pylibmc==1.5.0
+# sha256: VZxCRyjkBCDajJmLE8PE8IYbR1JpoKh2-xcY__J20QY
+# sha256: YhN9U7WsovukJHRLobsw6SoRXZqGgcvmpkEdskGx0a0
+django-pylibmc==0.6.0


### PR DESCRIPTION
This adds the ability to use a shared cache between all the dynos in the app. I've provisioned a 250mb cache for staging and deployed this and since then I haven't been able to replicate the login failure issues, which I suspect are related to the cache given that session-csrf stores anonymous CSRF tokens in the cache.

Plus it's just a good idea for us to use a shared cache anyway.

@mathjazz r?