### PR TITLE
Hide columns not needed in add locale view

### DIFF
--- a/pontoon/base/static/js/project.js
+++ b/pontoon/base/static/js/project.js
@@ -24,7 +24,7 @@ $(function() {
     e.preventDefault();
 
     var menu = $(this).parents('.menu');
-    menu.find('.sort span:eq(2)').toggle();
+    menu.find('.sort .progress, .latest').toggle();
     $(this).toggleClass('back')
       .find('span').toggleClass('fa-plus-square fa-chevron-left');
 


### PR DESCRIPTION
In /projects/SLUG/, if you click on Add to request new locales, activity and progress columns need to be hidden.

@Osmose r?