### PR TITLE
Properly detect in-place localization mode

### DIFF
--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -119,7 +119,7 @@
             {% endif %}
 
             <li class="download">Download
-              {% if project.url %}<i class="file-format html">HTML</i>{% endif %}
+              {% if page_url %}<i class="file-format html">HTML</i>{% endif %}
               <i class="file-format json">JSON</i>
             </li>
 
@@ -223,7 +223,7 @@
     </div>
     <div class="wrapper">
       <ul class="editables"></ul>
-      {% if project.url %}
+      {% if page_url %}
       <h2 id="not-on-page">Not on the current page</h2>
       {% endif %}
       <ul class="uneditables"></ul>
@@ -319,7 +319,7 @@
   <div id="drag" draggable="true"></div>
 </aside>
 
-{% if project.url %}
+{% if page_url %}
 <!-- Website placeholder + iframe fix: prevent iframes from capturing the mousemove events during a drag -->
 <iframe id="source"></iframe>
 <div id="iframe-cover"></div>


### PR DESCRIPTION
We might have projects with both, subpages with page_urls and resource
files without in-place localization.

@Osmose r?