### PR TITLE
Bug 1214670: Explicitly push master when dealing with git.

### DIFF
--- a/pontoon/administration/vcs.py
+++ b/pontoon/administration/vcs.py
@@ -161,7 +161,7 @@ class CommitToGit(CommitToRepository):
             raise CommitToRepositoryException(unicode(error))
 
         # Push
-        push = ["git", "push", self.url]
+        push = ["git", "push", self.url, 'master']
         code, output, error = execute(push, path)
         if code != 0:
             raise CommitToRepositoryException(unicode(error))


### PR DESCRIPTION
I don't get the warning locally but commit totally still works and I believe this will get rid of the warning.

@mathjazz r?