### PR TITLE
Proper asymmetric projects detection

### DIFF
--- a/pontoon/administration/files.py
+++ b/pontoon/administration/files.py
@@ -1217,9 +1217,6 @@ def dump_from_database(project, locale):
     if not locale_directory_path:
         return False
 
-    formats = Resource.objects.filter(project=project).values_list(
-        'format', flat=True).distinct()
-
     # Get relative paths to translated files only
     stats = Stats.objects.filter(locale=locale).exclude(approved_count=0) \
         .values("resource")
@@ -1227,12 +1224,11 @@ def dump_from_database(project, locale):
     relative_paths = resources.values_list('path', flat=True).distinct()
 
     # Asymmetric formats: Remove l10n files from locale repository
-    asymmetric = ['dtd', 'properties', 'ini', 'inc']
-
-    if all(x in formats for x in asymmetric):
+    project_resources = Resource.objects.filter(project=project)
+    if all(r.is_asymmetric for r in project_resources):
         for root, dirnames, filenames in os.walk(
                 locale_directory_path, topdown=False):
-            for extension in asymmetric:
+            for extension in Resource.ASYMMETRIC:
                 for filename in fnmatch.filter(filenames, '*.' + extension):
 
                     # Ignore specific files from Mozilla repos

--- a/pontoon/administration/files.py
+++ b/pontoon/administration/files.py
@@ -1228,7 +1228,7 @@ def dump_from_database(project, locale):
     if all(r.is_asymmetric for r in project_resources):
         for root, dirnames, filenames in os.walk(
                 locale_directory_path, topdown=False):
-            for extension in Resource.ASYMMETRIC:
+            for extension in Resource.ASYMMETRIC_FORMATS:
                 for filename in fnmatch.filter(filenames, '*.' + extension):
 
                     # Ignore specific files from Mozilla repos

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -263,10 +263,12 @@ class Resource(models.Model):
 
     ALLOWED_EXTENSIONS = [f[0] for f in FORMAT_CHOICES] + ['pot']
 
+    ASYMMETRIC = ('dtd', 'properties', 'ini', 'inc', 'l20n')
+
     @property
     def is_asymmetric(self):
         """Return True if this resource is in an asymmetric format."""
-        return self.format in ('dtd', 'properties', 'ini', 'inc', 'l20n')
+        return self.format in self.ASYMMETRIC
 
     def __unicode__(self):
         return '%s: %s' % (self.project.name, self.path)

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -263,12 +263,12 @@ class Resource(models.Model):
 
     ALLOWED_EXTENSIONS = [f[0] for f in FORMAT_CHOICES] + ['pot']
 
-    ASYMMETRIC = ('dtd', 'properties', 'ini', 'inc', 'l20n')
+    ASYMMETRIC_FORMATS = ('dtd', 'properties', 'ini', 'inc', 'l20n')
 
     @property
     def is_asymmetric(self):
         """Return True if this resource is in an asymmetric format."""
-        return self.format in self.ASYMMETRIC
+        return self.format in self.ASYMMETRIC_FORMATS
 
     def __unicode__(self):
         return '%s: %s' % (self.project.name, self.path)


### PR DESCRIPTION
Instead of checking if project contains at least one resource of any asymmetric format, we now check if all project formats are asymmetric.

Use Resource object's is_asymmetric property.

@Osmose, r?