### PR TITLE
Improve plurals

### DIFF
--- a/pontoon/base/migrations/0020_auto_20150904_0857.py
+++ b/pontoon/base/migrations/0020_auto_20150904_0857.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+def complete_plurals(apps, schema_editor):
+    Locale = apps.get_model('base', 'Locale')
+
+    for locale in LOCALES:
+        l = Locale.objects.get(code=locale['code'])
+        l.plural_rule = locale['plural_rule']
+        l.nplurals = locale['nplurals']
+        l.cldr_plurals = locale['cldr_plurals']
+        l.save()
+
+    # Also rename Panjabi to Punjabi
+    for pa in Locale.objects.filter(code__startswith='pa'):
+        pa.name = 'Punjabi'
+        pa.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0019_auto_20150820_1345'),
+    ]
+
+    operations = [
+        migrations.RunPython(complete_plurals)
+    ]
+
+
+LOCALES = [
+    {
+        'code': 'hy-AM',
+        'plural_rule': '(n != 1)',
+        'nplurals': 2,
+        'cldr_plurals': '1,5'
+    },
+    {
+        'code': 'as',
+        'plural_rule': '(n != 1)',
+        'nplurals': 2,
+        'cldr_plurals': '1,5'
+    },
+    {
+        'code': 'ilo',
+        'plural_rule': '(n != 1)',
+        'nplurals': 2,
+        'cldr_plurals': '1,5'
+    },
+    {
+        'code': 'ga-IE',
+        'plural_rule': 'n==1 ? 0 : n==2 ? 1 : n<7 ? 2 : n<11 ? 3 : 4',
+        'nplurals': 5,
+        'cldr_plurals': '1,2,3,4,5'
+    },
+    {
+        'code': 'ne-NP',
+        'plural_rule': '(n != 1)',
+        'nplurals': 2,
+        'cldr_plurals': '1,5'
+    },
+    {
+        'code': 'nb-NO',
+        'plural_rule': '(n != 1)',
+        'nplurals': 2,
+        'cldr_plurals': '1,5'
+    },
+    {
+        'code': 'nn-NO',
+        'plural_rule': '(n != 1)',
+        'nplurals': 2,
+        'cldr_plurals': '1,5'
+    },
+    {
+        'code': 'pa-IN',
+        'plural_rule': '(n != 1)',
+        'nplurals': 2,
+        'cldr_plurals': '1,5'
+    },
+    {
+        'code': 'pt-PT',
+        'plural_rule': '(n != 1)',
+        'nplurals': 2,
+        'cldr_plurals': '1,5'
+    },
+    {
+        'code': 'es-ES',
+        'plural_rule': '(n != 1)',
+        'nplurals': 2,
+        'cldr_plurals': '1,5'
+    },
+    {
+        'code': 'ta-LK',
+        'plural_rule': '(n != 1)',
+        'nplurals': 2,
+        'cldr_plurals': '1,5'
+    },
+    {
+        'code': 'fy-NL',
+        'plural_rule': '(n != 1)',
+        'nplurals': 2,
+        'cldr_plurals': '1,5'
+    },
+    {
+        'code': 'zu',
+        'plural_rule': '(n != 1)',
+        'nplurals': 2,
+        'cldr_plurals': '1,5'
+    },
+]

--- a/pontoon/base/migrations/0021_auto_20150904_1007.py
+++ b/pontoon/base/migrations/0021_auto_20150904_1007.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+def remove_pa_fy(apps, schema_editor):
+    Locale = apps.get_model('base', 'Locale')
+
+    for code in ['pa', 'fy']:
+        l = Locale.objects.get(code=code)
+        l.delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0020_auto_20150904_0857'),
+    ]
+
+    operations = [
+        migrations.RunPython(remove_pa_fy)
+    ]

--- a/pontoon/base/migrations/0022_remove_locale_nplurals.py
+++ b/pontoon/base/migrations/0022_remove_locale_nplurals.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0021_auto_20150904_1007'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='locale',
+            name='nplurals',
+        ),
+    ]

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -72,7 +72,6 @@ def validate_cldr(value):
 class Locale(models.Model):
     code = models.CharField(max_length=20, unique=True)
     name = models.CharField(max_length=128)
-    nplurals = models.SmallIntegerField(null=True, blank=True)
     plural_rule = models.CharField(max_length=128, blank=True)
 
     # CLDR Plurals
@@ -94,6 +93,16 @@ class Locale(models.Model):
         else:
             return map(int, self.cldr_plurals.split(','))
 
