### PR TITLE
Only grant new permissions to users with old can_localize permission

### DIFF
--- a/pontoon/base/migrations/0044_locale_translators.py
+++ b/pontoon/base/migrations/0044_locale_translators.py
@@ -11,10 +11,10 @@ def create_translators(apps, schema_editor):
     User = apps.get_model('auth', 'User')
 
     contributors_locale = (
-        User.objects.filter(translation__approved=True)
-            .annotate(translated_locales=models.Count('translation__locale', distinct=True),
-                approved_translations=models.Count('translation__pk', distinct=True))
-            .filter(approved_translations__gte=1, translated_locales=1)
+        User.objects
+            .filter(translation__approved=True, user_permissions__codename="can_localize")
+            .annotate(translated_locales=models.Count('translation__locale', distinct=True))
+            .filter(translated_locales=1)
     )
 
     for contributor in contributors_locale:


### PR DESCRIPTION
Two changes:

1. Permission shouldn't be granted to users who didn't have old (can_localize) permissions. They could have approved translations, because someone else approved them for them.

2. Also, approved_translations__gte=1 is implicit with translation__approved=True.

@jotes r?