### PR TITLE
Bug 1205445. Moved sphinx dependencies to separate file to fix builds

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,7 @@
+# sha256: _5spJogkCW_JETkEYF2D9qqBcQLA8XARW0s58K4GUfM
+# sha256: dPYz7Tph2h0dWcMYVIPIGp1zRr8Oe18prQdkpvFZtoo
+sphinx_rtd_theme==0.1.8
+
+# sha256: Ld8Y2jsGIfpD_uS3KQ2grnibRvuJkniorMzaGVxJeac
+# sha256: Gm5RMMK0LS3jAWk8KZ94zEvTUB54thDAjkXvxw4rURQ
+Sphinx==1.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+-r docs/requirements.txt
+
 # sha256: 0Bl46ajFHqezTscfP87RMmQ3zTZrnC4ZJlrOBQkk4OI
 # sha256: s6eaI9N7WgL6pVC5LLu-vrSqHXfmScPrOcGav1Ji2gQ
 argparse==1.3.0
@@ -164,10 +166,6 @@ snowballstemmer==1.2.0
 # sha256: nwLQNXGE3h8JPBABK1LnRUoQCL5qXBhat6Mwes6x0S4
 babel==1.3
 
-# sha256: _5spJogkCW_JETkEYF2D9qqBcQLA8XARW0s58K4GUfM
-# sha256: dPYz7Tph2h0dWcMYVIPIGp1zRr8Oe18prQdkpvFZtoo
-sphinx_rtd_theme==0.1.8
-
 # sha256: IvlnXkLcZAxEadT30hC67LXmlYI6-VTIE9UckwI1Z10
 Jinja2==2.5.5
 
@@ -176,9 +174,6 @@ Jinja2==2.5.5
 # sha256: cyCRkITm2sj0VAY4pGRHo71zD8oXKvwX0sA-7SLPT1E
 Pygments==2.0.2
 
-# sha256: Ld8Y2jsGIfpD_uS3KQ2grnibRvuJkniorMzaGVxJeac
-# sha256: Gm5RMMK0LS3jAWk8KZ94zEvTUB54thDAjkXvxw4rURQ
-Sphinx==1.3.1
 # sha256: SlwIPaNyS1CauqpJQ2oyf9EwkL3Ah8fIuUTQ1DeudTM
 # sha256: znfi_bqrquOT_84qYlKgpmbjl3xsL6HEjE3tBWl4WVE
 alabaster==0.7.4


### PR DESCRIPTION
This should fix docs @ readthedocs.org . You only need to set requirements file to 'requirements_docs.txt' in advanced settings.
Example build is available here: http://jotes-pontoon.readthedocs.org/en/latest/

@mathjazz @Osmose  could you review?
