### PR TITLE
Add STATIC_HOST setting to support CDN use.

### DIFF
--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -87,6 +87,10 @@ you create:
    SSH private key to use for authentication when Pontoon connects to VCS
    servers via SSH.
 
+``STATIC_HOST``
+   Optional. Hostname to prepend to static resources paths. Useful for serving
+   static files from a CDN. Example: ``//asdf.cloudfront.net``.
+
 ``SVN_LD_LIBRARY_PATH``
    Path to prepend to ``LD_LIBRARY_PATH`` when running SVN. This is necessary
    on Heroku because the Python buildpack alters the path in a way that breaks

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -41,6 +41,9 @@ DATABASES = {
 # Example: "/home/media/media.lawrence.com/static/"
 STATIC_ROOT = os.environ.get('STATIC_ROOT', path('static'))
 
+# Optional CDN hostname for static files, e.g. '//asdf.cloudfront.net'
+STATIC_HOST = os.environ.get('STATIC_HOST', '')
+
 SESSION_COOKIE_HTTPONLY = os.environ.get('SESSION_COOKIE_HTTPONLY', 'True') != 'False'
 SESSION_COOKIE_SECURE = os.environ.get('SESSION_COOKIE_SECURE', 'True') != 'False'
 
@@ -353,7 +356,7 @@ MEDIA_URL = '/media/'
 
 # URL prefix for static files.
 # Example: "http://media.lawrence.com/static/"
-STATIC_URL = '/static/'
+STATIC_URL = STATIC_HOST + '/static/'
 
 STATICFILES_STORAGE = 'pontoon.base.storage.GzipManifestPipelineStorage'
 STATICFILES_FINDERS = (


### PR DESCRIPTION
I've already had jp help set us up with a cloudfront CDN for prod (e.g. https://d183y7hobzemob.cloudfront.net/static/css/base.min.09ddf404e0aa.css). Once this hits prod we can set the `STATIC_HOST` environment variable and all of our static assets should be served through a CDN instead of directly through our site.

@mathjazz r?