### PR TITLE
Bug 952488 - Add locale managers UI

### DIFF
--- a/pontoon/base/signals.py
+++ b/pontoon/base/signals.py
@@ -1,8 +1,8 @@
 from guardian.models import GroupObjectPermission
 
-from django.core.exceptions import ObjectDoesNotExist
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ObjectDoesNotExist
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 
@@ -35,6 +35,7 @@ def create_locale_translators_group(sender, **kwargs):
 
     if kwargs['raw'] or instance.translators_group is not None:
         return
+
     try:
         locale_ct = ContentType.objects.get(app_label='base', model='locale')
         locale_group, _ = Group.objects.get_or_create(name='{} translators'.format(instance.code))
@@ -77,6 +78,7 @@ def assign_group_permissions(sender, **kwargs):
         return
 
     instance = kwargs['instance']
+
     try:
         locale_ct = ContentType.objects.get(app_label='base', model='locale')
         can_translate = Permission.objects.get(content_type=locale_ct, codename='can_translate_locale')

--- a/pontoon/base/static/css/locale_admin.css
+++ b/pontoon/base/static/css/locale_admin.css
@@ -1,0 +1,95 @@
+form {
+  padding: 25px 12px;
+  text-align: left;
+}
+
+p.intro {
+  color: #AAA;
+  font-style: italic;
+  font-weight: 300;
+  padding-bottom: 20px;
+}
+
+.user.select {
+  float: left;
+  width: auto;
+}
+
+.user.select.selected {
+  float: right;
+  text-align: right;
+}
+
+.user.select label {
+  color: #AAAAAA;
+  display: block;
+  text-transform: uppercase;
+}
+
+.user.select label a.active,
+.user.selected label {
+  color: #7BC876;
+}
+
+.user.select .menu {
+  border-bottom: 1px solid #5E6475;
+  margin: 2px 0 -4px -1px;
+  overflow: auto;
+  padding: 10px 0;
+  width: 295px;
+}
+
+.user.select .menu input[type="search"] {
+  width: 100%;
+}
+
+.user.select .menu ul {
+  height: 168px;
+  margin-bottom: 0;
+}
+
+.user.select .menu ul li {
+  cursor: pointer;
+  line-height: 17px;
+}
+
+.user.select .menu ul li .arrow {
+  display: none;
+  padding-top: 2px;
+}
+
+.user.select.available .menu ul li .arrow {
+  float: right;
+}
+
+.user.select .menu ul li.hover .arrow {
+  display: inline-block;
+}
+
+.user.available .menu ul li .arrow:after {
+  content: "";
+}
+
+.user.selected .menu ul li .arrow:after {
+  content: "";
+}
+
+.user.select .remove-all {
+  display: block;
+  margin-top: 5px;
+  text-align: right;
+  text-transform: uppercase;
+}
+
+.button {
+  background: #7BC876;
+  border: none;
+  border-radius: 3px;
+  color: #272A2F;
+  font-size: 14px;
+  font-weight: 400;
+  float: left;
+  height: 31px;
+  margin-top: 10px;
+  text-transform: uppercase;
+}

