### PR TITLE
Fix bug 1211271: Mark projects as changed on locale add.

### DIFF
--- a/pontoon/base/apps.py
+++ b/pontoon/base/apps.py
@@ -20,6 +20,9 @@ class BaseConfig(AppConfig):
         # tasks.
         from pontoon.base.celery import app as celery_app  # NOQA
 
+        # Load and register signals.
+        from pontoon.base import signals  # NOQA
+
     def monkeypatch(self):
         # Only patch once, ever.
         if BaseConfig._has_patched:

--- a/pontoon/base/migrations/0036_project_has_changed.py
+++ b/pontoon/base/migrations/0036_project_has_changed.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0035_remove_deleted_field'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='project',
+            name='has_changed',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -219,6 +219,9 @@ class Project(models.Model):
     # Disable project instead of deleting to keep translation memory & stats
     disabled = models.BooleanField(default=False)
 
+    # Whether this project has changed since the last sync.
+    has_changed = models.BooleanField(default=False)
+
     objects = ProjectQuerySet.as_manager()
 
     class Meta:
@@ -226,6 +229,15 @@ class Project(models.Model):
             ("can_manage", "Can manage projects"),
             ("can_localize", "Can localize projects"),
         )
+
+    @property
+    def needs_sync(self):
+        """
+        True if the project has changed since the last sync such that
+        another sync is required.
+        """
+        changes = ChangedEntityLocale.objects.filter(entity__resource__project=self)
+        return self.has_changed or changes.exists()
 
     @property
     def can_commit(self):

--- a/pontoon/base/signals.py
+++ b/pontoon/base/signals.py
@@ -1,0 +1,14 @@
+from django.db.models.signals import m2m_changed
+from django.dispatch import receiver
+
+from pontoon.base.models import Project
+
+
+@receiver(m2m_changed, sender=Project.locales.through)
+def project_locale_added(sender, **kwargs):
+    """When a new locale is added to a project, mark the project as changed."""
+    action = kwargs.get('action', None)
+    project = kwargs.get('instance', None)
+    if action == 'post_add' and project is not None:
+        project.has_changed = True
+        project.save(update_fields=['has_changed'])

--- a/pontoon/base/tests/test_models.py
+++ b/pontoon/base/tests/test_models.py
@@ -8,6 +8,7 @@ from mock import call, Mock, patch
 from pontoon.base.models import Entity, Repository, Translation, User
 from pontoon.base.tests import (
     assert_attributes_equal,
+    ChangedEntityLocaleFactory,
     EntityFactory,
     IdenticalTranslationFactory,
     LocaleFactory,
@@ -83,6 +84,17 @@ class ProjectTests(TestCase):
         project = ProjectFactory.create(repositories=[repo1, repo2, repo3])
         path = os.path.join(repo2.checkout_path, 'foo', 'bar')
         assert_equal(project.repository_for_path(path), repo2)
+
+    def test_needs_sync(self):
+        """
+        Project.needs_sync should be True if ChangedEntityLocale objects
+        exist for its entities or if Project.has_changed is True.
+        """
+        assert_true(ProjectFactory.create(has_changed=True).needs_sync)
+
+        project = ProjectFactory.create(has_changed=False)
+        ChangedEntityLocaleFactory.create(entity__resource__project=project)
+        assert_true(project.needs_sync)
 
 
 class ProjectPartsTests(TestCase):

--- a/pontoon/base/tests/test_signals.py
+++ b/pontoon/base/tests/test_signals.py
@@ -1,0 +1,18 @@
+from django_nose.tools import assert_false, assert_true
+
+from pontoon.base.tests import ProjectFactory, LocaleFactory, TestCase
+
+
+class SignalTests(TestCase):
+    def test_project_locale_added(self):
+        """
+        When a locale is added to a project, has_changed should be set
+        to True.
+        """
+        project = ProjectFactory.create(locales=[], has_changed=False)
+        assert_false(project.has_changed)
+
+        locale = LocaleFactory.create()
+        project.locales.add(locale)
+        project.refresh_from_db()
+        assert_true(project.has_changed)


### PR DESCRIPTION
By marking projects as changed when we update locales, we force sync to run even if there haven't been any new translations or changes in VCS.

This depends on #204 because I didn't want to handle the rebasing process after it gets merged. Feel free to comment just on the last commit, or wait until #204 lands. Probably the latter.

@mathjazz r?