### PR TITLE
POFile support for sync_projects

### DIFF
--- a/pontoon/base/formats/__init__.py
+++ b/pontoon/base/formats/__init__.py
@@ -5,14 +5,16 @@ See base.py for the ParsedResource base class.
 """
 import os.path
 
-from pontoon.base.formats import lang
+from pontoon.base.formats import lang, po
 
 
 # To add support for a new resource format, add an entry to this dict
 # where the key is the extension you're parsing and the value is a
 # callable returning an instance of a ParsedResource subclass.
 SUPPORTED_FORMAT_PARSERS = {
-    '.lang': lang.parse
+    '.lang': lang.parse,
+    '.po': po.parse,
+    '.pot': po.parse,
 }
 
 

--- a/pontoon/base/formats/base.py
+++ b/pontoon/base/formats/base.py
@@ -14,12 +14,12 @@ class ParsedResource(object):
         """
         raise NotImplementedError()
 
-    def save(self, path=None):
+    def save(self, locale):
         """
         Save any changes made the the VCSTranslation objects from
         self.translations back to the originally parsed resource file.
 
-        If path is not None, save changes to the given path instead of
-        the original file.
+        :param Locale locale:
+            Locale of the file being saved.
         """
         raise NotImplementedError()

--- a/pontoon/base/formats/lang.py
+++ b/pontoon/base/formats/lang.py
@@ -52,9 +52,8 @@ class LangFile(ParsedResource):
     def translations(self):
         return [c for c in self.children if isinstance(c, LangEntity)]
 
-    def save(self, path=None):
-        path = path or self.path
-        with codecs.open(path, 'w', 'utf-8') as f:
+    def save(self, locale):
+        with codecs.open(self.path, 'w', 'utf-8') as f:
             for child in self.children:
                 if isinstance(child, LangEntity):
                     self.write_entity(f, child)

--- a/pontoon/base/formats/lang.py
+++ b/pontoon/base/formats/lang.py
@@ -43,7 +43,7 @@ class LangEntity(VCSTranslation):
         return {'tags': list(self.tags)}
 
 
-class LangFile(ParsedResource):
+class LangResource(ParsedResource):
     def __init__(self, path, children):
         self.path = path
         self.children = children
@@ -157,4 +157,4 @@ def parse(path):
         content = f.read()
 
     children = LangVisitor().parse(content)
-    return LangFile(path, children)
+    return LangResource(path, children)

--- a/pontoon/base/formats/po.py
+++ b/pontoon/base/formats/po.py
@@ -32,10 +32,13 @@ class POEntity(VCSTranslation):
             source=po_entry.occurrences
         )
 
-    def update_entry(self):
+    def update_entry(self, locale):
         """Update the POEntry associated with this translation."""
         if self.po_entry.msgstr_plural:
-            self.po_entry.msgstr_plural = self.strings
+            self.po_entry.msgstr_plural = {
+                plural_form: self.strings.get(plural_form, '')
+                for plural_form in range(locale.nplurals or 1)
+            }
         else:
             self.po_entry.msgstr = self.strings.get(None, '')
 
@@ -62,7 +65,7 @@ class POResource(ParsedResource):
 
     def save(self, locale):
         for entity in self.translations:
-            entity.update_entry()
+            entity.update_entry(locale)
 
         metadata = self.pofile.metadata
         if len(self.translations) > 0:

