### PR TITLE
Bug 1178874: Add support for silme formats to sync_projects.

### DIFF
--- a/pontoon/base/__init__.py
+++ b/pontoon/base/__init__.py
@@ -9,3 +9,7 @@ MOZILLA_REPOS = (
     'ssh://hg.mozilla.org/users/m_owca.info/lightning-aurora/',
     'ssh://hg.mozilla.org/users/m_owca.info/seamonkey-aurora/',
 )
+
+
+class SyncError(RuntimeError):
+    """Error class for errors relating to the project sync process."""

--- a/pontoon/base/formats/__init__.py
+++ b/pontoon/base/formats/__init__.py
@@ -5,7 +5,7 @@ See base.py for the ParsedResource base class.
 """
 import os.path
 
-from pontoon.base.formats import lang, po, xliff
+from pontoon.base.formats import lang, po, silme, xliff
 
 
 # To add support for a new resource format, add an entry to this dict
@@ -16,17 +16,27 @@ SUPPORTED_FORMAT_PARSERS = {
     '.po': po.parse,
     '.pot': po.parse,
     '.xliff': xliff.parse,
+    '.dtd': silme.parse_dtd,
+    '.properties': silme.parse_properties,
+    '.ini': silme.parse_ini,
 }
 
 
-def parse(path):
+def parse(path, source_path=None):
     """
     Parse the resource file at the given path and return a
     ParsedResource with its translations.
