### PR TITLE
pep8 and pyflakes cleanups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
 before_script:
   - psql -c 'create database pontoon;' -U postgres
 script:
+  - pylama
   - python manage.py test
 addons:
   postgresql: "9.4"

--- a/bin/dump-verbatim.py
+++ b/bin/dump-verbatim.py
@@ -7,7 +7,6 @@ from optparse import make_option
 from pootle_store.models import Store, Unit
 
 import codecs
-import io
 import json
 import subprocess
 

--- a/pontoon/administration/files.py
+++ b/pontoon/administration/files.py
@@ -1,5 +1,4 @@
 import codecs
-import configparser
 import datetime
 import fnmatch
 import logging
@@ -91,9 +90,6 @@ def get_locale_directory(project, locale):
                 'path': os.path.join(root, dirname),
             }
 
-    # Projects not using locale directories (format=file)
-    formats = Resource.objects.filter(project=project).values_list(
-        'format', flat=True).distinct()
     if project.repository_type == 'file':
         return {
             'name': '',
@@ -308,7 +304,7 @@ def extract_po(project, locale, path, entities=False):
             update_stats(resource, locale)
 
         log.debug("[" + locale.code + "]: " + path + " saved to DB.")
-    except Exception as e:
+    except Exception:
         log.critical('PoExtractError for %s: %s' % (path, e))
 
 
@@ -651,7 +647,8 @@ def extract_to_database(project, locales=None):
             paths = source_paths
             entities = True
         else:
-            paths = get_locale_paths(project, locale, source_paths, source_directory['name'])
+            paths = get_locale_paths(
+                project, locale, source_paths, source_directory['name'])
             entities = isFile
 
         for path in paths:
@@ -742,7 +739,7 @@ def dump_po(project, locale, relative_path):
                     if 'fuzzy' in entry.flags:
                         entry.flags.remove('fuzzy')
 
-                except Translation.DoesNotExist as e:
+                except Translation.DoesNotExist:
                     pass
 
             else:
@@ -760,7 +757,7 @@ def dump_po(project, locale, relative_path):
                             if 'fuzzy' in entry.flags:
                                 entry.flags.remove('fuzzy')
 
-                        except Translation.DoesNotExist as e:
+                        except Translation.DoesNotExist:
                             pass
 
                     # Remove obsolete plural forms if exist
@@ -791,7 +788,6 @@ def dump_xliff(project, locale, relative_path):
     locale_directory_path = get_locale_directory(project, locale)["path"]
     path = os.path.join(locale_directory_path, relative_path)
     resource = Resource.objects.filter(project=project, path=relative_path)
-    entities = Entity.objects.filter(resource=resource, obsolete=False)
 
     with open(path, 'r+') as f:
         xf = xliff.xlifffile(f)
@@ -806,7 +802,7 @@ def dump_xliff(project, locale, relative_path):
             try:
                 entity = Entity.objects.get(resource=resource, key=key)
 
-            except Entity.DoesNotExist as e:
+            except Entity.DoesNotExist:
                 log.error('%s: Entity "%s" does not exist' % (path, original))
                 continue
 
@@ -816,7 +812,7 @@ def dump_xliff(project, locale, relative_path):
                     .latest('date').string
                 unit.settarget(translation)
 
-            except Translation.DoesNotExist as e:
+            except Translation.DoesNotExist:
                 # Remove "approved" attribute
                 try:
                     del unit.xmlelement.attrib['approved']
@@ -861,7 +857,7 @@ def dump_silme(parser, project, locale, relative_path):
                         .latest('date')
                     structure.modify_entity(key, translation.string)
 
-                except Translation.DoesNotExist as e:
+                except Translation.DoesNotExist:
                     # Remove untranslated and following newline
                     pos = structure.entity_pos(key)
                     structure.remove_entity(key)
@@ -879,7 +875,7 @@ def dump_silme(parser, project, locale, relative_path):
                             structure.remove_element(pos)
 
             # Obsolete entities
-            except KeyError as e:
+            except KeyError:
                 pass
 
         # Erase file and then write, otherwise content gets appended
@@ -924,7 +920,7 @@ def dump_lang(project, locale, relative_path):
 
     try:
         resource = Resource.objects.get(project=project, path=relative_path)
-    except Resource.DoesNotExist as e:
+    except Resource.DoesNotExist:
         log.info("Resource does not exist")
         return
 
@@ -952,7 +948,7 @@ def dump_lang(project, locale, relative_path):
                 try:
                     entity = Entity.objects.get(
                         resource=resource, string=original)
-                except Entity.DoesNotExist as e:
+                except Entity.DoesNotExist:
                     log.error('%s: Entity "%s" does not exist' %
                               (path, original))
                     continue
@@ -965,7 +961,7 @@ def dump_lang(project, locale, relative_path):
                     if translation == original:
                         translation += ' {ok}'
 
-                except Translation.DoesNotExist as e:
+                except Translation.DoesNotExist:
                     translation = original
 
         # Erase file and then write, otherwise content gets appended
@@ -989,9 +985,6 @@ def dump_l20n(project, locale, relative_path):
         structure = parser.parse(f.read())
         ast = L20nast
 
-        resource = Resource.objects.filter(project=project, path=relative_path)
-        entities = Entity.objects.filter(resource=resource, obsolete=False)
-
         for obj in structure.body:
             if obj.type == "Entity":
 
@@ -1006,7 +999,7 @@ def dump_l20n(project, locale, relative_path):
                             .latest('date')
                         attr.value.content[0] = translation.string
 
-                    except Translation.DoesNotExist as e:
+                    except Translation.DoesNotExist:
                         # Remove untranslated
                         obj.attrs.remove(attr)
 
@@ -1021,7 +1014,7 @@ def dump_l20n(project, locale, relative_path):
                             .latest('date')
                         obj.value.content[0] = translation.string
 
-                    except Translation.DoesNotExist as e:
+                    except Translation.DoesNotExist:
                         # Remove untranslated
                         obj.value = None
 
@@ -1053,7 +1046,7 @@ def dump_l20n(project, locale, relative_path):
                             )
                             obj.value.items.append(hashItem)
 
-                        except Translation.DoesNotExist as e:
+                        except Translation.DoesNotExist:
                             # Untranslated already removed on empty items
                             pass
 
@@ -1107,7 +1100,7 @@ def dump_inc(project, locale, relative_path):
                         entity=e, locale=locale, approved=True) \
                         .latest('date').string
                     line = '#define %s %s\n' % (key, translation)
-                except Translation.DoesNotExist as e:
+                except Translation.DoesNotExist:
                     line = original
                     pass
 

--- a/pontoon/administration/management/commands/commit_projects.py
+++ b/pontoon/administration/management/commands/commit_projects.py
@@ -1,8 +1,6 @@
-
-import datetime
-
 from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand, CommandError
