### PR TITLE
Fix bug 1201936: Handle invalid langfiles with blank translations.

### DIFF
--- a/pontoon/base/formats/lang.py
+++ b/pontoon/base/formats/lang.py
@@ -118,9 +118,10 @@ class LangVisitor(NodeVisitor):
     def visit_lang_file(self, node, children):
         """
         Find comments that are associated with an entity and add them
-        to the entity's comments list.
+        to the entity's comments list. Also assign order to entities.
         """
         comments = []
+        order = 0
         for child in children:
             if isinstance(child, LangComment):
                 comments.append(child)
@@ -128,6 +129,8 @@ class LangVisitor(NodeVisitor):
 
             if isinstance(child, LangEntity):
                 child.comments = [c.content for c in comments]
+                child.order = order
+                order += 1
 
             comments = []
 

--- a/pontoon/base/tests/formats/test_lang.py
+++ b/pontoon/base/tests/formats/test_lang.py
@@ -1,9 +1,10 @@
 import os.path
 from textwrap import dedent
 
-from django_nose.tools import assert_equal
+from django_nose.tools import assert_equal, assert_raises
 
 from pontoon.base.formats import lang
+from pontoon.base.formats.base import ParseError
 from pontoon.base.tests import assert_attributes_equal, TestCase
 from pontoon.base.tests.formats import FormatTestsMixin
 
@@ -135,3 +136,20 @@ class LangTests(FormatTestsMixin, TestCase):
         path, resource = self.parse_string(expected)
         resource.save(self.locale)
         self.assert_file_content(path, expected)
+
+    def test_parse_empty_translation(self):
+        """
+        If an entity has an empty translation, parse should raise a
+        ParseError.
+        """
+        with assert_raises(ParseError):
+            self.parse_string(dedent("""
+                # Comment
+                ;Source
+                Translated
+
+                ;Empty
+
+                ;Not Empty
+                Nope
+            """))

--- a/pontoon/base/tests/formats/test_lang.py
+++ b/pontoon/base/tests/formats/test_lang.py
@@ -8,8 +8,67 @@ from pontoon.base.tests import assert_attributes_equal, TestCase
 from pontoon.base.tests.formats import FormatTestsMixin
 
 
+BASE_LANG_FILE = """
+# Sample comment
+;Source String
+Translated String
+
+# First comment
+# Second comment
+;Multiple Comments
+Translated Multiple Comments
+
+;No Comments or Sources
+Translated No Comments or Sources
+"""
+
+
 class LangTests(FormatTestsMixin, TestCase):
     parse = staticmethod(lang.parse)
+    supports_source = False
+    supports_keys = False
+    supports_source_string = True
+
+    def test_parse_basic(self):
+        self.run_parse_basic(BASE_LANG_FILE, 0)
+
+    def test_parse_multiple_comments(self):
+        self.run_parse_multiple_comments(BASE_LANG_FILE, 1)
+
+    def test_parse_no_comments_no_sources(self):
+        self.run_parse_no_comments_no_sources(BASE_LANG_FILE, 2)
+
+    def test_save_basic(self):
+        input_string = dedent("""
+            # Comment
+            ;SourceString
+            Source String
+        """)
+        expected_string = dedent("""
+            # Comment
+            ;SourceString
+            New Translated String
+        """)
+
+        self.run_save_basic(input_string, expected_string)
+
+    def test_save_remove(self):
+        """
+        Deleting strings shouled replace the translation with the source
+        string.
+        """
+        input_string = dedent("""
+            # Comment
+            ;SourceString
+            Translated String
+        """)
+        expected_string = dedent("""
+            # Comment
+            ;SourceString
+            SourceString
+        """)
+
+        self.run_save_remove(input_string, expected_string)
 
     def test_load_utf8_bom(self):
         """

--- a/pontoon/base/vcs_models.py
+++ b/pontoon/base/vcs_models.py
@@ -61,7 +61,18 @@ class VCSProject(object):
         and allows tests that don't need to touch the resources to run
         with less mocking.
         """
-        return {path: VCSResource(self, path) for path in self.relative_resource_paths()}
+        # Avoid circular import; someday we should refactor to avoid.
+        from pontoon.base.formats.base import ParseError
+
+        resources = {}
+        for path in self.relative_resource_paths():
+            try:
+                resources[path] = VCSResource(self, path)
+            except ParseError as err:
+                log.error('Skipping resource {path} due to ParseError: {err}'.format(
+                    path=path, err=err
+                ))
+        return resources
 
     @property
     def entities(self):


### PR DESCRIPTION
While I was messing with the langfile tests I also added the standard format tests that we added for all the other supported formats.

@mathjazz r?