### PR TITLE
Fix bug 1204047: Avoid race conditions from translations during sync.

### DIFF
--- a/pontoon/base/migrations/0031_changedentitylocale_when.py
+++ b/pontoon/base/migrations/0031_changedentitylocale_when.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0030_repository_source_repo'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='changedentitylocale',
+            name='when',
+            field=models.DateTimeField(default=django.utils.timezone.now),
+        ),
+    ]

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -627,6 +627,7 @@ class ChangedEntityLocale(models.Model):
     """
     entity = models.ForeignKey(Entity)
     locale = models.ForeignKey(Locale)
+    when = models.DateTimeField(default=timezone.now)
 
     class Meta:
         unique_together = ('entity', 'locale')


### PR DESCRIPTION
When updating from VCS, only unapprove translations that existed before sync
started. This might cause multiple approved translations, so remove duplicate
approvals before committing the sync transaction.

@mathjazz r?