### PR TITLE
Properly detect asymmetric projects

### DIFF
--- a/pontoon/administration/files.py
+++ b/pontoon/administration/files.py
@@ -1229,7 +1229,7 @@ def dump_from_database(project, locale):
     # Asymmetric formats: Remove l10n files from locale repository
     asymmetric = ['dtd', 'properties', 'ini', 'inc']
 
-    if all(x in formats for x in asymmetric):
+    if all(x in asymmetric for x in formats):
         for root, dirnames, filenames in os.walk(
                 locale_directory_path, topdown=False):
             for extension in asymmetric:


### PR DESCRIPTION
Project is asymmetric, if any resource asymmetric (not all).

Fixes a regression:
https://github.com/mozilla/pontoon/commit/a85ee5c48299466393aa8c8c94b69e77e6a2c11e#diff-c5dc7820ff79f0945fc21de86ffc85aaL1040