### PR TITLE
Update raygun4py fork commit.

### DIFF
--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -395,7 +395,7 @@ LOGGING = {
 
 ## Tests
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
-NOSE_ARGS = ['--logging-filter=-django_browserid,-factory,-django.db',
+NOSE_ARGS = ['--logging-filter=-django_browserid,-factory,-django.db,-raygun4py',
              '--logging-clear-handlers']
 
 # Disable nose-progressive on CI due to ugly output.

--- a/requirements.txt
+++ b/requirements.txt
@@ -131,8 +131,8 @@ nose-progressive==1.5.1
 # sha256: 2pk9Q6BeOnBk_rEsexukn8UmtnBZFIR-zf8HLpvDEBs
 # raygun4py==3.0.1
 
-# sha256: m0Xd02Z0Ohg2aqibKrH1W5ln8ujL2w1DNQBo33ceT7U
-https://github.com/Osmose/raygun4py/archive/84b7054281f589fee2646dc4f64122bcf98f486c.zip#egg=raygun4py==3.0.1-osmose
+# sha256: AVJNORYtkB786KvHT4kbosH7rpS3a4UyB-57T15Di4I
+https://github.com/Osmose/raygun4py/archive/510b309704705cd66086792edf2d40ada74e2c21.zip#egg=raygun4py
 
 # sha256: F3sOgxHG7b_H0YQVen6A9otrh0xWRfcwDUH0dfBfIx4
 jsonpickle==0.7.0


### PR DESCRIPTION
The new commit contains fixes for raygun4py where it was printing errors to
stderr instead of logging them properly, causing extra output during test runs
and other situations.

https://github.com/Osmose/raygun4py/commit/52489dfe17e27119940f0a640e80a6a7577b0606 is the commit being added on top of our existing changes in the fork. Still waiting on Raygun to release a new version with our old fixes as well.

I also added a logging filter for raygun4py logging so we don't see "No API Key aaaaahhh" errors every time a test triggers the middleware.

@mathjazz r?