### PR TITLE
Make request locale UX more pleasant

### DIFF
--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -751,7 +751,7 @@ label {
 }
 
 .search-wrapper > a.new:after {
-  content: "Add";
+  content: "Request";
 }
 
 .locale .search-wrapper > a.back:after {

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -78,7 +78,7 @@ var Pontoon = (function (my) {
         success: function(data) {
           if (data !== "error") {
             Pontoon.endLoader(
-              'New locale (' + locale + ') requested.', '', true);
+              "New locale (" + locale + ") requested. We'll send you an email once it gets enabled.", "", true);
           } else {
             Pontoon.endLoader('Oops, something went wrong.', 'error');
           }
@@ -88,6 +88,7 @@ var Pontoon = (function (my) {
         },
         complete: function() {
           $('.locale .menu .search-wrapper > a').click();
+          window.scrollTo(0, 0);
         }
       });
     },


### PR DESCRIPTION
I'm trying to make messaging around requesting new locale clearer. Because I'm getting many duplicate submissions. Which means UX sucks. I suppose for several reasons:

1) On project pages with longer locale list, confirmation is never visible.
-> Scrolling to top after request is made.
2) "Add" implies users can add locales themselves to projects.
-> Changing to "Request".
3) We never told anyone they will be notified when locale is enabled via email.
-> Adding that to the confirmation message.

@Osmose @jotes r?