### PR TITLE
On dashboards, also show progress as percentage

### DIFF
--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -542,12 +542,18 @@ label {
   width: 160px;
 }
 
+.select .menu ul li .chart-wrapper .percent {
+  font-size: 12px;
+  margin-top: 1px;
+  text-align: right;
+}
+
 .select .menu ul li .chart {
   background: #FD5F60;
   float: right;
   height: 5px;
   margin-top: 6px;
-  width: 100%;
+  width: 120px;
 }
 
 .select .menu ul li .chart span {

--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -200,7 +200,6 @@ body > header .locale.select {
 .part.select .menu ul li > span:nth-child(2),
 .project.select .menu ul li > span:nth-child(2) {
   float: right;
-  text-align: right;
 }
 
 .menu li.horizontal-separator {

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -420,7 +420,7 @@ $(function() {
           untranslated = data.total - data.approved - data.translated - data.fuzzy,
           rect = chart[0].getBoundingClientRect(),
           height = $('.tooltip').outerHeight() + 15,
-          width = ($('.tooltip').outerWidth() - chart.outerWidth()) / 2,
+          width = ($('.tooltip').outerWidth() - $(this).outerWidth()) / 2,
           left = rect.left + window.scrollX - width,
           top = rect.top + window.scrollY - height;
 

--- a/pontoon/base/templates/locale_selector.html
+++ b/pontoon/base/templates/locale_selector.html
@@ -38,6 +38,7 @@
               <span class="translated" style="width:{{ l.chart.translated / l.chart.total * 100 }}%;"></span>
               <span class="fuzzy" style="width:{{ l.chart.fuzzy / l.chart.total * 100 }}%;"></span>
             </span>
+            <p class="percent">{{ (l.chart.approved / l.chart.total * 100) | round(0, 'floor') | int }}%</p>
           </span>
         </a>
           {% endif %}

--- a/pontoon/base/templates/project_selector.html
+++ b/pontoon/base/templates/project_selector.html
@@ -35,6 +35,7 @@
               <span class="translated" style="width:{{ p.chart.translated / p.chart.total * 100 }}%;"></span>
               <span class="fuzzy" style="width:{{ p.chart.fuzzy / p.chart.total * 100 }}%;"></span>
             </span>
+            <p class="percent">{{ (p.chart.approved / p.chart.total * 100) | round(0, 'floor') | int }}%</p>
           </span>
           {% endif %}
         {% if url_prefix %}


### PR DESCRIPTION
Sometimes it's hard to distinguish if progress chart is at 99.99% or 100%.
Percentage allows localizers to quickly see if there's work to do or not.
For that reason, we also use floor as rounding function, because showing
100% when 9999/10000 strings are translated is a red herring.

@Osmose r?