### PR TITLE
Bug 1201431: remove missing files & folders from HG

### DIFF
--- a/bin/mozilla-en-US.py
+++ b/bin/mozilla-en-US.py
@@ -76,8 +76,8 @@ def pull(url, target):
 
 
 def push(path):
-    # Add
-    execute(['hg', 'add'], path)
+    # Add new and remove missing
+    execute(['hg', 'addremove'], path)
 
     # Commit
     code, output, error = execute(['hg', 'commit', '-m', 'Update'], path)

--- a/pontoon/administration/vcs.py
+++ b/pontoon/administration/vcs.py
@@ -182,8 +182,8 @@ class CommitToHg(CommitToRepository):
         user = user or self.user
         author = self.get_author(user)
 
-        # Add
-        add = ["hg", "add"]
+        # Add new and remove missing
+        add = ["hg", "addremove"]
         execute(add, path)
 
         # Commit


### PR DESCRIPTION
We need this pretty quickly, because the merge day just happenned today instead of Monday. I'm only implementing it for HG for now, which is also the only place we currently need it.

It works on the old Pontoon server (within the mozilla-en-US script):
http://hg.mozilla.org/users/m_owca.info/firefox-aurora/rev/72d219e997ef

I'll add tests once I extend it to other VCS types. Although I'm not exactly sure how to test these things.

@Osmose @jotes r?