### PR TITLE
Bug 1214392: Denormalize latest activity.

### DIFF
--- a/pontoon/base/migrations/0038_add_latest_translation.py
+++ b/pontoon/base/migrations/0038_add_latest_translation.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import django.db.models.deletion
+from django.db import models, migrations
+
+
+def migrate_locales_to_new_locales(apps, schema_editor):
+    """Copy locales from the old ManyToMany to the new one."""
+    Project = apps.get_model('base', 'Project')
+    ProjectLocale = apps.get_model('base', 'ProjectLocale')
+    for project in Project.objects.all():
+        for locale in project.locales.all():
+            ProjectLocale.objects.create(project=project, locale=locale)
+
+
+def migrate_new_locales_to_locales(apps, schema_editor):
+    """Copy locales from the new ManyToMany to the old one."""
+    Project = apps.get_model('base', 'Project')
+    for project in Project.objects.all():
+        for locale in project.new_locales.all():
+            project.locales.add(locale)
+
+
+def latest_activity(translation):
+    """
+    Return the date and user associated with the latest activity on
+    this translation.
+    """
+    if translation.approved_date is not None and translation.approved_date > translation.date:
+        return {'date': translation.approved_date, 'user': translation.approved_user}
+    else:
+        return {'date': translation.date, 'user': translation.user}
+
+
+def check_latest_translation(translation, instance):
+    """
+    Check if the given model instance has a `latest_activity`
+    attribute and, if it does, see if this translation is more
+    recent than it. If so, replace it and save.
+    """
+    latest = instance.latest_translation
+    if latest is None or latest_activity(translation)['date'] > latest_activity(latest)['date']:
+        instance.latest_translation = translation
+        instance.save(update_fields=['latest_translation'])
+
+
+def create_latest_translation(apps, schema_editor):
+    """
+    Populate the latest_translation fields by searching the existing
+    translations.
+    """
+    Stats = apps.get_model('base', 'Stats')
+    ProjectLocale = apps.get_model('base', 'ProjectLocale')
+    Translation = apps.get_model('base', 'Translation')
+    for stats in Stats.objects.all():
+        project = stats.resource.project
+        locale = stats.locale
+        path = stats.resource.path
+        translations = Translation.objects.filter(
+            entity__resource__project=project,
+            entity__resource__path=path,
+            locale=locale
+        )
+
+        if not translations.exists():
+            continue
+        latest_creation = translations.order_by('-date')[0]
+        approvals = (
+            translations
+            .filter(approved_date__isnull=False)
+            .order_by('-approved_date')
+        )
+
+        # Choose whether the latest creation or latest approval is the
+        # latest translation.
+        if not approvals.exists():
+            stats.latest_translation = latest_creation
+        else:
+            latest_approval = approvals[0]
+            if (latest_approval.approved_date
+                    and latest_creation.date < latest_approval.approved_date):
+                stats.latest_translation = latest_approval
+            else:
+                stats.latest_translation = latest_creation
+
+        # Update the project and locale as well.
+        stats.save(update_fields=['latest_translation'])
+        check_latest_translation(stats.latest_translation, project)
+        check_latest_translation(stats.latest_translation, locale)
+
+        try:
+            project_locale = ProjectLocale.objects.get(project=project, locale=locale)
+            check_latest_translation(stats.latest_translation, project_locale)
+        except ProjectLocale.DoesNotExist:
+            pass
+
+
+def noop(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0037_entity_resource_related_names'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ProjectLocale',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('latest_translation', models.ForeignKey(related_name='+', on_delete=django.db.models.deletion.SET_NULL, blank=True, to='base.Translation', null=True)),
+            ],
+        ),
+        migrations.AddField(
+            model_name='locale',
+            name='latest_translation',
+            field=models.ForeignKey(related_name='+', on_delete=django.db.models.deletion.SET_NULL, blank=True, to='base.Translation', null=True),
+        ),
+        migrations.AddField(
+            model_name='project',
+            name='latest_translation',
+            field=models.ForeignKey(related_name='+', on_delete=django.db.models.deletion.SET_NULL, blank=True, to='base.Translation', null=True),
+        ),
+        migrations.AddField(
+            model_name='stats',
+            name='latest_translation',
+            field=models.ForeignKey(related_name='+', on_delete=django.db.models.deletion.SET_NULL, blank=True, to='base.Translation', null=True),
+        ),
+        migrations.AddField(
+            model_name='projectlocale',
+            name='locale',
+            field=models.ForeignKey(to='base.Locale'),
+        ),
+        migrations.AddField(
+            model_name='projectlocale',
+            name='project',
+            field=models.ForeignKey(to='base.Project'),
+        ),
+        migrations.AddField(
+            model_name='project',
+            name='new_locales',
+            field=models.ManyToManyField(related_name='+', through='base.ProjectLocale', to='base.Locale'),
+        ),
+        migrations.RunPython(migrate_locales_to_new_locales, migrate_new_locales_to_locales),
+        migrations.RemoveField(
+            model_name='project',
+            name='locales',
+        ),
+        migrations.RemoveField(
+            model_name='project',
+            name='new_locales',
+        ),
+        migrations.AddField(
+            model_name='project',
+            name='locales',
+            field=models.ManyToManyField(to='base.Locale', through='base.ProjectLocale'),
+        ),
+        migrations.RunPython(create_latest_translation, noop),
+    ]