+
+    :param path:
+        Path to the resource file to parse.
+    :param source_path:
+        Path to the corresponding resource file in the source directory
+        for the resource we're parsing. Asymmetric formats need this
+        for saving. Defaults to None.
     """
     root, extension = os.path.splitext(path)
     if extension in SUPPORTED_FORMAT_PARSERS:
-        return SUPPORTED_FORMAT_PARSERS[extension](path)
+        return SUPPORTED_FORMAT_PARSERS[extension](path, source_path=source_path)
     else:
         raise ValueError('Translation format {0} is not supported.'
                          .format(extension))

--- a/pontoon/base/formats/lang.py
+++ b/pontoon/base/formats/lang.py
@@ -152,7 +152,7 @@ class LangVisitor(NodeVisitor):
             return []
 
 
-def parse(path):
+def parse(path, source_path=None):
     # Read as utf-8-sig in case there's a BOM at the start of the file
     # that we want to remove.
     with codecs.open(path, 'r', 'utf-8-sig') as f:

--- a/pontoon/base/formats/po.py
+++ b/pontoon/base/formats/po.py
@@ -95,6 +95,6 @@ class POResource(ParsedResource):
         return '<POResource {self.pofile.fpath}>'.format(self=self)
 
 
-def parse(path):
+def parse(path, source_path=None):
     pofile = polib.pofile(path)
     return POResource(pofile)

--- a/pontoon/base/formats/silme.py
+++ b/pontoon/base/formats/silme.py
@@ -1,0 +1,161 @@
+from __future__ import absolute_import  # Same name as silme library.
+"""
+Parser for silme-compatible translation formats.
+"""
+import codecs
+from collections import OrderedDict
+
+import silme
+from silme.format.dtd import FormatParser as DTDParser
+from silme.format.ini import FormatParser as IniParser
+from silme.format.properties import FormatParser as PropertiesParser
+
+from pontoon.base import SyncError
+from pontoon.base.formats.base import ParsedResource
+from pontoon.base.vcs_models import VCSTranslation
+
+
+class SilmeEntity(VCSTranslation):
+    def __init__(self, silme_object, comments=None, order=0):
+        self.silme_object = silme_object
+        self.strings = {None: self.silme_object.value} if self.silme_object.value else {}
+        self.comments = comments or []
+        self.order = order
+        self.last_translator = None
+        self.last_update = None
+
+    @property
+    def key(self):
+        return self.silme_object.id
+
+    @property
+    def source_string(self):
+        return self.silme_object.value or ''
+
+    @property
+    def source_string_plural(self):
+        return ''
+
+    @property
+    def fuzzy(self):
+        return False
+
+    @fuzzy.setter
+    def fuzzy(self, fuzzy):
+        pass  # We don't use fuzzy in silme
+
+    @property
+    def source(self):
+        return []
+
+    def __eq__(self, other):
+        return self.key == other.key and self.strings.get(None) == other.strings.get(None)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+
+class SilmeResource(ParsedResource):
+    def __init__(self, parser, path, source_resource=None):
+        self.parser = parser
+        self.path = path
+        self.source_resource = source_resource
+
+        # Preserve entity order via an OrderedDict.
+        if source_resource:
+            self.entities = source_resource.entities
+        else:
+            self.entities = OrderedDict()
+
+        with codecs.open(path, 'r', 'utf-8') as f:
+            self.structure = parser.get_structure(f.read())
+
+        comments = []
+        current_order = 0
+        for obj in self.structure:
+            if isinstance(obj, silme.core.entity.Entity):
+                entity = SilmeEntity(obj, comments, current_order)
+                self.entities[entity.key] = entity
+                current_order += 1
+                comments = []
+            elif isinstance(obj, silme.core.structure.Comment):
+                for comment in obj:
+                    # Silme groups comments together, so we strip
+                    # whitespace and split them up.
+                    lines = unicode(comment).strip().split('\n')
+                    comments += [line.strip() for line in lines]
+
+    @property
+    def translations(self):
+        return self.entities.values()
+
+    def save(self, locale):
+        """
+        Load the source resource, modify it with changes made to this
+        Resource instance, and save it over the locale-specific
+        resource.
+        """
+        if self.source_resource is None:
+            raise SyncError('Cannot save silme resource {0}: No source resource given.'
+                            .format(self.path))
+
+        with codecs.open(self.source_resource.path, 'r', 'utf-8') as f:
+            new_structure = self.parser.get_structure(f.read())
+
+        # Update translations in the copied resource.
+        entities = [
+            SilmeEntity(obj) for obj in new_structure if isinstance(obj, silme.core.entity.Entity)
+        ]
+        for silme_entity in entities:
+            key = silme_entity.key
+
+            translated_entity = self.entities.get(key)
+
+            have_translation = (
+                translated_entity
+                and None in translated_entity.strings
+                and translated_entity != silme_entity
+            )
+            if have_translation:
+                new_structure.modify_entity(key, translated_entity.strings[None])
+            else:
+                # Remove untranslated entity and following newline
+                pos = new_structure.entity_pos(key)
+                new_structure.remove_entity(key)
+
+                try:
+                    line = new_structure[pos]
+                except IndexError:
+                    # No newline at end of file
+                    continue
+
+                if type(line) == unicode and line.startswith('\n'):
+                    line = line[len('\n'):]
+                    new_structure[pos] = line
+                    if len(line) is 0:
+                        new_structure.remove_element(pos)
+
+        with codecs.open(self.path, 'w', 'utf-8') as f:
+            f.write(self.parser.dump_structure(new_structure))
+
+
+def parse(parser, path, source_path=None):
+    # TODO: Cache the source resource to avoid re-parsing it a bunch.
+    if source_path is not None:
+        source_resource = SilmeResource(parser, source_path)
+    else:
+        source_resource = None
+
+    return SilmeResource(parser, path, source_resource=source_resource)
+
+
+def parse_properties(path, source_path=None):
+    return parse(PropertiesParser, path, source_path)
+
+
+def parse_ini(path, source_path=None):
+    return parse(IniParser, path, source_path)
+
+
+def parse_dtd(path, source_path=None):
+    return parse(DTDParser, path, source_path)

--- a/pontoon/base/formats/xliff.py
+++ b/pontoon/base/formats/xliff.py
@@ -98,7 +98,7 @@ class XLIFFResource(ParsedResource):
             f.writelines(str(self.xliff_file))
 
 
-def parse(path):
+def parse(path, source_path=None):
     with open(path) as f:
         xliff_file = xliff.xlifffile(f)
     return XLIFFResource(path, xliff_file)

--- a/pontoon/base/tests/formats/__init__.py
+++ b/pontoon/base/tests/formats/__init__.py
@@ -34,6 +34,10 @@ class FormatTestsMixin(object):
     # located).
     supports_source = False
 
+    # Supports source strings in translated resource. Asymmetric formats
+    # do not support this.
+    supoorts_source_string = False
+
     def setUp(self):
         super(FormatTestsMixin, self).setUp()
         self.locale = LocaleFactory.create(
@@ -43,12 +47,16 @@ class FormatTestsMixin(object):
             plural_rule='(n != 1)',
         )
 
-    def parse_string(self, string):
+    def parse_string(self, string, source_string=None):
         fd, path = tempfile.mkstemp()
         with os.fdopen(fd, 'w') as f:
             f.write(string)
 
-        return path, self.parse(path)
+        if source_string is not None:
+            source_path, source_resource = self.parse_string(source_string)
+            return path, self.parse(path, source_path=source_path)
+        else:
+            return path, self.parse(path)
 
     def key(self, source_string):
         """
