### PR TITLE
Contrary to our configuration, Chinese doesn't use plurals

### DIFF
--- a/pontoon/base/migrations/0018_auto_20150820_0925.py
+++ b/pontoon/base/migrations/0018_auto_20150820_0925.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+def change_chinese_plurals(apps, schema_editor):
+    Locale = apps.get_model('base', 'Locale')
+    Translation = apps.get_model('base', 'Translation')
+
+    for locale in Locale.objects.filter(name="Chinese"):
+        locale.nplurals = 1
+        locale.plural_rule = '0'
+        locale.cldr_plurals = '5'
+        locale.save()
+
+        # Delete plural translations
+        Translation.objects.filter(locale=locale, plural_form=1).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0017_entity_source_jsonfield'),
+    ]
+
+    operations = [
+        migrations.RunPython(change_chinese_plurals)
+    ]


### PR DESCRIPTION
For more details, see:
http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html#zh
http://localization-guide.readthedocs.org/en/latest/l10n/pluralforms.html#f2

This PR resets Chinese plurals configuration and removes Chinese translations in plural forms.

@Osmose, r?