### PR TITLE
Use AJAX to fetch main menu data

### DIFF
--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -234,6 +234,10 @@ body > header .project.select {
   float: right;
 }
 
+.project.select .menu ul li:not(.current) {
+  display: none;
+}
+
 .menu li.horizontal-separator {
   border-top: 1px solid #525A65;
   height: 0;

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -1541,6 +1541,23 @@ var Pontoon = (function (my) {
 
 
     /*
+     * Load project details to main menu
+     */
+    loadMainMenu: function () {
+      $('.project .menu .name:not([data-details])').each(function() {
+        $.ajax({
+          url: '/projects/' + $(this).data('slug') + '/details/',
+          success: function(data) {
+            $('.project .menu .name[data-slug=' + data.slug + ']')
+              .data('details', data.details)
+              .parent('li').show();
+          }
+        });
+      });
+    },
+
+
+    /*
      * Create user interface
      */
     createUI: function () {
@@ -1551,6 +1568,7 @@ var Pontoon = (function (my) {
         $('.notification').css('opacity', 100);
       }
 
+      self.loadMainMenu();
       self.attachMainHandlers();
       self.renderEntityList();
       self.updateProgress();

--- a/pontoon/base/templates/project_selector.html
+++ b/pontoon/base/templates/project_selector.html
@@ -25,7 +25,7 @@
       <li class="clearfix{% if project and project == p %} current{% endif %}">
         <span class="name"
           data-slug="{{ p.slug }}"
-          {% if project %}data-details="{{ p.locales_parts_stats()|to_json }}"{% endif %}>
+          {% if project and project == p %}data-details="{{ p.locales_parts_stats()|to_json }}"{% endif %}>
           {% if p and p.chart %}<a href="{% if locale %}{{ url('pontoon.locale.project', locale.code, p.slug) }}{% elif admin %}{{ url('pontoon.admin.project', p.slug) }}{% else %}{{ url('pontoon.project', p.slug) }}{% endif %}" class="clearfix">{% endif %}
             {{ p.name }}
           {% if p and p.chart %}</a>{% endif %}

--- a/pontoon/base/urls.py
+++ b/pontoon/base/urls.py
@@ -54,6 +54,10 @@ urlpatterns = patterns(
         views.ProjectContributorsView.as_view(),
         name='pontoon.project.contributors'),
 
+    # AJAX: Get project details
+    url(r'^projects/(?P<slug>[\w-]+)/details/$', views.get_project_details,
+        name='pontoon.project.details'),
+
     # Translate project
     url(r'^(?P<locale>[A-Za-z0-9\-\@\.]+)/(?P<slug>[\w-]+)/(?P<part>.+)/$',
         views.translate,

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -21,6 +21,7 @@ from django.db.models import Count, F, Q
 from django.http import (
     Http404,
     HttpResponse,
+    HttpResponseBadRequest,
     HttpResponseRedirect,
 )
 
@@ -397,6 +398,21 @@ def search(request, template='search.html'):
     }
 
     return render(request, template, data)
+
+
+def get_project_details(request, slug):
+    """Get project locales with their pages/paths and stats."""
+    if not request.is_ajax():
+        raise HttpResponseBadRequest
+
+    project = get_object_or_404(Project, slug=slug)
+
+    data = {
+        "slug": slug,
+        "details": project.locales_parts_stats(),
+    }
+
+    return HttpResponse(json.dumps(data), content_type='application/json')
 
 
 def entities(request, template=None):


### PR DESCRIPTION
This changes the way we load project, locale, resource and stats data for the main menu. Instead of loading data as part of the main server request, we make separate AJAX requests for each project. Except for the currently translated project, so its resources/subpages/search are available immediately.

AJAX requests are triggered all at once, without any smart logic, letting the browser handle them within its limits. Requests are made after loading entities, which performs better than the other way around. Projects in the project menu are hidden until their AJAX request completes.

This is deployed on [staging](https://mozilla-pontoon-staging.herokuapp.com/) and is showing significant performance improvements:
- Main request: 12s vs 2s (> 80%)
- All requests: 18s vs 9s (> 80%)
- Full page load including the new main menu AJAX calls: 18s vs 14s (> 20%)

PROS
- Decreases homepage main request (/) time by > 80%.
- Decreases homepage total request (all) time by > 50%.
- Decreases homepage fully loaded time (incl. new AJAX calls) time by > 20%.
- Decreases homepage HTML size by > 80%.
- No more homepage timeouts!

CONS
- Main menu is fully ready a few seconds after page load.
- Possible: memory consumption.

I'm impressed how big of an improvement this is given the size of a changeset. What also surprises me is the full page load time being shorter than without this PR. It must be related to the fact that I'm splitting one huge server request into serveral smaller ones. Something to note for optimizing get-entities/ request.

Next, I'm thinking about changing the Go button into AJAX call as well. That would allow users to switch between resources/subpages (and projects/locales) without triggering project-details/ AJAX requests again.

@Osmose @jotes r?