### PR TITLE
Test for actual pks instead of guessing what they are.

### DIFF
--- a/pontoon/base/tests/test_models.py
+++ b/pontoon/base/tests/test_models.py
@@ -640,12 +640,12 @@ class EntityTests(TestCase):
             'key': '',
             'path': 'main.lang',
             'translation': [{
-                'pk': 4,
+                'pk': self.main_translation.pk,
                 'fuzzy': False,
                 'string': 'Translated String',
                 'approved': False
             }, {
-                'pk': 5,
+                'pk': self.main_translation_plural.pk,
                 'fuzzy': False,
                 'string': 'Translated Plural String',
                 'approved': False
@@ -654,7 +654,7 @@ class EntityTests(TestCase):
             'source': [],
             'original_plural': 'Plural Source String',
             'marked_plural': 'Plural Source String',
-            'pk': 4,
+            'pk': self.main_entity.pk,
             'original': 'Source String'
         })
 


### PR DESCRIPTION
We cannot predict the PKs being assigned, but we do have access to what their values are supposed to be, so we can still assert them!

I don't think this calls for review so I'm skipping it, but leaving a PR here just to note the change.