+
 from pontoon.administration.files import dump_from_database, update_from_repository, extract_to_database
 from pontoon.administration.vcs import commit_to_vcs
 from pontoon.base.models import (

--- a/pontoon/administration/management/commands/import_verbatim.py
+++ b/pontoon/administration/management/commands/import_verbatim.py
@@ -2,8 +2,6 @@ from datetime import datetime
 from django.contrib.auth.models import Permission, User
 from django.core.management.base import (
     BaseCommand,
-    CommandError,
-    NoArgsCommand,
 )
 from pontoon.base.models import Translation
 

--- a/pontoon/administration/management/commands/update_projects.py
+++ b/pontoon/administration/management/commands/update_projects.py
@@ -1,6 +1,3 @@
-
-import datetime
-
 from django.core.management.base import BaseCommand, CommandError
 
 from pontoon.administration.files import (

--- a/pontoon/administration/models.py
+++ b/pontoon/administration/models.py
@@ -1,3 +1,0 @@
-from django.db import models
-
-# Create your models here.

--- a/pontoon/administration/tests/test_vcs.py
+++ b/pontoon/administration/tests/test_vcs.py
@@ -6,6 +6,7 @@ from pontoon.base.tests import CONTAINS, TestCase
 
 
 class VCSRepositoryTests(TestCase):
+
     def test_execute_log_error(self):
         """
         If the return code from execute is non-zero and log_errors is
@@ -14,10 +15,11 @@ class VCSRepositoryTests(TestCase):
         repo = VCSRepository('/path')
 
         with patch('pontoon.administration.vcs.execute') as mock_execute, \
-             patch('pontoon.administration.vcs.log') as mock_log:
+                patch('pontoon.administration.vcs.log') as mock_log:
             mock_execute.return_value = 1, 'output', 'stderr'
             assert_equal(
                 repo.execute('command', cwd='working_dir', log_errors=True),
                 (1, 'output', 'stderr')
             )
-            mock_log.error.assert_called_with(CONTAINS('stderr', 'command', 'working_dir'))
+            mock_log.error.assert_called_with(
+                CONTAINS('stderr', 'command', 'working_dir'))

--- a/pontoon/administration/views.py
+++ b/pontoon/administration/views.py
@@ -1,8 +1,6 @@
 import base64
 import json
 import logging
-import os
-import shutil
 import traceback
 
 from django.core.urlresolvers import reverse
@@ -24,7 +22,6 @@ from pontoon.base.models import (
     Entity,
     Locale,
     Project,
-    Repository,
     Resource,
     UserProfile,
     get_projects_with_stats,
@@ -90,7 +87,6 @@ def manage_project(request, slug=None, template='admin_project.html'):
     subtitle = 'Add project'
     pk = None
     project = None
-    message = 'Please wait while strings are imported from the repository.'
 
     # Save project
     if request.method == 'POST':
@@ -103,8 +99,10 @@ def manage_project(request, slug=None, template='admin_project.html'):
             project = Project.objects.get(pk=pk)
             form = ProjectForm(request.POST, instance=project)
             # Needed if form invalid
-            subpage_formset = SubpageInlineFormSet(request.POST, instance=project)
-            repo_formset = RepositoryInlineFormSet(request.POST, instance=project)
+            subpage_formset = SubpageInlineFormSet(
+                request.POST, instance=project)
+            repo_formset = RepositoryInlineFormSet(
+                request.POST, instance=project)
             subtitle = 'Edit project'
 
         # Add a new project
@@ -116,8 +114,10 @@ def manage_project(request, slug=None, template='admin_project.html'):
 
         if form.is_valid():
             project = form.save(commit=False)
-            subpage_formset = SubpageInlineFormSet(request.POST, instance=project)
-            repo_formset = RepositoryInlineFormSet(request.POST, instance=project)
+            subpage_formset = SubpageInlineFormSet(
+                request.POST, instance=project)
+            repo_formset = RepositoryInlineFormSet(
+                request.POST, instance=project)
 
             if subpage_formset.is_valid() and repo_formset.is_valid():
                 project.save()
@@ -125,7 +125,8 @@ def manage_project(request, slug=None, template='admin_project.html'):
                 form.save_m2m()
                 subpage_formset.save()
                 repo_formset.save()
-                # Properly displays formsets, but removes errors (if valid only)
+                # Properly displays formsets, but removes errors (if valid
+                # only)
                 subpage_formset = SubpageInlineFormSet(instance=project)
                 repo_formset = RepositoryInlineFormSet(instance=project)
                 subtitle += '. Saved.'

--- a/pontoon/base/formats/po.py
+++ b/pontoon/base/formats/po.py
@@ -100,7 +100,6 @@ def parse(path, source_path=None):
     try:
         pofile = polib.pofile(path)
     except IOError as err:
-        wrapped = ParseError(u'Failed to parse {path}: {err}'.format(path=path, err=err))
-        raise wrapped, None, sys.exc_info()[2]
+        raise ParseError(u'Failed to parse {path}: {err}'.format(path=path, err=err)), None, sys.exc_info()[2]
 
     return POResource(pofile)

--- a/pontoon/base/migrations/0001_initial.py
+++ b/pontoon/base/migrations/0001_initial.py
@@ -15,7 +15,8 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Entity',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.AutoField(verbose_name='ID',
+                                        serialize=False, auto_created=True, primary_key=True)),
                 ('string', models.TextField()),
                 ('string_plural', models.TextField(blank=True)),
                 ('key', models.TextField(blank=True)),
@@ -28,7 +29,8 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Locale',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.AutoField(verbose_name='ID',
+                                        serialize=False, auto_created=True, primary_key=True)),
                 ('code', models.CharField(unique=True, max_length=20)),
                 ('name', models.CharField(max_length=128)),
                 ('nplurals', models.SmallIntegerField(null=True, blank=True)),
@@ -38,18 +40,26 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Project',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.AutoField(verbose_name='ID',
+                                        serialize=False, auto_created=True, primary_key=True)),
                 ('name', models.CharField(unique=True, max_length=128)),
                 ('slug', models.SlugField(unique=True)),
-                ('repository_type', models.CharField(default=b'File', max_length=20, verbose_name=b'Type', choices=[(b'file', b'File'), (b'git', b'Git'), (b'hg', b'HG'), (b'svn', b'SVN'), (b'transifex', b'Transifex')])),
-                ('repository_url', models.CharField(max_length=2000, verbose_name=b'URL', blank=True)),
+                ('repository_type', models.CharField(default=b'File', max_length=20, verbose_name=b'Type', choices=[
+                 (b'file', b'File'), (b'git', b'Git'), (b'hg', b'HG'), (b'svn', b'SVN'), (b'transifex', b'Transifex')])),
+                ('repository_url', models.CharField(
+                    max_length=2000, verbose_name=b'URL', blank=True)),
                 ('repository_path', models.TextField(blank=True)),
-                ('transifex_project', models.CharField(max_length=128, verbose_name=b'Project', blank=True)),
-                ('transifex_resource', models.CharField(max_length=128, verbose_name=b'Resource', blank=True)),
-                ('info_brief', models.TextField(verbose_name=b'Project info', blank=True)),
+                ('transifex_project', models.CharField(
+                    max_length=128, verbose_name=b'Project', blank=True)),
+                ('transifex_resource', models.CharField(
+                    max_length=128, verbose_name=b'Resource', blank=True)),
+                ('info_brief', models.TextField(
+                    verbose_name=b'Project info', blank=True)),
                 ('url', models.URLField(verbose_name=b'URL', blank=True)),
-                ('width', models.PositiveIntegerField(null=True, verbose_name=b'Default website (iframe) width in pixels. If set,         sidebar will be opened by default.', blank=True)),
-                ('links', models.BooleanField(verbose_name=b'Keep links on the project website clickable')),
+                ('width', models.PositiveIntegerField(
+                    null=True, verbose_name=b'Default website (iframe) width in pixels. If set,         sidebar will be opened by default.', blank=True)),
+                ('links', models.BooleanField(
+                    verbose_name=b'Keep links on the project website clickable')),
                 ('disabled', models.BooleanField(default=False)),
                 ('locales', models.ManyToManyField(to='base.Locale')),
             ],
@@ -60,17 +70,20 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Resource',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.AutoField(verbose_name='ID',
+                                        serialize=False, auto_created=True, primary_key=True)),
                 ('path', models.TextField()),
                 ('entity_count', models.PositiveIntegerField(default=0)),
-                ('format', models.CharField(blank=True, max_length=20, verbose_name=b'Format', choices=[(b'po', b'po'), (b'properties', b'properties'), (b'dtd', b'dtd'), (b'ini', b'ini'), (b'lang', b'lang')])),
+                ('format', models.CharField(blank=True, max_length=20, verbose_name=b'Format', choices=[
+                 (b'po', b'po'), (b'properties', b'properties'), (b'dtd', b'dtd'), (b'ini', b'ini'), (b'lang', b'lang')])),
                 ('project', models.ForeignKey(to='base.Project')),
             ],
         ),
         migrations.CreateModel(
             name='Stats',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.AutoField(verbose_name='ID',
+                                        serialize=False, auto_created=True, primary_key=True)),
                 ('translated_count', models.PositiveIntegerField(default=0)),
                 ('approved_count', models.PositiveIntegerField(default=0)),
                 ('fuzzy_count', models.PositiveIntegerField(default=0)),
@@ -81,7 +94,8 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Subpage',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.AutoField(verbose_name='ID',
+                                        serialize=False, auto_created=True, primary_key=True)),
                 ('name', models.CharField(max_length=128)),
                 ('url', models.URLField(verbose_name=b'URL', blank=True)),
                 ('project', models.ForeignKey(to='base.Project')),
@@ -90,25 +104,30 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Translation',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.AutoField(verbose_name='ID',
+                                        serialize=False, auto_created=True, primary_key=True)),
                 ('string', models.TextField()),
                 ('plural_form', models.SmallIntegerField(null=True, blank=True)),
                 ('date', models.DateTimeField()),
                 ('approved', models.BooleanField(default=False)),
                 ('approved_date', models.DateTimeField(null=True, blank=True)),
                 ('fuzzy', models.BooleanField(default=False)),
-                ('approved_user', models.ForeignKey(related_name='approvers', blank=True, to=settings.AUTH_USER_MODEL, null=True)),
+                ('approved_user', models.ForeignKey(related_name='approvers',
+                                                    blank=True, to=settings.AUTH_USER_MODEL, null=True)),
                 ('entity', models.ForeignKey(to='base.Entity')),
                 ('locale', models.ForeignKey(to='base.Locale')),
-                ('user', models.ForeignKey(blank=True, to=settings.AUTH_USER_MODEL, null=True)),
+                ('user', models.ForeignKey(blank=True,
+                                           to=settings.AUTH_USER_MODEL, null=True)),
             ],
         ),
         migrations.CreateModel(
             name='UserProfile',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.AutoField(verbose_name='ID',
+                                        serialize=False, auto_created=True, primary_key=True)),
                 ('transifex_username', models.CharField(max_length=40, blank=True)),
-                ('transifex_password', models.CharField(max_length=128, blank=True)),
+                ('transifex_password', models.CharField(
+                    max_length=128, blank=True)),
                 ('svn_username', models.CharField(max_length=40, blank=True)),
                 ('svn_password', models.CharField(max_length=128, blank=True)),
                 ('quality_checks', models.BooleanField(default=True)),

--- a/pontoon/base/migrations/0002_initial_data.py
+++ b/pontoon/base/migrations/0002_initial_data.py
@@ -31,7 +31,8 @@ def load_initial_data(apps, schema_editor):
     # model. Our workaround is to use the auto-generated intermediate
     # model directly to create the relation between project and locales.
     locale = Locale.objects.get(code='en-GB')
-    Project.locales.through.objects.create(project_id=project.id, locale_id=locale.id)
+    Project.locales.through.objects.create(
+        project_id=project.id, locale_id=locale.id)
 
 
 class Migration(migrations.Migration):

--- a/pontoon/base/migrations/0003_auto_user_profile_related_name.py
+++ b/pontoon/base/migrations/0003_auto_user_profile_related_name.py
@@ -15,6 +15,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='userprofile',
             name='user',
-            field=models.OneToOneField(related_name='profile', to=settings.AUTH_USER_MODEL),
+            field=models.OneToOneField(
+                related_name='profile', to=settings.AUTH_USER_MODEL),
         ),
     ]

--- a/pontoon/base/migrations/0004_auto_20150515_0927.py
+++ b/pontoon/base/migrations/0004_auto_20150515_0927.py
@@ -14,6 +14,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='resource',
             name='format',
-            field=models.CharField(blank=True, max_length=20, verbose_name=b'Format', choices=[(b'po', b'po'), (b'xliff', b'xliff'), (b'properties', b'properties'), (b'dtd', b'dtd'), (b'ini', b'ini'), (b'lang', b'lang')]),
+            field=models.CharField(blank=True, max_length=20, verbose_name=b'Format', choices=[(
+                b'po', b'po'), (b'xliff', b'xliff'), (b'properties', b'properties'), (b'dtd', b'dtd'), (b'ini', b'ini'), (b'lang', b'lang')]),
         ),
     ]

--- a/pontoon/base/migrations/0006_auto_20150602_0616.py
+++ b/pontoon/base/migrations/0006_auto_20150602_0616.py
@@ -14,6 +14,8 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='resource',
             name='format',
-            field=models.CharField(blank=True, max_length=20, verbose_name=b'Format', choices=[(b'po', b'po'), (b'xliff', b'xliff'), (b'properties', b'properties'), (b'dtd', b'dtd'), (b'inc', b'inc'), (b'ini', b'ini'), (b'lang', b'lang')]),
+            field=models.CharField(blank=True, max_length=20, verbose_name=b'Format',
+                                   choices=[(b'po', b'po'), (b'xliff', b'xliff'), (b'properties', b'properties'),
+                                            (b'dtd', b'dtd'), (b'inc', b'inc'), (b'ini', b'ini'), (b'lang', b'lang')]),
         ),
     ]

--- a/pontoon/base/migrations/0007_auto_20150710_0944.py
+++ b/pontoon/base/migrations/0007_auto_20150710_0944.py
@@ -15,12 +15,14 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='locale',
             name='cldr_plurals',
-            field=models.CommaSeparatedIntegerField(blank=True, max_length=11, verbose_name=b'CLDR Plurals', validators=[pontoon.base.models.validate_cldr]),
+            field=models.CommaSeparatedIntegerField(
+                blank=True, max_length=11, verbose_name=b'CLDR Plurals', validators=[pontoon.base.models.validate_cldr]),
         ),
         migrations.AlterField(
             model_name='resource',
             name='format',
-            field=models.CharField(blank=True, max_length=20, verbose_name=b'Format', choices=[(b'po', b'po'), (b'xliff', b'xliff'), (b'properties', b'properties'), (b'dtd', b'dtd'), (b'inc', b'inc'), (b'ini', b'ini'), (b'lang', b'lang'), (b'l20n', b'l20n')]),
+            field=models.CharField(blank=True, max_length=20, verbose_name=b'Format', choices=[(b'po', b'po'), (b'xliff', b'xliff'), (
+                b'properties', b'properties'), (b'dtd', b'dtd'), (b'inc', b'inc'), (b'ini', b'ini'), (b'lang', b'lang'), (b'l20n', b'l20n')]),
         ),
         migrations.AlterField(
             model_name='translation',

--- a/pontoon/base/migrations/0008_auto_20150710_0946.py
+++ b/pontoon/base/migrations/0008_auto_20150710_0946.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import migrations
 
 
 def add_cldr_plurals_to_locales(apps, schema_editor):

--- a/pontoon/base/migrations/0010_translation_extra.py
+++ b/pontoon/base/migrations/0010_translation_extra.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import migrations
 import jsonfield.fields
 import pontoon.base.models
 
@@ -16,6 +16,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='translation',
             name='extra',
-            field=jsonfield.fields.JSONField(default=pontoon.base.models.extra_default),
+            field=jsonfield.fields.JSONField(
+                default=pontoon.base.models.extra_default),
         ),
     ]

--- a/pontoon/base/migrations/0011_auto_20150803_1524.py
+++ b/pontoon/base/migrations/0011_auto_20150803_1524.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import migrations
 
 
 class Migration(migrations.Migration):

--- a/pontoon/base/migrations/0012_auto_20150804_0859.py
+++ b/pontoon/base/migrations/0012_auto_20150804_0859.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import migrations
 
 
 def remove_unused_locales(apps, schema_editor):
@@ -20,25 +20,25 @@ class Migration(migrations.Migration):
     ]
 
 UNUSED_LOCALES = [u'af-ZA', u'aln', u'am', u'am-ET', u'ar-SA', u'arn', u'as-IN',
-    u'az-AZ', u'bal', u'be-BY', u'be@tarask', u'bg-BG', u'bn', u'bo', u'bo-CN',
-    u'bs-BA', u'ca-ES', u'ca@valencia', u'crh', u'cs-CZ', u'cy-GB', u'da-DK',
-    u'de-CH', u'de-DE', u'dz', u'dz-BT', u'el-GR', u'en', u'en-AU', u'en-CA',
-    u'en-IE', u'en-US', u'es-BO', u'es-CO', u'es-CR', u'es-DO', u'es-EC',
-    u'es-NI', u'es-PA', u'es-PE', u'es-PR', u'es-PY', u'es-SV', u'es-UY',
-    u'es-VE', u'et-EE', u'eu-ES', u'fa-IR', u'fi-FI', u'fil', u'fo', u'fo-FO',
-    u'fr-CA', u'fr-CH', u'fr-FR', u'frp', u'gl-ES', u'gu', u'gun', u'ha',
-    u'he-IL', u'hi', u'hne', u'hr-HR', u'ht-HT', u'hu-HU', u'hy', u'ia',
-    u'id-ID', u'ig', u'is-IS', u'it-IT', u'ja-JP', u'jv', u'ka-GE', u'kk-KZ',
-    u'km-KH', u'kn-IN', u'ko-KR', u'ks', u'ks-IN', u'ku-IQ', u'kw', u'ky',
-    u'la', u'lb', u'li', u'ln', u'lo', u'lo-LA', u'lt-LT', u'lv-LV', u'mg',
-    u'mi', u'mk-MK', u'ml-IN', u'mn-MN', u'mr-IN', u'ms-MY', u'mt', u'mt-MT',
-    u'my-MM', u'nah', u'nap', u'nb', u'nds', u'ne', u'nl-BE', u'nl-NL', u'nn',
-    u'no', u'no-NO', u'nr', u'or-IN', u'pap', u'pl-PL', u'pms', u'ps',
-    u'ro-RO', u'ru-RU', u'rw', u'sc', u'sco', u'se', u'si-LK', u'sk-SK',
-    u'sl-SI', u'sm', u'sn', u'so', u'sq-AL', u'sr-RS', u'sr-RS@latin',
-    u'sr@latin', u'st', u'st-ZA', u'su', u'sv', u'sv-FI', u'sw-KE', u'ta-IN',
-    u'te-IN', u'tg', u'tg-TJ', u'th-TH', u'ti', u'tk', u'tl', u'tl-PH', u'tlh',
-    u'to', u'tr-TR', u'tt', u'ug', u'uk-UA', u'ur-PK', u've', u'vi-VN', u'vls',
-    u'wa', u'wo-SN', u'yi', u'yo', u'zh', u'zh-CN.GB2312', u'zh-HK',
-    u'zh-TW.Big5', u'zu-ZA'
-]
+                  u'az-AZ', u'bal', u'be-BY', u'be@tarask', u'bg-BG', u'bn', u'bo', u'bo-CN',
+                  u'bs-BA', u'ca-ES', u'ca@valencia', u'crh', u'cs-CZ', u'cy-GB', u'da-DK',
+                  u'de-CH', u'de-DE', u'dz', u'dz-BT', u'el-GR', u'en', u'en-AU', u'en-CA',
+                  u'en-IE', u'en-US', u'es-BO', u'es-CO', u'es-CR', u'es-DO', u'es-EC',
+                  u'es-NI', u'es-PA', u'es-PE', u'es-PR', u'es-PY', u'es-SV', u'es-UY',
+                  u'es-VE', u'et-EE', u'eu-ES', u'fa-IR', u'fi-FI', u'fil', u'fo', u'fo-FO',
+                  u'fr-CA', u'fr-CH', u'fr-FR', u'frp', u'gl-ES', u'gu', u'gun', u'ha',
+                  u'he-IL', u'hi', u'hne', u'hr-HR', u'ht-HT', u'hu-HU', u'hy', u'ia',
+                  u'id-ID', u'ig', u'is-IS', u'it-IT', u'ja-JP', u'jv', u'ka-GE', u'kk-KZ',
+                  u'km-KH', u'kn-IN', u'ko-KR', u'ks', u'ks-IN', u'ku-IQ', u'kw', u'ky',
+                  u'la', u'lb', u'li', u'ln', u'lo', u'lo-LA', u'lt-LT', u'lv-LV', u'mg',
+                  u'mi', u'mk-MK', u'ml-IN', u'mn-MN', u'mr-IN', u'ms-MY', u'mt', u'mt-MT',
+                  u'my-MM', u'nah', u'nap', u'nb', u'nds', u'ne', u'nl-BE', u'nl-NL', u'nn',
+                  u'no', u'no-NO', u'nr', u'or-IN', u'pap', u'pl-PL', u'pms', u'ps',
+                  u'ro-RO', u'ru-RU', u'rw', u'sc', u'sco', u'se', u'si-LK', u'sk-SK',
+                  u'sl-SI', u'sm', u'sn', u'so', u'sq-AL', u'sr-RS', u'sr-RS@latin',
+                  u'sr@latin', u'st', u'st-ZA', u'su', u'sv', u'sv-FI', u'sw-KE', u'ta-IN',
+                  u'te-IN', u'tg', u'tg-TJ', u'th-TH', u'ti', u'tk', u'tl', u'tl-PH', u'tlh',
+                  u'to', u'tr-TR', u'tt', u'ug', u'uk-UA', u'ur-PK', u've', u'vi-VN', u'vls',
+                  u'wa', u'wo-SN', u'yi', u'yo', u'zh', u'zh-CN.GB2312', u'zh-HK',
+                  u'zh-TW.Big5', u'zu-ZA'
+                  ]

--- a/pontoon/base/migrations/0013_add_en_US.py
+++ b/pontoon/base/migrations/0013_add_en_US.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import migrations
 
 
 def add_back_source_locales(apps, schema_editor):

--- a/pontoon/base/migrations/0014_auto_20150806_0948.py
+++ b/pontoon/base/migrations/0014_auto_20150806_0948.py
@@ -14,7 +14,8 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='ChangedEntityLocale',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('id', models.AutoField(verbose_name='ID',
+                                        serialize=False, auto_created=True, primary_key=True)),
                 ('entity', models.ForeignKey(to='base.Entity')),
                 ('locale', models.ForeignKey(to='base.Locale')),
             ],
@@ -22,7 +23,8 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='entity',
             name='changed_locales',
-            field=models.ManyToManyField(help_text=b'List of locales in which translations for this entity have changed since the last sync.', to='base.Locale', through='base.ChangedEntityLocale'),
+            field=models.ManyToManyField(help_text=b'List of locales in which translations for this entity have changed since the last sync.',
+                                         to='base.Locale', through='base.ChangedEntityLocale'),
         ),
         migrations.AlterUniqueTogether(
             name='changedentitylocale',

--- a/pontoon/base/migrations/0015_remove_project_last_synced.py
+++ b/pontoon/base/migrations/0015_remove_project_last_synced.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import migrations
 
 
 class Migration(migrations.Migration):

--- a/pontoon/base/migrations/0016_auto_20150810_1301.py
+++ b/pontoon/base/migrations/0016_auto_20150810_1301.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import migrations
 
 
 def add_tagalog_locale(apps, schema_editor):
     Locale = apps.get_model('base', 'Locale')
-    locale = Locale.objects.create(
+    Locale.objects.create(
         code='tl',
         name='Tagalog',
         nplurals=2,

--- a/pontoon/base/migrations/0017_entity_source_jsonfield.py
+++ b/pontoon/base/migrations/0017_entity_source_jsonfield.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 import json
 
-from django.db import models, migrations
+from django.db import migrations
 import jsonfield.fields
 
 

--- a/pontoon/base/migrations/0018_auto_20150820_0925.py
+++ b/pontoon/base/migrations/0018_auto_20150820_0925.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import migrations
 
 
 def change_chinese_plurals(apps, schema_editor):

--- a/pontoon/base/migrations/0019_auto_20150820_1345.py
+++ b/pontoon/base/migrations/0019_auto_20150820_1345.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import migrations
 
 
 class Migration(migrations.Migration):

--- a/pontoon/base/migrations/0020_auto_20150904_0857.py
+++ b/pontoon/base/migrations/0020_auto_20150904_0857.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import migrations
 
 
 def complete_plurals(apps, schema_editor):

--- a/pontoon/base/migrations/0021_auto_20150904_1007.py
+++ b/pontoon/base/migrations/0021_auto_20150904_1007.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import migrations
 
 
 def remove_pa_fy(apps, schema_editor):

--- a/pontoon/base/migrations/0022_remove_locale_nplurals.py
+++ b/pontoon/base/migrations/0022_remove_locale_nplurals.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import migrations
 
 
 class Migration(migrations.Migration):

--- a/pontoon/base/migrations/0025_add_repository.py
+++ b/pontoon/base/migrations/0025_add_repository.py
@@ -14,9 +14,12 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Repository',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('type', models.CharField(default=b'file', max_length=255, choices=[(b'file', b'File'), (b'git', b'Git'), (b'hg', b'HG'), (b'svn', b'SVN'), (b'transifex', b'Transifex')])),
-                ('url', models.CharField(max_length=2000, verbose_name=b'URL', blank=True)),
+                ('id', models.AutoField(verbose_name='ID',
+                                        serialize=False, auto_created=True, primary_key=True)),
+                ('type', models.CharField(default=b'file', max_length=255, choices=[
+                 (b'file', b'File'), (b'git', b'Git'), (b'hg', b'HG'), (b'svn', b'SVN'), (b'transifex', b'Transifex')])),
+                ('url', models.CharField(max_length=2000,
+                                         verbose_name=b'URL', blank=True)),
                 ('project', models.ForeignKey(to='base.Project')),
             ],
             options={

--- a/pontoon/base/migrations/0027_auto_20150910_1735.py
+++ b/pontoon/base/migrations/0027_auto_20150910_1735.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import migrations
 
 
 class Migration(migrations.Migration):

--- a/pontoon/base/migrations/0028_auto_20150915_0013.py
+++ b/pontoon/base/migrations/0028_auto_20150915_0013.py
@@ -14,6 +14,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='repository',
             name='project',
-            field=models.ForeignKey(related_name='repositories', to='base.Project'),
+            field=models.ForeignKey(
+                related_name='repositories', to='base.Project'),
         ),
     ]

--- a/pontoon/base/migrations/0029_repository_multi_locale.py
+++ b/pontoon/base/migrations/0029_repository_multi_locale.py
@@ -14,6 +14,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='repository',
             name='multi_locale',
-            field=models.BooleanField(default=False, help_text=b'\n        If true, this repo corresponds to multiple locale-specific repos. The\n        URL should have the string "{locale_code}" in it, which will be replaced\n        by the locale codes of all enabled locales for the project during pulls\n        and and commits.\n    '),
+            field=models.BooleanField(
+                default=False, help_text=b'\n        If true, this repo corresponds to multiple locale-specific repos. The\n        URL should have the string "{locale_code}" in it, which will be replaced\n        by the locale codes of all enabled locales for the project during pulls\n        and and commits.\n    '),
         ),
     ]

--- a/pontoon/base/migrations/0030_repository_source_repo.py
+++ b/pontoon/base/migrations/0030_repository_source_repo.py
@@ -14,6 +14,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='repository',
             name='source_repo',
-            field=models.BooleanField(default=False, help_text=b'\n        If true, this repo contains the source strings directly in the\n        root of the repo. Checkouts of this repo will have "en-US"\n        appended to the end of their path so that they are detected as\n        source directories.\n    '),
+            field=models.BooleanField(
+                default=False, help_text=b'\n        If true, this repo contains the source strings directly in the\n        root of the repo. Checkouts of this repo will have "en-US"\n        appended to the end of their path so that they are detected as\n        source directories.\n    '),
         ),
     ]

--- a/pontoon/base/migrations/0032_repository_last_synced_revisions.py
+++ b/pontoon/base/migrations/0032_repository_last_synced_revisions.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import migrations
 import jsonfield.fields
 
 

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -35,9 +35,9 @@ class UserTranslationsManager(models.Manager):
         with counts of translations.
         """
         translation_query = (
-            ~Q(translation__string=F('translation__entity__string'))
-            & ~Q(translation__string=F('translation__entity__string_plural'))
-            & Q(translation__user__isnull=False)
+            ~Q(translation__string=F('translation__entity__string')) & ~
+            Q(translation__string=F('translation__entity__string_plural')) &
+            Q(translation__user__isnull=False)
         )
         for arg in args:
             translation_query &= arg

--- a/pontoon/base/tests/formats/__init__.py
+++ b/pontoon/base/tests/formats/__init__.py
@@ -1,6 +1,3 @@
-import os
-import tempfile
-
 from django_nose.tools import assert_equal
 
 from pontoon.base.tests import (

--- a/pontoon/base/tests/formats/test_po.py
+++ b/pontoon/base/tests/formats/test_po.py
@@ -236,18 +236,18 @@ class POTests(FormatTestsMixin, TestCase):
     def test_save_metadata(self):
         """Ensure pofile metadata is updated correctly."""
         test_input = self.generate_pofile('',
-            language='different_code',
-            generator='Not Pontoon',
-            plural_forms='nplurals=1; plural=0;'
-        )
+                                          language='different_code',
+                                          generator='Not Pontoon',
+                                          plural_forms='nplurals=1; plural=0;'
+                                          )
         path, resource = self.parse_string(test_input)
 
         resource.save(self.locale)
         self.assert_file_content(path, self.generate_pofile('',
-            language='test_locale',
-            generator='Pontoon',
-            plural_forms='nplurals=2; plural=(n != 1);'
-        ))
+                                                            language='test_locale',
+                                                            generator='Pontoon',
+                                                            plural_forms='nplurals=2; plural=(n != 1);'
+                                                            ))
 
     def test_save_extra_metadata(self):
         """

--- a/pontoon/base/tests/formats/test_silme.py
+++ b/pontoon/base/tests/formats/test_silme.py
@@ -214,7 +214,6 @@ class PropertiesTests(FormatTestsMixin, TestCase):
         self.run_parse_basic(BASE_PROPERTIES_FILE, 0)
 
     def test_parse_multiple_comments(self):
-        #import ipdb; ipdb.set_trace()
         self.run_parse_multiple_comments(BASE_PROPERTIES_FILE, 1)
 
     def test_parse_no_comments_no_sources(self):

--- a/pontoon/base/tests/test_models.py
+++ b/pontoon/base/tests/test_models.py
@@ -24,6 +24,7 @@ from pontoon.base.utils import aware_datetime
 
 
 class ProjectTests(TestCase):
+
     def test_can_commit_no_repos(self):
         """can_commit should be False if there are no repos."""
         project = ProjectFactory.create(repositories=[])
@@ -86,6 +87,7 @@ class ProjectTests(TestCase):
 
 
 class ProjectPartsTests(TestCase):
+
     def setUp(self):
         self.locale, self.locale_other = LocaleFactory.create_batch(2)
         self.project = ProjectFactory.create(
@@ -187,6 +189,7 @@ class ProjectPartsTests(TestCase):
 
 
 class RepositoryTests(TestCase):
+
     def test_checkout_path(self):
         """checkout_path should be determined by the repo URL."""
         repo = RepositoryFactory.create(
@@ -261,7 +264,8 @@ class RepositoryTests(TestCase):
         )
         locale = LocaleFactory.create(code='test-locale')
 
-        assert_equal(repo.locale_url(locale), 'https://example.com/path/to/test-locale/')
+        assert_equal(repo.locale_url(locale),
+                     'https://example.com/path/to/test-locale/')
 
     def test_locale_url_non_multi_locale(self):
         """If the repo isn't multi-locale, throw a ValueError."""