--- a/pontoon/base/migrations/0039_projectlocales_unique.py
+++ b/pontoon/base/migrations/0039_projectlocales_unique.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0038_add_latest_translation'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='projectlocale',
+            unique_together=set([('project', 'locale')]),
+        ),
+    ]

--- a/pontoon/base/signals.py
+++ b/pontoon/base/signals.py
@@ -1,14 +1,19 @@
-from django.db.models.signals import m2m_changed
+from django.db.models.signals import post_save
 from django.dispatch import receiver
 
-from pontoon.base.models import Project
+from pontoon.base.models import ProjectLocale
 
 
-@receiver(m2m_changed, sender=Project.locales.through)
+@receiver(post_save, sender=ProjectLocale)
 def project_locale_added(sender, **kwargs):
-    """When a new locale is added to a project, mark the project as changed."""
-    action = kwargs.get('action', None)
-    project = kwargs.get('instance', None)
-    if action == 'post_add' and project is not None:
+    """
+    When a new locale is added to a project, mark the project as
+    changed.
+    """
+    created = kwargs.get('created', False)
+    raw = kwargs.get('raw', False)
+    project_locale = kwargs.get('instance', None)
+    if created and not raw and project_locale is not None:
+        project = project_locale.project
         project.has_changed = True
         project.save(update_fields=['has_changed'])

--- a/pontoon/base/templates/locale_selector.html
+++ b/pontoon/base/templates/locale_selector.html
@@ -32,7 +32,7 @@
         <span class="language {{ l.code|lower }}">{% if l and l.chart %}<a href="{% if project %}{{ url('pontoon.locale.project', l.code, project.slug) }}{% else %}{{ url('pontoon.locale', l.code) }}{% endif %}" class="clearfix">{% endif %}{{ l.name }}{% if l and l.chart %}</a>{% endif %}</span>
         <span class="code">{% if l and l.chart %}<a class="code" href="{% if project %}{{ url('pontoon.locale.project', l.code, project.slug) }}{% else %}{{ url('pontoon.locale', l.code) }}{% endif %}" class="clearfix">{% endif %}{{ l.code }}{% if l and l.chart %}</a>{% endif %}</span>
         {% if not locale and l.chart %}
-          {{ latest_activity.span(l.latest_activity(project)) }}
+          {{ latest_activity.span(l.get_latest_activity(project|default(none))) }}
         {% endif %}
         {% if l and l.chart and l.chart.total %}
         <span class="chart-wrapper">

--- a/pontoon/base/templates/part_selector.html
+++ b/pontoon/base/templates/part_selector.html
@@ -42,7 +42,7 @@
             </a>
           </span>
 
-          {{ latest_activity.span(project.latest_activity(locale, p['resource__path'])) }}
+          {{ latest_activity.span(p['latest_activity']) }}
 
           <span class="chart-wrapper">
             <a href="{{ url('pontoon.translate', locale.code, project.slug, p['resource__path']) }}" class="clearfix">

--- a/pontoon/base/templates/project_selector.html
+++ b/pontoon/base/templates/project_selector.html
@@ -31,7 +31,7 @@
           {% if p and p.chart %}</a>{% endif %}
         </span>
         {% if not project %}
-          {{ latest_activity.span(p.latest_activity(locale)) }}
+          {{ latest_activity.span(p.get_latest_activity(locale|default(none))) }}
         {% endif %}
         {% if p and p.chart and p.chart.total %}
         <span class="chart-wrapper">

