### PR TITLE
Fix bug 1203057: Allow blank translations in silme.

### DIFF
--- a/pontoon/base/formats/silme.py
+++ b/pontoon/base/formats/silme.py
@@ -30,11 +30,10 @@ class SilmeEntity(VCSTranslation):
         self.last_translator = None
         self.last_update = None
 
-        if copy_string and self.silme_object.value:
+        if copy_string:
             self.strings = {None: self.silme_object.value}
         else:
             self.strings = {}
-
 
     @property
     def key(self):
@@ -42,7 +41,7 @@ class SilmeEntity(VCSTranslation):
 
     @property
     def source_string(self):
-        return self.silme_object.value or ''
+        return self.silme_object.value
 
     @property
     def source_string_plural(self):

--- a/pontoon/base/tests/formats/__init__.py
+++ b/pontoon/base/tests/formats/__init__.py
@@ -231,6 +231,25 @@ class FormatTestsMixin(object):
                 source_string_plural='Plural %(count)s strings with missing translations',
             )
 
+    def run_parse_empty_translation(self, input_string, translation_index):
+        """Test that empty translations are parsed properly."""
+        path, resource = self.parse_string(input_string)
+        assert_attributes_equal(
+            resource.translations[translation_index],
+            comments=[],
+            source=[],
+            key=self.key('Empty Translation'),
+            strings={None: u''},
+            fuzzy=False,
+            order=translation_index,
+        )
+
+        if self.supports_source_string:
+            assert_attributes_equal(
+                resource.translations[translation_index],
+                source_string='Empty Translation',
+            )
+
     def assert_file_content(self, file_path, expected_content, strip=True):
         with open(file_path) as f:
             actual_content = f.read()

--- a/pontoon/base/tests/formats/test_silme.py
+++ b/pontoon/base/tests/formats/test_silme.py
@@ -14,6 +14,8 @@ BASE_DTD_FILE = """
 <!ENTITY MultipleComments "Translated Multiple Comments">
 
 <!ENTITY NoCommentsorSources "Translated No Comments or Sources">
+
+<!ENTITY EmptyTranslation "">
 """
 
 
@@ -35,6 +37,9 @@ class DTDTests(FormatTestsMixin, TestCase):
 
     def test_parse_no_comments_no_sources(self):
         self.run_parse_no_comments_no_sources(BASE_DTD_FILE, 2)
+
+    def test_parse_empty_translation(self):
+        self.run_parse_empty_translation(BASE_DTD_FILE, 3)
 
     def test_save_basic(self):
         input_string = dedent("""
@@ -131,6 +136,8 @@ SourceString=Translated String
 MultipleComments=Translated Multiple Comments
 
 NoCommentsorSources=Translated No Comments or Sources
+
+EmptyTranslation=
 """
 
 
@@ -153,6 +160,9 @@ class PropertiesTests(FormatTestsMixin, TestCase):
 
     def test_parse_no_comments_no_sources(self):
         self.run_parse_no_comments_no_sources(BASE_PROPERTIES_FILE, 2)
+
+    def test_parse_empty_translation(self):
+        self.run_parse_empty_translation(BASE_PROPERTIES_FILE, 3)
 
     def test_save_basic(self):
         input_string = dedent("""
@@ -253,6 +263,8 @@ SourceString=Translated String
 MultipleComments=Translated Multiple Comments
 
 NoCommentsorSources=Translated No Comments or Sources
+
+EmptyTranslation=
 """
 
 
@@ -270,11 +282,13 @@ class IniTests(FormatTestsMixin, TestCase):
         self.run_parse_basic(BASE_INI_FILE, 0)
 
     def test_parse_multiple_comments(self):
-        #import ipdb; ipdb.set_trace()
         self.run_parse_multiple_comments(BASE_INI_FILE, 1)
 
     def test_parse_no_comments_no_sources(self):
         self.run_parse_no_comments_no_sources(BASE_INI_FILE, 2)
+
+    def test_parse_empty_translation(self):
+        self.run_parse_empty_translation(BASE_INI_FILE, 3)
 
     def test_save_basic(self):
         input_string = dedent("""


### PR DESCRIPTION
The problem is that blank translations would be exported as missing translations by the silme format plugin (meaning Entity.strings would be `{}` instead of `{None: ''}`). Thus, sync thought that VCS had no translation and unapproved all translations in the database, instead of identifying the empty translation as the correct one.

@mathjazz r?