### PR TITLE
Change placeables style

### DIFF
--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -3,10 +3,14 @@ body {
 }
 
 mark.placeable {
-  background: transparent;
-  color: #FE8388;
+  background: #4D5967;
+  border: 1px solid #5E6475;
+  border-radius: 2px;
+  color: #CCCCCC;
   font-style: normal;
   font-weight: normal;
+  margin: 0 1px;
+  padding: 0 2px;
 }
 
 #project-load {
@@ -857,6 +861,10 @@ body > header aside p {
 
 #source-pane #original mark.placeable {
   cursor: pointer;
+}
+
+#source-pane #original mark.placeable:hover {
+  color: #7BC876;
 }
 
 #editor nav ul {


### PR DESCRIPTION
Marking placeables with red color is not the best idea, because we use
this color to mark untranslated strings. They also stand out in the
entity list.

Instead, we put them in rounded boxes now, to make them look more like
HTML tags. Boxes also allows us to display empty space placeables. And
we use neutral UI colors.

@Osmose r?