@@ -66,18 +74,23 @@ class FormatTestsMixin(object):
         """Basic translation with a comment and source."""
         path, resource = self.parse_string(input_string)
         assert_attributes_equal(
-            resource.translations[0],
+            resource.translations[translation_index],
             comments=['Sample comment'],
             key=self.key('Source String'),
-            source_string='Source String',
-            source_string_plural='',
             strings={None: 'Translated String'},
             fuzzy=False,
             order=translation_index,
         )
 
         if self.supports_source:
-            assert_equal(resource.translations[0].source, [('file.py', '1')])
+            assert_equal(resource.translations[translation_index].source, [('file.py', '1')])
+
+        if self.supports_source_string:
+            assert_attributes_equal(
+                resource.translations[translation_index],
+                source_string='Source String',
+                source_string_plural=''
+            )
 
     def run_parse_multiple_comments(self, input_string, translation_index):
         path, resource = self.parse_string(input_string)
@@ -86,12 +99,17 @@ class FormatTestsMixin(object):
             comments=['First comment', 'Second comment'],
             source=[],
             key=self.key('Multiple Comments'),
-            source_string='Multiple Comments',
-            source_string_plural='',
             strings={None: 'Translated Multiple Comments'},
             fuzzy=False,
             order=translation_index,
         )
+
+        if self.supports_source_string:
+            assert_attributes_equal(
+                resource.translations[translation_index],
+                source_string='Multiple Comments',
+                source_string_plural=''
+            )
 
     def run_parse_multiple_sources(self, input_string, translation_index):
         path, resource = self.parse_string(input_string)
@@ -100,12 +118,17 @@ class FormatTestsMixin(object):
             comments=[],
             source=[('file.py', '2'), ('file.py', '3')],
             key=self.key('Multiple Sources'),
-            source_string='Multiple Sources',
-            source_string_plural='',
             strings={None: 'Translated Multiple Sources'},
             fuzzy=False,
             order=translation_index,
         )
+
+        if self.supports_source_string:
+            assert_attributes_equal(
+                resource.translations[translation_index],
+                source_string='Multiple Sources',
+                source_string_plural=''
+            )
 
     def run_parse_fuzzy(self, input_string, translation_index):
         path, resource = self.parse_string(input_string)
@@ -114,12 +137,17 @@ class FormatTestsMixin(object):
             comments=[],
             source=[],
             key=self.key('Fuzzy'),
-            source_string='Fuzzy',
-            source_string_plural='',
             strings={None: 'Translated Fuzzy'},
             fuzzy=True,
             order=translation_index,
         )
+
+        if self.supports_source_string:
+            assert_attributes_equal(
+                resource.translations[translation_index],
+                source_string='Fuzzy',
+                source_string_plural=''
+            )
 
     def run_parse_no_comments_no_sources(self, input_string, translation_index):
         path, resource = self.parse_string(input_string)
@@ -128,12 +156,17 @@ class FormatTestsMixin(object):
             comments=[],
             source=[],
             key=self.key('No Comments or Sources'),