--- a/pontoon/base/formats/po.py
+++ b/pontoon/base/formats/po.py
@@ -1,0 +1,95 @@
+"""
+Parser for to pofile translation format.
+"""
+from datetime import datetime
+
+import polib
+
+from pontoon.base.formats.base import ParsedResource
+from pontoon.base.vcs_models import VCSTranslation
+
+
+class POEntity(VCSTranslation):
+    def __init__(self, po_entry, order):
+        self.po_entry = po_entry
+
+        if po_entry.msgstr_plural:
+            strings = po_entry.msgstr_plural
+        else:
+            strings = {None: po_entry.msgstr}
+
+        # Remove empty strings from the string dict.
+        strings = {key: value for key, value in strings.items() if value}
+
+        super(POEntity, self).__init__(
+            key=po_entry.msgid,  # Pofiles use the source as the key.
+            source_string=po_entry.msgid,
+            source_string_plural=po_entry.msgid_plural,
+            strings=strings,
+            comments=po_entry.comment.split('\n') if po_entry.comment else [],
+            fuzzy='fuzzy' in po_entry.flags,
+            order=order,
+            source=po_entry.occurrences
+        )
+
+    def update_entry(self):
+        """Update the POEntry associated with this translation."""
+        if self.po_entry.msgstr_plural:
+            self.po_entry.msgstr_plural = self.strings
+        else:
+            self.po_entry.msgstr = self.strings.get(None, '')
+
+        if self.fuzzy:
+            self.po_entry.flags.append('fuzzy')
+        elif 'fuzzy' in self.po_entry.flags:
+            self.po_entry.flags.remove('fuzzy')
+
+    def __repr__(self):
+        return '<POEntity {key}>'.format(key=self.key.encode('utf-8'))
+
+
+class POResource(ParsedResource):
+    def __init__(self, pofile):
+        self.pofile = pofile
+        self.entities = [
+            POEntity(entry, k) for k, entry in enumerate(self.pofile)
+            if not entry.obsolete
+        ]
+
+    @property
+    def translations(self):
+        return self.entities
+
+    def save(self, locale):
+        for entity in self.translations:
+            entity.update_entry()
+
+        metadata = self.pofile.metadata
+        if len(self.translations) > 0:
+            latest_translation = max(
+                self.translations,
+                key=lambda t: t.last_updated or datetime.min
+            )
+            if latest_translation.last_updated:
+                metadata['PO-Revision-Date'] = latest_translation.last_updated.strftime(
+                    '%Y-%m-%d %H:%M%z'
+                )
+            if latest_translation.last_translator:
+                metadata['Last-Translator'] = latest_translation.last_translator.display_name
+
+        metadata.update({
+            'Language': locale.code.replace('-', '_'),
+            'X-Generator': 'Pontoon',
+            'Plural-Forms': ('nplurals={locale.nplurals}; plural={locale.plural_rule};'
+                             .format(locale=locale))
+        })
+
+        self.pofile.save()
+
+    def __repr__(self):
+        return '<POResource {self.pofile.fpath}>'.format(self=self)
+
+
+def parse(path):
+    pofile = polib.pofile(path)
+    return POResource(pofile)

--- a/pontoon/base/migrations/0017_entity_source_jsonfield.py
+++ b/pontoon/base/migrations/0017_entity_source_jsonfield.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import json
+
+from django.db import models, migrations
+import jsonfield.fields
+
+
+def migrate_old_source_fields(apps, schema_editor):
+    """Convert source fields to valid JSON."""
+    Entity = apps.get_model('base', 'Entity')
+    for entity in Entity.objects.all():
+        try:
+            entity.source = json.dumps(eval(entity.source))
+        except SyntaxError:
+            if entity.source:
+                entity.source = json.dumps([entity.source])
+            else:
+                entity.source = '[]'
+        entity.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0016_auto_20150810_1301'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            migrate_old_source_fields,
+            lambda apps, schema_editor: None  # JSON is valid Python
+        ),
+        migrations.AlterField(
+            model_name='entity',
+            name='source',
+            field=jsonfield.fields.JSONField(default=list, blank=True),
+        ),
+    ]

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -300,7 +300,7 @@ class Entity(DirtyFieldsMixin, models.Model):
     key = models.TextField(blank=True)  # Needed for webL10n
     comment = models.TextField(blank=True)
     order = models.PositiveIntegerField(default=0)
-    source = models.TextField(blank=True)  # Path to source code file
+    source = JSONField(blank=True, default=list)  # List of paths to source code files
     obsolete = models.BooleanField(default=False)
 
     changed_locales = models.ManyToManyField(
@@ -401,12 +401,6 @@ class Entity(DirtyFieldsMixin, models.Model):
         entities_array = []
 
         for entity in entities:
-
-            try:
-                source = eval(entity.source)
-            except SyntaxError:
-                source = entity.source
-
             translation_array = []
 
             if entity.string_plural == "":
@@ -427,7 +421,7 @@ class Entity(DirtyFieldsMixin, models.Model):
                 'format': entity.resource.format,
                 'comment': entity.comment,
                 'order': entity.order,
-                'source': source,
+                'source': entity.source,
                 'obsolete': entity.obsolete,
                 'translation': translation_array,
             })
