### PR TITLE
Add reverse FK names and optimize locale list.

### DIFF
--- a/pontoon/base/migrations/0037_entity_resource_related_names.py
+++ b/pontoon/base/migrations/0037_entity_resource_related_names.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0036_project_has_changed'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='entity',
+            name='resource',
+            field=models.ForeignKey(related_name='entities', to='base.Resource'),
+        ),
+        migrations.AlterField(
+            model_name='resource',
+            name='project',
+            field=models.ForeignKey(related_name='resources', to='base.Project'),
+        ),
+    ]

--- a/pontoon/base/templates/locale_selector.html
+++ b/pontoon/base/templates/locale_selector.html
@@ -31,7 +31,7 @@
       <li class="clearfix{% if locale and locale == l %} current{% endif %}{% if l and l.chart %} filter{% endif %}">
         <span class="language {{ l.code|lower }}">{% if l and l.chart %}<a href="{% if project %}{{ url('pontoon.locale.project', l.code, project.slug) }}{% else %}{{ url('pontoon.locale', l.code) }}{% endif %}" class="clearfix">{% endif %}{{ l.name }}{% if l and l.chart %}</a>{% endif %}</span>
         <span class="code">{% if l and l.chart %}<a class="code" href="{% if project %}{{ url('pontoon.locale.project', l.code, project.slug) }}{% else %}{{ url('pontoon.locale', l.code) }}{% endif %}" class="clearfix">{% endif %}{{ l.code }}{% if l and l.chart %}</a>{% endif %}</span>
-        {% if not locale %}
+        {% if not locale and l.chart %}
           {{ latest_activity.span(l.latest_activity(project)) }}
         {% endif %}
         {% if l and l.chart and l.chart.total %}

--- a/pontoon/base/tests/test_models.py
+++ b/pontoon/base/tests/test_models.py
@@ -113,9 +113,8 @@ class ProjectPartsTests(TestCase):
 
     def _fetch_locales_parts_stats(self):
         # Fake Prefetch
-        resources = Entity.objects.filter(obsolete=False).values('resource')
-        self.project.active_resources = self.project.resource_set.filter(
-            pk__in=resources
+        self.project.active_resources = self.project.resources.filter(
+            entities__obsolete=False
         )
 
         return self.project.locales_parts_stats()
@@ -407,7 +406,7 @@ class TranslationQuerySetTests(TestCase):
         return submission date and user.
         """
         latest_submission = self._translation(self.user0, submitted=(1970, 1, 3), approved=None)
-        
+
         # latest approval
         self._translation(self.user1, submitted=(1970, 1, 1), approved=(1970, 1, 2))
         assert_equal(Translation.objects.all().latest_activity(), {

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -123,8 +123,9 @@ def projects(request, template='projects.html'):
     log.debug("Project overview.")
 
     projects = Project.objects.filter(
-        disabled=False, pk__in=Resource.objects.values('project')) \
-        .order_by("name")
+        disabled=False,
+        resources__isnull=False,
+    ).distinct().order_by("name")
 
     data = {
         'projects': get_projects_with_stats(projects),

--- a/pontoon/sync/changeset.py
+++ b/pontoon/sync/changeset.py
@@ -73,7 +73,7 @@ class ChangeSet(object):
 
         # Store locales and resources for FK relationships.
         self.locales = {l.code: l for l in Locale.objects.all()}
-        self.resources = {r.path: r for r in self.db_project.resource_set.all()}
+        self.resources = {r.path: r for r in self.db_project.resources.all()}
 
         # Perform the changes and fill the lists for bulk creation and
         # updating.

--- a/pontoon/sync/core.py
+++ b/pontoon/sync/core.py
@@ -127,10 +127,10 @@ def handle_entity(changeset, db_project, key, db_entity, vcs_entity):
 def update_resources(db_project, vcs_project):
     """Update the database on what resource files exist in VCS."""
     relative_paths = vcs_project.resources.keys()
-    db_project.resource_set.exclude(path__in=relative_paths).delete()
+    db_project.resources.exclude(path__in=relative_paths).delete()
 
     for relative_path, vcs_resource in vcs_project.resources.items():
-        resource, created = db_project.resource_set.get_or_create(path=relative_path)
+        resource, created = db_project.resources.get_or_create(path=relative_path)
         resource.format = Resource.get_path_format(relative_path)
         resource.entity_count = len(vcs_resource.entities)
         resource.save()
@@ -138,7 +138,7 @@ def update_resources(db_project, vcs_project):
 
 def update_project_stats(db_project, vcs_project, changeset):
     """Update the Stats entries in the database."""
-    for resource in db_project.resource_set.all():
+    for resource in db_project.resources.all():
         for locale in db_project.locales.all():
             # We only want to create/update the stats object if the resource
             # exists in the current locale, UNLESS the file is asymmetric.


### PR DESCRIPTION
Only fetch data for locales active in the project, and avoid
selecting all the project locales for each locale in the project.

Testing with django-debug-toolbar on a project with 3 locales, the project page with the locale listing went from 235 database queries to 18 and loads significantly faster.

This also has some query fixes I found while I was looking that don't particularly improve our performance, but improve our comprehensibility.

@mathjazz r?