### PR TITLE
Remove chrome:// URLs from tiles CSS

### DIFF
--- a/pontoon/sites/static/tiles/css/newTab.css
+++ b/pontoon/sites/static/tiles/css/newTab.css
@@ -357,7 +357,6 @@ input[type=button] {
   -moz-margin-end: 8px;
   background-repeat: no-repeat;
   background-position: center;
-  background-image: url(chrome://global/skin/icons/autocomplete-search.svg#search-icon);
   background-size: 26px 26px;
 }
 
@@ -365,12 +364,10 @@ input[type=button] {
   width: 38px; /* 26 image width + 6 left "padding" + 6 right "padding" */
   -moz-margin-end: 5px;
   background-size: 26px;
-  background-image: url("chrome://browser/skin/magnifier.png");
 }
 
 @media not all and (max-resolution: 1dppx) {
   #newtab-search-logo.magnifier {
-    background-image: url("chrome://browser/skin/magnifier@2x.png");
   }
 }
 
@@ -569,7 +566,6 @@ input[type=button] {
   -moz-margin-end: 8px;
   width: 16px;
   height: 16px;
-  list-style-image: url("chrome://mozapps/skin/places/defaultFavicon.png");
 }
 
 .newtab-customize-panel-subitem > label,
@@ -615,7 +611,7 @@ input[type=button] {
 
 .newtab-customize-complex-option:hover > .selectable:not([selected]),
 .selectable:not([selected]):hover {
-  background: url("chrome://global/skin/menu/shared-menu-check-hover.svg") no-repeat #FFFFFF;
+  background: #FFFFFF;
   background-size: 16px 16px;
   background-position: 15px 15px;
   color: #171F26;
@@ -627,7 +623,7 @@ input[type=button] {
 
 .newtab-customize-panel-item[selected],
 .newtab-search-panel-engine[selected] {
-  background: url("chrome://global/skin/menu/shared-menu-check-active.svg") no-repeat transparent;
+  background: transparent;
   background-size: 16px 16px;
   background-position: 15px 15px;
   color: black;
@@ -642,7 +638,7 @@ input[type=button] {
 }
 
 .newtab-customize-panel-subitem[selected] > .checkbox {
-  background: url("chrome://global/skin/menu/shared-menu-check-black.svg") no-repeat #FFFFFF;
+  background: #FFFFFF;
   background-size: 9px 9px;
   background-position: center;
   color: #333333;

--- a/pontoon/sites/static/tiles/css/newTabSkin.css
+++ b/pontoon/sites/static/tiles/css/newTabSkin.css
@@ -64,7 +64,6 @@
 /* CUSTOMIZE */
 #newtab-customize-button,
 .newtab-customize {
-  background-image: -moz-image-rect(url(chrome://browser/skin/newtab/controls.svg), 0, 32, 32, 0);
   background-size: 28px;
   height: 38px;
   width: 38px;
@@ -80,7 +79,6 @@
 }
 
 #newtab-customize-button:-moz-any(:hover, :active, [active]) {
-  background-image: -moz-image-rect(url(chrome://browser/skin/newtab/controls.svg), 0, 64, 32, 32);
   background-color: #FFFFFF;
   border: solid 1px #CCCCCC;
   border-radius: 2px;
@@ -119,7 +117,7 @@
 .newtab-intro-cell .newtab-thumbnail,
 .newtab-intro-cell-hover .newtab-thumbnail {
   background-color: #cae1f4;
-  background-image: url("chrome://browser/skin/newtab/../images/whimsycorn.png");
+  background-image: url(../images/whimsycorn.png);
 }
 
 .newtab-site[dragged] {
@@ -178,7 +176,6 @@
 }
 
 .newtab-site[pinned] .newtab-title::before {
-  background-image: -moz-image-rect(url("chrome://browser/skin/newtab/controls.svg"), 7, 278, 28, 266);
   background-size: 10px;
   content: "";
   height: 17px;
@@ -201,31 +198,4 @@
   border: none;
   height: 24px;
   width: 24px;
-}
-
-.newtab-control-pin,
-.newtab-site[pinned] .newtab-control-pin:hover:active {
-  background-image: -moz-image-rect(url(chrome://browser/skin/newtab/controls.svg), 0, 96, 32, 64);
-}
-
-.newtab-control-pin:hover,
-.newtab-site[pinned] .newtab-control-pin:hover {
-  background-image: -moz-image-rect(url(chrome://browser/skin/newtab/controls.svg), 0, 160, 32, 128);
-}
-
-.newtab-control-pin:hover:active,
-.newtab-site[pinned] .newtab-control-pin {
-  background-image: -moz-image-rect(url(chrome://browser/skin/newtab/controls.svg), 0, 128, 32, 96);
-}
-
-.newtab-control-block {
-  background-image: -moz-image-rect(url(chrome://browser/skin/newtab/controls.svg), 0, 192, 32, 160);
-}
-
-.newtab-control-block:hover {
-  background-image: -moz-image-rect(url(chrome://browser/skin/newtab/controls.svg), 0, 224, 32, 192);
-}
-
-.newtab-control-block:hover:active {
-  background-image: -moz-image-rect(url(chrome://browser/skin/newtab/controls.svg), 0, 256, 32, 224);
 }


### PR DESCRIPTION
They prevent Pontoon from building in production by raising
whitenoise.django.MissingFileError.

@jotes r?