@@ -652,8 +646,9 @@ def get_translation(entity, locale, plural_form=None, fuzzy=None):
 
 
 def save_entity(resource, string, string_plural="", comment="",
-                order=0, key="", source=""):
+                order=0, key="", source=None):
     """Add new or update existing entity."""
+    source = source or []
 
     # Update existing entity
     try:

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -211,6 +211,11 @@ class Project(models.Model):
         """
         path = self.source_directory_path()
         for absolute_path in self.resources_for_path(path):
+            # .pot files in the source directory need to be renamed to
+            # .po files for the locale directories.
+            if absolute_path.endswith('.pot'):
+                absolute_path = absolute_path[:-1]
+
             yield os.path.relpath(absolute_path, path)
 
     def resources_for_path(self, path):

--- a/pontoon/base/static/js/translate_old.js
+++ b/pontoon/base/static/js/translate_old.js
@@ -215,7 +215,7 @@ var Pontoon = (function (my) {
       if (entity.path) {
         $('#metadata').append('<span>' + entity.path + '</span>');
       }
-      if (entity.key) {
+      if (entity.key && entity.key != entity.original) {
         $('#metadata').append('<span>Key: ' + entity.key + '</span>');
       }
 

--- a/pontoon/base/tests/formats/test_po.py
+++ b/pontoon/base/tests/formats/test_po.py
@@ -289,7 +289,10 @@ class POTests(TestCase):
         """)))
 
     def test_save_plural_remove(self):
-        """Any missing plurals should be removed from the pofile."""
+        """
+        Any missing plurals should be set to an empty string in the
+        pofile.
+        """
         test_input = self.generate_pofile(dedent("""
             msgid "Plural %(count)s string"
             msgid_plural "Plural %(count)s strings"
@@ -307,6 +310,7 @@ class POTests(TestCase):
             msgid "Plural %(count)s string"
             msgid_plural "Plural %(count)s strings"
             msgstr[0] "New Plural"
+            msgstr[1] ""
         """)))
 
     def test_save_remove_fuzzy(self):

