### PR TITLE
Bug 1178880 project locale dashboard with search

### DIFF
--- a/pontoon/administration/templates/admin_project.html
+++ b/pontoon/administration/templates/admin_project.html
@@ -15,7 +15,7 @@
   <aside>
     <a href="{{ url('pontoon.admin.project.new') }}">Add new</a>
     {% if translate_locale and form.slug.value() != '' %}
-    <a class="translate{% if not ready %} hidden{% endif %}" href="{{ url('pontoon.translate', translate_locale, form.slug.value()) }}">Translate</a>
+    <a class="translate{% if not ready %} hidden{% endif %}" href="{{ url('pontoon.locale.project', translate_locale, form.slug.value()) }}">Translate</a>
     {% endif %}
   </aside>
   {% endif %}

--- a/pontoon/base/static/css/locale_project.css
+++ b/pontoon/base/static/css/locale_project.css
@@ -1,0 +1,11 @@
+body > .container {
+  width: 1035px;
+}
+
+.menu .sort span.name {
+    width: 520px;
+}
+
+.part.select .menu ul li .name {
+  width: 519px; /* Instead of 520px; because of padding */
+}

--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -388,7 +388,7 @@ label {
   background: #3f4752;
   font-size: 16px;
   height: 20px;
-  margin: 10px 10px 10px 0px;
+  margin: 10px 10px 10px 0;
   overflow: hidden;
   padding: 10px 20px 10px 40px;
   text-overflow: ellipsis;
@@ -455,12 +455,16 @@ label {
   color: #272A2F;
 }
 
-.project.select {
+.project.select,
+.locale.select,
+.part.select {
   padding-left: 0;
   width: 100%;
 }
 
-.project.select .menu {
+.project.select .menu,
+.locale.select .menu,
+.part.select .menu {
   bottom: auto;
   display: inline-block;
   position: relative;
@@ -470,18 +474,23 @@ label {
   box-sizing: border-box;
 }
 
-.project.select input[type="search"] {
+.project.select input[type="search"],
+.locale.select input[type="search"],
+.part.select input[type="search"] {
   width: 100%;
 
   -moz-box-sizing: border-box;
   box-sizing: border-box;
 }
 
-.project.select .menu ul {
+.project.select .menu ul,
+.locale.select .menu ul,
+.part.select .menu ul {
   max-height: none;
 }
 
-.project.select .menu ul li .name {
+.project.select .menu ul li .name,
+.part.select .menu ul li .name {
   overflow: hidden;
   padding-left: 1px; /* Insted of 0; because of overflow */
   text-overflow: ellipsis;
@@ -489,34 +498,53 @@ label {
   width: 219px; /* Instead of 220px; because of padding */
 }
 
-.locale.select {
-  padding-left: 0;
-  width: 100%;
+.part .menu nav ul li {
+  border: 1px solid transparent;
+  border-bottom-color: #5E6475;
 }
 
-.locale.select .menu {
-  bottom: auto;
-  display: inline-block;
-  position: relative;
-  width: 100%;
-
-  -moz-box-sizing: border-box;
-  box-sizing: border-box;
+.part .menu nav ul li.hover {
+  background: transparent;
 }
 
-.locale.select input[type="search"] {
-  width: 100%;
+.part .menu nav ul li.active {
+  border-color: #5E6475;
+  border-bottom-color: transparent;
+}
 
-  -moz-box-sizing: border-box;
-  box-sizing: border-box;
+/* TODO: this is needed (but shouldn't be) for pixel perfect tab borders */
+.part .menu nav ul li:last-child.active {
+  width: calc(50% + 2px);
+  margin-left: -2px;
+  padding-left: 2px;
+}
+
+.part .menu section {
+  padding-top: 20px;
+}
+
+.part .menu section .check-box {
+  cursor: pointer;
+  display: table;
+  padding-left: 1px;
+  text-align: left;
+}
+
+.part .menu section .check-box.hover {
+  background: transparent;
+  color: inherit;
+}
+
+.part .menu section .check-box:hover {
+  color: #FFFFFF;
+}
+
+.part .menu section .check-box input[type="checkbox"] {
+  display: none;
 }
 
 .locale.select .new ~ input[type="search"] {
   padding-right: 50px;
-}
-
-.locale.select .menu ul {
-  max-height: none;
 }
 
 .locale.select .menu ul li span.language {
@@ -578,6 +606,7 @@ label {
   font-size: 12px;
   margin-right: 10px;
   overflow: hidden;
+  padding-top: 2px;
   white-space: nowrap;
   width: 293px;
 }
@@ -715,7 +744,7 @@ label {
   content: "Add";
 }
 
-.search-wrapper > a.back:after {
+.locale .search-wrapper > a.back:after {
   content: "Back";
 }
 
@@ -729,6 +758,7 @@ label {
   background: transparent;
   color: #FFFFFF;
   float: none;
+  font-weight: 300;
   padding-left: 25px;
   padding-right: 0;
   width: 200px;
@@ -776,7 +806,7 @@ form .about p a:visited {
   border-color: #3F4752 transparent transparent transparent;
   bottom: -16px;
   left: 92px; /* Must be (tooltip width + tooltip padding + bottom) / 2 */
-  clip: rect(0 16px 8px 0px);
+  clip: rect(0 16px 8px 0);
   -webkit-clip-path: polygon(0 0, 100% 0, 100% 50%, 0 50%);
   clip-path: polygon(0 0, 100% 0, 100% 50%, 0 50%);
 }
@@ -828,6 +858,10 @@ form .about p a:visited {
   opacity: 0;
 }
 
+.notification.menu-open {
+  right: 240px;
+}
+
 .notification li {
   list-style: none;
   text-align: left;
@@ -836,6 +870,10 @@ form .about p a:visited {
 .notification li.error,
 .notification li.warning {
   color: #FD5F60;
+}
+
+.notification li.right240{
+  right: 240px;
 }
 
 img.rounded {
@@ -989,7 +1027,8 @@ noscript p {
   width: 20px;
 }
 
-body > form {
+body > form,
+body > .container {
   height: auto;
   margin: 0 auto;
   padding: 50px 0 100px;
@@ -1021,14 +1060,17 @@ body > form {
   user-select: none;
 }
 
-.quality-checks .fa:before,
-.quality-checks.enabled:hover .fa:before {
-  color: #FD5F60;
-  content: "";
+.check-box .fa {
+  margin-right: 6px;
 }
 
-.quality-checks:hover .fa:before,
-.quality-checks.enabled .fa:before {
+.check-box .fa:before {
+  color: #FD5F60;
+  content: "";
+
+}
+
+.check-box.enabled .fa:before {
   color: #7BC876;
   content: "";
 }
@@ -1072,4 +1114,37 @@ body > form {
 
 #helpers > section ul li p.original {
   color: #AAAAAA;
+}
+
+.tabs nav ul li {
+  float: left;
+  padding: 0;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.part .tabs nav ul li {
+  width: 50%;
+
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+.tabs nav ul li a {
+  display: inline-block;
+  outline: none;
+  padding: 10px;
+  width: 100%;
+
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+.part .tabs nav ul li a span.fa {
+  float: none;
+  padding-right: 5px;
+}
+
+.tabs > section {
+  display: none;
 }

--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -152,13 +152,14 @@ body > header .loader {
   margin-left: 10px;
 }
 
-body > header .project.select {
-  margin-left: 10px;
+body > header .project.select,
+body > header .locale.select,
+body > header .part.select {
   width: auto;
 }
 
-body > header .locale.select {
-  width: auto;
+body > header .project.select {
+  margin-left: 10px;
 }
 
 .select > .button.breadcrumbs {
@@ -179,6 +180,12 @@ body > header .locale.select {
   top: 60px;
 }
 
+.part .selector .icon {
+  float: left;
+  margin: 1px 10px 0 0;
+  color: #7BC876;
+}
+
 .project.select .menu,
 .part.select .menu {
   display: none;
@@ -187,7 +194,14 @@ body > header .locale.select {
 }
 
 .part.select .menu {
-  width: 580px;
+  width: 600px;
+}
+
+.part .menu section {
+  border: 1px solid #5E6475;
+  border-top: transparent;
+  margin-top: -1px;
+  padding: 20px 10px 10px;
 }
 
 .locale.select .menu {
@@ -198,7 +212,8 @@ body > header .locale.select {
 
 .menu ul,
 .project.select .menu ul,
-.locale.select .menu ul {
+.locale.select .menu ul,
+.part.select .menu ul {
   margin: 0;
   max-height: 318px;
 }
@@ -374,6 +389,7 @@ body > header .notification {
   top: 70px;
   visibility: visible;
   width: auto;
+  z-index: 25;
 }
 
 body > header .notification.hide {
@@ -644,7 +660,7 @@ body > header aside p {
 }
 
 #entitylist > .wrapper {
-  bottom: 0px;
+  bottom: 0;
   overflow-y: auto;
   position: absolute;
   top: 44px;
@@ -877,7 +893,7 @@ body > header aside p {
   border-bottom: 1px solid #5E6475;
   border-right: 1px solid #5E6475;
   display: table-cell;
-  text-align: center;
+  float: none;
 }
 
 #editor nav li:last-child {
@@ -895,16 +911,12 @@ body > header aside p {
 
 #editor nav li a {
   color: #CCCCCC;
-  display: block;
-  outline: none;
-  padding: 10px;
-  text-transform: uppercase;
 }
 
 #editor nav li a > span > span {
-  left: 0px;
+  left: 0;
   position: absolute;
-  right: 0px;
+  right: 0;
   top: 2px;
   vertical-align: 0;
   visibility: hidden;
@@ -939,6 +951,12 @@ body > header aside p {
 
 #plural-tabs ul li {
   display: none;
+  text-transform: uppercase;
+}
+
+#plural-tabs ul li a {
+  display: inline-block;
+  padding: 10px;
 }
 
 #plural-tabs ul li a sup {
@@ -1058,7 +1076,6 @@ body > header aside p {
 
 #helpers > section {
   bottom: 0;
-  display: none;
   left: 0;
   overflow-y: auto;
   padding-top: 25px;
@@ -1067,26 +1084,27 @@ body > header aside p {
   top: 43px;
 }
 
-#helpers > section#custom-search .search-wrapper {
-  margin-bottom: 0;
+#helpers > section.custom-search .search-wrapper {
+  margin: 0 10px 10px;
 }
 
-#helpers > section#custom-search .icon {
-  right: 10px;
+#helpers > section.custom-search .icon {
+  left: 2px;
+  right: auto;
 }
 
-#helpers > section#custom-search.loading .icon,
-#helpers > section#custom-search .icon.fa-cog {
+#helpers > section.custom-search.loading .icon,
+#helpers > section.custom-search .icon.fa-cog {
   display: none;
 }
 
-#helpers > section#custom-search.loading .icon.fa-cog {
+#helpers > section.custom-search.loading .icon.fa-cog {
   display: block;
 }
 
-#helpers > section#custom-search input[type=search] {
+#helpers > section.custom-search input[type=search] {
   background: transparent;
-  padding-left: 10px;
+  padding: 10px 10px 5px 25px;
 }
 
 #helpers > section ul li {
@@ -1119,8 +1137,8 @@ body > header aside p {
   float: right;
 }
 
-#helpers > section#history ul li > header .stress,
-#helpers > section#other-locales ul li > header .stress {
+#helpers > section.history ul li > header .stress,
+#helpers > section.other-locales ul li > header .stress {
   padding-right: 0;
 }
 

--- a/pontoon/base/static/css/user.css
+++ b/pontoon/base/static/css/user.css
@@ -104,10 +104,10 @@
 }
 
 .info .fa {
-  padding-right: 6px;
+  margin-right: 6px;
 }
 
-.info li.quality-checks {
+.info li.check-box {
   cursor: pointer;
   display: inline-block;
 }

--- a/pontoon/base/static/js/locale_project.js
+++ b/pontoon/base/static/js/locale_project.js
@@ -1,0 +1,47 @@
+$(function() {
+  // Remove default Enter handler
+  $('.part .menu .search-project input[type=search]').off('keyup.search');
+
+  // Search entire project with Enter
+  $('form.search-form').submit(function(e) {
+    var action = 'search/',
+        keyword = $(this).find('[type="search"]').val();
+
+    if (keyword.length > 0) {
+      if ($('.locale .selector .language').length) {
+        var locale = $('.locale .selector .language').attr('class').split(' ')[1],
+            project = $('.project .selector .title').data('slug'),
+            action = '/' + locale + '/' + project + '/' + action;
+      }
+
+      // At least one non case-sensitive option must be selected
+      if ($('.options :checked').length > 1 || ($('.options :checked').length && !$('.options [name=casesensitive]:checked').length)) {
+        $(this).attr('action', action);
+        return;
+      }
+    }
+
+    return false;
+  });
+
+  // Focus search field when switching tabs
+  $(".tabs nav a").click(function (e) {
+    $('.part .menu input[type=search]:visible').trigger("keyup").focus();
+  });
+
+  // If showing search results, show search pane by default
+  var search = window.location.search,
+      tab = 'resources';
+  if (search) {
+    tab = 'search-project';
+  }
+  $('.part .menu nav a[href=#' + tab + ']').click();
+
+  // Select options
+  $('.search-project .options li').click(function() {
+    $(this).toggleClass('enabled');
+    var checkbox = $(this).find("input[type=checkbox]");
+    checkbox.prop("checked", !checkbox.prop("checked"));
+  });
+
+});

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -47,7 +47,7 @@ var Pontoon = (function (my) {
         $('.notification')
           .html('<li class="' + (type || "") + '">' + text + '</li>')
           .css('opacity', 100)
-          .removeClass('hide');
+          .removeClass('hide menu-open');
       }
 
       if (!persist) {
@@ -146,8 +146,8 @@ var Pontoon = (function (my) {
      */
     getMachinery: function (original, target, loader) {
       var self = this,
-          tab_id = target || 'machinery',
-          loader = loader || 'helpers li a[href="#' + tab_id + '"]',
+          tab_id = target || 'helpers > .machinery',
+          loader = loader || 'helpers li a[href="#machinery"]',
           ul = $('#' + tab_id).find('ul').empty(),
           tab = $('#' + loader).addClass('loading'),
           requests = 0;
@@ -447,7 +447,7 @@ $(function() {
   // Menu search
   $('.menu input[type=search]').click(function (e) {
     e.stopPropagation();
-  }).keyup(function(e) {
+  }).on('keyup.search', function(e) {
     if (e.which === 9) {
       return;
     }
@@ -522,8 +522,26 @@ $(function() {
     ul.append(listitems);
   });
 
+  // Tabs
+  $(".tabs nav a").click(function (e) {
+    e.preventDefault();
+    e.stopPropagation();
+
+    var tab = $(this),
+        section = tab.attr('href').substr(1);
+
+    tab
+      .parents("li")
+        .siblings().removeClass('active').end()
+        .addClass('active').end()
+
+      .parents(".tabs")
+        .find('section').hide().end()
+        .find('section.' + section).show();
+  });
+
   // Toggle quality checks
-  $('.quality-checks').click(function() {
+  $('.check-box.quality-checks').click(function() {
     var self = $(this);
     Pontoon.startLoader();
 
@@ -538,6 +556,7 @@ $(function() {
           self.toggleClass('enabled');
           var status = self.is('.enabled') ? 'enabled' : 'disabled';
           Pontoon.endLoader('Quality checks ' + status + '.');
+          $('.notification').addClass('menu-open');
         }
       },
       error: function() {
@@ -573,6 +592,16 @@ $(function() {
     if ($('.menu').is(':visible')) {
       var menu = $('.menu:visible'),
           hovered = menu.find('li.hover');
+
+      // Skip for the Search project menu
+      if (menu.is('.search-project:visible').length) {
+        return;
+      }
+
+      // Skip for the tabs
+      if (menu.is('.tabs')) {
+        return;
+      }
 
       // Up arrow
       if (key === 38) {

--- a/pontoon/base/templates/locale_project.html
+++ b/pontoon/base/templates/locale_project.html
@@ -1,0 +1,29 @@
+{% extends "landing.html" %}
+
+{% block title %}Pontoon &middot; {{ project.name }} &middot; {{ locale.name }} ({{ locale.code }}){% endblock %}
+
+{% block class %}locale-project{% endblock %}
+
+{% block before %}
+<!-- Server data -->
+<div id="server" class="hidden"
+     {% if csrf_token %}data-csrf="{{ csrf_token }}"{% endif %}
+     >
+</div>
+{% endblock %}
+
+{% block subtitle %}{{ project.name }} &middot; {{ locale.name }} ({{ locale.code }}){% endblock %}
+
+{% block middle %}
+<div class="container">
+    {% include 'part_selector.html' %}
+</div>
+{% endblock %}
+
+{% block extend_css %}
+  {% stylesheet 'locale_project' %}
+{% endblock %}
+
+{% block extend_js %}
+  {% javascript 'locale_project' %}
+{% endblock %}

--- a/pontoon/base/templates/locale_selector.html
+++ b/pontoon/base/templates/locale_selector.html
@@ -29,14 +29,14 @@
     <ul>
       {% for l in locales %}
       <li class="clearfix{% if locale and locale == l %} current{% endif %}{% if l and l.chart %} filter{% endif %}">
-        <span class="language {{ l.code|lower }}">{% if l and l.chart %}<a href="{% if project %}{{ url('pontoon.translate', l.code, project.slug) }}{% else %}{{ url('pontoon.locale', l.code) }}{% endif %}" class="clearfix">{% endif %}{{ l.name }}{% if l and l.chart %}</a>{% endif %}</span>
-        <span class="code">{% if l and l.chart %}<a class="code" href="{% if project %}{{ url('pontoon.translate', l.code, project.slug) }}{% else %}{{ url('pontoon.locale', l.code) }}{% endif %}" class="clearfix">{% endif %}{{ l.code }}{% if l and l.chart %}</a>{% endif %}</span>
+        <span class="language {{ l.code|lower }}">{% if l and l.chart %}<a href="{% if project %}{{ url('pontoon.locale.project', l.code, project.slug) }}{% else %}{{ url('pontoon.locale', l.code) }}{% endif %}" class="clearfix">{% endif %}{{ l.name }}{% if l and l.chart %}</a>{% endif %}</span>
+        <span class="code">{% if l and l.chart %}<a class="code" href="{% if project %}{{ url('pontoon.locale.project', l.code, project.slug) }}{% else %}{{ url('pontoon.locale', l.code) }}{% endif %}" class="clearfix">{% endif %}{{ l.code }}{% if l and l.chart %}</a>{% endif %}</span>
         {% if not locale %}
           {{ latest_activity.span(l.latest_activity(project)) }}
         {% endif %}
         {% if l and l.chart and l.chart.total %}
         <span class="chart-wrapper">
-          {% if l and l.chart %}<a href="{% if project %}{{ url('pontoon.translate', l.code, project.slug) }}{% else %}{{ url('pontoon.locale', l.code) }}{% endif %}" class="clearfix">{% endif %}
+          {% if l and l.chart %}<a href="{% if project %}{{ url('pontoon.locale.project', l.code, project.slug) }}{% else %}{{ url('pontoon.locale', l.code) }}{% endif %}" class="clearfix">{% endif %}
           <span class="chart" data-chart="{{ l.chart|to_json }}">
             <span class="approved" style="width:{{ l.chart.approved / l.chart.total * 100 }}%;"></span>
             <span class="translated" style="width:{{ l.chart.translated / l.chart.total * 100 }}%;"></span>

--- a/pontoon/base/templates/part_selector.html
+++ b/pontoon/base/templates/part_selector.html
@@ -1,0 +1,97 @@
+{% import 'latest_activity.html' as latest_activity %}
+{% set search = request.GET.urlencode() %}
+
+<!-- Part selector -->
+<div class="part select">
+  {% if part %}
+  <div class="button breadcrumbs selector" title="{% if not search %}{{ part }}{% endif %}">
+    <div class="icon fa {% if search %}fa-search{% else %}fa-file-o{% endif %}"></div>
+    <span class="title noselect">{% if search %}{{ request.GET['keyword'] }}{% else %}{{ part.rsplit('/')[-1] }}{% endif %}</span>
+  </div>
+  {% endif %}
+
+  <div class="menu tabs">
+    <nav>
+      <ul>
+        <li class="active"><a href="#resources"><span class="fa fa-file-o"></span>Resources</a></li>
+        <li><a href="#search-project"><span class="fa fa-search"></span>Search</a></li>
+      </ul>
+    </nav>
+
+    <section class="resources">
+      <div class="search-wrapper clearfix">
+        <div class="icon fa fa-search"></div>
+        <input type="search" autocomplete="off" autofocus>
+      </div>
+
+      {% if not part %}
+      <div class="sort clearfix">
+        <span class="name asc">File Name<i class="fa"></i></span>
+        <span class="latest">Latest activity<i class="fa"></i></span>
+        <span class="progress">Progress<i class="fa"></i></span>
+      </div>
+      {% endif %}
+
+      <ul>
+        {% if not part %}
+        {% for p in parts %}
+        <li class="clearfix">
+          <span class="name">
+            <a href="{{ url('pontoon.translate', locale.code, project.slug, p['resource__path']) }}" class="clearfix">
+              {{ p['resource__path'] }}
+            </a>
+          </span>
+
+          {{ latest_activity.span(project.latest_activity(locale, p['resource__path'])) }}
+
+          <span class="chart-wrapper">
+            <a href="{{ url('pontoon.translate', locale.code, project.slug, p['resource__path']) }}" class="clearfix">
+              <span class="chart" data-chart="{{ {'translated': p['translated_count'], 'fuzzy': p['fuzzy_count'], 'total': p['resource__entity_count'], 'approved': p['approved_count']}|to_json }}">
+                <span class="approved" style="width:{{ p['approved_count'] / p['resource__entity_count'] * 100 }}%;"></span>
+                <span class="translated" style="width:{{ p['translated_count'] / p['resource__entity_count'] * 100 }}%;"></span>
+                <span class="fuzzy" style="width:{{ p['fuzzy_count'] / p['resource__entity_count'] * 100 }}%;"></span>
+              </span>
+              <span class="percent">{{ (p['approved_count'] / p['resource__entity_count'] * 100) | round(0, 'floor') | int }}%</span>
+            </a>
+          </span>
+        </li>
+        {% endfor %}
+        {% endif %}
+
+        <li class="no-match">No results</li>
+      </ul>
+    </section>
+
+    <section class="search-project">
+      <form class="search-form" method="get">
+        <div class="search-wrapper clearfix">
+          <div class="icon fa fa-search"></div>
+          <input type="search" autocomplete="off" autofocus name="keyword" value="{% if search %}{{ request.GET['keyword'] }}{% endif %}" placeholder="Search entire project">
+        </div>
+
+        <ul class="options">
+          <li data-name="sources" class="check-box{% if request.GET.get('sources', None) or not search %}{{ ' enabled' }}{% endif %}">
+            <i class="fa fa-fw"></i>Source strings
+            <input type="checkbox" name="sources"{% if request.GET.get('sources', None) or not search %}{{ ' checked' }}{% endif %}>
+          </li>
+          <li data-name="translations" class="check-box{% if request.GET.get('translations', None) or not search %}{{ ' enabled' }}{% endif %}">
+            <i class="fa fa-fw"></i>Translations
+            <input type="checkbox" name="translations"{% if request.GET.get('translations', None) or not search %}{{ ' checked' }}{% endif %}>
+          </li>
+          <li data-name="comments" class="check-box{% if request.GET.get('comments', None) %}{{ ' enabled' }}{% endif %}">
+            <i class="fa fa-fw"></i>Comments
+            <input type="checkbox" name="comments"{% if request.GET.get('comments', None) %}{{ ' checked' }}{% endif %}>
+          </li>
+          <li data-name="keys" class="check-box{% if request.GET.get('keys', None) %}{{ ' enabled' }}{% endif %}">
+            <i class="fa fa-fw"></i>Keys
+            <input type="checkbox" name="keys"{% if request.GET.get('keys', None) %}{{ ' checked' }}{% endif %}>
+          </li>
+          <li data-name="casesensitive" class="check-box{% if request.GET.get('casesensitive', None) %}{{ ' enabled' }}{% endif %}">
+            <i class="fa fa-fw"></i>Case sensitive
+            <input type="checkbox" name="casesensitive"{% if request.GET.get('casesensitive', None) %}{{ ' checked' }}{% endif %}>
+          </li>
+        </ul>
+      </form>
+    </section>
+  </div>
+</div>

--- a/pontoon/base/templates/project_selector.html
+++ b/pontoon/base/templates/project_selector.html
@@ -1,7 +1,7 @@
 {% import 'latest_activity.html' as latest_activity %}
 
 {% if projects|length > 0 %}
-<!-- Project select -->
+<!-- Project selector -->
 <div class="project select">
   {% if project and project.name != '' %}
   <div class="button breadcrumbs selector">
@@ -25,8 +25,8 @@
       <li class="clearfix{% if project and project == p %} current{% endif %}">
         <span class="name"
           data-slug="{{ p.slug }}"
-          {% if project %}data-details="{{ p.locales_parts_stats|to_json }}"{% endif %}>
-          {% if p and p.chart %}<a href="{% if locale %}{{ url('pontoon.translate', locale.code, p.slug) }}{% elif admin %}{{ url('pontoon.admin.project', p.slug) }}{% else %}{{ url('pontoon.project', p.slug) }}{% endif %}" class="clearfix">{% endif %}
+          {% if project %}data-details="{{ p.locales_parts_stats()|to_json }}"{% endif %}>
+          {% if p and p.chart %}<a href="{% if locale %}{{ url('pontoon.locale.project', locale.code, p.slug) }}{% elif admin %}{{ url('pontoon.admin.project', p.slug) }}{% else %}{{ url('pontoon.project', p.slug) }}{% endif %}" class="clearfix">{% endif %}
             {{ p.name }}
           {% if p and p.chart %}</a>{% endif %}
         </span>
@@ -35,7 +35,7 @@
         {% endif %}
         {% if p and p.chart and p.chart.total %}
         <span class="chart-wrapper">
-          {% if p and p.chart %}<a href="{% if locale %}{{ url('pontoon.translate', locale.code, p.slug) }}{% elif admin %}{{ url('pontoon.admin.project', p.slug) }}{% else %}{{ url('pontoon.project', p.slug) }}{% endif %}" class="clearfix">{% endif %}
+          {% if p and p.chart %}<a href="{% if locale %}{{ url('pontoon.locale.project', locale.code, p.slug) }}{% elif admin %}{{ url('pontoon.admin.project', p.slug) }}{% else %}{{ url('pontoon.project', p.slug) }}{% endif %}" class="clearfix">{% endif %}
           <span class="chart" data-chart="{{ p.chart|to_json }}">
             <span class="approved" style="width:{{ p.chart.approved / p.chart.total * 100 }}%;"></span>
             <span class="translated" style="width:{{ p.chart.translated / p.chart.total * 100 }}%;"></span>

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -15,6 +15,7 @@
      {% if project.width %}data-width="{{ project.width }}"{% endif %}
      {% if project.links %}data-links="{{ project.links|lower }}"{% endif %}
      {% if part %}data-part="{{ part }}"{% endif %}
+     {% if search %}data-search="{{ search }}"{% endif %}
      {% if redirect %}data-redirect="{{ redirect }}"{% endif %}
      {% if user.email %}data-email="{{ user.email }}"{% endif %}
      {% if user.first_name %}data-name="{{ user.first_name }}"{% endif %}
@@ -32,21 +33,7 @@
 
     {% include 'locale_selector.html' %}
 
-    <!-- Part selector -->
-    <div class="part select{% if not part %} hidden{% endif %}">
-      <div class="button breadcrumbs selector" title="{{ part }}">
-        <span class="title noselect">{% if part %}{{ part.rsplit('/')[-1] }}{% endif %}</span>
-      </div>
-      <div class="menu">
-        <div class="search-wrapper clearfix">
-          <div class="icon fa fa-search"></div>
-          <input type="search" autocomplete="off">
-        </div>
-        <ul>
-          <li class="no-match">No results</li>
-        </ul>
-      </div>
-    </div>
+    {% include 'part_selector.html' %}
 
     <!-- Go -->
     <div class="go select">
@@ -114,7 +101,7 @@
           <ul>
             {% if user.is_authenticated() %}
             <li data-url="{{ url('pontoon.profile') }}"><i class="fa fa-user fa-fw"></i>View profile</li>
-            <li class="quality-checks{% if user.profile.quality_checks %} enabled{% endif %}"><i class="fa fa-fw"></i>Quality checks</li>
+            <li class="quality-checks check-box{% if user.profile.quality_checks %} enabled{% endif %}"><i class="fa fa-fw"></i>Quality checks</li>
             <li class="horizontal-separator"></li>
             {% endif %}
 
@@ -144,7 +131,6 @@
             {% else %}
             <li class="sign-in"><i class="fa fa-sign-in fa-fw"></i>Sign in</li>
             {% endif %}
-
           </ul>
         </div>
 
@@ -282,29 +268,29 @@
       <button id="save">Save</button>
     </menu>
 
-    <div id="helpers">
+    <div id="helpers" class="tabs">
       <nav>
         <ul>
-          <li class="active"><a href="#history"><span>History<span class="fa fa-cog fa-lg fa-spin"></span></a></span></li>
-          <li><a href="#machinery"><span>Machinery<span class="fa fa-cog fa-lg fa-spin"></span></a></span></li>
-          <li><a href="#other-locales"><span>Locales<span class="fa fa-cog fa-lg fa-spin"></span></a></span></li>
-          <li><a href="#custom-search"><span>Search<span class="fa fa-cog fa-lg fa-spin"></span></a></span></li>
+          <li class="active"><a href="#history"><span>History<span class="fa fa-cog fa-lg fa-spin"></span></span></a></li>
+          <li><a href="#machinery"><span>Machinery<span class="fa fa-cog fa-lg fa-spin"></span></span></a></li>
+          <li><a href="#other-locales"><span>Locales<span class="fa fa-cog fa-lg fa-spin"></span></span></a></li>
+          <li><a href="#custom-search"><span>Search<span class="fa fa-cog fa-lg fa-spin"></span></span></a></li>
         </ul>
       </nav>
 
-      <section id="history">
+      <section class="history">
         <ul></ul>
       </section>
 
-      <section id="machinery">
+      <section class="machinery">
         <ul></ul>
       </section>
 
-      <section id="other-locales">
+      <section class="other-locales">
         <ul></ul>
       </section>
 
-      <section id="custom-search">
+      <section class="custom-search">
         <div class="search-wrapper clearfix">
           <div class="icon fa fa-search"></div>
           <div class="icon fa fa-cog fa-spin"></div>
@@ -346,6 +332,7 @@
 
 {% block extend_js %}
   {% javascript 'translate' %}
+  {% javascript 'locale_project' %}
 
   <script src="https://login.persona.org/include.js"></script>
 {% endblock %}

--- a/pontoon/base/templates/user.html
+++ b/pontoon/base/templates/user.html
@@ -39,7 +39,7 @@
   <li><span class="fa fa-fw fa-envelope"></span><a href="mailto:{{ contributor.email }}">{{ contributor.email }}</a></li>
   <li><span class="fa fa-fw fa-lock"></span>Can submit {% if contributor.has_perm('base.can_localize') %}and approve {% endif %}translations</li>
   {% if user.is_authenticated() and user.email == contributor.email %}
-  <li class="quality-checks{% if user.profile.quality_checks %} enabled{% endif %}"><span class="fa fa-fw"></span>Quality checks</li>
+  <li class="check-box quality-checks{% if user.profile.quality_checks %} enabled{% endif %}"><span class="fa fa-fw"></span>Quality checks</li>
   {% endif %}
 </ul>
 
@@ -95,7 +95,7 @@
             <figcaption>{{ event.date.strftime('%H:%M') }}</figcaption>
           </figure>
           {% if event.project %}
-            <a href="{{ url('pontoon.translate', event.translation.locale.code, event.project.slug) }}">{{ event.project.name }}</a>
+            <a href="{{ url('pontoon.translate', event.translation.locale.code, event.project.slug, event.translation.entity.resource.path) }}">{{ event.project.name }}</a>
           {% endif %}
         </div>
       </div>

--- a/pontoon/base/tests/test_models.py
+++ b/pontoon/base/tests/test_models.py
@@ -117,16 +117,18 @@ class ProjectPartsTests(TestCase):
             pk__in=resources
         )
 
-        return self.project.locales_parts_stats
+        return self.project.locales_parts_stats()
 
     def test_locales_parts_stats_no_page_one_resource(self):
         """
-        Return empty list in no subpage and only one resource defined.
+        Return resource paths and stats in no subpage and one resource defined.
         """
         project_details = self._fetch_locales_parts_stats()
         details = project_details.get(self.locale.code)
 
-        assert_equal(details, [])
+        assert_equal(len(details), 1)
+        assert_equal(details[0]['resource__path'], '/main/path.po')
+        assert_equal(details[0]['translated_count'], 0)
 
     def test_locales_parts_stats_no_page_multiple_resources(self):
         """

--- a/pontoon/base/urls.py
+++ b/pontoon/base/urls.py
@@ -49,15 +49,15 @@ urlpatterns = patterns(
         views.project,
         name='pontoon.project'),
 
-    # Translate project's part
+    # Translate project
     url(r'^(?P<locale>[A-Za-z0-9\-\@\.]+)/(?P<slug>[\w-]+)/(?P<part>.+)/$',
         views.translate,
-        name='pontoon.translate.part'),
-
-    # Translate project
-    url(r'^(?P<locale>[A-Za-z0-9\-\@\.]+)/(?P<slug>[\w-]+)/$',
-        views.translate,
         name='pontoon.translate'),
+
+    # Locale-project dashboard
+    url(r'^(?P<locale>[A-Za-z0-9\-\@\.]+)/(?P<slug>[\w-]+)/$',
+        views.locale_project,
+        name='pontoon.locale.project'),
 
     # List contributors
     url(r'^contributors/$',

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -210,6 +210,12 @@ PIPELINE_CSS = {
         ),
         'output_filename': 'css/admin_project.min.css',
     },
+    'locale_project': {
+        'source_filenames': (
+            'css/locale_project.css',
+        ),
+        'output_filename': 'css/locale_project.min.css',
+    },
     'locales': {
         'source_filenames': (
             'css/locales.css',
@@ -255,6 +261,12 @@ PIPELINE_JS = {
             'js/jquery.timeago.js',
         ),
         'output_filename': 'js/main.min.js',
+    },
+    'locale_project': {
+        'source_filenames': (
+            'js/locale_project.js',
+        ),
+        'output_filename': 'js/locale_project.min.js',
     },
     'project': {
         'source_filenames': (


### PR DESCRIPTION
This brings search across entire project, one of the most requested features by localizers. Full description is available as part of 3 commit messages. (I don't know how 9289678 ended up there, please ignore it before I remove it from this PR.)

@Osmose, I'd like to hear your feedback.

I decided to stick with my original plan of having joint Search and Resources/Subpages menu. Having separate menus is problematic, because it doesn't allow selecting resources when you're on the results page. I will however change the design to put resource selection and search in tabs.

For now it only searches original strings. I'd like to add options for searching translations, suggestions, comments, keys, and search case sensitive.

I'll add and update tests before asking for full code review.