-            source_string='No Comments or Sources',
-            source_string_plural='',
             strings={None: 'Translated No Comments or Sources'},
             fuzzy=False,
             order=translation_index,
         )
+
+        if self.supports_source_string:
+            assert_attributes_equal(
+                resource.translations[translation_index],
+                source_string='No Comments or Sources',
+                source_string_plural=''
+            )
 
     def run_parse_missing_traslation(self, input_string, translation_index):
         path, resource = self.parse_string(input_string)
@@ -142,12 +175,17 @@ class FormatTestsMixin(object):
             comments=[],
             source=[],
             key=self.key('Missing Translation'),
-            source_string='Missing Translation',
-            source_string_plural='',
             strings={},
             fuzzy=False,
             order=translation_index,
         )
+
+        if self.supports_source_string:
+            assert_attributes_equal(
+                resource.translations[translation_index],
+                source_string='Missing Translation',
+                source_string_plural=''
+            )
 
     def run_parse_plural_translation(self, input_string, translation_index):
         path, resource = self.parse_string(input_string)
@@ -156,8 +194,6 @@ class FormatTestsMixin(object):
             comments=[],
             source=[],
             key=self.key('Plural %(count)s string'),
-            source_string='Plural %(count)s string',
-            source_string_plural='Plural %(count)s strings',
             strings={
                 0: 'Translated Plural %(count)s string',
                 1: 'Translated Plural %(count)s strings'
@@ -166,6 +202,13 @@ class FormatTestsMixin(object):
             order=translation_index,
         )
 
+        if self.supports_source_string:
+            assert_attributes_equal(
+                resource.translations[translation_index],
+                source_string='Plural %(count)s string',
+                source_string_plural='Plural %(count)s strings',
+            )
+
     def run_parse_plural_translation_missing(self, input_string, translation_index):
         path, resource = self.parse_string(input_string)
         assert_attributes_equal(
@@ -173,8 +216,6 @@ class FormatTestsMixin(object):
             comments=[],
             source=[],
             key=self.key('Plural %(count)s string with missing translations'),
-            source_string='Plural %(count)s string with missing translations',
-            source_string_plural='Plural %(count)s strings with missing translations',
             strings={
                 1: 'Translated Plural %(count)s strings with missing translations'
             },
@@ -182,19 +223,34 @@ class FormatTestsMixin(object):
             order=translation_index,
         )
 
-    def assert_file_content(self, file_path, expected_content):
+        if self.supports_source_string:
+            assert_attributes_equal(
+                resource.translations[translation_index],
+                source_string='Plural %(count)s string with missing translations',
+                source_string_plural='Plural %(count)s strings with missing translations',
+            )
+
+    def assert_file_content(self, file_path, expected_content, strip=True):
         with open(file_path) as f:
-            self.assertMultiLineEqual(f.read(), expected_content)
+            actual_content = f.read()
+
+            # Strip leading and trailing whitespace by default as we
+            # normally don't care about this.
+            if strip:
+                actual_content = actual_content.strip()
+                expected_content = expected_content.strip()
+
+            self.assertMultiLineEqual(actual_content, expected_content)
 
     # Save tests take in an input and expected string that contain the
     # state of the translation file before and after the change being
     # tested is made to the parsed resource and saved.
 
-    def run_save_basic(self, input_string, expected_string):
+    def run_save_basic(self, input_string, expected_string, source_string=None):
         """
         Test saving changes to an entity with a single translation.
         """
-        path, resource = self.parse_string(input_string)
+        path, resource = self.parse_string(input_string, source_string=source_string)
 
         translation = resource.translations[0]
         translation.strings[None] = 'New Translated String'
@@ -203,9 +259,9 @@ class FormatTestsMixin(object):
 
         self.assert_file_content(path, expected_string)
 
-    def run_save_remove(self, input_string, expected_string):
+    def run_save_remove(self, input_string, expected_string, source_string=None):
         """Test saving a removed entity with a single translation."""
