### PR TITLE
Bug 1190843: Fix escaping HTML

### DIFF
--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -116,20 +116,10 @@ var Pontoon = (function (my) {
     /*
      * Do not render HTML tags
      *
-     * string HTML snippet that has to be displayed as code instead of rendered
+     * string String that has to be displayed as is instead of rendered
      */
     doNotRender: function (string) {
-      return string.replace(/</g, '&lt;').replace(/>/g, '&gt;');
-    },
-
-
-    /*
-     * Reverse function: do render HTML tags
-     *
-     * string HTML snippet that has to be rendered instead of displayed as code
-     */
-    doRender: function (string) {
-      return string.replace(/&lt;/g, '<').replace(/&gt;/g, '>');
+      return $('<div/>').text(string).html()
     },
 
 

--- a/pontoon/base/static/js/translate_old.js
+++ b/pontoon/base/static/js/translate_old.js
@@ -587,7 +587,7 @@ var Pontoon = (function (my) {
 
         var textarea = $('#translation'),
             pos = textarea[0].selectionStart,
-            placeable = self.doRender($(this).text()),
+            placeable = $(this).text(),
             before = textarea.val(),
             after = before.substring(0, pos) + placeable + before.substring(pos);
 
@@ -721,7 +721,7 @@ var Pontoon = (function (my) {
 
         var entity = $('#editor')[0].entity,
             original = entity['original' + self.isPluralized()],
-            source = self.doRender(original);
+            source = original;
 
         $('#translation').val(source).focus();
         $('#translation-length .current-length').html(source.length);
@@ -837,8 +837,8 @@ var Pontoon = (function (my) {
         e.stopPropagation();
         e.preventDefault();
 
-        var translation = $(this).find('.translation').html(),
-            source = self.doRender(translation);
+        var translation = $(this).find('.translation').text(),
+            source = translation;
         $('#translation').val(source).focus();
         $('#translation-length .current-length').html(source.length);
 
@@ -895,8 +895,8 @@ var Pontoon = (function (my) {
                     // Make newest alternative translation active
                     if (next.length > 0) {
                       next.click();
-                      translation = next.find('.translation').html();
-                      entity.translation[pluralForm].string = self.doRender(translation);
+                      translation = next.find('.translation').text();
+                      entity.translation[pluralForm].string = translation;
                       entity.ui.find('.translation-string')
                         .html(self.doNotRender(translation));
                       if (self.user.localizer) {


### PR DESCRIPTION
This fix unifies the way we display translations, original strings and
comments across the entire app. E.g. `&hellip;` and `<br />` now always
show up as is instead of being rendered sometimes.

It also unifies the way we insert these escaped strings into textarea when
e.g. copying them from suggestions or pasting placeables. We simply use
jQuery's .text() method.