### PR TITLE
Only show entities for which locale has stats for

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -422,7 +422,11 @@ class Entity(DirtyFieldsMixin, models.Model):
     @classmethod
     def for_project_locale(self, project, locale, paths=None):
         """Get project entities with locale translations."""
-        entities = self.objects.filter(resource__project=project, obsolete=False)
+        entities = self.objects.filter(
+            resource__project=project,
+            resource__stats__locale=locale,
+            obsolete=False
+        )
 
         if paths:
             entities = entities.filter(resource__path__in=paths) or entities


### PR DESCRIPTION
This is needed for project-locale pairs which only use one resource,
whereas source locale uses multiple resources. In such cases, we have
been showing all entities to the locale, which is clearly wrong.

@Osmose I have to merge this immediately.
