### PR TITLE
Bug 1179950: Enable timezone support.

### DIFF
--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -90,6 +90,10 @@ you create:
 .. _Babel: http://babeljs.io/
 .. _Yuglify: https://github.com/yui/yuglify
 
+``TZ``
+   Timezone for the dynos that will run the app. Pontoon operates in UTC, so set
+   this to ``UTC``.
+
 Add-ons
 -------
 Pontoon is designed to run with the following add-ons enabled:

--- a/pontoon/administration/files.py
+++ b/pontoon/administration/files.py
@@ -16,6 +16,7 @@ import urllib2
 import zipfile
 
 from django.conf import settings
+from django.utils import timezone
 from pontoon.administration.vcs import update_from_vcs
 from translate.storage import xliff
 
@@ -809,7 +810,7 @@ def dump_po(project, locale, relative_path):
     locale_directory_path = get_locale_directory(project, locale)["path"]
     path = os.path.join(locale_directory_path, relative_path)
     po = polib.pofile(path)
-    date = datetime.datetime(1, 1, 1)
+    date = timezone.make_aware(datetime.min)
     newest = Translation()
     resource = Resource.objects.filter(project=project, path=relative_path)
     entities = Entity.objects.filter(resource=resource, obsolete=False)

--- a/pontoon/administration/management/commands/sync_projects.py
+++ b/pontoon/administration/management/commands/sync_projects.py
@@ -325,7 +325,10 @@ class ChangeSet(object):
             vcs_translation.fuzzy = any(t for t in db_translations if t.fuzzy)
 
             if len(db_translations) > 0:
-                last_translation = max(db_translations, key=lambda t: t.date or datetime.min)
+                last_translation = max(
+                    db_translations,
+                    key=lambda t: t.date or timezone.make_aware(datetime.min)
+                )
                 vcs_translation.last_updated = last_translation.date
                 vcs_translation.last_translator = last_translation.user
 

--- a/pontoon/administration/tests/test_sync_projects.py
+++ b/pontoon/administration/tests/test_sync_projects.py
@@ -1,5 +1,4 @@
 import os.path
-from datetime import datetime
 
 from django.core.management.base import CommandError
 from django_nose.tools import (
@@ -29,6 +28,7 @@ from pontoon.base.tests import (
     UserFactory,
     VCSEntityFactory,
 )
+from pontoon.base.utils import aware_datetime
 from pontoon.base.vcs_models import VCSProject
 
 
@@ -41,7 +41,7 @@ class FakeCheckoutTestCase(TestCase):
         timezone_patch = patch.object(sync_projects, 'timezone')
         self.mock_timezone = timezone_patch.start()
         self.addCleanup(timezone_patch.stop)
-        self.mock_timezone.now.return_value = datetime(1970, 1, 1)
+        self.mock_timezone.now.return_value = aware_datetime(1970, 1, 1)
 
         self.translated_locale = LocaleFactory.create(code='translated-locale')
         self.inactive_locale = LocaleFactory.create(code='inactive-locale')
@@ -115,7 +115,7 @@ class FakeCheckoutTestCase(TestCase):
             plural_form=None,
             locale=self.translated_locale,
             string='Translated String',
-            date=datetime(1970, 1, 1),
+            date=aware_datetime(1970, 1, 1),
             approved=True,
             extra={'tags': []}
         )
@@ -179,7 +179,7 @@ class CommandTests(FakeCheckoutTestCase):
         deletion.
         """
         self.create_db_entities_translations()
-        self.main_db_translation.deleted = datetime(1970, 1, 1)
+        self.main_db_translation.deleted = aware_datetime(1970, 1, 1)
         self.main_db_translation.save()
 
         self.command.handle_project = Mock()
@@ -550,7 +550,7 @@ class ChangeSetTests(FakeCheckoutTestCase):
             string='Translated String',
             plural_form=None,
             approved=True,
-            approved_date=datetime(1970, 1, 1),
+            approved_date=aware_datetime(1970, 1, 1),
             fuzzy=False
         )
 
@@ -629,7 +629,7 @@ class ChangeSetTests(FakeCheckoutTestCase):
         assert_attributes_equal(
             self.main_db_translation,
             approved=True,
-            approved_date=datetime(1970, 1, 1)
+            approved_date=aware_datetime(1970, 1, 1)
         )
 
     def test_update_db_new_translation(self):
@@ -648,7 +648,7 @@ class ChangeSetTests(FakeCheckoutTestCase):
             string='Translated String',
             plural_form=None,
             approved=True,
-            approved_date=datetime(1970, 1, 1),
+            approved_date=aware_datetime(1970, 1, 1),
             fuzzy=False,
             extra={'tags': []}
         )
@@ -661,7 +661,7 @@ class ChangeSetTests(FakeCheckoutTestCase):
         self.create_db_entities_translations()
 
         self.main_db_translation.approved = True
-        self.main_db_translation.approved_date = datetime(1970, 1, 1)
+        self.main_db_translation.approved_date = aware_datetime(1970, 1, 1)
         self.main_db_translation.approved_user = UserFactory.create()
         self.main_db_translation.save()
         self.main_vcs_translation.strings[None] = 'New Translated String'

--- a/pontoon/base/formats/po.py
+++ b/pontoon/base/formats/po.py
@@ -3,6 +3,8 @@ Parser for to pofile translation format.
 """
 from datetime import datetime
 
+from django.utils import timezone
+
 import polib
 
 from pontoon.base.formats.base import ParsedResource