--- a/pontoon/base/tests/formats/test_po.py
+++ b/pontoon/base/tests/formats/test_po.py
@@ -1,0 +1,385 @@
+import os
+import tempfile
+from datetime import datetime
+from textwrap import dedent
+
+from pontoon.base.formats import po
+from pontoon.base.tests import (
+    assert_attributes_equal,
+    LocaleFactory,
+    TestCase,
+    UserFactory
+)
+
+
+BASE_POFILE = """
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-08-04 12:30+0000\n"
+"PO-Revision-Date: 2015-08-17 09:19:54+0000\n"
+"Last-Translator: mkelly <mkelly@mozilla.com>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Generated-By: Babel 0.9.5\n"
+"X-Generator: Pontoon\n"
+
+#. Sample comment
+#: file.py:1
+msgid "Source String"
+msgstr "Translated String"
+
+#. First comment
+#. Second comment
+msgid "Multiple Comments"
+msgstr "Translated Multiple Comments"
+
+#: file.py:2
+#: file.py:3
+msgid "Multiple Sources"
+msgstr "Translated Multiple Sources"
+
+#, fuzzy
+msgid "Fuzzy"
+msgstr "Translated Fuzzy"
+
+msgid "No Comments or Sources"
+msgstr "Translated No Comments or Sources"
+
+msgid "Missing Translation"
+msgstr ""
+
+msgid "Plural %(count)s string"
+msgid_plural "Plural %(count)s strings"
+msgstr[0] "Translated Plural %(count)s string"
+msgstr[1] "Translated Plural %(count)s strings"
+
+msgid "Plural %(count)s string with missing translations"
+msgid_plural "Plural %(count)s strings with missing translations"
+msgstr[0] ""
+msgstr[1] "Translated Plural %(count)s strings with missing translations"
+"""
+
+HEADER_TEMPLATE = """#\x20
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\\n"
+"Report-Msgid-Bugs-To: \\n"
+"POT-Creation-Date: 2015-08-04 12:30+0000\\n"
+"PO-Revision-Date: {revision_date}\\n"
+"Last-Translator: {last_translator}\\n"
+"Language-Team: LANGUAGE <LL@li.org>\\n"
+"Language: {language}\\n"
+"MIME-Version: 1.0\\n"
+"Content-Type: text/plain; charset=UTF-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"Plural-Forms: {plural_forms}\\n"
+"Generated-By: Babel 0.9.5\\n"
+"X-Generator: {generator}\\n"
+"""
+
+
+class POTests(TestCase):
+    maxDiff = None
+
+    def setUp(self):
+        self.locale = LocaleFactory.create(
+            code='test-locale',
+            name='Test Locale',
+            nplurals=2,
+            plural_rule='(n != 1)',
+        )
+
+    def parse_string(self, string):
+        fd, path = tempfile.mkstemp()
+        with os.fdopen(fd, 'w') as f:
+            f.write(string)
+
+        return path, po.parse(path)
+
+    def test_parse_basic(self):
+        """Basic translation with a comment and source."""
+        path, resource = self.parse_string(BASE_POFILE)
+        assert_attributes_equal(
+            resource.translations[0],
+            comments=['Sample comment'],
+            source=[('file.py', '1')],
+            key='Source String',
+            source_string='Source String',
+            source_string_plural='',
+            strings={None: 'Translated String'},
+            fuzzy=False,
+            order=0,
+        )
+
+    def test_parse_multiple_comments(self):
+        path, resource = self.parse_string(BASE_POFILE)
+        assert_attributes_equal(
+            resource.translations[1],
+            comments=['First comment', 'Second comment'],
+            source=[],
+            key='Multiple Comments',
+            source_string='Multiple Comments',
+            source_string_plural='',
+            strings={None: 'Translated Multiple Comments'},
+            fuzzy=False,
+            order=1,
+        )
+
+    def test_parse_multiple_sources(self):
+        path, resource = self.parse_string(BASE_POFILE)
+        assert_attributes_equal(
+            resource.translations[2],
+            comments=[],
+            source=[('file.py', '2'), ('file.py', '3')],
+            key='Multiple Sources',
+            source_string='Multiple Sources',
+            source_string_plural='',
+            strings={None: 'Translated Multiple Sources'},
+            fuzzy=False,
+            order=2,
+        )
+
+    def test_parse_fuzzy(self):
+        path, resource = self.parse_string(BASE_POFILE)
+        assert_attributes_equal(
+            resource.translations[3],
+            comments=[],
+            source=[],
+            key='Fuzzy',
+            source_string='Fuzzy',
+            source_string_plural='',
+            strings={None: 'Translated Fuzzy'},
+            fuzzy=True,
+            order=3,
+        )
+
+    def test_parse_no_comments_no_sources(self):
+        path, resource = self.parse_string(BASE_POFILE)
+        assert_attributes_equal(
+            resource.translations[4],
+            comments=[],
+            source=[],
+            key='No Comments or Sources',
+            source_string='No Comments or Sources',
+            source_string_plural='',
+            strings={None: 'Translated No Comments or Sources'},
+            fuzzy=False,
+            order=4,
+        )
+
+    def test_parse_missing_traslation(self):
+        path, resource = self.parse_string(BASE_POFILE)
+        assert_attributes_equal(
+            resource.translations[5],
+            comments=[],
+            source=[],
+            key='Missing Translation',
+            source_string='Missing Translation',
+            source_string_plural='',
+            strings={},
+            fuzzy=False,
+            order=5,
+        )
+
+    def test_parse_plural_translation(self):
+        path, resource = self.parse_string(BASE_POFILE)
+        assert_attributes_equal(
+            resource.translations[6],
+            comments=[],
+            source=[],
+            key='Plural %(count)s string',
+            source_string='Plural %(count)s string',
+            source_string_plural='Plural %(count)s strings',
+            strings={
+                0: 'Translated Plural %(count)s string',
+                1: 'Translated Plural %(count)s strings'
+            },
+            fuzzy=False,
+            order=6,
+        )
+
+    def test_parse_plural_translation_missing(self):
+        path, resource = self.parse_string(BASE_POFILE)
+        assert_attributes_equal(
+            resource.translations[7],
+            comments=[],
+            source=[],
+            key='Plural %(count)s string with missing translations',
+            source_string='Plural %(count)s string with missing translations',
+            source_string_plural='Plural %(count)s strings with missing translations',
+            strings={
+                1: 'Translated Plural %(count)s strings with missing translations'
+            },
+            fuzzy=False,
+            order=7,
+        )
+
+    def generate_pofile(
+        self, body,
+        revision_date='2015-08-04 12:30+0000',
+        last_translator='example <example@example.com>',
+        language='test_locale',
+        plural_forms='nplurals=2; plural=(n != 1);',
+        generator='Pontoon'
+    ):
+        header = HEADER_TEMPLATE.format(
+            revision_date=revision_date,
+            last_translator=last_translator,
+            language=language,
+            plural_forms=plural_forms,
+            generator=generator
+        )
+        return header + body
+
+    def assert_pofile_equal(self, pofile_path, expected_content):
+        with open(pofile_path) as f:
+            self.assertMultiLineEqual(f.read(), expected_content)
+
+    def test_save_basic(self):
+        """
+        Test saving changes to an entity with a single translation.
+        """
+        test_input = self.generate_pofile(dedent("""
+            #. Comment
+            #: file.py:1
+            msgid "Source String"
+            msgstr "Translated String"
+        """))
+        path, resource = self.parse_string(test_input)
+
+        translation = resource.translations[0]
+        translation.strings[None] = 'New Translated String'
+        translation.fuzzy = True
+        resource.save(self.locale)
+
+        self.assert_pofile_equal(path, self.generate_pofile(dedent("""
+            #. Comment
+            #: file.py:1
+            #, fuzzy
+            msgid "Source String"
+            msgstr "New Translated String"
+        """)))
+
+    def test_save_plural(self):
+        test_input = self.generate_pofile(dedent("""
+            msgid "Plural %(count)s string"
+            msgid_plural "Plural %(count)s strings"
+            msgstr[0] "Translated Plural %(count)s string"
+            msgstr[1] "Translated Plural %(count)s strings"
+        """))
+        path, resource = self.parse_string(test_input)
+
+        translation = resource.translations[0]
+        translation.strings[0] = 'New Plural'
+        translation.strings[1] = 'New Plurals'
+        resource.save(self.locale)
+
+        self.assert_pofile_equal(path, self.generate_pofile(dedent("""
+            msgid "Plural %(count)s string"
+            msgid_plural "Plural %(count)s strings"
+            msgstr[0] "New Plural"
+            msgstr[1] "New Plurals"
+        """)))
+
+    def test_save_plural_remove(self):
+        """Any missing plurals should be removed from the pofile."""
+        test_input = self.generate_pofile(dedent("""
+            msgid "Plural %(count)s string"
+            msgid_plural "Plural %(count)s strings"
+            msgstr[0] "Translated Plural %(count)s string"
+            msgstr[1] "Translated Plural %(count)s strings"
+        """))
+        path, resource = self.parse_string(test_input)
+
+        translation = resource.translations[0]
+        translation.strings[0] = 'New Plural'
+        del translation.strings[1]
+        resource.save(self.locale)
+
+        self.assert_pofile_equal(path, self.generate_pofile(dedent("""
+            msgid "Plural %(count)s string"
+            msgid_plural "Plural %(count)s strings"
+            msgstr[0] "New Plural"
+        """)))
+
+    def test_save_remove_fuzzy(self):
+        test_input = self.generate_pofile(dedent("""
+            #, fuzzy
+            msgid "Source String"
+            msgstr "Translated String"
+        """))
+        path, resource = self.parse_string(test_input)
+
+        resource.translations[0].fuzzy = False
+        resource.save(self.locale)
+
+        self.assert_pofile_equal(path, self.generate_pofile(dedent("""
+            msgid "Source String"
+            msgstr "Translated String"
+        """)))
+
+    def test_save_metadata(self):
+        """Ensure pofile metadata is updated correctly."""
+        test_input = self.generate_pofile('',
+            language='different_code',
+            generator='Not Pontoon',
+            plural_forms='nplurals=1; plural=0;'
+        )
+        path, resource = self.parse_string(test_input)
+
+        resource.save(self.locale)
+        self.assert_pofile_equal(path, self.generate_pofile('',
+            language='test_locale',
+            generator='Pontoon',
+            plural_forms='nplurals=2; plural=(n != 1);'
+        ))
+
+    def test_save_extra_metadata(self):
+        """
+        If last_updated or last_translator is set on the latest
+        translation, update the metadata for those fields.
+        """
+        test_input = self.generate_pofile(
+            dedent("""
+                msgid "Latest"
+                msgstr "Latest"
+
+                msgid "Older"
+                msgstr "Older"
+            """),
+            revision_date='2012-01-01 00:00+0000',
+            last_translator='last <last@example.com>'
+        )
+        path, resource = self.parse_string(test_input)
+
+        latest_translation, older_translation = resource.translations
+        latest_translation.last_updated = datetime(2015, 1, 1, 0, 0, 0)
+        latest_translation.last_translator = UserFactory(
+            first_name='New',
+            email='new@example.com'
+        )
+        older_translation.last_updated = datetime(1970, 1, 1, 0, 0, 0)
+        older_translation.last_translator = UserFactory(
+            first_name='Old',
+            email='old@example.com'
+        )
+        resource.save(self.locale)
+
+        self.assert_pofile_equal(path, self.generate_pofile(
+            dedent("""
+                msgid "Latest"
+                msgstr "Latest"
+
+                msgid "Older"
+                msgstr "Older"
+            """),
+            revision_date='2015-01-01 00:00',
+            last_translator='New <new@example.com>'
+        ))

