### PR TITLE
Fix bug 1201212: Do not approve translations with fuzzy VCS counterparts

### DIFF
--- a/pontoon/sync/changeset.py
+++ b/pontoon/sync/changeset.py
@@ -196,7 +196,7 @@ class ChangeSet(object):
                                             plural_form=plural_form,
                                             string=string)
                 if db_translation:
-                    if not db_translation.approved:
+                    if not db_translation.approved and not vcs_translation.fuzzy:
                         db_translation.approved = True
                         db_translation.approved_date = self.now
                     db_translation.fuzzy = vcs_translation.fuzzy

--- a/pontoon/sync/tests/test_changeset.py
+++ b/pontoon/sync/tests/test_changeset.py
@@ -209,6 +209,24 @@ class ChangeSetTests(FakeCheckoutTestCase):
             approved_date=aware_datetime(1970, 1, 1)
         )
 
+    def test_update_db_dont_approve_fuzzy(self):
+        """
+        Do not approve un-approved translations that have non-fuzzy
+        counterparts in VCS.
+        """
+        self.main_db_translation.approved = False
+        self.main_db_translation.approved_date = None
+        self.main_db_translation.save()
+        self.main_vcs_translation.fuzzy = True
+
+        self.update_main_db_entity()
+        self.main_db_translation.refresh_from_db()
+        assert_attributes_equal(
+            self.main_db_translation,
+            approved=False,
+            approved_date=None
+        )
+
     def test_update_db_new_translation(self):
         """
         If a matching translation does not exist in the database, create a new


### PR DESCRIPTION
Before this PR, we approved all DB translations with matching VCS counterparts, including the ones with fuzzy VCS counterparts.

Such translations were marked as both, approved and fuzzy in Pontoon, which means:
A. They were treated as approved in the translate view.
B. They were treated as fuzzy in sync (didn't get committed).
C. They were treated as both in stats, so stats were broken.

This PR fixes A. C will be fixed the next time sync will run for these projects. We can also do it manually.

@Osmose r?