### PR TITLE
Fix bug 1209423: Correctly handle MOZ_LANGPACK_CONTRIBUTORS.

### DIFF
--- a/pontoon/base/tests/__init__.py
+++ b/pontoon/base/tests/__init__.py
@@ -23,7 +23,7 @@ from pontoon.base.models import (
     Subpage,
     Translation,
 )
-from pontoon.base.vcs_models import VCSEntity
+from pontoon.base.vcs_models import VCSEntity, VCSTranslation
 
 
 class TestCase(BaseTestCase):
@@ -170,6 +170,16 @@ class VCSEntityFactory(factory.Factory):
 
     class Meta:
         model = VCSEntity
+
+
+class VCSTranslationFactory(factory.Factory):
+    key = Sequence(lambda n: 'key-{0}'.format(n))
+    strings = factory.Dict({})
+    comments = factory.List([])
+    fuzzy = False
+
+    class Meta:
+        model = VCSTranslation
 
 
 def assert_redirects(response, expected_url, status_code=302, host=None):

--- a/pontoon/base/tests/test_vcs_models.py
+++ b/pontoon/base/tests/test_vcs_models.py
@@ -1,11 +1,18 @@
 import os
 import os.path
 
-from django_nose.tools import assert_equal
+from django_nose.tools import assert_equal, assert_false, assert_true
 from mock import Mock, patch, PropertyMock
 
 from pontoon.base.models import Project
-from pontoon.base.tests import CONTAINS, ProjectFactory, RepositoryFactory, TestCase
+from pontoon.base.tests import (
+    CONTAINS,
+    ProjectFactory,
+    RepositoryFactory,
+    TestCase,
+    VCSEntityFactory,
+    VCSTranslationFactory,
+)
 from pontoon.base.formats.base import ParseError
 from pontoon.base.vcs_models import VCSProject
 
@@ -109,3 +116,19 @@ class VCSProjectTests(TestCase):
                 list(self.vcs_project.resources_for_path('/root')),
                 [os.path.join('/root', 'foo.pot')]
             )
+
+
+class VCSEntityTests(TestCase):
+    def test_has_translation_for(self):
+        """
+        Return True if a translation exists for the given locale, even
+        if the translation is empty/falsey.
+        """
+        empty_translation = VCSTranslationFactory(strings={})
+        full_translation = VCSTranslationFactory(strings={None: 'TRANSLATED'})
+        entity = VCSEntityFactory()
+        entity.translations = {'empty': empty_translation, 'full': full_translation}
+
+        assert_false(entity.has_translation_for('missing'))
+        assert_true(entity.has_translation_for('empty'))
+        assert_true(entity.has_translation_for('full'))

--- a/pontoon/base/vcs_models.py
+++ b/pontoon/base/vcs_models.py
@@ -225,7 +225,7 @@ class VCSEntity(object):
 
     def has_translation_for(self, locale_code):
         """Return True if a translation exists for the given locale."""
-        return bool(self.translations.get(locale_code, False))
+        return locale_code in self.translations
 
 
 class VCSTranslation(object):


### PR DESCRIPTION
When importing strings from VCS, only uncomment the entity when parsing
source resources. When exporting strings, only uncomment the entity if
Pontoon has a translation for it.

@mathjazz r?