### PR TITLE
Fix bug 1207829: Filter region.properties properly.

### DIFF
--- a/pontoon/base/vcs_models.py
+++ b/pontoon/base/vcs_models.py
@@ -136,7 +136,7 @@ class VCSProject(object):
         for root, dirnames, filenames in os.walk(path):
             # Ignore certain files in Mozilla repositories.
             if self.db_project.repository_url in MOZILLA_REPOS:
-                filenames = [f for f in filenames if f.endswith('region.properties')]
+                filenames = [f for f in filenames if not f.endswith('region.properties')]
 
             for filename in filenames:
                 if is_resource(filename):


### PR DESCRIPTION
@mathjazz r?

Note that this isn't entirely correct, as it still uses the `repository_url` property, which defaults to the first repo defined in the database for the project. But it should function correctly for the repos as we currently have them and I've filed [bug 1209375](https://bugzilla.mozilla.org/show_bug.cgi?id=1209375) with what I think the proper long-term fix is.