--- a/pontoon/base/tests/__init__.py
+++ b/pontoon/base/tests/__init__.py
@@ -17,6 +17,7 @@ from pontoon.base.models import (
     Entity,
     Locale,
     Project,
+    ProjectLocale,
     Repository,
     Resource,
     Stats,
@@ -81,7 +82,7 @@ class ProjectFactory(DjangoModelFactory):
 
         if extracted:
             for locale in extracted:
-                self.locales.add(locale)
+                ProjectLocaleFactory.create(project=self, locale=locale)
 
     @factory.post_generation
     def repositories(self, create, extracted, **kwargs):
@@ -93,6 +94,11 @@ class ProjectFactory(DjangoModelFactory):
                 self.repositories.add(repository)
         else:  # Default to a single valid repo.
             self.repositories.add(RepositoryFactory.build())
+
+
+class ProjectLocaleFactory(DjangoModelFactory):
+    class Meta:
+        model = ProjectLocale
 
 
 class RepositoryFactory(DjangoModelFactory):

--- a/pontoon/base/tests/test_signals.py
+++ b/pontoon/base/tests/test_signals.py
@@ -1,6 +1,13 @@
 from django_nose.tools import assert_false, assert_true
 
-from pontoon.base.tests import ProjectFactory, LocaleFactory, TestCase
+from pontoon.base.models import ProjectLocale
+from pontoon.base.tests import (
+    ProjectFactory,
+    ProjectLocaleFactory,
+    LocaleFactory,
+    TestCase,
+    TranslationFactory,
+)
 
 
 class SignalTests(TestCase):
@@ -13,6 +20,27 @@ class SignalTests(TestCase):
         assert_false(project.has_changed)
 
         locale = LocaleFactory.create()
-        project.locales.add(locale)
+        ProjectLocaleFactory.create(project=project, locale=locale)
         project.refresh_from_db()
         assert_true(project.has_changed)
+
+    def test_project_locale_modified(self):
+        """
+        If ProjectLocale is modified (like setting the
+        latest_translation), has_changed should not be modified.
+        """
+        locale = LocaleFactory.create()
+        project = ProjectFactory.create(locales=[locale])
+        project.has_changed = False
+        project.save()
+
+        project.refresh_from_db()
+        assert_false(project.has_changed)
+
+        project_locale = ProjectLocale.objects.get(project=project, locale=locale)
+        project_locale.latest_translation = TranslationFactory.create(
+            entity__resource__project=project, locale=locale)
+        project_locale.save()
+
+        project.refresh_from_db()
+        assert_false(project.has_changed)

--- a/pontoon/base/tests/test_utils.py
+++ b/pontoon/base/tests/test_utils.py
@@ -1,7 +1,8 @@
-from django_nose.tools import assert_false, assert_true
+from django_nose.tools import assert_equal, assert_false, assert_is_none, assert_true
 
-from pontoon.base.tests import TestCase
-from pontoon.base.utils import extension_in
+from pontoon.base.tests import ProjectFactory, TestCase
+from pontoon.base.models import Project
+from pontoon.base.utils import extension_in, get_object_or_none
 
 
 class UtilsTests(TestCase):
@@ -15,3 +16,8 @@ class UtilsTests(TestCase):
 
         # Unintuitive, but that's how splitext works.
         assert_false(extension_in('filename.tar.gz', ['tar.gz']))
+
+    def test_get_object_or_none(self):
+        project = ProjectFactory.create(slug='exists')
+        assert_is_none(get_object_or_none(Project, slug='does-not-exist'))
+        assert_equal(get_object_or_none(Project, slug='exists'), project)

--- a/pontoon/base/utils.py
+++ b/pontoon/base/utils.py
@@ -375,3 +375,14 @@ def extension_in(filename, extensions):
         return True
     else:
         return False
+
+
+def get_object_or_none(model, *args, **kwargs):
+    """
+    Get an instance of the given model, returning None instead of
+    raising an error if an instance cannot be found.
+    """
+    try:
+        return model.objects.get(*args, **kwargs)
+    except model.DoesNotExist:
+        return None


### PR DESCRIPTION
This relies on #216, will rebase after that gets merged. Pay attention to the last commit only.

This denormalizes the latest activity such that Project, Resource, Locale, and ProjectLocale (which was previously an implicit through model for Project.locales) all have a `latest_translation` field that gets updated when translations are saved. The listings that show the latest activity now efficiently pull the `latest_translation` field when trying to figure out which translation qualifies as the latest activity, as opposed to doing a bunch of queries to find the latest activity.

Locally this led to a major drop in load time for the project, locale, and resource listings for me. It also reduced the number of database queries on each page by quite a bit.

@mathjazz r?