-        path, resource = self.parse_string(input_string)
+        path, resource = self.parse_string(input_string, source_string=source_string)
 
         translation = resource.translations[0]
         translation.strings = {}
@@ -213,8 +269,8 @@ class FormatTestsMixin(object):
 
         self.assert_file_content(path, expected_string)
 
-    def run_save_plural(self, input_string, expected_string):
-        path, resource = self.parse_string(input_string)
+    def run_save_plural(self, input_string, expected_string, source_string=None):
+        path, resource = self.parse_string(input_string, source_string=source_string)
 
         translation = resource.translations[0]
         translation.strings[0] = 'New Plural'
@@ -223,12 +279,12 @@ class FormatTestsMixin(object):
 
         self.assert_file_content(path, expected_string)
 
-    def run_save_plural_remove(self, input_string, expected_string):
+    def run_save_plural_remove(self, input_string, expected_string, source_string=None):
         """
         Any missing plurals should be set to an empty string in the
         pofile.
         """
-        path, resource = self.parse_string(input_string)
+        path, resource = self.parse_string(input_string, source_string=source_string)
 
         translation = resource.translations[0]
         translation.strings[0] = 'New Plural'
@@ -237,10 +293,21 @@ class FormatTestsMixin(object):
 
         self.assert_file_content(path, expected_string)
 
-    def run_save_remove_fuzzy(self, input_string, expected_string):
-        path, resource = self.parse_string(input_string)
+    def run_save_remove_fuzzy(self, input_string, expected_string, source_string=None):
+        path, resource = self.parse_string(input_string, source_string=source_string)
 
         resource.translations[0].fuzzy = False
+        resource.save(self.locale)
+
+        self.assert_file_content(path, expected_string)
+
+    def run_save_source_no_changes(self, source_string, input_string, expected_string):
+        """
+        Test what happens when no changes are made. Useful for tests
+        that check different combinations of an entity in the source vs.
+        the translated resource.
+        """
+        path, resource = self.parse_string(input_string, source_string=source_string)
         resource.save(self.locale)
 
         self.assert_file_content(path, expected_string)

--- a/pontoon/base/tests/formats/test_po.py
+++ b/pontoon/base/tests/formats/test_po.py
@@ -86,6 +86,7 @@ class POTests(FormatTestsMixin, TestCase):
     parse = staticmethod(po.parse)
     supports_keys = False
     supports_source = True
+    supports_source_string = True
 
     def test_parse_basic(self):
         self.run_parse_basic(BASE_POFILE, 0)

