### PR TITLE
Fix server error after locale added, but not imported

### DIFF
--- a/pontoon/base/templates/locale_selector.html
+++ b/pontoon/base/templates/locale_selector.html
@@ -34,7 +34,7 @@
         {% if not locale %}
           {{ latest_activity.span(l.latest_activity(project)) }}
         {% endif %}
-        {% if l and l.chart %}
+        {% if l and l.chart and l.chart.total %}
         <span class="chart-wrapper">
           {% if l and l.chart %}<a href="{% if project %}{{ url('pontoon.translate', l.code, project.slug) }}{% else %}{{ url('pontoon.locale', l.code) }}{% endif %}" class="clearfix">{% endif %}
           <span class="chart" data-chart="{{ l.chart|to_json }}">


### PR DESCRIPTION
After locale was added to the project and before it got imported, dashboards
with locale selector (namely project dashboard) failed with server error,
becuse we had no chart data an attempted to divide with None.

@Osmose r?