### PR TITLE
Css fixes

### DIFF
--- a/pontoon/base/static/css/locale_project.css
+++ b/pontoon/base/static/css/locale_project.css
@@ -3,7 +3,16 @@ body > .container {
 }
 
 .menu .sort span.name {
-    width: 520px;
+  width: 520px;
+}
+
+.part .menu ul {
+  margin-bottom: -1px;
+}
+
+.part .menu section {
+  border-top: 1px solid #5E6475;
+  padding-top: 27px;
 }
 
 .part.select .menu ul li .name {

--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -499,8 +499,9 @@ label {
 }
 
 .part .menu nav ul li {
-  border: 1px solid transparent;
-  border-bottom-color: #5E6475;
+  border-color: transparent;
+  border-style: solid solid none;
+  border-width: 1px 1px 0;
 }
 
 .part .menu nav ul li.hover {
@@ -508,8 +509,8 @@ label {
 }
 
 .part .menu nav ul li.active {
+  background: #272A2F;
   border-color: #5E6475;
-  border-bottom-color: transparent;
 }
 
 .part .menu nav ul li.hover a {
@@ -519,13 +520,6 @@ label {
 .part .menu nav ul li.active a,
 .part .menu nav ul li:hover a {
   color: #FFFFFF;
-}
-
-/* TODO: this is needed (but shouldn't be) for pixel perfect tab borders */
-.part .menu nav ul li:last-child.active {
-  width: calc(50% + 2px);
-  margin-left: -2px;
-  padding-left: 2px;
 }
 
 .part .menu section {

--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -199,7 +199,6 @@ body > header .project.select {
 
 .part .menu section {
   border: 1px solid #5E6475;
-  border-top: transparent;
   margin-top: -1px;
   padding: 20px 10px 10px;
 }

--- a/pontoon/base/static/css/users.css
+++ b/pontoon/base/static/css/users.css
@@ -10,6 +10,11 @@
   display: none;
 }
 
+.about {
+  margin-top: 40px;
+  margin-bottom: -40px;
+}
+
 table {
   font-size: 14px;
   text-align: left;


### PR DESCRIPTION
@jotes r?

Tabs in the resource/search menu aren't align properly in production, because "calc(50% + 2px)" is eaten by minifer. This solution uses less-hacky approach for tab positioning.