### PR TITLE
Fix tooltip flickering

### DIFF
--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -724,6 +724,9 @@ label {
   border-color: #3F4752 transparent transparent transparent;
   bottom: -16px;
   left: 82px; /* Must be (tooltip width + tooltip padding + bottom) / 2 */
+  clip: rect(0 16px 8px 0px);
+  -webkit-clip-path: polygon(0 0, 100% 0, 100% 50%, 0 50%);
+  clip-path: polygon(0 0, 100% 0, 100% 50%, 0 50%);
 }
 
 .tooltip div {


### PR DESCRIPTION
When hovering progress charts on project or team or admin page, tooltip
flickers if you hover over the handle (arrow). This solution clips the
arrow, so that hovering over it is not possible, which means flickering
is gone. To achieve this, I use CSS clip property (deprecated, but
needed for Firefox), -webkit-clip-path (needed for WebKit) and clip-path
(standard).

@Osmose r?