### PR TITLE
Fix bug 1190572: Replace untranslated icon

### DIFF
--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -235,7 +235,7 @@ body > header .locale.select {
 
 .status:before {
   color: #FD5F60;
-  content: "";
+  content: "";
 }
 
 .translated .status:before {


### PR DESCRIPTION
Untranslated icon looked like a prohibitive road sign, giving the
impression of "Don't come in here, you don't have a permission to enter".
It was also clashing with unchecked status of our custom checkbox (used
e.g. for enabling/disabling quality checks).

I dare to merge this.