### PR TITLE
Fix bug 1212738: Send proper plural_form when updating translations.

### DIFF
--- a/pontoon/base/static/js/translate_old.js
+++ b/pontoon/base/static/js/translate_old.js
@@ -1185,6 +1185,15 @@ var Pontoon = (function (my) {
         }
       }
 
+      // If the entity has a plural string, but the locale has nplurals == 1,
+      // then pluralForm is -1 and needs to be normalized to 0 so that it is
+      // stored in the database as a pluralized string.
+      // TODO: Get a better flag for pluralized strings than original_plural.
+      var submittedPluralForm = pluralForm;
+      if (entity.original_plural && submittedPluralForm === -1) {
+        submittedPluralForm = 0;
+      }
+
       $.ajax({
         url: '/update/',
         type: 'POST',
@@ -1193,7 +1202,7 @@ var Pontoon = (function (my) {
           locale: self.locale.code,
           entity: entity.pk,
           translation: translation,
-          plural_form: pluralForm,
+          plural_form: submittedPluralForm,
           original: entity['original' + self.isPluralized()],
           ignore_check: inplace || $('#quality').is(':visible') || !syncLocalStorage
         },


### PR DESCRIPTION
Turns out my initial assessment in [bug 1212738](https://bugzilla.mozilla.org/show_bug.cgi?id=1212738) about the fix was wrong; the UI depends on `pluralForm` being `-1` for locales with `nplurals == 1`, regardless of what is stored in the database as the plural form of the string.

This fixes the issue on our current UI, but it's a bandaid. The hopeful future redesign/re-implementation will have to take a few things into consideration:

1. This was caused by a conflation of UI logic and app logic. Because we determined the plural form from which DOM elements were visible, the UI requirement of hiding the plural tabs for locales with `nplurals == 1` got conflated with our logic of what plural form to store in the database.
2. We don't currently have any good way to represent in the database whether an entity is pluralized or not. There's checking for `string_plural` but that seems to be not quite right. `vcs_models` uses a dict with a `None` key for singular entities and numbers for pluralized entities, but I'm not entirely happy with that either.

In any case, this should fix things for us now.