### PR TITLE
Fix bug 1201707: Add support for multiple repos.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ tmp/*
 .env
 docs/_build
 venv
+/media/

--- a/pontoon/administration/files.py
+++ b/pontoon/administration/files.py
@@ -715,10 +715,6 @@ def update_from_repository(project):
                     os.path.join(repository_url_master, l.code),
                     os.path.join(repository_path_master, l.code))
 
-    # Store project repository_path
-    project.repository_path = repository_path
-    project.save()
-
 
 def dump_po(project, locale, relative_path):
     """Dump .po (gettext) file with relative path from database."""

--- a/pontoon/administration/forms.py
+++ b/pontoon/administration/forms.py
@@ -1,0 +1,26 @@
+from django.forms import ModelForm
+from django.forms.models import inlineformset_factory
+
+from pontoon.base.models import Project, Repository, Subpage
+
+
+class ProjectForm(ModelForm):
+    class Meta:
+        model = Project
+        fields = ('name', 'slug', 'locales', 'transifex_project',
+                  'transifex_resource', 'info_brief', 'url', 'width',
+                  'links', 'disabled')
+
+
+SubpageInlineFormSet = inlineformset_factory(
+    Project, Subpage,
+    extra=1,
+    fields=('project', 'name', 'url')
+)
+
+
+RepositoryInlineFormSet = inlineformset_factory(
+    Project, Repository,
+    extra=1,
+    fields=('type', 'url', 'multi_locale', 'source_repo'),
+)

--- a/pontoon/administration/static/css/admin_project.css
+++ b/pontoon/administration/static/css/admin_project.css
@@ -131,7 +131,8 @@ form a:link, form a:visited {
   text-transform: uppercase;
 }
 
-form a.add-subpage {
+form a.add-subpage,
+form a.add-repo {
   font-size: 14px;
   letter-spacing: 0;
   margin-top: 17px;
@@ -185,6 +186,16 @@ form a.add-subpage {
 .checkbox label {
   float: left;
   padding: 6px 0 0 13px;
+}
+
+.repository .locale-wrapper {
+  padding-top: 20px;
+}
+
+.repository .locale-wrapper label,
+.repository .source-wrapper label,
+.repository .delete-wrapper label {
+  display: inline;
 }
 
 .repository.authenticate .bottom label {
@@ -328,7 +339,8 @@ form a.add-subpage {
   text-transform: uppercase;
 }
 
-.subpages[data-count] {
+.subpages[data-count],
+.repository-empty {
   display: none;
 }
 

--- a/pontoon/administration/static/js/admin_project.js
+++ b/pontoon/administration/static/js/admin_project.js
@@ -22,7 +22,7 @@ $(function() {
     if ($('input[type=text]:not("input[type=search], #id_transifex_username, #id_transifex_password"):focus').length > 0) {
       var key = e.keyCode || e.which;
       if (key === 13) { // Enter
-        // A short delay to allow digest of autocomplete before submit 
+        // A short delay to allow digest of autocomplete before submit
         setTimeout(function() {
           $('form').submit();
         }, 1);
@@ -168,6 +168,19 @@ $(function() {
     $('.subpages:last').before('<div class="subpages clearfix">' + form + '</div>');
     count++;
     $('#id_subpage_set-TOTAL_FORMS').val(count);
+  });
+
+  // Add repo
+  $('.add-repo').click(function(e) {
+    e.preventDefault();
+    var $totalForms = $('#id_repositories-TOTAL_FORMS');
+    var count = parseInt($totalForms.val(), 10);
+
+    var $emptyForm = $('.repository-empty');
+    var form = $emptyForm.html().replace(/__prefix__/g, count);
+    $('.repository:last').after('<div class="repository clearfix">' + form + '</div>');
+
+    $totalForms.val(count + 1);
   });
 
   // Delete project

--- a/pontoon/administration/templates/admin_project.html
+++ b/pontoon/administration/templates/admin_project.html
@@ -30,7 +30,6 @@
   <input type="hidden" value="{{ csrf_token }}" name="csrfmiddlewaretoken">
   {% if pk %}
   <input type="hidden" value="{{ pk }}" name="pk">
-  {{ form.repository_path.as_hidden() }}
   {% endif %}
 
   <div class="clearfix">
@@ -78,64 +77,62 @@
       {{ form.locales.errors }}
   </div>
 
-  <h2>Repository</h2>
+  <h2>
+    <span>Repositories</span>
+    <a href="#add-subpage" class="add-repo">Add more</a>
+  </h2>
 
-  <div class="repository clearfix{% if autoupdate %} autoupdate{% endif %}">
+  {{ repo_formset.management_form }}
+  {{ repo_formset.non_form_errors() }}
+  {% for repo_form in repo_formset %}
+    <div class="repository clearfix">
+      {{ repo_form.id }}
       <section class="type-wrapper">
-          {{ form.repository_type.label_tag() }}
-          <div class="type select">
-            <div class="hidden">
-              {{ form.repository_type }}
-            </div>
-            <div class="button selector">
-              <span class="title"></span>
-              <span> &#9652;</span>
-            </div>
-            <ul class="menu">
-              {% for choice in REPOSITORY_TYPE_CHOICES %}
-                  <li data-type="{{ choice[0] }}">{{ choice[1] }}</li>
-              {% endfor %}
-            </ul>
-          </div>
-          <p class="authentication-title">Please sign in</p>
+        {{ repo_form.type.label_tag() }}
+        {{ repo_form.type }}
       </section>
-      <section class="details-wrapper" data-repository-type="{{ form.repository_type.value()|lower }}">
-          <div class="repo">
-              {{ form.repository_url.label_tag() }}
-              {{ form.repository_url }}
-              {% if pk %}
-              <button title="Update all locales from repository" data-source="repository" class="button update">
-                  <span class="fa fa-refresh"></span>
-              </button>
-              {% endif %}
-          </div>
-          <div class="transifex clearfix">
-              {{ form.transifex_project.label_tag() }}
-              {{ form.transifex_resource.label_tag() }}
-              {{ form.transifex_project }}
-              {{ form.transifex_resource }}
-              {% if pk %}
-              <button title="Update all locales from Transifex" data-source="transifex" class="button update">
-                  <span class="fa fa-refresh"></span>
-              </button>
-              <section class="authentication-form">
-                  <label for="id_transifex_username">Username or email</label>
-                  <label for="id_transifex_password">Password</label>
-                  <input id="id_transifex_username" name="transifex_username" type="text" />
-                  <input id="id_transifex_password" name="transifex_password" type="password" />
-              </section>
-              <div class="bottom">
-                  <label class="remember">
-                      <input name="remember" type="checkbox" />Remember me
-                  </label>
-                  <a class="new" target="_blank" href="http://www.transifex.com/signup/">New to Transifex?</a>
-              </div>
-              {% endif %}
-          </div>
+      <section class="details-wrapper">
+        <div class="repo">
+          {{ repo_form.url.label_tag() }}
+          {{ repo_form.url }}
+        </div>
       </section>
-      {{ form.repository_url.errors }}
-      {{ form.transifex_project.errors }}
-      {{ form.transifex_resource.errors }}
+      <section class="locale-wrapper">
+        {{ repo_form.multi_locale.label_tag() }}
+        {{ repo_form.multi_locale }}
+      </section>
+      <section class="source-wrapper">
+        {{ repo_form.source_repo.label_tag() }}
+        {{ repo_form.source_repo }}
+      </section>
+      <section class="delete-wrapper">
+        <div class="delete">
+          {{ repo_form.DELETE.label_tag() }}
+          {{ repo_form.DELETE }}
+        </div>
+      </section>
+      {{ repo_form.errors }}
+    </div>
+  {% endfor %}
+  <div class="repository-empty clearfix">
+    {{ repo_formset.empty_form.id }}
+    <section class="type-wrapper">
+      {{ repo_formset.empty_form.type.label_tag() }}
+      {{ repo_formset.empty_form.type }}
+    </section>
+    <section class="details-wrapper">
+      <div class="repo">
+        {{ repo_formset.empty_form.url.label_tag() }}
+        {{ repo_formset.empty_form.url }}
+      </div>
+    </section>
+    <section class="delete-wrapper">
+      <div class="delete">
+        {{ repo_formset.empty_form.DELETE.label_tag() }}
+        {{ repo_formset.empty_form.DELETE }}
+      </div>
+    </section>
+    {{ repo_formset.empty_form.errors }}
   </div>
 
   <h2>Website</h2>
@@ -161,8 +158,8 @@
       <a href="#add-subpage" class="add-subpage">Add more</a>
   </h2>
 
-  {{ formset.management_form }}
-  {% for form in formset %}
+  {{ subpage_formset.management_form }}
+  {% for form in subpage_formset %}
       {{ form.id }}
   <div class="subpages clearfix">
       {{ form.name.label_tag(label_suffix='') }}
@@ -175,15 +172,15 @@
       {{ form.url.errors }}
   </div>
   {% endfor %}
-  <div class="subpages clearfix" data-count="{{ formset.total_form_count() }}">
-      {{ formset.empty_form.name.label_tag(label_suffix='') }}
-      {{ formset.empty_form.url.label_tag(label_suffix='') }}
-      {{ formset.empty_form.name }}
-      {{ formset.empty_form.url }}
+  <div class="subpages clearfix" data-count="{{ subpage_formset.total_form_count() }}">
+      {{ subpage_formset.empty_form.name.label_tag(label_suffix='') }}
+      {{ subpage_formset.empty_form.url.label_tag(label_suffix='') }}
+      {{ subpage_formset.empty_form.name }}
+      {{ subpage_formset.empty_form.url }}
       <button title="Delete subpage" class="button delete-subpage fa fa-trash-o" tabindex="-1"></button>
-      {{ formset.empty_form.DELETE }}
-      {{ formset.empty_form.name.errors }}
-      {{ formset.empty_form.url.errors }}
+      {{ subpage_formset.empty_form.DELETE }}
+      {{ subpage_formset.empty_form.name.errors }}
+      {{ subpage_formset.empty_form.url.errors }}
   </div>
 
   <h2>Project info <span class="small">(optional)</span></h2>

--- a/pontoon/base/migrations/0025_add_repository.py
+++ b/pontoon/base/migrations/0025_add_repository.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0024_locale_team_description'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Repository',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('type', models.CharField(default=b'file', max_length=255, choices=[(b'file', b'File'), (b'git', b'Git'), (b'hg', b'HG'), (b'svn', b'SVN'), (b'transifex', b'Transifex')])),
+                ('url', models.CharField(max_length=2000, verbose_name=b'URL', blank=True)),
+                ('project', models.ForeignKey(to='base.Project')),
+            ],
+            options={
+                'ordering': ['id'],
+            },
+        ),
+        migrations.AlterUniqueTogether(
+            name='repository',
+            unique_together=set([('project', 'url')]),
+        ),
+    ]

--- a/pontoon/base/migrations/0026_migrate_repository_info.py
+++ b/pontoon/base/migrations/0026_migrate_repository_info.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def copy_repo_attributes_to_relation(apps, schema_editor):
+    """
+    Copy data in Project.repository_* attributes to Repository
+    instances.
+    """
+    Project = apps.get_model('base', 'Project')
+    Repository = apps.get_model('base', 'Repository')
+    for project in Project.objects.all():
+        repo = Repository(
+            project=project,
+            type=project.repository_type,
+            url=project.repository_url,
+        )
+        repo.save()
+
+
+def copy_relation_to_repo_attributes(apps, schema_editor):
+    """
+    Copy data in Repository instances to Project.repository_*
+    attributes.
+    """
+    Project = apps.get_model('base', 'Project')
+    for project in Project.objects.all():
+        repo = project.repository_set.first()
+        if repo is not None:
+            project.repository_type = repo.type
+            project.repository_url = repo.url
+            project.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('base', '0025_add_repository'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            copy_repo_attributes_to_relation,
+            copy_relation_to_repo_attributes
+        ),
+    ]

--- a/pontoon/base/migrations/0027_auto_20150910_1735.py
+++ b/pontoon/base/migrations/0027_auto_20150910_1735.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0026_migrate_repository_info'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='project',
+            name='repository_path',
+        ),
+        migrations.RemoveField(
+            model_name='project',
+            name='repository_type',
+        ),
+        migrations.RemoveField(
+            model_name='project',
+            name='repository_url',
+        ),
+    ]

--- a/pontoon/base/migrations/0028_auto_20150915_0013.py
+++ b/pontoon/base/migrations/0028_auto_20150915_0013.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0027_auto_20150910_1735'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='repository',
+            name='project',
+            field=models.ForeignKey(related_name='repositories', to='base.Project'),
+        ),
+    ]

--- a/pontoon/base/migrations/0029_repository_multi_locale.py
+++ b/pontoon/base/migrations/0029_repository_multi_locale.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0028_auto_20150915_0013'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='repository',
+            name='multi_locale',
+            field=models.BooleanField(default=False, help_text=b'\n        If true, this repo corresponds to multiple locale-specific repos. The\n        URL should have the string "{locale_code}" in it, which will be replaced\n        by the locale codes of all enabled locales for the project during pulls\n        and and commits.\n    '),
+        ),
+    ]

--- a/pontoon/base/migrations/0030_repository_source_repo.py
+++ b/pontoon/base/migrations/0030_repository_source_repo.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0029_repository_multi_locale'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='repository',
+            name='source_repo',
+            field=models.BooleanField(default=False, help_text=b'\n        If true, this repo contains the source strings directly in the\n        root of the repo. Checkouts of this repo will have "en-US"\n        appended to the end of their path so that they are detected as\n        source directories.\n    '),
+        ),
+    ]

--- a/pontoon/base/tests/__init__.py
+++ b/pontoon/base/tests/__init__.py
@@ -18,6 +18,7 @@ from pontoon.base.models import (
     Entity,
     Locale,
     Project,
+    Repository,
     Resource,
     Stats,
     Translation,
@@ -64,6 +65,26 @@ class ProjectFactory(DjangoModelFactory):
         if extracted:
             for locale in extracted:
                 self.locales.add(locale)
+
+    @factory.post_generation
+    def repositories(self, create, extracted, **kwargs):
+        if not create:
+            return
+
+        if extracted is not None:
+            for repository in extracted:
+                self.repositories.add(repository)
+        else:  # Default to a single valid repo.
+            self.repositories.add(RepositoryFactory.build())
+
+
+class RepositoryFactory(DjangoModelFactory):
+    project = SubFactory(ProjectFactory)
+    type = Repository.GIT
+    url = Sequence(lambda n: 'https://example.com/url_{0}.git'.format(n))
+
+    class Meta:
+        model = Repository
 
 
 class ResourceFactory(DjangoModelFactory):

--- a/pontoon/base/vcs_models.py
+++ b/pontoon/base/vcs_models.py
@@ -86,24 +86,19 @@ class VCSProject(object):
         raise Exception('No source directory found for project {0}'
                         .format(self.db_project.slug))
 
-    def locale_directory_path(self, locale_code=None):
+    def locale_directory_path(self, locale_code):
         """
         Path to the directory where strings for the given locale are
         stored.
-
-        If locale_code is None, return the path to the directory where
-        source strings are stored.
         """
         path = self.checkout_path
-        locale_code = locale_code or self.source_directory_name()
-        if locale_code is not None:
-            for root, dirnames, filenames in os.walk(path):
-                if locale_code in dirnames:
-                    return os.path.join(root, locale_code)
+        for root, dirnames, filenames in os.walk(path):
+            if locale_code in dirnames:
+                return os.path.join(root, locale_code)
 
-                locale_variant = locale_code.replace('-', '_')
-                if locale_variant in dirnames:
-                    return os.path.join(root, locale_variant)
+            locale_variant = locale_code.replace('-', '_')
+            if locale_variant in dirnames:
+                return os.path.join(root, locale_variant)
 
         raise Exception('Directory for locale `{0}` not found'.format(
                         locale_code or 'source'))


### PR DESCRIPTION
Firefox and friends have multiple repos where strings are stored. The
old sync process used some magic code during sync to detect this and
download and commit strings to multiple repositories. This commit adds
support directly to Pontoon for multiple repos so that the new sync
process can support these special repos.

The old sync process still works by assuming that the first-found repo
is the singular repo that it expects.

While this adds UI to the admin interface, it's unpolished due to our
future plans of replacing the admin interface with the Django admin. In
addition, some code for supporting Transifex and File repos has been
removed due to those features also being slated for removal. Rather
than properly support these unused and about-to-die features, we do the
lazy thing and ignore them.

@mathjazz I'll be updating this with tests, but it's about ready for some preliminary feedback and testing.