--- a/pontoon/base/tests/test_models.py
+++ b/pontoon/base/tests/test_models.py
@@ -1,0 +1,38 @@
+from django_nose.tools import assert_equal
+from mock import Mock
+
+from pontoon.base.tests import ProjectFactory, TestCase
+
+
+class ProjectTests(TestCase):
+    def setUp(self):
+        self.project = ProjectFactory.create()
+
+    def test_relative_resource_paths(self):
+        self.project.source_directory_path = Mock(return_value='/root/')
+        self.project.resources_for_path = Mock(return_value=[
+            '/root/foo.po',
+            '/root/meh/bar.po'
+        ])
+
+        assert_equal(
+            list(self.project.relative_resource_paths()),
+            ['foo.po', 'meh/bar.po']
+        )
+
+    def test_relative_resource_paths_pot(self):
+        """
+        If a resource ends in .pot, replace the extension with .po since
+        relative paths are used within non-source locales that do not
+        have .pot files.
+        """
+        self.project.source_directory_path = Mock(return_value='/root/')
+        self.project.resources_for_path = Mock(return_value=[
+            '/root/foo.pot',
+            '/root/meh/bar.pot'
+        ])
+
+        assert_equal(
+            list(self.project.relative_resource_paths()),
+            ['foo.po', 'meh/bar.po']
+        )


### PR DESCRIPTION
This PR adds support for the po/pot formats to sync_projects. It also updates sync_projects to support plural strings and sources for formats that require them.

Because I had to modify sync_projects a bit, I based this PR off the existing #105 PR. That should be merged before this, and I can rebase once it lands. In the meantime, you can view individual commits to see the three extra commits this adds.

This also adds tests for the pofile parser. They're designed to be generic enough that any format can use them as long as they provide the proper input and output files for each test, but I haven't yet actually done the work yet to make them generic. I figure the PR for xliff can support that so we can have a common set of "requirements" that each format supports, with opt-ins to optional features (for example, testing for plurals on po and xliff formats, but not for langfiles).

I've also done local testing and things seem to work, using the Affiliates project as a testcase, but this could definitely use some more attention on a manual testing side. :D
@mathjazz r?