--- a/pontoon/base/tests/formats/test_silme.py
+++ b/pontoon/base/tests/formats/test_silme.py
@@ -1,0 +1,289 @@
+from textwrap import dedent
+
+from pontoon.base.formats import silme
+from pontoon.base.tests import TestCase
+from pontoon.base.tests.formats import FormatTestsMixin
+
+
+BASE_DTD_FILE = """
+<!-- Sample comment -->
+<!ENTITY SourceString "Translated String">
+
+<!-- First comment -->
+<!-- Second comment -->
+<!ENTITY MultipleComments "Translated Multiple Comments">
+
+<!ENTITY NoCommentsorSources "Translated No Comments or Sources">
+"""
+
+
+class DTDTests(FormatTestsMixin, TestCase):
+    parse = staticmethod(silme.parse_dtd)
+    supports_keys = False
+    supports_source = False
+    supports_source_string = False
+
+    def key(self, source_string):
+        """DTD keys can't contain spaces."""
+        return super(DTDTests, self).key(source_string).replace(' ', '')
+
+    def test_parse_basic(self):
+        self.run_parse_basic(BASE_DTD_FILE, 0)
+
+    def test_parse_multiple_comments(self):
+        self.run_parse_multiple_comments(BASE_DTD_FILE, 1)
+
+    def test_parse_no_comments_no_sources(self):
+        self.run_parse_no_comments_no_sources(BASE_DTD_FILE, 2)
+
+    def test_save_basic(self):
+        input_string = dedent("""
+            <!-- Comment -->
+            <!ENTITY SourceString "Source String">
+        """)
+        expected_string = dedent("""
+            <!-- Comment -->
+            <!ENTITY SourceString "New Translated String">
+        """)
+
+        self.run_save_basic(input_string, expected_string, source_string=input_string)
+
+    def test_save_remove(self):
+        """Deleting strings removes them completely from the DTD file."""
+        input_string = dedent("""
+            <!-- Comment -->
+            <!ENTITY SourceString "Source String">
+        """)
+        expected_string = dedent("""
+            <!-- Comment -->
+        """)
+
+        self.run_save_remove(input_string, expected_string, source_string=input_string)
+
+    def test_save_source_removed(self):
+        """
+        If an entity is missing from the source resource, remove it from
+        the translated resource.
+        """
+        source_string = dedent("""
+            <!ENTITY SourceString "Source String">
+        """)
+        input_string = dedent("""
+            <!ENTITY MissingSourceString "Translated Missing String">
+            <!ENTITY SourceString "Translated String">
+        """)
+        expected_string = dedent("""
+            <!ENTITY SourceString "Translated String">
+        """)
+
+        self.run_save_source_no_changes(source_string, input_string, expected_string)
+
+    def test_save_source_no_translation(self):
+        """
+        If an entity is missing from the translated resource and has no
+        translation, do not add it back in.
+        """
+        source_string = dedent("""
+            <!ENTITY SourceString "Source String">
+            <!ENTITY OtherSourceString "Other String">
+        """)
+        input_string = dedent("""
+            <!ENTITY OtherSourceString "Translated Other String">
+        """)
+
+        self.run_save_source_no_changes(source_string, input_string, input_string)
+
+
+BASE_PROPERTIES_FILE = """
+# Sample comment
+SourceString=Translated String
+
+# First comment
+# Second comment
+MultipleComments=Translated Multiple Comments
+
+NoCommentsorSources=Translated No Comments or Sources
+"""
+
+
+class PropertiesTests(FormatTestsMixin, TestCase):
+    parse = staticmethod(silme.parse_properties)
+    supports_keys = False
+    supports_source = False
+    supports_source_string = False
+
+    def key(self, source_string):
+        """Properties keys can't contain spaces."""
+        return super(PropertiesTests, self).key(source_string).replace(' ', '')
+
+    def test_parse_basic(self):
+        self.run_parse_basic(BASE_PROPERTIES_FILE, 0)
+
+    def test_parse_multiple_comments(self):
+        #import ipdb; ipdb.set_trace()
+        self.run_parse_multiple_comments(BASE_PROPERTIES_FILE, 1)
+
+    def test_parse_no_comments_no_sources(self):
+        self.run_parse_no_comments_no_sources(BASE_PROPERTIES_FILE, 2)
+
+    def test_save_basic(self):
+        input_string = dedent("""
+            # Comment
+            SourceString=Source String
+        """)
+        expected_string = dedent("""
+            # Comment
+            SourceString=New Translated String
+        """)
+
+        self.run_save_basic(input_string, expected_string, source_string=input_string)
+
+    def test_save_remove(self):
+        """
+        Deleting strings removes them completely from the properties
+        file.
+        """
+        input_string = dedent("""
+            # Comment
+            SourceString=Source String
+        """)
+        expected_string = dedent("""
+            # Comment
+        """)
+
+        self.run_save_remove(input_string, expected_string, source_string=input_string)
+
+    def test_save_source_removed(self):
+        """
+        If an entity is missing from the source resource, remove it from
+        the translated resource.
+        """
+        source_string = dedent("""
+            SourceString=Source String
+        """)
+        input_string = dedent("""
+            MissingSourceString=Translated Missing String
+            SourceString=Translated String
+        """)
+        expected_string = dedent("""
+            SourceString=Translated String
+        """)
+
+        self.run_save_source_no_changes(source_string, input_string, expected_string)
+
+    def test_save_source_no_translation(self):
+        """
+        If an entity is missing from the translated resource and has no
+        translation, do not add it back in.
+        """
+        source_string = dedent("""
+            SourceString=Source String
+            OtherSourceString=Other String
+        """)
+        input_string = dedent("""
+            OtherSourceString=Translated Other String
+        """)
+
+        self.run_save_source_no_changes(source_string, input_string, input_string)
+
+
+BASE_INI_FILE = """
+[Strings]
+# Sample comment
+SourceString=Translated String
+
+# First comment
+# Second comment
+MultipleComments=Translated Multiple Comments
+
+NoCommentsorSources=Translated No Comments or Sources
+"""
+
+
+class IniTests(FormatTestsMixin, TestCase):
+    parse = staticmethod(silme.parse_properties)
+    supports_keys = False
+    supports_source = False
+    supports_source_string = False
+
+    def key(self, source_string):
+        """Ini keys can't contain spaces."""
+        return super(IniTests, self).key(source_string).replace(' ', '')
+
+    def test_parse_basic(self):
+        self.run_parse_basic(BASE_INI_FILE, 0)
+
+    def test_parse_multiple_comments(self):
+        #import ipdb; ipdb.set_trace()
+        self.run_parse_multiple_comments(BASE_INI_FILE, 1)
+
+    def test_parse_no_comments_no_sources(self):
+        self.run_parse_no_comments_no_sources(BASE_INI_FILE, 2)
+
+    def test_save_basic(self):
+        input_string = dedent("""
+            [Strings]
+            # Comment
+            SourceString=Source String
+        """)
+        expected_string = dedent("""
+            [Strings]
+            # Comment
+            SourceString=New Translated String
+        """)
+
+        self.run_save_basic(input_string, expected_string, source_string=input_string)
+
+    def test_save_remove(self):
+        """
+        Deleting strings removes them completely from the ini file.
+        """
+        input_string = dedent("""
+            [Strings]
+            # Comment
+            SourceString=Source String
+        """)
+        expected_string = dedent("""
+            [Strings]
+            # Comment
+        """)
+
+        self.run_save_remove(input_string, expected_string, source_string=input_string)
+
+    def test_save_source_removed(self):
+        """
+        If an entity is missing from the source resource, remove it from
+        the translated resource.
+        """
+        source_string = dedent("""
+            [Strings]
+            SourceString=Source String
+        """)
+        input_string = dedent("""
+            [Strings]
+            MissingSourceString=Translated Missing String
+            SourceString=Translated String
+        """)
+        expected_string = dedent("""
+            [Strings]
+            SourceString=Translated String
+        """)
+
+        self.run_save_source_no_changes(source_string, input_string, expected_string)
+
+    def test_save_source_no_translation(self):
+        """
+        If an entity is missing from the translated resource and has no
+        translation, do not add it back in.
+        """
+        source_string = dedent("""
+            [Strings]
+            SourceString=Source String
+            OtherSourceString=Other String
+        """)
+        input_string = dedent("""
+            [Strings]
+            OtherSourceString=Translated Other String
+        """)
+
+        self.run_save_source_no_changes(source_string, input_string, input_string)

