### PR TITLE
Fix bug 1193359: Replace unsafe glyph with FA icon

### DIFF
--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -240,7 +240,7 @@ body > header .locale.select {
 
 .unchanged .status:before {
   color: #AAAAAA;
-  content: "";
+  content: "";
 }
 
 .all .status {

--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -240,7 +240,7 @@ body > header .locale.select {
 
 .unchanged .status:before {
   color: #AAAAAA;
-  content: "";
+  content: "";
 }
 
 .all .status {
@@ -718,6 +718,7 @@ body > header aside p {
 
 #entitylist .no-match div  {
   color: #7BC876;
+  display: block;
   font-size: 128px;
   margin-bottom: 20px;
 }

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -227,7 +227,7 @@
       <h2 id="not-on-page">Not on the current page</h2>
       {% endif %}
       <ul class="uneditables"></ul>
-      <h3 class="no-match"><div>ఠ_ఠ</div>No results</h3>
+      <h3 class="no-match"><div class="fa fa-thumbs-down"></div>No results</h3>
     </div>
   </div>
 


### PR DESCRIPTION
Also replaces "Unchanged" filter icon (thumb up) with bars (equivalency),
because the new "No results" icons was too similar and might apply relation.

@Osmose, r?