+    @classmethod
+    def cldr_plural_to_id(self, cldr_plural):
+        for i in self.CLDR_PLURALS:
+            if i[1] == cldr_plural:
+                return i[0]
+
+    @property
+    def nplurals(self):
+        return len(self.cldr_plurals_list())
+
     def __unicode__(self):
         return self.name
 
@@ -105,12 +114,6 @@ class Locale(models.Model):
             'plural_rule': self.plural_rule,
             'cldr_plurals': self.cldr_plurals_list(),
         })
-
-    @classmethod
-    def cldr_plural_to_id(self, cldr_plural):
-        for i in self.CLDR_PLURALS:
-            if i[1] == cldr_plural:
-                return i[0]
 
     class Meta:
         ordering = ['name', 'code']

--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -920,8 +920,11 @@ body > header aside p {
   display: none;
 }
 
-#plural-tabs ul li a span {
+#plural-tabs ul li a sup {
   color: #7BC876;
+  font-size: 11px;
+  font-weight: 400;
+  padding-left: 1px;
 }
 
 #editor > menu {

--- a/pontoon/base/static/js/translate_old.js
+++ b/pontoon/base/static/js/translate_old.js
@@ -236,16 +236,16 @@ var Pontoon = (function (my) {
 
           // Get example number for each plural form based on locale plural rule
           if (!this.locale.examples) {
-            var examples = this.locale.examples = {},
-                rule = null,
+            var CLDR_PLURALS = ['zero', 'one', 'two', 'few', 'many', 'other'],
+                examples = this.locale.examples = {},
                 n = 0;
 
             if (nplurals === 2) {
-              examples[0] = 1;
-              examples[1] = 2;
+              examples = {0: 1, 1: 2};
+
             } else {
               while (Object.keys(examples).length < nplurals) {
-                rule = eval(this.locale.plural_rule);
+                var rule = eval(this.locale.plural_rule);
                 if (!examples[rule]) {
                   examples[rule] = n;
                 }
@@ -253,9 +253,10 @@ var Pontoon = (function (my) {
               }
             }
 
-            $('#plural-tabs li a span').each(function(i) {
-              $(this).html(examples[i]);
-              return i < nplurals-1;
+            $.each(this.locale.cldr_plurals, function(i) {
+              $('#plural-tabs li:eq(' + i + ') a')
+                .find('span').html(CLDR_PLURALS[this]).end()
+                .find('sup').html(examples[i]);
             });
           }
           $('#plural-tabs li:lt(' + nplurals + ')').css('display', 'table-cell');

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -250,12 +250,12 @@
 
     <nav id="plural-tabs">
       <ul>
-        <li class="active"><a href="#plural1">Plural <span></span></a></li>
-        <li><a href="#plural2">Plural <span></span></a></li>
-        <li><a href="#plural3">Plural <span></span></a></li>
-        <li><a href="#plural4">Plural <span></span></a></li>
-        <li><a href="#plural5">Plural <span></span></a></li>
-        <li><a href="#plural6">Plural <span></span></a></li>
+        <li class="active"><a href="#plural1"><span></span><sup></sup></a></li>
+        <li><a href="#plural2"><span></span><sup></sup></a></li>
+        <li><a href="#plural3"><span></span><sup></sup></a></li>
+        <li><a href="#plural4"><span></span><sup></sup></a></li>
+        <li><a href="#plural5"><span></span><sup></sup></a></li>
+        <li><a href="#plural6"><span></span><sup></sup></a></li>
       </ul>
     </nav>
     <textarea dir="auto" lang="{{ locale.code }}" id="translation" placeholder="Enter translation"></textarea>

--- a/pontoon/base/tests/formats/__init__.py
+++ b/pontoon/base/tests/formats/__init__.py
@@ -39,8 +39,8 @@ class FormatTestsMixin(object):
         self.locale = LocaleFactory.create(
             code='test-locale',
             name='Test Locale',
-            nplurals=2,
             plural_rule='(n != 1)',
+            cldr_plurals='1,5',
         )
 
     def parse_string(self, string):


### PR DESCRIPTION
This changes a few things related to plurals:

1. Plural forms are displayed as CLDR values now (one, two, many...) with supscripted example number, calculated from plural rule.

2. For that to work, I had to add missing plural data for all locales. I also removed two unused (duplicate) locales and nplurals field, which can be calculated from the CLDR plurals list length.

@Osmose r?