### PR TITLE
Search2terminology

### DIFF
--- a/pontoon/base/templates/500.html
+++ b/pontoon/base/templates/500.html
@@ -372,9 +372,10 @@
           <ul class="links">
             <li><a href="/">Home</a></li>
             <li><a href="/projects">Projects</a></li>
+            <li><a href="/teams">Teams</a></li>
             <li><a href="/contributors">Contributors</a></li>
+            <li><a href="/terminology">Terminology</a></li>
             <li><a href="https://developer.mozilla.org/en-US/docs/Localizing_with_Pontoon" target="_blank">Help</a></li>
-            <li><a href="https://developer.mozilla.org/en-US/docs/Implementing_Pontoon_Mozilla" target="_blank">Developers</a></li>
           </ul>
         </nav>
 

--- a/pontoon/base/templates/landing.html
+++ b/pontoon/base/templates/landing.html
@@ -11,7 +11,7 @@
         <li><a href="{{ url('pontoon.projects') }}">Projects</a></li>
         <li><a href="{{ url('pontoon.teams') }}">Teams</a></li>
         <li><a href="{{ url('pontoon.contributors') }}">Contributors</a></li>
-        <li><a href="{{ url('pontoon.search') }}">Search</a></li>
+        <li><a href="{{ url('pontoon.search') }}">Terminology</a></li>
         <li><a href="https://developer.mozilla.org/en-US/docs/Localizing_with_Pontoon" target="_blank">Help</a></li>
         <li id="admin"{% if not perms.base.can_manage %} class="hidden"{% endif %}><a href="{{ url('pontoon.admin') }}">Admin</a></li>
         <li id="signout"{% if not user.is_authenticated() %} class="hidden"{% endif %}><a href="{{ url('signout') }}" title="{{ user.email }}">Sign out</a></li>

--- a/pontoon/base/urls.py
+++ b/pontoon/base/urls.py
@@ -75,9 +75,13 @@ urlpatterns = patterns(
         name='pontoon.profile'),
 
     # Terminology Search
-    url(r'^search/$',
+    url(r'^terminology/$',
         views.search,
         name='pontoon.search'),
+
+    # Legacy: Redirect to /terminology
+    url(r'^search/$',
+        RedirectView.as_view(url="/terminology/", permanent=True)),
 
     # AJAX
     url(r'^get-entities/', views.entities,

--- a/pontoon/base/urls.py
+++ b/pontoon/base/urls.py
@@ -81,7 +81,7 @@ urlpatterns = patterns(
 
     # Legacy: Redirect to /terminology
     url(r'^search/$',
-        RedirectView.as_view(url="/terminology/", permanent=True)),
+        RedirectView.as_view(pattern_name='pontoon.search', permanent=True)),
 
     # AJAX
     url(r'^get-entities/', views.entities,


### PR DESCRIPTION
Rename both, the title and the URL from Search to Terminology. Search can mean many things and Terminology is much more specific. Also keep the legacy /search URL and redirect it to /terminology. Also update links on static 500 page.

@Osmose r?