@@ -71,7 +73,7 @@ class POResource(ParsedResource):
         if len(self.translations) > 0:
             latest_translation = max(
                 self.translations,
-                key=lambda t: t.last_updated or datetime.min
+                key=lambda t: t.last_updated or timezone.make_aware(datetime.min)
             )
             if latest_translation.last_updated:
                 metadata['PO-Revision-Date'] = latest_translation.last_updated.strftime(

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -391,7 +391,7 @@ class Entity(DirtyFieldsMixin, models.Model):
         if user.has_perm('base.can_localize') and not translation.approved:
             translation.approved = True
             translation.approved_user = user
-            translation.approved_date = datetime.datetime.now()
+            translation.approved_date = timezone.now()
 
         translation.save()
 
@@ -741,7 +741,7 @@ def save_translation(entity, locale, string, plural_form=None, fuzzy=False):
     """Add new or update existing translation."""
 
     approved = not fuzzy
-    now = datetime.datetime.now()
+    now = timezone.now()
     translations = Translation.objects.filter(
         entity=entity, locale=locale, plural_form=plural_form)
     translations_equal = translations.filter(string=string)

--- a/pontoon/base/tests/formats/test_po.py
+++ b/pontoon/base/tests/formats/test_po.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from textwrap import dedent
 
 from pontoon.base.formats import po
@@ -7,6 +6,7 @@ from pontoon.base.tests import (
     UserFactory
 )
 from pontoon.base.tests.formats import FormatTestsMixin
+from pontoon.base.utils import aware_datetime
 
 
 BASE_POFILE = """
@@ -253,12 +253,12 @@ class POTests(FormatTestsMixin, TestCase):
         path, resource = self.parse_string(test_input)
 
         latest_translation, older_translation = resource.translations
-        latest_translation.last_updated = datetime(2015, 1, 1, 0, 0, 0)
+        latest_translation.last_updated = aware_datetime(2015, 1, 1, 0, 0, 0)
         latest_translation.last_translator = UserFactory(
             first_name='New',
             email='new@example.com'
         )
-        older_translation.last_updated = datetime(1970, 1, 1, 0, 0, 0)
+        older_translation.last_updated = aware_datetime(1970, 1, 1, 0, 0, 0)
         older_translation.last_translator = UserFactory(
             first_name='Old',
             email='old@example.com'
@@ -273,6 +273,6 @@ class POTests(FormatTestsMixin, TestCase):
                 msgid "Older"
                 msgstr "Older"
             """),
-            revision_date='2015-01-01 00:00',
+            revision_date='2015-01-01 00:00+0000',
             last_translator='New <new@example.com>'
         ))

--- a/pontoon/base/utils.py
+++ b/pontoon/base/utils.py
@@ -4,11 +4,14 @@ import os
 import re
 import requests
 import traceback
+from datetime import datetime
 
 from django.conf import settings
 from django.contrib.auth.models import Permission
 from django.http import HttpResponse
+from django.utils import timezone
 from django.utils.translation import trans_real
+
 from translate.filters import checks
 from translate.storage import base as storage_base
 from translate.storage.placeables import base, general, parse
@@ -354,3 +357,8 @@ def match_attr(collection, **attributes):
                       for attrib, value in attributes.items()),
         default=None
     )
+
+
+def aware_datetime(*args, **kwargs):
+    """Return an aware datetime using Django's configured timezone."""
+    return timezone.make_aware(datetime(*args, **kwargs))

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -30,6 +30,7 @@ from django.http import (
 )
 
 from django.shortcuts import render
+from django.utils import timezone
 from django.utils.datastructures import MultiValueDictKeyError
 from django_browserid.views import Verify as BrowserIDVerifyBase
 from operator import itemgetter
@@ -527,8 +528,7 @@ def get_translation_history(request, template=None):
 
     if len(translations) > 0:
         payload = []
-        zone = pytz.timezone(settings.TIME_ZONE)
-        offset = datetime.datetime.now(zone).strftime('%z')
+        offset = timezone.now().strftime('%z')
 
         for t in translations:
             u = t.user
@@ -599,7 +599,7 @@ def delete_translation(request, template=None):
     if next.pk is not None and request.user.has_perm('base.can_localize'):
         next.approved = True
         next.approved_user = request.user
-        next.approved_date = datetime.datetime.now()
+        next.approved_date = timezone.now()
         next.save()
 
     return HttpResponse(json.dumps({
@@ -668,7 +668,7 @@ def update_translation(request, template=None):
     if ignore_check == 'true' or not quality_checks:
         ignore = True
 
-    now = datetime.datetime.now()
+    now = timezone.now()
     can_localize = request.user.has_perm('base.can_localize')
     translations = Translation.objects.filter(
         entity=e, locale=l, plural_form=plural_form)
@@ -703,7 +703,7 @@ def update_translation(request, template=None):
                     t.user = user
 
                 t.approved = True
-                t.approved_date = datetime.datetime.now()
+                t.approved_date = timezone.now()
                 t.fuzzy = False
 
                 if t.approved_user is None:

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -436,6 +436,9 @@ SLAVE_DATABASES = []
 
 ## Internationalization.
 
+# Enable timezone-aware datetimes.
+USE_TZ = True
+
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.
@@ -443,7 +446,7 @@ SLAVE_DATABASES = []
 # timezone as the operating system.
 # If running in a Windows environment this must be set to the same as your
 # system time zone.
-TIME_ZONE = 'America/Los_Angeles'
+TIME_ZONE = os.environ.get('TZ', 'UTC')
 
 # If you set this to False, Django will make some optimizations so as not
 # to load the internationalization machinery.


### PR DESCRIPTION
This will require a config change to the Heroku apps before deploying them, namely setting the `TZ` environment variable to `UTC`.

I believe this will also fix bug 1199763.

@mathjazz r?