--- a/pontoon/base/tests/formats/test_silme.py
+++ b/pontoon/base/tests/formats/test_silme.py
@@ -93,6 +93,34 @@ class DTDTests(FormatTestsMixin, TestCase):
 
         self.run_save_source_no_changes(source_string, input_string, input_string)
 
+    def test_save_translation_missing(self):
+        source_string = dedent("""
+            <!ENTITY String "Source String">
+            <!ENTITY MissingString "Missing Source String">
+        """)
+        input_string = dedent("""
+            <!ENTITY String "Translated String">
+        """)
+        expected_string = dedent("""
+            <!ENTITY String "Translated String">
+            <!ENTITY MissingString "Translated Missing String">
+        """)
+
+        self.run_save_translation_missing(source_string, input_string, expected_string)
+
+    def test_save_translation_identical(self):
+        source_string = dedent("""
+            <!ENTITY String "Source String">
+        """)
+        input_string = dedent("""
+            <!ENTITY String "Translated String">
+        """)
+        expected_string = dedent("""
+            <!ENTITY String "Source String">
+        """)
+
+        self.run_save_translation_identical(source_string, input_string, expected_string)
+
 
 BASE_PROPERTIES_FILE = """
 # Sample comment
@@ -185,6 +213,34 @@ class PropertiesTests(FormatTestsMixin, TestCase):
         """)
 
         self.run_save_source_no_changes(source_string, input_string, input_string)
