### PR TITLE
Also commit files that aren't in the repository yet

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -721,6 +721,10 @@ def update_entity_count(resource):
             stats, created = Stats.objects.get_or_create(
                 resource=resource, locale=locale)
 
+            # Existing stats were set to 0 beforehand and need to be restored
+            if not created:
+                update_stats(resource, locale)
+
 
 def update_stats(resource, locale):
     """Save stats for given resource and locale."""


### PR DESCRIPTION
We set stats to 0 after repository is updated and than reset them during
extract. But we never reset them for files that use assymetric file
format and aren't in the locale repository yet. Since we also rely on
stats when picking files to dump and commit, these files never ended
up in the repository. This is a regression and should land asap.

I tested this with Firefox for Android Aurora locally and works as expected.

@Osmose, r? This is quite a serious one.