@@ -286,7 +290,8 @@ class RepositoryTests(TestCase):
 
         with self.settings(MEDIA_ROOT='/media/root'):
             test_path = '/media/root/projects/test-project/path/to/match/foo/bar.po'
-            assert_equal(repo.url_for_path(test_path), 'https://example.com/path/to/match/')
+            assert_equal(repo.url_for_path(test_path),
+                         'https://example.com/path/to/match/')
 
     def test_url_for_path_no_match(self):
         """
@@ -302,9 +307,10 @@ class RepositoryTests(TestCase):
             repo.url_for_path('/media/root/path/to/match/foo/bar.po')
 
     def test_pull(self):
-        repo = RepositoryFactory.create(type=Repository.GIT, url='https://example.com')
+        repo = RepositoryFactory.create(
+            type=Repository.GIT, url='https://example.com')
         with patch('pontoon.base.models.update_from_vcs') as update_from_vcs, \
-             patch('pontoon.base.models.get_revision') as mock_get_revision:
+                patch('pontoon.base.models.get_revision') as mock_get_revision:
             mock_get_revision.return_value = 'asdf'
             assert_equal(repo.pull(), {'single_locale': 'asdf'})
             update_from_vcs.assert_called_with(
@@ -331,7 +337,7 @@ class RepositoryTests(TestCase):
         repo.locale_checkout_path = lambda locale: '/media/' + locale.code
 
         with patch('pontoon.base.models.update_from_vcs') as update_from_vcs, \
-             patch('pontoon.base.models.get_revision') as mock_get_revision:
+                patch('pontoon.base.models.get_revision') as mock_get_revision:
             # Return path as the revision so different locales return
             # different values.
             mock_get_revision.side_effect = lambda type, path: path
@@ -346,7 +352,8 @@ class RepositoryTests(TestCase):
             ])
 
     def test_commit(self):
-        repo = RepositoryFactory.create(type=Repository.GIT, url='https://example.com')
+        repo = RepositoryFactory.create(
+            type=Repository.GIT, url='https://example.com')
         with patch('pontoon.base.models.commit_to_vcs') as commit_to_vcs:
             repo.commit('message', 'author', 'path')
             commit_to_vcs.assert_called_with(
@@ -382,6 +389,7 @@ class RepositoryTests(TestCase):
 
 
 class TranslationQuerySetTests(TestCase):
+
     def setUp(self):
         self.user0, self.user1 = UserFactory.create_batch(2)
 
@@ -398,8 +406,12 @@ class TranslationQuerySetTests(TestCase):
         If latest activity in Translation QuerySet is translation submission,
         return submission date and user.
         """
