### PR TITLE
Fix IndexError when resource has no stats in translate view.

### DIFF
--- a/pontoon/base/tests/__init__.py
+++ b/pontoon/base/tests/__init__.py
@@ -6,6 +6,7 @@ from django.contrib.auth.models import User
 from django.template.defaultfilters import slugify
 from django.test import TestCase as BaseTestCase
 
+from django_browserid.tests import mock_browserid
 from django_nose.tools import assert_equal
 
 from pontoon.base.models import (
@@ -14,13 +15,25 @@ from pontoon.base.models import (
     Locale,
     Project,
     Resource,
+    Stats,
     Translation,
 )
 from pontoon.base.vcs_models import VCSEntity
 
 
 class TestCase(BaseTestCase):
-    pass
+    def client_login(self, user=None):
+        """
+        Authenticate the test client as the given user. If no user is
+        given, a test user is created and returned.
+        """
+        if user is None:
+            user = UserFactory.create()
+
+        with mock_browserid(user.email):
+            self.client.login(assertion='asdf', audience='asdf')
+
+        return user
 
 
 class UserFactory(DjangoModelFactory):
@@ -90,6 +103,14 @@ class TranslationFactory(DjangoModelFactory):
 
     class Meta:
         model = Translation
+
+
+class StatsFactory(DjangoModelFactory):
+    resource = SubFactory(ResourceFactory)
+    locale = SubFactory(LocaleFactory)
+
+    class Meta:
+        model = Stats
 
 
 class VCSEntityFactory(factory.Factory):

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -270,11 +270,12 @@ def translate(request, locale, slug, part=None, template='translate.html'):
 
     # Set part if subpages not defined and entities in more than one file
     else:
-        resources = Resource.objects.filter(project=p, entity_count__gt=0)
+        paths = (Resource.objects
+                    .filter(project=p, entity_count__gt=0, stats__locale=l)
+                    .order_by('path')
+                    .values_list('path', flat=True))
 
-        if resources.count() > 1:
-            paths = resources.filter(stats__locale=l) \
-                .order_by('path').values_list('path', flat=True)
+        if paths:
             data['part'] = part if part in paths else paths[0]
 
     # Set error data


### PR DESCRIPTION
Specifically, if a resource has no stats for a given locale, but it has
stats for other locales, viewing strings for that locale in translate
causes an IndexError due to the view code only filtering out unimportant
locales _after_ checking the existence of stats for the resource.

@mathjazz r?