### PR TITLE
Bug 1191718: Only update DB during sync when necessary.

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -12,6 +12,7 @@ from django.db.models.signals import post_save
 from django.forms import ModelForm
 from django.utils import timezone
 
+from dirtyfields import DirtyFieldsMixin
 from jsonfield import JSONField
 
 from pontoon.base import MOZILLA_REPOS, utils
@@ -284,7 +285,7 @@ class Subpage(models.Model):
         return self.name
 
 
-class Entity(models.Model):
+class Entity(DirtyFieldsMixin, models.Model):
     resource = models.ForeignKey(Resource)
     string = models.TextField()
     string_plural = models.TextField(blank=True)
@@ -399,7 +400,7 @@ def extra_default():
     return {}
 
 
-class Translation(models.Model):
+class Translation(DirtyFieldsMixin, models.Model):
     entity = models.ForeignKey(Entity)
     locale = models.ForeignKey(Locale)
     user = models.ForeignKey(User, null=True, blank=True)

--- a/pontoon/base/vcs_models.py
+++ b/pontoon/base/vcs_models.py
@@ -109,10 +109,18 @@ class VCSTranslation(object):
     pontoon.base.models.Translation.plural_form and the values equal the
     translation for that plural form.
     """
-    def __init__(self, key, source_string, strings, comments, fuzzy, extra):
+    def __init__(self, key, source_string, strings, comments, fuzzy):
         self.key = key
         self.source_string = source_string
         self.strings = strings
         self.comments = comments
         self.fuzzy = fuzzy
-        self.extra = extra
+
+    @property
+    def extra(self):
+        """
+        Return a dict of custom properties to store in the database.
+        Useful for subclasses from specific formats that have extra data
+        that needs to be preserved.
+        """
+        return {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -181,3 +181,5 @@ pylibmc==1.5.0
 # sha256: VZxCRyjkBCDajJmLE8PE8IYbR1JpoKh2-xcY__J20QY
 # sha256: YhN9U7WsovukJHRLobsw6SoRXZqGgcvmpkEdskGx0a0
 django-pylibmc==0.6.0
+# sha256: U_5sxKvAXajw8DIgLVoQ298q3k1CvHD1ZVeykr8ycok
+django-dirtyfields==0.7


### PR DESCRIPTION
Uses django-dirtyfields to determine if an Entity or Translation has actually
changed, so that we only update the database in cases where changes are
necessary rather than blindly updating all the time.

My local sync test case went from 34 seconds to 20 seconds with this change. Progress!

@mathjazz r?