-        latest_submission = self._translation(self.user0, submitted=(1970, 1, 3), approved=None)
-        latest_approval = self._translation(self.user1, submitted=(1970, 1, 1), approved=(1970, 1, 2))
+        latest_submission = self._translation(
+            self.user0, submitted=(1970, 1, 3), approved=None)
+
+        self._translation(self.user1, submitted=(
+            1970, 1, 1), approved=(1970, 1, 2))
+
         assert_equal(Translation.objects.all().latest_activity(), {
             'date': latest_submission.date,
             'user': latest_submission.user
@@ -410,8 +422,12 @@ class TranslationQuerySetTests(TestCase):
         If latest activity in Translation QuerySet is translation approval,
         return approval date and user.
         """
-        latest_submission = self._translation(self.user0, submitted=(1970, 1, 2), approved=(1970, 1, 2))
-        latest_approval = self._translation(self.user1, submitted=(1970, 1, 1), approved=(1970, 1, 3))
+        # Latest submission
+        self._translation(
+            self.user0, submitted=(1970, 1, 2), approved=(1970, 1, 2))
+
+        latest_approval = self._translation(
+            self.user1, submitted=(1970, 1, 1), approved=(1970, 1, 3))
         assert_equal(Translation.objects.all().latest_activity(), {
             'date': latest_approval.date,
             'user': latest_approval.user
@@ -423,14 +439,17 @@ class TranslationQuerySetTests(TestCase):
 
 
 class UserTranslationManagerTests(TestCase):
+
     @override_settings(EXCLUDE=('excluded@example.com',))
     def test_excluded_contributors(self):
         """
         Checks if contributors with mails in settings.EXCLUDE are excluded
         from top contributors list.
         """
-        included_contributor = TranslationFactory.create(user__email='included@example.com').user
-        excluded_contributor = TranslationFactory.create(user__email='excluded@example.com').user
+        included_contributor = TranslationFactory.create(
+            user__email='included@example.com').user
+        excluded_contributor = TranslationFactory.create(
+            user__email='excluded@example.com').user
 
         top_contributors = User.translators.with_translation_counts()
         assert_true(included_contributor in top_contributors)
@@ -440,7 +459,8 @@ class UserTranslationManagerTests(TestCase):
         """
         Checks if user contributors without translations aren't returned.
         """
-        active_contributor = TranslationFactory.create(user__email='active@example.com').user
+        active_contributor = TranslationFactory.create(
+            user__email='active@example.com').user
         inactive_contributor = UserFactory.create(email='inactive@example.com')
 
         top_contributors = User.translators.with_translation_counts()
@@ -493,9 +513,12 @@ class UserTranslationManagerTests(TestCase):
         Helper method, creates contributor with given translations counts.
         """
         contributor = UserFactory.create()
-        TranslationFactory.create_batch(approved, user=contributor, approved=True, **kwargs)
-        TranslationFactory.create_batch(unapproved, user=contributor, approved=False, fuzzy=False, **kwargs)
-        TranslationFactory.create_batch(needs_work, user=contributor, fuzzy=True, **kwargs)
+        TranslationFactory.create_batch(
+            approved, user=contributor, approved=True, **kwargs)
+        TranslationFactory.create_batch(
+            unapproved, user=contributor, approved=False, fuzzy=False, **kwargs)
+        TranslationFactory.create_batch(
+            needs_work, user=contributor, fuzzy=True, **kwargs)
         return contributor
 
     def test_translation_counts(self):
@@ -504,9 +527,12 @@ class UserTranslationManagerTests(TestCase):
         Tests creates 3 contributors with different numbers translations and checks if their counts match.
         """
 
-        first_contributor = self.create_contributor_with_translation_counts(approved=7, unapproved=3, needs_work=2)
-        second_contributor = self.create_contributor_with_translation_counts(approved=5, unapproved=9, needs_work=2)
-        third_contributor = self.create_contributor_with_translation_counts(approved=1, unapproved=2, needs_work=5)
+        first_contributor = self.create_contributor_with_translation_counts(
+            approved=7, unapproved=3, needs_work=2)
+        second_contributor = self.create_contributor_with_translation_counts(
+            approved=5, unapproved=9, needs_work=2)
+        third_contributor = self.create_contributor_with_translation_counts(
+            approved=1, unapproved=2, needs_work=5)
 
         top_contributors = User.translators.with_translation_counts()
         assert_equal(top_contributors.count(), 3)
@@ -516,14 +542,14 @@ class UserTranslationManagerTests(TestCase):
         assert_equal(top_contributors[2], third_contributor)
 
         assert_attributes_equal(top_contributors[0], translations_count=16,
-            translations_approved_count=5, translations_unapproved_count=9,
-            translations_needs_work_count=2)
+                                translations_approved_count=5, translations_unapproved_count=9,
+                                translations_needs_work_count=2)
         assert_attributes_equal(top_contributors[1], translations_count=12,
-            translations_approved_count=7, translations_unapproved_count=3,
-            translations_needs_work_count=2)
+                                translations_approved_count=7, translations_unapproved_count=3,
+                                translations_needs_work_count=2)
         assert_attributes_equal(top_contributors[2], translations_count=8,
-            translations_approved_count=1, translations_unapproved_count=2,
-            translations_needs_work_count=5)
+                                translations_approved_count=1, translations_unapproved_count=2,
+                                translations_needs_work_count=5)
 
     def test_period_filters(self):
         """
@@ -532,41 +558,47 @@ class UserTranslationManagerTests(TestCase):
         """
 
         first_contributor = self.create_contributor_with_translation_counts(approved=12, unapproved=1, needs_work=2,
-            date=aware_datetime(2015, 3, 2))
-        second_contributor = self.create_contributor_with_translation_counts(approved=2, unapproved=11, needs_work=2,
-            date=aware_datetime(2015, 6, 1))
+                                                                            date=aware_datetime(2015, 3, 2))
+        # Second contributor
+        self.create_contributor_with_translation_counts(approved=2, unapproved=11, needs_work=2,
+                                                        date=aware_datetime(2015, 6, 1))
 
-        TranslationFactory.create_batch(5, approved=True, user=first_contributor, date=aware_datetime(2015, 7, 2))
+        TranslationFactory.create_batch(
+            5, approved=True, user=first_contributor, date=aware_datetime(2015, 7, 2))
 
-        top_contributors = User.translators.with_translation_counts(aware_datetime(2015, 6, 10))
+        top_contributors = User.translators.with_translation_counts(
+            aware_datetime(2015, 6, 10))
 
         assert_equal(top_contributors.count(), 1)
         assert_attributes_equal(top_contributors[0], translations_count=5,
-            translations_approved_count=5, translations_unapproved_count=0,
-            translations_needs_work_count=0)
+                                translations_approved_count=5, translations_unapproved_count=0,
+                                translations_needs_work_count=0)
 
-        top_contributors = User.translators.with_translation_counts(aware_datetime(2015, 5, 10))
+        top_contributors = User.translators.with_translation_counts(
+            aware_datetime(2015, 5, 10))
 
         assert_equal(top_contributors.count(), 2)
         assert_attributes_equal(top_contributors[0], translations_count=15,
-            translations_approved_count=2, translations_unapproved_count=11,
-            translations_needs_work_count=2)
+                                translations_approved_count=2, translations_unapproved_count=11,
+                                translations_needs_work_count=2)
         assert_attributes_equal(top_contributors[1], translations_count=5,
-            translations_approved_count=5, translations_unapproved_count=0,
-            translations_needs_work_count=0)
+                                translations_approved_count=5, translations_unapproved_count=0,
+                                translations_needs_work_count=0)
 
-        top_contributors = User.translators.with_translation_counts(aware_datetime(2015, 1, 10))
+        top_contributors = User.translators.with_translation_counts(
+            aware_datetime(2015, 1, 10))
 
         assert_equal(top_contributors.count(), 2)
         assert_attributes_equal(top_contributors[0], translations_count=20,
-            translations_approved_count=17, translations_unapproved_count=1,
-            translations_needs_work_count=2)
+                                translations_approved_count=17, translations_unapproved_count=1,
+                                translations_needs_work_count=2)
         assert_attributes_equal(top_contributors[1], translations_count=15,
-            translations_approved_count=2, translations_unapproved_count=11,
-            translations_needs_work_count=2)
+                                translations_approved_count=2, translations_unapproved_count=11,
+                                translations_needs_work_count=2)
 
 
 class EntityTests(TestCase):
+
     def setUp(self):
         self.locale = LocaleFactory.create(
             cldr_plurals="0,1"
@@ -627,11 +659,14 @@ class EntityTests(TestCase):
         other_project = ProjectFactory.create(
             locales=[self.locale, other_locale]
         )
-        obsolete_entity = EntityFactory.create(
+
+        # Obsolete entity
+        EntityFactory.create(
             obsolete=True,
             resource=self.main_resource,
             string='Obsolete String'
         )
+
         entities = Entity.for_project_locale(self.project, other_locale)
         assert_equal(len(entities), 0)
         entities = Entity.for_project_locale(other_project, self.locale)
@@ -698,7 +733,8 @@ class EntityTests(TestCase):
         locale.
         """
         subpages = [self.subpage.name]
-        entities = Entity.for_project_locale(self.project, self.locale, subpages)
+        entities = Entity.for_project_locale(
+            self.project, self.locale, subpages)
 
         assert_equal(len(entities), 1)
         self.assert_serialized_entity(
@@ -712,19 +748,24 @@ class EntityTests(TestCase):
 
         assert_equal(entities[0]['original'], 'Source String')
         assert_equal(entities[0]['original_plural'], 'Plural Source String')
-        assert_equal(entities[0]['translation'][0]['string'], 'Translated String')
-        assert_equal(entities[0]['translation'][1]['string'], 'Translated Plural String')
+        assert_equal(entities[0]['translation'][0][
+                     'string'], 'Translated String')
+        assert_equal(entities[0]['translation'][1][
+                     'string'], 'Translated Plural String')
 
     def test_for_project_locale_order(self):
         """
         Return entities in correct order.
         """
-        entity_second = EntityFactory.create(
+        # Entity second
+        EntityFactory.create(
             order=1,
             resource=self.main_resource,
             string='Second String'
         )
-        entity_first = EntityFactory.create(
+
+        # Entity first
+        EntityFactory.create(
             order=0,
             resource=self.main_resource,
             string='First String'

--- a/pontoon/base/tests/test_vcs_models.py
+++ b/pontoon/base/tests/test_vcs_models.py
@@ -17,10 +17,12 @@ from pontoon.base.formats.base import ParseError
 from pontoon.base.vcs_models import VCSProject
 
 
-TEST_CHECKOUT_PATH = os.path.join(os.path.dirname(__file__), 'directory_detection_tests')
+TEST_CHECKOUT_PATH = os.path.join(
+    os.path.dirname(__file__), 'directory_detection_tests')
 
 
 class VCSProjectTests(TestCase):
+
     def setUp(self):
         # Force the checkout path to point to a test directory to make
         # resource file loading pass during tests.
@@ -83,7 +85,8 @@ class VCSProjectTests(TestCase):
         When searching for source directories, prefer directories named
         `templates` over all others.
         """
-        checkout_path = os.path.join(TEST_CHECKOUT_PATH, 'scoring_templates_test')
+        checkout_path = os.path.join(
+            TEST_CHECKOUT_PATH, 'scoring_templates_test')
         self.mock_checkout_path.return_value = checkout_path
 
         assert_equal(
@@ -109,7 +112,8 @@ class VCSProjectTests(TestCase):
         When searching for source directories, prefer directories with
         source-only formats over all others.
         """
-        checkout_path = os.path.join(TEST_CHECKOUT_PATH, 'scoring_source_files_test')
+        checkout_path = os.path.join(
+            TEST_CHECKOUT_PATH, 'scoring_source_files_test')
         self.mock_checkout_path.return_value = checkout_path
 
         assert_equal(
@@ -122,7 +126,8 @@ class VCSProjectTests(TestCase):
         If VCSResource() raises a ParseError while loading, log an error
         and skip the resource.
         """
-        self.vcs_project.relative_resource_paths = Mock(return_value=['failure', 'success'])
+        self.vcs_project.relative_resource_paths = Mock(
+            return_value=['failure', 'success'])
 
         # Fail only if the path is failure so we can test the ignore.
         def vcs_resource_constructor(project, path):
@@ -132,11 +137,13 @@ class VCSProjectTests(TestCase):
                 return 'successful resource'
 
         with patch('pontoon.base.vcs_models.VCSResource') as MockVCSResource, \
-             patch('pontoon.base.vcs_models.log') as mock_log:
+                patch('pontoon.base.vcs_models.log') as mock_log:
             MockVCSResource.side_effect = vcs_resource_constructor
 
-            assert_equal(self.vcs_project.resources, {'success': 'successful resource'})
-            mock_log.error.assert_called_with(CONTAINS('failure', 'error message'))
+            assert_equal(self.vcs_project.resources, {
+                         'success': 'successful resource'})
+            mock_log.error.assert_called_with(
+                CONTAINS('failure', 'error message'))
 
     def test_resource_for_path_region_properties(self):
         """
@@ -149,7 +156,7 @@ class VCSProjectTests(TestCase):
         self.project.repositories.add(RepositoryFactory.build(url=url))
 
         with patch('pontoon.base.vcs_models.os', wraps=os) as mock_os, \
-             patch('pontoon.base.vcs_models.MOZILLA_REPOS', [url]):
+                patch('pontoon.base.vcs_models.MOZILLA_REPOS', [url]):
             mock_os.walk.return_value = [
                 ('/root', [], ['foo.pot', 'region.properties'])
             ]
@@ -161,6 +168,7 @@ class VCSProjectTests(TestCase):
 
 
 class VCSEntityTests(TestCase):
+
     def test_has_translation_for(self):
         """
         Return True if a translation exists for the given locale, even
@@ -169,7 +177,8 @@ class VCSEntityTests(TestCase):
         empty_translation = VCSTranslationFactory(strings={})
         full_translation = VCSTranslationFactory(strings={None: 'TRANSLATED'})
         entity = VCSEntityFactory()
-        entity.translations = {'empty': empty_translation, 'full': full_translation}
+        entity.translations = {
+            'empty': empty_translation, 'full': full_translation}
 
         assert_false(entity.has_translation_for('missing'))
         assert_true(entity.has_translation_for('empty'))

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -1,15 +1,10 @@
 import base64
-from collections import defaultdict
-import datetime
 import hashlib
 import json
 import Levenshtein
 import logging
 import math
-import os
-import pytz
 import requests
-import traceback
 import xml.etree.ElementTree as ET
 import urllib
 
@@ -17,7 +12,6 @@ from dateutil.relativedelta import relativedelta
 
 from django.conf import settings
 from django.contrib import messages
-from django.contrib.auth import authenticate, login
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.core.mail import send_mail
@@ -27,8 +21,6 @@ from django.db.models import Count, F, Prefetch
 from django.http import (
     Http404,
     HttpResponse,
-    HttpResponseBadRequest,
-    HttpResponseForbidden,
     HttpResponseRedirect,
 )
 
@@ -37,7 +29,6 @@ from django.utils import timezone
 from django.utils.datastructures import MultiValueDictKeyError
 from django_browserid.views import Verify as BrowserIDVerifyBase
 from operator import itemgetter
-from pontoon.administration.vcs import commit_to_vcs
 from pontoon.administration import files
 from pontoon.base import utils
 
@@ -48,7 +39,6 @@ from pontoon.base.models import (
     Resource,
     Subpage,
     Translation,
-    Stats,
     UserProfile,
     get_locales_with_project_stats,
     get_locales_with_stats,
@@ -130,8 +120,6 @@ def project(request, slug, template='project.html'):
             'none': None,
         }
         return HttpResponseRedirect(reverse('pontoon.home'))
-
-    locales = p.locales.all().order_by("name")
 
     data = {
         'locales': get_locales_with_project_stats(p),
@@ -224,7 +212,8 @@ def translate(request, locale, slug, part=None, template='translate.html'):
             Prefetch(
                 'resource_set',
                 queryset=Resource.objects.filter(
-                    pk__in=Entity.objects.filter(obsolete=False).values('resource')
+                    pk__in=Entity.objects.filter(
+                        obsolete=False).values('resource')
                 ),
                 to_attr='active_resources'
             )
@@ -268,9 +257,9 @@ def translate(request, locale, slug, part=None, template='translate.html'):
     # Set part if subpages not defined and entities in more than one file
     else:
         paths = (Resource.objects
-                    .filter(project=p, entity_count__gt=0, stats__locale=l)
-                    .order_by('path')
-                    .values_list('path', flat=True))
+                 .filter(project=p, entity_count__gt=0, stats__locale=l)
+                 .order_by('path')
+                 .values_list('path', flat=True))
 
         if len(paths) > 1:
             data['part'] = part if part in paths else paths[0]
@@ -1285,6 +1274,7 @@ def request_locale(request):
 
 
 class BrowserIDVerify(BrowserIDVerifyBase):
+
     def login_success(self):
         # Check for permission to localize if not granted on every login
         if not self.user.has_perm('base.can_localize'):

--- a/pontoon/settings/__init__.py
+++ b/pontoon/settings/__init__.py
@@ -1,11 +1,11 @@
 import sys
 
-from .base import *
+from .base import * # noqa
 
 
 # Import local settings if they exist (usually only in development).
 try:
-    from .local import *
+    from .local import * # noqa
 except ImportError, exc:
     pass
 
@@ -14,6 +14,6 @@ except ImportError, exc:
 TEST = len(sys.argv) > 1 and sys.argv[1] == 'test'
 if TEST:
     try:
-        from .test import *
+        from .test import * # noqa
     except ImportError:
         pass

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -3,7 +3,7 @@ import os
 import socket
 
 from django.utils.functional import lazy
-
+from django_sha2 import get_password_hashers
 import dj_database_url
 
 
@@ -321,7 +321,7 @@ else:
 # Site ID is used by Django's Sites framework.
 SITE_ID = 1
 
-## Media and templates.
+# Media and templates.
 
 # Absolute path to the directory that holds media.
 # Example: "/home/media/media.lawrence.com/"
@@ -354,7 +354,7 @@ def _allowed_hosts():
     return [host]
 ALLOWED_HOSTS = lazy(_allowed_hosts, list)()
 
-## Auth
+# Auth
 # The first hasher in this list will be used for new passwords.
 # Any other hasher in the list can be used for existing passwords.
 # Playdoh ships with Bcrypt+HMAC by default because it's the most secure.
@@ -368,10 +368,9 @@ BASE_PASSWORD_HASHERS = (
     'django.contrib.auth.hashers.UnsaltedMD5PasswordHasher',
 )
 
-from django_sha2 import get_password_hashers
 PASSWORD_HASHERS = get_password_hashers(BASE_PASSWORD_HASHERS, HMAC_KEYS)
 
-## Logging
+# Logging
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
@@ -394,7 +393,7 @@ LOGGING = {
     }
 }
 
-## Tests
+# Tests
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 NOSE_ARGS = ['--logging-filter=-django_browserid,-factory,-django.db,-raygun4py',
              '--logging-clear-handlers']
@@ -435,7 +434,7 @@ PORT = 80
 # Names for slave databases from the DATABASES setting.
 SLAVE_DATABASES = []
 
-## Internationalization.
+# Internationalization.
 
 # Enable timezone-aware datetimes.
 USE_TZ = True

--- a/pontoon/sites/admin.py
+++ b/pontoon/sites/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-# Register your models here.

--- a/pontoon/sites/models.py
+++ b/pontoon/sites/models.py
@@ -1,3 +1,0 @@
-from django.db import models
-
-# Create your models here.

--- a/pontoon/sites/tests.py
+++ b/pontoon/sites/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/pontoon/sites/urls.py
+++ b/pontoon/sites/urls.py
@@ -2,20 +2,20 @@ from django.conf.urls import patterns, url
 import views
 
 urlpatterns = patterns('',
-    # Sites pages
-    url(r'^tiles/$', views.sites_snippet_page,
-        kwargs=dict(template="tiles.html",
-                    repository_url="https://svn.mozilla.org/projects/l10n-misc/trunk/firefoxtiles/en-US/",
-                    default_filename="tiles.lang"),
-        name='sites-tiles'),
-    url(r'^snippets/$', views.sites_snippet_page,
-        kwargs=dict(template="snippets.html",
-                    repository_url="https://svn.mozilla.org/projects/l10n-misc/trunk/snippets/en-US/",
-                    default_filename="jan2014.lang"),
-        name='sites-snippets'),
-    url(r'^updater/$', views.sites_snippet_page,
-        kwargs=dict(template="updater.html",
-                    repository_url="https://svn.mozilla.org/projects/l10n-misc/trunk/firefoxupdater/en-US/",
-                    default_filename="updater.lang"),
-        name='sites-updater'),
-)
+                       # Sites pages
+                       url(r'^tiles/$', views.sites_snippet_page,
+                           kwargs=dict(template="tiles.html",
+                                       repository_url="https://svn.mozilla.org/projects/l10n-misc/trunk/firefoxtiles/en-US/",
+                                       default_filename="tiles.lang"),
+                           name='sites-tiles'),
+                       url(r'^snippets/$', views.sites_snippet_page,
+                           kwargs=dict(template="snippets.html",
+                                       repository_url="https://svn.mozilla.org/projects/l10n-misc/trunk/snippets/en-US/",
+                                       default_filename="jan2014.lang"),
+                           name='sites-snippets'),
+                       url(r'^updater/$', views.sites_snippet_page,
+                           kwargs=dict(template="updater.html",
+                                       repository_url="https://svn.mozilla.org/projects/l10n-misc/trunk/firefoxupdater/en-US/",
+                                       default_filename="updater.lang"),
+                           name='sites-updater'),
+                       )

--- a/pontoon/sites/views.py
+++ b/pontoon/sites/views.py
@@ -15,18 +15,22 @@ def sites_snippet_page(request, template, repository_url, default_filename):
     """Downloads snippets file from given repository_url and passes it to given template."""
     try:
         snippets_file = request.GET.get('file', default_filename)
-        snippets_contents = urllib2.urlopen(urljoin(repository_url, snippets_file)).read()
-        snippets = [s[1:].decode('utf-8') for s in snippets_contents.splitlines() if s.startswith(';')]
+        snippets_contents = urllib2.urlopen(
+            urljoin(repository_url, snippets_file)).read()
+        snippets = [s[1:].decode(
+            'utf-8') for s in snippets_contents.splitlines() if s.startswith(';')]
     except IOError:
-        log.error('Sites download error: %s', urljoin(repository_url, snippets_file))
+        log.error('Sites download error: %s', urljoin(
+            repository_url, snippets_file))
         return HttpResponseBadRequest("Couldn't download or find file: %s" % urljoin(repository_url, snippets_file))
 
     try:
         # Previous php version starts from indexes from 1.
-        snippet_index = int(request.GET.get('snippet', 1))-1
-        if len(snippets) <= snippet_index: raise ValueError()
+        snippet_index = int(request.GET.get('snippet', 1)) - 1
+        if len(snippets) <= snippet_index:
+            raise ValueError()
     except ValueError:
         return HttpResponseBadRequest("Snippet index is invalid")
 
     return render(request, "sites/{}".format(template), dict(snippets=snippets,
-        snippet_index=snippet_index))
+                                                             snippet_index=snippet_index))

--- a/pontoon/urls.py
+++ b/pontoon/urls.py
@@ -5,41 +5,43 @@ from django.views.generic import TemplateView
 
 
 urlpatterns = patterns('',
-    # Legacy: Locale redirect for compatibility with i18n ready URL scheme
-    (r'^en-US(?P<url>.+)$', RedirectView.as_view(url="%(url)s", permanent=True)),
+                       # Legacy: Locale redirect for compatibility with i18n
+                       # ready URL scheme
+                       (r'^en-US(?P<url>.+)$',
+                        RedirectView.as_view(url="%(url)s", permanent=True)),
 
-    # Admin
-    (r'admin/', include('pontoon.administration.urls')),
+                       # Admin
+                       (r'admin/', include('pontoon.administration.urls')),
 
-    # Sites
-    (r'sites/', include('pontoon.sites.urls')),
+                       # Sites
+                       (r'sites/', include('pontoon.sites.urls')),
 
-    # Django admin
-    (r'^a/', include(admin.site.urls)),
+                       # Django admin
+                       (r'^a/', include(admin.site.urls)),
 
-    # Test project: Pontoon Intro
-    url(r'^intro/$', 'pontoon.intro.views.intro'),
+                       # Test project: Pontoon Intro
+                       url(r'^intro/$', 'pontoon.intro.views.intro'),
 
-    # BrowserID
-    (r'', include('django_browserid.urls')),
+                       # BrowserID
+                       (r'', include('django_browserid.urls')),
 
-    # Logout
-    url(r'^signout/$', 'django.contrib.auth.views.logout', {'next_page': '/'},
-        name='signout'),
+                       # Logout
+                       url(r'^signout/$', 'django.contrib.auth.views.logout', {'next_page': '/'},
+                           name='signout'),
 
-    # Error pages
-    url(r'^403/$', TemplateView.as_view(template_name='403.html')),
-    url(r'^404/$', TemplateView.as_view(template_name='404.html')),
-    url(r'^500/$', TemplateView.as_view(template_name='500.html')),
+                       # Error pages
+                       url(r'^403/$', TemplateView.as_view(template_name='403.html')),
+                       url(r'^404/$', TemplateView.as_view(template_name='404.html')),
+                       url(r'^500/$', TemplateView.as_view(template_name='500.html')),
 
-    # Favicon
-    url(r'^favicon\.ico$',
-        RedirectView.as_view(url='/static/img/favicon.ico', permanent=True)),
+                       # Favicon
+                       url(r'^favicon\.ico$',
+                           RedirectView.as_view(url='/static/img/favicon.ico', permanent=True)),
 
-    # Include script
-    url(r'^pontoon\.js$',
-        RedirectView.as_view(url='/static/js/pontoon.js', permanent=True)),
+                       # Include script
+                       url(r'^pontoon\.js$',
+                           RedirectView.as_view(url='/static/js/pontoon.js', permanent=True)),
 
-    # Main app: Must be at the end
-    (r'', include('pontoon.base.urls')),
-)
+                       # Main app: Must be at the end
+                       (r'', include('pontoon.base.urls')),
+                       )

--- a/pontoon/wsgi.py
+++ b/pontoon/wsgi.py
@@ -7,6 +7,7 @@ https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
 import os
 
 from django.core.wsgi import get_wsgi_application
+from whitenoise.django import DjangoWhiteNoise
 
 
 # Set settings env var before importing whitenoise as it depends on
@@ -14,5 +15,4 @@ from django.core.wsgi import get_wsgi_application
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'pontoon.settings')
 
 
-from whitenoise.django import DjangoWhiteNoise
 application = DjangoWhiteNoise(get_wsgi_application())

--- a/pylama.ini
+++ b/pylama.ini
@@ -1,0 +1,15 @@
+[pylama]
+linters = pylint,pep8,pyflakes
+ignore = E501
+
+[pylama:pep8]
+max_line_length = 120
+
+[pylama:*/pontoon-intro/]
+skip = 1
+
+[pylama:docs/conf.py]
+skip = 1
+
+[pylama:bin/peep.py]
+skip = 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,6 +44,8 @@ oauthlib==0.1.3
 # sha256: INKg1YmmksEd9Um9fNqDxmXu8qg-AXuEP-zflW7brXQ
 polib==1.0.6
 
+pylama==7.0.4
+
 # sha256: rxL5lFTolenkMMdXI8O5QZwLzNDqd4A2YtaprFb2Qls
 py-bcrypt==0.3
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-import os
-
 from setuptools import setup, find_packages
 
 
@@ -12,6 +10,6 @@ setup(name='pontoon',
       license='',
       url='',
       include_package_data=True,
-      classifiers = [],
+      classifiers=[],
       packages=find_packages(exclude=['tests']),
       install_requires=[])


### PR DESCRIPTION
Hi, i've ran pyflakes and pep8 to make some cleanups. Most of them are fixed, however there are 3 relatively important errors:
```
$ pylama
pontoon/administration/files.py:806:1: E0602 undefined name 'original' [pyflakes]
pontoon/administration/views.py:299:1: E0602 undefined name '_save_entity' [pyflakes]
pontoon/administration/views.py:303:1: E0602 undefined name '_save_translation' [pyflakes]
```
Also, i've added syntax checking to travis-ci to validate every PR against pep8/pyflakes compatibility. I think it will improve readability and reliability of code.
@mathjazz @Osmose could you tell me if that's good enough to merge or if you agree with general idea? Thx in advance.