### PR TITLE
Subpage names don't need to match resource paths anymore

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -429,6 +429,11 @@ class Entity(DirtyFieldsMixin, models.Model):
         )
 
         if paths:
+            try:
+                subpage = Subpage.objects.get(project=project, name__in=paths)
+                paths = subpage.resources.values_list("path")
+            except Subpage.DoesNotExist:
+                pass
             entities = entities.filter(resource__path__in=paths) or entities
 
         entities = entities.prefetch_related(


### PR DESCRIPTION
If we wanted to match subpage against specific resource(s), its name
had to be exactly the same as the path to the resource file. Which is
lame. This is no loner required. As a consequence, we can now have
several different subpages matched agains the same resource.

@Osmose r?