--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -457,14 +457,16 @@ label {
 
 .project.select,
 .locale.select,
-.part.select {
+.part.select,
+.user.select {
   padding-left: 0;
   width: 100%;
 }
 
 .project.select .menu,
 .locale.select .menu,
-.part.select .menu {
+.part.select .menu,
+.user.select .menu {
   bottom: auto;
   display: inline-block;
   position: relative;
@@ -972,6 +974,11 @@ body > nav,
   color: #7BC876;
 }
 
+.submenu.tabs {
+  border-bottom: 1px solid #5E6475;
+  margin: 0 12px 10px;
+}
+
 .submenu .links {
   margin: 0 0 50px;
 }
@@ -986,36 +993,23 @@ body > nav,
 }
 
 .submenu.tabs .links {
-  display: inline-block;
-  margin-bottom: 3px;
-  padding: 10px 12px;
+  display: table;
+  margin-bottom: -1px;
+  table-layout: fixed;
   width: 100%;
-
-  -moz-box-sizing: border-box;
-  box-sizing: border-box;
 }
 
 .submenu.tabs .links li {
-  border: 1px solid transparent;
-  border-bottom-color: #5E6475;
-  float: left;
+  border-color: transparent;
+  border-style: solid solid none;
+  border-width: 1px 1px 0;
+  display: table-cell;
   margin: 0;
-  width: 50%;
-
-  -moz-box-sizing: border-box;
-  box-sizing: border-box;
 }
 
 .submenu.tabs .links li.active {
   border-color: #5E6475;
-  border-bottom-color: transparent;
-}
-
-/* TODO: this is needed (but shouldn't be) for pixel perfect tab borders */
-.submenu.tabs .links li:last-child.active {
-  width: calc(50% + 2px);
-  margin-left: -2px;
-  padding-left: 2px;
+  background: #272A2F;
 }
 
 .submenu.tabs .links a {

--- a/pontoon/base/static/css/users.css
+++ b/pontoon/base/static/css/users.css
@@ -2,6 +2,7 @@
   margin-bottom: -40px;
 }
 
+.submenu.tabs,
 .submenu {
   margin-top: 40px;
 }

--- a/pontoon/base/static/js/locale_admin.js
+++ b/pontoon/base/static/js/locale_admin.js
@@ -1,0 +1,48 @@
+$(function() {
+
+  // Before submitting the form, update selected users
+  $('form').submit(function (e) {
+    var selected = $('.user.selected li').map(function() {
+      return $(this).data('id');
+    }).get();
+    $('[name="users-selected"]').val(selected);
+  });
+
+  // Switch available users
+  $('.user.available label a').click(function(e) {
+    e.preventDefault();
+
+    $(this).addClass('active').siblings('a').removeClass('active');
+    $('.user.available li').show();
+
+    if ($(this).is('.contributors')) {
+      $('.user.available li:not(".contributor")').hide();
+    }
+
+    $('#available').trigger("keyup").focus();
+  });
+
+  // While in contributors tab, search contributors only
+  $('.menu input[type=search]').on('keyup.search', function(e) {
+    if ($('.user.available label a.contributors').is('.active')) {
+      $('.user.available li:not(".contributor")').hide();
+    }
+  });
+
+  // Select users
+  $('.user.select').on('click.pontoon', 'li', function (e) {
+    var target = $(this).parents('.select').siblings('.select').find('ul'),
+        clone = $(this).remove();
+
+    target.prepend(clone.removeClass('hover'));
+    $('#available').trigger("keyup").focus();
+  });
+
+  // Remove all users
+  $('.remove-all').click(function (e) {
+    e.preventDefault();
+
+    $('.selected li').click();
+  });
+
+});

--- a/pontoon/base/templates/locale.html
+++ b/pontoon/base/templates/locale.html
@@ -10,19 +10,23 @@
 
 {% block middle %}
 <div class="container">
-	{% if locale.team_description %}
-		<div class="about">
-			<p>{{ locale.team_description|safe }}</p>
-		</div>
-	{% endif %}
+    {% if locale.team_description %}
+        <div class="about">
+            <p>{{ locale.team_description|safe }}</p>
+        </div>
+    {% endif %}
 
-	{{ Menu.submenu((
-		(url('pontoon.locale', locale.code), 'Projects', ''),
-		(url('pontoon.locale.contributors', locale.code), 'Contributors', 'contributors')
-	), request.path.split('/')[2]|default(''), 'submenu tabs') }}
+    {% set current_page = request.path.split('/')[2]|default('') %}
+    {% call Menu.submenu(class='submenu tabs') %}
+        {{ Menu.item('Projects', url('pontoon.locale', locale.code), is_active = (current_page == '')) }}
+        {{ Menu.item('Contributors', url('pontoon.locale.contributors', locale.code), is_active = (current_page == 'contributors')) }}
+        {% if request.user.has_perm('base.can_manage_locale', locale) %}
+            {{ Menu.item('Admin', url('pontoon.locale.admin', locale.code), is_active = (current_page == 'admin')) }}
+        {% endif %}
+    {% endcall %}
 
-	{% block locale_subpage %}
-		{% include 'project_selector.html' %}
-	{% endblock %}
+    {% block locale_subpage %}
+        {% include 'project_selector.html' %}
+    {% endblock %}
 </div>
 {% endblock %}

--- a/pontoon/base/templates/locale_admin.html
+++ b/pontoon/base/templates/locale_admin.html
@@ -1,0 +1,62 @@
+{% extends 'locale.html' %}
+
+{% block title %}{{ super() }} &middot; Admin {% endblock %}
+
+{% block locale_subpage %}
+<form method="POST" action="{{ url('pontoon.locale.admin', locale.code) }}">
+  <input type="hidden" value="{{ csrf_token }}" name="csrfmiddlewaretoken">
+  <input type="hidden" name="users-selected">
+
+  <p class="intro">Translators can submit and approve translations in projects available for your team.</p>
+
+  <div class="clearfix">
+      <div class="user select available">
+        <label for="available"><a class="all active" href="#">All users</a> | <a class="contributors" href="#">Contributors</a></label>
+        <div class="menu">
+
+          <div class="search-wrapper clearfix">
+            <div class="icon fa fa-search"></div>
+            <input id="available" type="search" autocomplete="off">
+          </div>
+
+          <ul>
+            {% for user in users_all %}
+            <li class="clearfix{% if user in users_contributors %} contributor{% endif %}" data-id="{{ user.id }}" title="{{ user.first_name }}">{{ user.email }}<span class="arrow fa"></span></li>
+            {% endfor %}
+          </ul>
+
+        </div>
+      </div>
+
+      <div class="user select selected">
+        <label for="selected">Translators</label>
+        <div class="menu">
+
+          <div class="search-wrapper clearfix">
+            <div class="icon fa fa-search"></div>
+            <input id="selected" type="search" autocomplete="off">
+          </div>
+
+          <ul>
+            {% for user in users_translators %}
+            <li class="clearfix{% if user in users_contributors %} contributor{% endif %}" data-id="{{ user.id }}" title="{{ user.first_name }}"><span class="arrow fa"></span>{{ user.email }}</li>
+            {% endfor %}
+          </ul>
+
+        </div>
+
+        <a class="remove-all" href="#remove-all">&larr; Remove all</a>
+      </div>
+  </div>
+
+  <button class="button">Save</button>
+</form>
+{% endblock %}
+
+{% block extend_css %}
+  {% stylesheet 'locale_admin' %}
+{% endblock %}
+
+{% block extend_js %}
+  {% javascript 'locale_admin' %}
+{% endblock %}

--- a/pontoon/base/templates/locale_contributors.html
+++ b/pontoon/base/templates/locale_contributors.html
@@ -3,8 +3,6 @@
 
 {% block title %}{{ super() }} &middot; Contributors {% endblock %}
 
-{% block class %}locale{% endblock %}
-
 {% block locale_subpage %}
   {% if contributors %}
     {{ Contributors.select_period(period, url('pontoon.locale.contributors', locale.code)) }}

--- a/pontoon/base/templates/project.html
+++ b/pontoon/base/templates/project.html
@@ -28,10 +28,11 @@
     </div>
   {% endif %}
 
-  {{ Menu.submenu((
-    (url('pontoon.project', project.slug), 'Teams', ''),
-    (url('pontoon.project.contributors', project.slug), 'Contributors', 'contributors')
-  ), request.path.split('/')[3]|default(''), 'submenu tabs') }}
+  {% set current_page = request.path.split('/')[3]|default('') %}
+  {% call Menu.submenu(class='submenu tabs') %}
+      {{ Menu.item('Teams', url('pontoon.project', project.slug), is_active = (current_page == '')) }}
+      {{ Menu.item('Contributors', url('pontoon.project.contributors', project.slug), is_active = (current_page == 'contributors')) }}
+  {% endcall %}
 
   {% block project_subpage %}
     {% include 'locale_selector.html' %}

--- a/pontoon/base/templates/widgets/contributors.html
+++ b/pontoon/base/templates/widgets/contributors.html
@@ -2,15 +2,13 @@
 
 {# Widget to select period for filtering contributors #}
 {% macro select_period(period, viewurl) %}
-{{
-	Menu.submenu((
-		(viewurl, 'All time', None),
-		(viewurl + '?period=12', '12 months', 12),
-		(viewurl + '?period=6', '6 months', 6),
-		(viewurl + '?period=3', '3 months', 3),
-		(viewurl + '?period=1', 'Last month', 1),
-	), period)
-}}
+    {% call Menu.submenu() %}
+        {{ Menu.item('All time', viewurl, is_active = (period == None)) }}
+        {{ Menu.item('12 months', viewurl + '?period=12', is_active = (period == 12)) }}
+        {{ Menu.item('6 months', viewurl + '?period=6', is_active = (period == 6)) }}
+        {{ Menu.item('3 months', viewurl + '?period=3', is_active = (period == 3)) }}
+        {{ Menu.item('Last month', viewurl + '?period=1', is_active = (period == 1)) }}
+    {% endcall %}
 {% endmacro %}
 
 {# Widget to display list of contributors. #}

--- a/pontoon/base/templates/widgets/menu.html
+++ b/pontoon/base/templates/widgets/menu.html
@@ -1,12 +1,15 @@
-{# defines menu widget #}
-{% macro submenu(choices=(), value=None, menuclass='submenu') %}
-<div class="{{ menuclass }}">
+{# Menu widget #}
+{% macro submenu(class='submenu') %}
+<div class="{{ class }}">
   <ul class="links">
-    {% for choiceurl, label, val in choices %}
-    <li {% if val == value %}class="active"{% endif %}>
-      <a href="{{ choiceurl }}">{{ label }}</a>
-    </li>
-    {% endfor %}
+    {{ caller() }}
   </ul>
 </div>
+{% endmacro %}
+
+{# Menu item #}
+{% macro item(label, url, is_active) %}
+  <li {% if is_active %}class="active"{% endif %}>
+    <a href="{{ url }}">{{ label }}</a>
+  </li>
 {% endmacro %}

--- a/pontoon/base/tests/test_views.py
+++ b/pontoon/base/tests/test_views.py
@@ -222,7 +222,7 @@ class ProjectContributorsTests(ViewTestCase):
         """
         Checks if view handles invalid project.
         """
-        assert_code(self.client.get('/projects/project_doesnt_exist/contributors'), 404)
+        assert_code(self.client.get('/projects/project_doesnt_exist/contributors/'), 404)
 
     def test_project_top_contributors(self):
         """
@@ -238,11 +238,11 @@ class ProjectContributorsTests(ViewTestCase):
 
         with patch.object(views.ProjectContributorsView, 'render_to_response', return_value=HttpResponse('')) as mock_render:
 
-            self.client.get('/projects/{}/contributors'.format(first_project.slug))
+            self.client.get('/projects/{}/contributors/'.format(first_project.slug))
             assert_equal(mock_render.call_args[0][0]['project'], first_project)
             assert_equal(list(mock_render.call_args[0][0]['contributors']), [first_project_contributor])
 
-            self.client.get('/projects/{}/contributors'.format(second_project.slug))
+            self.client.get('/projects/{}/contributors/'.format(second_project.slug))
             assert_equal(mock_render.call_args[0][0]['project'], second_project)
             assert_equal(list(mock_render.call_args[0][0]['contributors']), [second_project_contributor])
 
@@ -273,7 +273,7 @@ class LocaleContributorsTests(ViewTestCase):
         """
         Tests if view is returning an error on the missing locale.
         """
-        assert_code(self.client.get('/missing-locale/contributors'), 404)
+        assert_code(self.client.get('/missing-locale/contributors/'), 404)
 
     def test_locale_top_contributors(self):
         """
@@ -288,11 +288,11 @@ class LocaleContributorsTests(ViewTestCase):
             entity__resource__project__locales=[second_locale]).user
 
         with patch.object(views.LocaleContributorsView, 'render_to_response', return_value=HttpResponse('')) as mock_render:
-            self.client.get('/{}/contributors'.format(first_locale.code))
+            self.client.get('/{}/contributors/'.format(first_locale.code))
             assert_equal(mock_render.call_args[0][0]['locale'], first_locale)
             assert_equal(list(mock_render.call_args[0][0]['contributors']), [first_locale_contributor])
 
-            self.client.get('/{}/contributors'.format(second_locale.code))
+            self.client.get('/{}/contributors/'.format(second_locale.code))
             assert_equal(mock_render.call_args[0][0]['locale'], second_locale)
             assert_equal(list(mock_render.call_args[0][0]['contributors']), [second_locale_contributor])
 

--- a/pontoon/base/urls.py
+++ b/pontoon/base/urls.py
@@ -50,13 +50,23 @@ urlpatterns = patterns(
         name='pontoon.project'),
 
     # List project contributors
-    url(r'^projects/(?P<slug>[\w-]+)/contributors$',
+    url(r'^projects/(?P<slug>[\w-]+)/contributors/$',
         views.ProjectContributorsView.as_view(),
         name='pontoon.project.contributors'),
 
     # AJAX: Get project details
     url(r'^projects/(?P<slug>[\w-]+)/details/$', views.get_project_details,
         name='pontoon.project.details'),
+
+    # List team contributors
+    url(r'^(?P<code>[A-Za-z0-9\-\@\.]+)/contributors/$',
+        views.LocaleContributorsView.as_view(),
+        name='pontoon.locale.contributors'),
+
+    # Team admin
+    url(r'^(?P<locale>[A-Za-z0-9\-\@\.]+)/admin/$',
+        views.locale_admin,
+        name='pontoon.locale.admin'),
 
     # Translate project
     url(r'^(?P<locale>[A-Za-z0-9\-\@\.]+)/(?P<slug>[\w-]+)/(?P<part>.+)/$',
@@ -134,10 +144,5 @@ urlpatterns = patterns(
     url(r'^(?P<locale>[A-Za-z0-9\-\@\.]+)/$',
         views.locale,
         name='pontoon.locale'),
-
-    # List team contributors
-    url(r'^(?P<code>[A-Za-z0-9\-\@\.]+)/contributors$',
-        views.LocaleContributorsView.as_view(),
-        name='pontoon.locale.contributors'),
 
 )

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -186,6 +186,7 @@ AUTHENTICATION_BACKENDS = [
 # This variable is required by django-guardian.
 # App supports giving permissions for anonymous users.
 ANONYMOUS_USER_ID = -1
+GUARDIAN_RAISE_403 = True
 
 PIPELINE_COMPILERS = (
     'pipeline.compilers.es6.ES6Compiler',
@@ -215,6 +216,12 @@ PIPELINE_CSS = {
             'css/admin_project.css',
         ),
         'output_filename': 'css/admin_project.min.css',
+    },
+    'locale_admin': {
+        'source_filenames': (
+            'css/locale_admin.css',
+        ),
+        'output_filename': 'css/locale_admin.min.css',
     },
     'locale_project': {
         'source_filenames': (
@@ -275,6 +282,12 @@ PIPELINE_JS = {
             'js/jquery.timeago.js',
         ),
         'output_filename': 'js/main.min.js',
+    },
+    'locale_admin': {
+        'source_filenames': (
+            'js/locale_admin.js',
+        ),
+        'output_filename': 'js/locale_admin.min.js',
     },
     'locale_project': {
         'source_filenames': (

--- a/pontoon/sync/tests/test_core.py
+++ b/pontoon/sync/tests/test_core.py
@@ -336,7 +336,7 @@ class CommitChangesTests(FakeCheckoutTestCase):
         commit_changes(self.db_project, self.vcs_project, self.changeset)
         self.repository.commit.assert_called_with(
             CONTAINS(first_author.display_name, second_author.display_name),
-            first_author,
+            second_author,
             os.path.join(FAKE_CHECKOUT_PATH, self.translated_locale.code)
         )
 

--- a/pontoon/urls.py
+++ b/pontoon/urls.py
@@ -13,10 +13,10 @@ urlpatterns = patterns('',
     (r'^pt/(?P<url>.*)$', RedirectView.as_view(url="/pt-PT/%(url)s", permanent=True)),
 
     # Admin
-    (r'admin/', include('pontoon.administration.urls')),
+    (r'^admin/', include('pontoon.administration.urls')),
 
     # Sites
-    (r'sites/', include('pontoon.sites.urls')),
+    (r'^sites/', include('pontoon.sites.urls')),
 
     # Django admin
     (r'^a/', include(admin.site.urls)),


### PR DESCRIPTION
Adding team admin page, available to locale managers, where they can select privileged users. This PR is branched from #219, so only check the last commit. I will rebase once #219 gets merged.

I'm especially interested in more elegant solution for exposing the "Admin" in Locale dashboard to locale managers only.

@jotes @Osmose r?