### PR TITLE
Bug 1178874: Add xliff support to sync_projects.

### DIFF
--- a/pontoon/base/formats/__init__.py
+++ b/pontoon/base/formats/__init__.py
@@ -5,7 +5,7 @@ See base.py for the ParsedResource base class.
 """
 import os.path
 
-from pontoon.base.formats import lang, po
+from pontoon.base.formats import lang, po, xliff
 
 
 # To add support for a new resource format, add an entry to this dict
@@ -15,6 +15,7 @@ SUPPORTED_FORMAT_PARSERS = {
     '.lang': lang.parse,
     '.po': po.parse,
     '.pot': po.parse,
+    '.xliff': xliff.parse,
 }
 
 

--- a/pontoon/base/formats/xliff.py
+++ b/pontoon/base/formats/xliff.py
@@ -1,0 +1,104 @@
+"""
+Parser for the xliff translation format.
+"""
+from translate.storage import xliff
+
+from pontoon.base.formats.base import ParsedResource
+from pontoon.base.vcs_models import VCSTranslation
+
+
+class XLIFFEntity(VCSTranslation):
+    """
+    Interface for modifying a single entity in an xliff file.
+    """
+    def __init__(self, order, unit):
+        self.order = order
+        self.unit = unit
+        self.strings = {None: self.target_string} if self.target_string else {}
+        self.last_translator = None
+        self.last_update = None
+
+    @property
+    def key(self):
+        return self.unit.getid()
+
+    @property
+    def source_string(self):
+        return unicode(self.unit.get_rich_source()[0])
+
+    @property
+    def source_string_plural(self):
+        return ''
+
+    @property
+    def comments(self):
+        notes = self.unit.getnotes()
+        return notes.split('\n') if notes else []
+
+    @property
+    def fuzzy(self):
+        return False
+
+    @fuzzy.setter
+    def fuzzy(self, fuzzy):
+        pass  # We don't use fuzzy in XLIFF
+
+    @property
+    def source(self):
+        return []
+
+    @property
+    def target_string(self):
+        return unicode(self.unit.get_rich_target()[0])
+
+    @target_string.setter
+    def target_string(self, value):
+        self.unit.settarget(value)
+
+    def sync_changes(self):
+        """
+        Apply any changes made to this object to the backing unit in the
+        xliff file.
+        """
+        if None in self.strings:
+            self.target_string = self.strings[None]
+        else:
+            xml = self.unit.xmlelement
+
+            if 'approved' in xml.attrib:
+                del xml.attrib['approved']
+
+            target = xml.find(self.unit.namespaced('target'))
+            if target is not None:
+                xml.remove(target)
+
+
+class XLIFFResource(ParsedResource):
+    def __init__(self, path, xliff_file):
+        self.path = path
+        self.xliff_file = xliff_file
+        self.entities = [
+            XLIFFEntity(order, unit) for order, unit in enumerate(self.xliff_file.units)
+        ]
+
+    @property
+    def translations(self):
+        return self.entities
+
+    def save(self, locale):
+        for entity in self.entities:
+            entity.sync_changes()
+
+        # Update target-language where necessary.
+        file_node = self.xliff_file.namespaced('file')
+        for node in self.xliff_file.document.getroot().iterchildren(file_node):
+            node.set('target-language', locale.code)
+
+        with open(self.path, 'w') as f:
+            f.writelines(str(self.xliff_file))
+
+
+def parse(path):
+    with open(path) as f:
+        xliff_file = xliff.xlifffile(f)
+    return XLIFFResource(path, xliff_file)

--- a/pontoon/base/tests/formats/__init__.py
+++ b/pontoon/base/tests/formats/__init__.py
@@ -1,0 +1,246 @@
+import os
+import tempfile
+
+from django_nose.tools import assert_equal
+
+from pontoon.base.tests import (
+    assert_attributes_equal,
+    LocaleFactory,
+)
+
+
+class FormatTestsMixin(object):
+    """
+    Mixin for tests and methods that are common to all supported
+    formats.
+
+    Each format we support should have a test class that subclasses this
+    class and overrides the tests for features that it supports. If a
+    format doesn't support a particular feature, don't override the
+    test method for that feature and it won't be run.
+    """
+    maxDiff = None
+
+    # Subclasses should override the following attributes to customize
+    # how these tests are run.
+
+    # Parse function for the format we're testing.
+    parse = None
+
+    # Supports keys that are separate from source strings.
+    supports_keys = False
+
+    # Supports source (the filename and line where a translation is
+    # located).
+    supports_source = False
+
+    def setUp(self):
+        super(FormatTestsMixin, self).setUp()
+        self.locale = LocaleFactory.create(
+            code='test-locale',
+            name='Test Locale',
+            nplurals=2,
+            plural_rule='(n != 1)',
+        )
+
+    def parse_string(self, string):
+        fd, path = tempfile.mkstemp()
+        with os.fdopen(fd, 'w') as f:
+            f.write(string)
+
+        return path, self.parse(path)
+
+    def key(self, source_string):
+        """
+        Return the expected key for an entity with the given source
+        string based on whether the format we're testing supports unique
+        keys or not.
+        """
+        return source_string if not self.supports_keys else source_string + ' Key'
+
+    # Parse tests assume that they're running off of a common
+    # translation file, passed in as the first argument. The second
+    # argument is the index of the entity used for that test.
+
+    def run_parse_basic(self, input_string, translation_index):
+        """Basic translation with a comment and source."""
+        path, resource = self.parse_string(input_string)
+        assert_attributes_equal(
+            resource.translations[0],
+            comments=['Sample comment'],
+            key=self.key('Source String'),
+            source_string='Source String',
+            source_string_plural='',
+            strings={None: 'Translated String'},
+            fuzzy=False,
+            order=translation_index,
+        )
+
+        if self.supports_source:
+            assert_equal(resource.translations[0].source, [('file.py', '1')])
+
+    def run_parse_multiple_comments(self, input_string, translation_index):
+        path, resource = self.parse_string(input_string)
+        assert_attributes_equal(
+            resource.translations[translation_index],
+            comments=['First comment', 'Second comment'],
+            source=[],
+            key=self.key('Multiple Comments'),
+            source_string='Multiple Comments',
+            source_string_plural='',
+            strings={None: 'Translated Multiple Comments'},
+            fuzzy=False,
+            order=translation_index,
+        )
+
+    def run_parse_multiple_sources(self, input_string, translation_index):
+        path, resource = self.parse_string(input_string)
+        assert_attributes_equal(
+            resource.translations[translation_index],
+            comments=[],
+            source=[('file.py', '2'), ('file.py', '3')],
+            key=self.key('Multiple Sources'),
+            source_string='Multiple Sources',
+            source_string_plural='',
+            strings={None: 'Translated Multiple Sources'},
+            fuzzy=False,
+            order=translation_index,
+        )
+
+    def run_parse_fuzzy(self, input_string, translation_index):
+        path, resource = self.parse_string(input_string)
+        assert_attributes_equal(
+            resource.translations[translation_index],
+            comments=[],
+            source=[],
+            key=self.key('Fuzzy'),
+            source_string='Fuzzy',
+            source_string_plural='',
+            strings={None: 'Translated Fuzzy'},
+            fuzzy=True,
+            order=translation_index,
+        )
+
+    def run_parse_no_comments_no_sources(self, input_string, translation_index):
+        path, resource = self.parse_string(input_string)
+        assert_attributes_equal(
+            resource.translations[translation_index],
+            comments=[],
+            source=[],
+            key=self.key('No Comments or Sources'),
+            source_string='No Comments or Sources',
+            source_string_plural='',
+            strings={None: 'Translated No Comments or Sources'},
+            fuzzy=False,
+            order=translation_index,
+        )
+
+    def run_parse_missing_traslation(self, input_string, translation_index):
+        path, resource = self.parse_string(input_string)
+        assert_attributes_equal(
+            resource.translations[translation_index],
+            comments=[],
+            source=[],
+            key=self.key('Missing Translation'),
+            source_string='Missing Translation',
+            source_string_plural='',
+            strings={},
+            fuzzy=False,
+            order=translation_index,
+        )
+
+    def run_parse_plural_translation(self, input_string, translation_index):
+        path, resource = self.parse_string(input_string)
+        assert_attributes_equal(
+            resource.translations[translation_index],
+            comments=[],
+            source=[],
+            key=self.key('Plural %(count)s string'),
+            source_string='Plural %(count)s string',
+            source_string_plural='Plural %(count)s strings',
+            strings={
+                0: 'Translated Plural %(count)s string',
+                1: 'Translated Plural %(count)s strings'
+            },
+            fuzzy=False,
+            order=translation_index,
+        )
+
+    def run_parse_plural_translation_missing(self, input_string, translation_index):
+        path, resource = self.parse_string(input_string)
+        assert_attributes_equal(
+            resource.translations[translation_index],
+            comments=[],
+            source=[],
+            key=self.key('Plural %(count)s string with missing translations'),
+            source_string='Plural %(count)s string with missing translations',
+            source_string_plural='Plural %(count)s strings with missing translations',
+            strings={
+                1: 'Translated Plural %(count)s strings with missing translations'
+            },
+            fuzzy=False,
+            order=translation_index,
+        )
+
+    def assert_file_content(self, file_path, expected_content):
+        with open(file_path) as f:
+            self.assertMultiLineEqual(f.read(), expected_content)
+
+    # Save tests take in an input and expected string that contain the
+    # state of the translation file before and after the change being
+    # tested is made to the parsed resource and saved.
+
+    def run_save_basic(self, input_string, expected_string):
+        """
+        Test saving changes to an entity with a single translation.
+        """
+        path, resource = self.parse_string(input_string)
+
+        translation = resource.translations[0]
+        translation.strings[None] = 'New Translated String'
+        translation.fuzzy = True
+        resource.save(self.locale)
+
+        self.assert_file_content(path, expected_string)
+
+    def run_save_remove(self, input_string, expected_string):
+        """Test saving a removed entity with a single translation."""
+        path, resource = self.parse_string(input_string)
+
+        translation = resource.translations[0]
+        translation.strings = {}
+        resource.save(self.locale)
+
+        self.assert_file_content(path, expected_string)
+
+    def run_save_plural(self, input_string, expected_string):
+        path, resource = self.parse_string(input_string)
+
+        translation = resource.translations[0]
+        translation.strings[0] = 'New Plural'
+        translation.strings[1] = 'New Plurals'
+        resource.save(self.locale)
+
+        self.assert_file_content(path, expected_string)
+
+    def run_save_plural_remove(self, input_string, expected_string):
+        """
+        Any missing plurals should be set to an empty string in the
+        pofile.
+        """
+        path, resource = self.parse_string(input_string)
+
+        translation = resource.translations[0]
+        translation.strings[0] = 'New Plural'
+        del translation.strings[1]
+        resource.save(self.locale)
+
+        self.assert_file_content(path, expected_string)
+
+    def run_save_remove_fuzzy(self, input_string, expected_string):
+        path, resource = self.parse_string(input_string)
+
+        resource.translations[0].fuzzy = False
+        resource.save(self.locale)
+
+        self.assert_file_content(path, expected_string)

--- a/pontoon/base/tests/formats/test_xliff.py
+++ b/pontoon/base/tests/formats/test_xliff.py
@@ -1,0 +1,128 @@
+from difflib import Differ
+from textwrap import dedent
+
+from pontoon.base.formats import xliff
+from pontoon.base.tests import TestCase
+from pontoon.base.tests.formats import FormatTestsMixin
+
+
+BASE_XLIFF_FILE = """
+<xliff>
+    <file original="filename" source-language="en" datatype="plaintext" target-language="en">
+        <body>
+            <trans-unit id="Source String Key">
+                <source>Source String</source>
+                <target>Translated String</target>
+                <note>Sample comment</note>
+            </trans-unit>
+            <trans-unit id="Multiple Comments Key">
+                <source>Multiple Comments</source>
+                <target>Translated Multiple Comments</target>
+                <note>First comment</note>
+                <note>Second comment</note>
+            </trans-unit>
+            <trans-unit id="No Comments or Sources Key">
+                <source>No Comments or Sources</source>
+                <target>Translated No Comments or Sources</target>
+            </trans-unit>
+            <trans-unit id="Missing Translation Key">
+                <source>Missing Translation</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>
+"""
+
+
+XLIFF_TEMPLATE = """
+<xliff>
+    <file original="filename" source-language="en" datatype="plaintext" target-language="{locale_code}">
+        <body>
+            {body}
+        </body>
+    </file>
+</xliff>
+"""
+
+
+class XLIFFTests(FormatTestsMixin, TestCase):
+    parse = staticmethod(xliff.parse)
+    supports_keys = True
+    supports_source = False
+
+    def key(self, source_string):
+        """XLIFF keys are prefixed with the file name."""
+        return u'filename\x04' + super(XLIFFTests, self).key(source_string)
+
+    def assert_file_content(self, file_path, expected_content):
+        """
+        Compare XML file contents as XML rather than direct strings.
+        """
+        with open(file_path) as f:
+            file_content = f.read()
+
+            # Generate a diff for the error message.
+            result = Differ().compare(
+                file_content.splitlines(1),
+                expected_content.splitlines(1)
+            )
+            msg = 'XML strings are not equal:\n' + ''.join(result)
+
+            self.assertXMLEqual(file_content, expected_content, msg)
+
+    def test_parse_basic(self):
+        self.run_parse_basic(BASE_XLIFF_FILE, 0)
+
+    def test_parse_multiple_comments(self):
+        self.run_parse_multiple_comments(BASE_XLIFF_FILE, 1)
+
+    def test_parse_no_comments_no_sources(self):
+        self.run_parse_no_comments_no_sources(BASE_XLIFF_FILE, 2)
+
+    def test_parse_missing_traslation(self):
+        self.run_parse_missing_traslation(BASE_XLIFF_FILE, 3)
+
+    def generate_xliff(self, body, locale_code='en'):
+        return XLIFF_TEMPLATE.format(body=body, locale_code=locale_code)
+
+    def test_save_basic(self):
+        """
+        Test saving changes to an entity with a single translation.
+
+        Also happens to test if the locale code is saved correctly.
+        """
+        input_string = self.generate_xliff(dedent("""
+            <trans-unit id="Source String Key">
+                <source>Source String</source>
+                <target>Translated String</target>
+                <note>Comment</note>
+            </trans-unit>
+        """))
+
+        expected_string = self.generate_xliff(dedent("""
+            <trans-unit id="Source String Key" approved="yes">
+                <source>Source String</source>
+                <target state="translated">New Translated String</target>
+                <note>Comment</note>
+            </trans-unit>
+        """), locale_code=self.locale.code)
+
+        super(XLIFFTests, self).run_save_basic(input_string, expected_string)
+
+    def test_save_remove(self):
+        input_string = self.generate_xliff(dedent("""
+            <trans-unit id="Source String Key" approved="yes">
+                <source>Source String</source>
+                <target state="translated">Translated String</target>
+                <note>Comment</note>
+            </trans-unit>
+        """))
+
+        expected_string = self.generate_xliff(dedent("""
+            <trans-unit id="Source String Key">
+                <source>Source String</source>
+                <note>Comment</note>
+            </trans-unit>
+        """), locale_code=self.locale.code)
+
+        super(XLIFFTests, self).run_save_remove(input_string, expected_string)


### PR DESCRIPTION
Also refactors the pontoon.base.formats tests to be reusable between formats.

@mathjazz r?