### PR TITLE
Fix bug 1201212: Preserve fuzzy status for po entities.

### DIFF
--- a/pontoon/administration/management/commands/sync_projects.py
+++ b/pontoon/administration/management/commands/sync_projects.py
@@ -36,6 +36,14 @@ class Command(BaseCommand):
             help='Do not commit changes to VCS'
         )
 
+        parser.add_argument(
+            '--no-pull',
+            action='store_true',
+            dest='no_pull',
+            default=False,
+            help='Do not pull new commits from VCS'
+        )
+
     def log(self, msg, *args, **kwargs):
         """Log a message to the console."""
         self.stdout.write(msg.format(*args, **kwargs))
@@ -53,6 +61,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         self.verbosity = options['verbosity']
         self.no_commit = options['no_commit']
+        self.no_pull = options['no_pull']
 
         self.log('SYNC PROJECTS: start')
         projects = Project.objects.filter(disabled=False)
@@ -76,7 +85,8 @@ class Command(BaseCommand):
 
     def handle_project(self, db_project):
         # Pull changes from VCS and update what we know about the files.
-        update_from_repository(db_project)
+        if not self.no_pull:
+            update_from_repository(db_project)
         vcs_project = VCSProject(db_project)
         self.update_resources(db_project, vcs_project)
 

--- a/pontoon/administration/tests/test_sync_projects.py
+++ b/pontoon/administration/tests/test_sync_projects.py
@@ -128,6 +128,7 @@ class CommandTests(FakeCheckoutTestCase):
         self.command = sync_projects.Command()
         self.command.verbosity = 0
         self.command.no_commit = False
+        self.command.no_pull = False
 
         update_from_repo_patch = patch.object(sync_projects, 'update_from_repository')
         self.mock_update_from_repository = update_from_repo_patch.start()
@@ -140,6 +141,7 @@ class CommandTests(FakeCheckoutTestCase):
     def execute_command(self, *args, **kwargs):
         kwargs.setdefault('verbosity', 0)
         kwargs.setdefault('no_commit', False)
+        kwargs.setdefault('no_pull', False)
         return self.command.handle(*args, **kwargs)
 
     def test_handle_disabled_projects(self):
@@ -240,6 +242,15 @@ class CommandTests(FakeCheckoutTestCase):
         self.command.no_commit = True
         self.command.handle_project(self.db_project)
         assert_false(self.command.commit_projects.called)
+
+    def test_handle_project_no_pull(self):
+        """
+        Don't call update_from_repository if command.no_pull is True.
+        """
+        with patch.object(sync_projects, 'update_from_repository') as update_from_repository:
+            self.command.no_pull = True
+            self.command.handle_project(self.db_project)
+        assert_false(update_from_repository.called)
 
     def call_handle_entity(self, key, db_entity, vcs_entity):
         return self.command.handle_entity(

--- a/pontoon/base/formats/po.py
+++ b/pontoon/base/formats/po.py
@@ -46,7 +46,7 @@ class POEntity(VCSTranslation):
 
         if self.fuzzy and 'fuzzy' not in self.po_entry.flags:
             self.po_entry.flags.append('fuzzy')
-        elif 'fuzzy' in self.po_entry.flags:
+        elif not self.fuzzy and 'fuzzy' in self.po_entry.flags:
             self.po_entry.flags.remove('fuzzy')
 
     def __repr__(self):

--- a/pontoon/base/tests/formats/__init__.py
+++ b/pontoon/base/tests/formats/__init__.py
@@ -351,12 +351,8 @@ class FormatTestsMixin(object):
 
         self.assert_file_content(path, expected_string)
 
-    def run_save_source_no_changes(self, source_string, input_string, expected_string):
-        """
-        Test what happens when no changes are made. Useful for tests
-        that check different combinations of an entity in the source vs.
-        the translated resource.
-        """
+    def run_save_no_changes(self, input_string, expected_string, source_string=None):
+        """Test what happens when no changes are made."""
         path, resource = self.parse_string(input_string, source_string=source_string)
         resource.save(self.locale)
 

--- a/pontoon/base/tests/formats/test_po.py
+++ b/pontoon/base/tests/formats/test_po.py
@@ -219,6 +219,20 @@ class POTests(FormatTestsMixin, TestCase):
 
         self.run_save_remove_fuzzy(input_string, expected_string)
 
+    def test_save_preserve_fuzzy(self):
+        """
+        If the fuzzy status of an entity doesn't change, make sure to
+        not remove it.
+        """
+        input_string = self.generate_pofile(dedent("""
+            #, fuzzy
+            msgid "Source String"
+            msgstr "Translated String"
+        """))
+
+        # String should be unchanged.
+        self.run_save_no_changes(input_string, input_string)
+
     def test_save_metadata(self):
         """Ensure pofile metadata is updated correctly."""
         test_input = self.generate_pofile('',

--- a/pontoon/base/tests/formats/test_silme.py
+++ b/pontoon/base/tests/formats/test_silme.py
@@ -76,7 +76,7 @@ class DTDTests(FormatTestsMixin, TestCase):
             <!ENTITY SourceString "Translated String">
         """)
 
-        self.run_save_source_no_changes(source_string, input_string, expected_string)
+        self.run_save_no_changes(input_string, expected_string, source_string=source_string)
 
     def test_save_source_no_translation(self):
         """
@@ -91,7 +91,7 @@ class DTDTests(FormatTestsMixin, TestCase):
             <!ENTITY OtherSourceString "Translated Other String">
         """)
 
-        self.run_save_source_no_changes(source_string, input_string, input_string)
+        self.run_save_no_changes(input_string, input_string, source_string=source_string)
 
     def test_save_translation_missing(self):
         source_string = dedent("""
@@ -197,7 +197,7 @@ class PropertiesTests(FormatTestsMixin, TestCase):
             SourceString=Translated String
         """)
 
-        self.run_save_source_no_changes(source_string, input_string, expected_string)
+        self.run_save_no_changes(input_string, expected_string, source_string=source_string)
 
     def test_save_source_no_translation(self):
         """
@@ -212,7 +212,7 @@ class PropertiesTests(FormatTestsMixin, TestCase):
             OtherSourceString=Translated Other String
         """)
 
-        self.run_save_source_no_changes(source_string, input_string, input_string)
+        self.run_save_no_changes(input_string, input_string, source_string=source_string)
 
     def test_save_translation_missing(self):
         source_string = dedent("""
@@ -325,7 +325,7 @@ class IniTests(FormatTestsMixin, TestCase):
             SourceString=Translated String
         """)
 
-        self.run_save_source_no_changes(source_string, input_string, expected_string)
+        self.run_save_no_changes(input_string, expected_string, source_string=source_string)
 
     def test_save_source_no_translation(self):
         """
@@ -342,7 +342,7 @@ class IniTests(FormatTestsMixin, TestCase):
             OtherSourceString=Translated Other String
         """)
 
-        self.run_save_source_no_changes(source_string, input_string, input_string)
+        self.run_save_no_changes(input_string, input_string, source_string=source_string)
 
     def test_save_translation_missing(self):
         source_string = dedent("""


### PR DESCRIPTION
Our pofile sync code had an issue where it would remove the fuzzy flag for an entity if it was fuzzy in VCS, because we weren't checking that the entity was marked as not fuzzy before removing the flag.

To help debug this issue I also added a `--no-pull` argument to `sync_projects` that skips updating from VCS during sync. This let me test syncing on a specific SVN commit, which is really useful for debugging.

@mathjazz r?