### PR TITLE
Notify New Relic on deploy.

### DIFF
--- a/bin/post_compile
+++ b/bin/post_compile
@@ -1,4 +1,15 @@
 #!/usr/bin/env bash
+
+# Compile static assets
 export PATH=/app/.heroku/node/bin:$PATH
 ./manage.py migrate --noinput
 ./manage.py collectstatic --noinput
+
+# Inform New Relic that a deploy is happening.
+if [ -n "${NEW_RELIC_API_KEY}" ] && [ -n "${NEW_RELIC_APP_NAME}" ]; then
+    echo "Sending deploy notification to New Relic...."
+    curl -sS -H "x-api-key:${NEW_RELIC_API_KEY}" \
+         -d "deployment[app_name]=${NEW_RELIC_APP_NAME}" \
+         -d "deployment[revision]=${SOURCE_VERSION}" \
+         https://api.newrelic.com/deployments.xml > /dev/null
+fi

--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -55,6 +55,14 @@ you create:
 ``HMAC_KEY``
    Required. Secret key used for hashing passwords.
 
+``NEW_RELIC_API_KEY``
+   Optional. API key for accessing the New Relic REST API. Used to mark deploys
+   on New Relic.
+
+``NEW_RELIC_APP_NAME``
+   Optional. Name to give to this app on New Relic. Required if you're using
+   New Relic.
+
 ``SECRET_KEY``
    Required. Secret key used for sessions, cryptographic signing, etc.
 


### PR DESCRIPTION
Was trying to figure out performance stuff this morning and got tired of not knowing when deploys are happening while on New Relic.

The necessary environment variables are already on staging and prod. I tested on staging earlier and it seems to work fine: https://rpm.newrelic.com/accounts/263620/applications/8734596/deployments

@mathjazz r?