### PR TITLE
Track Entity.has_changed status in the database.

### DIFF
--- a/pontoon/base/migrations/0014_auto_20150806_0948.py
+++ b/pontoon/base/migrations/0014_auto_20150806_0948.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0013_add_en_US'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ChangedEntityLocale',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('entity', models.ForeignKey(to='base.Entity')),
+                ('locale', models.ForeignKey(to='base.Locale')),
+            ],
+        ),
+        migrations.AddField(
+            model_name='entity',
+            name='changed_locales',
+            field=models.ManyToManyField(help_text=b'List of locales in which translations for this entity have changed since the last sync.', to='base.Locale', through='base.ChangedEntityLocale'),
+        ),
+        migrations.AlterUniqueTogether(
+            name='changedentitylocale',
+            unique_together=set([('entity', 'locale')]),
+        ),
+    ]

--- a/pontoon/base/migrations/0015_remove_project_last_synced.py
+++ b/pontoon/base/migrations/0015_remove_project_last_synced.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0014_auto_20150806_0948'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='project',
+            name='last_synced',
+        ),
+    ]


### PR DESCRIPTION
Instead of querying for translations every time we need to see if an entity has
changed for a particular locale, we instead store whether the entity has changed
in the database whenever translations are saved. This significantly speeds up
sync_projects by removing a ton of unnecessary database queries.

@mathjazz r?