### PR TITLE
Update stats after sync.

### DIFF
--- a/pontoon/administration/management/commands/sync_projects.py
+++ b/pontoon/administration/management/commands/sync_projects.py
@@ -15,7 +15,8 @@ from pontoon.base.models import (
     Locale,
     Project,
     Resource,
-    Translation
+    Translation,
+    update_stats
 )
 from pontoon.base.utils import match_attr
 from pontoon.base.vcs_models import VCSProject
@@ -94,6 +95,12 @@ class Command(BaseCommand):
         # Apply the changeset to the files and then commit them.
         changeset.execute()
         self.commit_changes(db_project, changeset)
+
+        # Update the stats for all the resources and locales in this
+        # project.
+        for resource in db_project.resource_set.all():
+            for locale in db_project.locales.all():
+                update_stats(resource, locale)
 
         # Clear out the list of changed locales for entity in this
         # project now that we've finished syncing.


### PR DESCRIPTION
Stats weren't actually being updated due to the bulk actions in `sync_projects`, now they're updated once all the action has happened for each project. Yay!

@mathjazz r?