+
+    def test_save_translation_missing(self):
+        source_string = dedent("""
+            String=Source String
+            MissingString=Missing Source String
+        """)
+        input_string = dedent("""
+            String=Translated String
+        """)
+        expected_string = dedent("""
+            String=Translated String
+            MissingString=Translated Missing String
+        """)
+
+        self.run_save_translation_missing(source_string, input_string, expected_string)
+
+    def test_save_translation_identical(self):
+        source_string = dedent("""
+            String=Source String
+        """)
+        input_string = dedent("""
+            String=Translated String
+        """)
+        expected_string = dedent("""
+            String=Source String
+        """)
+
+        self.run_save_translation_identical(source_string, input_string, expected_string)
 
 
 BASE_INI_FILE = """
@@ -287,3 +343,37 @@ class IniTests(FormatTestsMixin, TestCase):
         """)
 
         self.run_save_source_no_changes(source_string, input_string, input_string)
+
+    def test_save_translation_missing(self):
+        source_string = dedent("""
+            [Strings]
+            String=Source String
+            MissingString=Missing Source String
+        """)
+        input_string = dedent("""
+            [Strings]
+            String=Translated String
+        """)
+        expected_string = dedent("""
+            [Strings]
+            String=Translated String
+            MissingString=Translated Missing String
+        """)
+
+        self.run_save_translation_missing(source_string, input_string, expected_string)
+
+    def test_save_translation_identical(self):
+        source_string = dedent("""
+            [Strings]
+            String=Source String
+        """)
+        input_string = dedent("""
+            [Strings]
+            String=Translated String
+        """)
+        expected_string = dedent("""
+            [Strings]
+            String=Source String
+        """)
+
+        self.run_save_translation_identical(source_string, input_string, expected_string)

--- a/pontoon/base/tests/formats/test_xliff.py
+++ b/pontoon/base/tests/formats/test_xliff.py
@@ -49,6 +49,7 @@ class XLIFFTests(FormatTestsMixin, TestCase):
     parse = staticmethod(xliff.parse)
     supports_keys = True
     supports_source = False
+    supports_source_string = True
 
     def key(self, source_string):
         """XLIFF keys are prefixed with the file name."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,8 +65,8 @@ requests==2.6.2
 # sha256: 4rCwWTbCdrHt0uFSVVMjO2Zt-eKbXDuiI-7XOCd8gqA
 rsa==3.1.4
 
-# sha256: zHL2c3Bvjys836kQT6Z51ptf22Hn4Xm2cmFH7y5i0iQ
-http://hg.mozilla.org/l10n/silme/archive/b21c5151136e.zip#egg=silme==0.9.0b
+# sha256: bt5oqLoOA4Aee1HKWrheVQ_071HioK6CY7bg-KwEouQ
+https://github.com/Osmose/silme/archive/v0.9.1.zip#egg=silme
 
 # sha256: QYqTw5en7asj5ViNvAZ6x0pyPts9VBvUk295R252Rdo
 # sha256: 4kBSQR_E-9H2cmNVN8P8IzDZSBsYwDF2lbRiWVEskdU


### PR DESCRIPTION
Adds support for ini, dtd, and properties files, including more format tests for them. This also switches us to using the silme fork at https://github.com/Osmose/silme/ instead of the HG-hosted version.

This also changes how we build entities in vcs_models; in order to support both asymmetric and symmetric formats, we first build entities based on the source resource files, and then load translations from each translated resource. 

I did manual testing for DTD files, but haven't yet manually tested ini and properties files. Suggestions on good projects to use for testing those are welcome, otherwise we can just test on staging before merging.

@mathjazz r?