### PR TITLE
Fix Django SHA in requirements.txt.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -80,6 +80,7 @@ dj-database-url==0.3.0
 # sha256: EgxGIdHk9a2r4KaDRj0b56WmuZLt1HZNMjxifSKSUeA
 django-dotenv==1.3.0
 
+# sha256: I3bD2MX0lbMCsRLXIyyEdhEwxDDhhAwFoqArKPF91ZY
 # sha256: gmmWyB4cx3NQASTVwZIS5KdoGlXuFp-rkIXyswFacNg
 django==1.8.4
 


### PR DESCRIPTION
When I tried installing the requirements via peep I got an error with the Django hash not match. I've updated it to the has that works for me.

@mathjazz Can you confirm if this hash works for you? If not, then maybe there's something wrong on my end?