### PR TITLE
Make a better icon for "No results"

### DIFF
--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -227,7 +227,7 @@
       <h2 id="not-on-page">Not on the current page</h2>
       {% endif %}
       <ul class="uneditables"></ul>
-      <h3 class="no-match"><div class="fa fa-thumbs-down"></div>No results</h3>
+      <h3 class="no-match"><div class="fa fa-exclamation-circle"></div>No results</h3>
     </div>
   </div>
 


### PR DESCRIPTION
We currently use the `fa-thumbs-down` for "No results", this gesture is not a friendly gesture.
I think the `fa-exclamation-circle` is a good choice.

Do I need to write a bug for the tiny patch?