### PR TITLE
Fix bug 1191718: Don't sync when there are no changes.

### DIFF
--- a/pontoon/administration/tests/test_vcs.py
+++ b/pontoon/administration/tests/test_vcs.py
@@ -1,0 +1,23 @@
+from django_nose.tools import assert_equal
+from mock import patch
+
+from pontoon.administration.vcs import VCSRepository
+from pontoon.base.tests import CONTAINS, TestCase
+
+
+class VCSRepositoryTests(TestCase):
+    def test_execute_log_error(self):
+        """
+        If the return code from execute is non-zero and log_errors is
+        True, log an error message.
+        """
+        repo = VCSRepository('/path')
+
+        with patch('pontoon.administration.vcs.execute') as mock_execute, \
+             patch('pontoon.administration.vcs.log') as mock_log:
+            mock_execute.return_value = 1, 'output', 'stderr'
+            assert_equal(
+                repo.execute('command', cwd='working_dir', log_errors=True),
+                (1, 'output', 'stderr')
+            )
+            mock_log.error.assert_called_with(CONTAINS('stderr', 'command', 'working_dir'))

--- a/pontoon/base/migrations/0032_repository_last_synced_revisions.py
+++ b/pontoon/base/migrations/0032_repository_last_synced_revisions.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import jsonfield.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0031_changedentitylocale_when'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='repository',
+            name='last_synced_revisions',
+            field=jsonfield.fields.JSONField(default=dict, blank=True),
+        ),
+    ]


### PR DESCRIPTION
Now we track the revision number/hash from the last time we synced, and
use that to determine if VCS has changed since the last sync. If not,
and there are no changes in the DB, we can skip syncing completely.

If things fail, sync should default to assuming changes exist, degrading gracefully to the old behavior.

@mathjazz r?