### PR TITLE
Cycle celery workers and add --force option to sync_projects.

### DIFF
--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -35,6 +35,10 @@ you create:
    Celery or executed immediately and synchronously. Set this to ``False`` on
    production.
 
+``CELERYD_MAX_TASKS_PER_CHILD``
+   Maximum number of tasks a Celery worker process can execute before it’s
+   replaced with a new one. Defaults to 20 tasks.
+
 ``DISABLE_COLLECTSTATIC``
    Disables running ``./manage.py collectstatic`` during the build. Should be
    set to ``1``.

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -68,6 +68,12 @@ BROKER_URL = os.environ.get('RABBITMQ_URL', None)
 # environment is configured.
 CELERY_ALWAYS_EAGER = os.environ.get('CELERY_ALWAYS_EAGER', 'True') != 'False'
 
+# Limit the number of tasks a celery worker can handle before being replaced.
+try:
+    CELERYD_MAX_TASKS_PER_CHILD = int(os.environ.get('CELERYD_MAX_TASKS_PER_CHILD', ''))
+except ValueError:
+    CELERYD_MAX_TASKS_PER_CHILD = 20
+
 # Microsoft Translator API Key
 MICROSOFT_TRANSLATOR_API_KEY = os.environ.get('MICROSOFT_TRANSLATOR_API_KEY', '')
 

--- a/pontoon/sync/management/commands/sync_projects.py
+++ b/pontoon/sync/management/commands/sync_projects.py
@@ -25,6 +25,14 @@ class Command(BaseCommand):
             help='Do not pull new commits from VCS'
         )
 
+        parser.add_argument(
+            '--force',
+            action='store_true',
+            dest='force',
+            default=False,
+            help='Always sync even if there are no changes'
+        )
+
     def handle(self, *args, **options):
         """
         Collect the projects we want to sync and trigger worker jobs to
@@ -46,5 +54,6 @@ class Command(BaseCommand):
                 sync_project.delay(
                     project.pk,
                     no_pull=options['no_pull'],
-                    no_commit=options['no_commit']
+                    no_commit=options['no_commit'],
+                    force=options['force'],
                 )

--- a/pontoon/sync/tasks.py
+++ b/pontoon/sync/tasks.py
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 
 
 @shared_task(base=PontoonTask)
-def sync_project(project_pk, no_pull=False, no_commit=False):
+def sync_project(project_pk, no_pull=False, no_commit=False, force=False):
     """Fetch the project with the given PK and perform sync on it."""
     try:
         db_project = Project.objects.get(pk=project_pk)
@@ -44,7 +44,7 @@ def sync_project(project_pk, no_pull=False, no_commit=False):
 
     # If the repos haven't changed since the last sync and there are
     # no Pontoon-side changes for this project, quit early.
-    if not repos_changed and not db_project.needs_sync:
+    if not force and not repos_changed and not db_project.needs_sync:
         log.info('Skipping project {0}, no changes detected.'.format(db_project.slug))
         return
 

--- a/pontoon/sync/tests/test_sync_projects.py
+++ b/pontoon/sync/tests/test_sync_projects.py
@@ -15,6 +15,7 @@ class CommandTests(TestCase):
         self.command.verbosity = 0
         self.command.no_commit = False
         self.command.no_pull = False
+        self.command.force = False
 
         Project.objects.filter(slug='pontoon-intro').delete()
 
@@ -24,6 +25,7 @@ class CommandTests(TestCase):
         kwargs.setdefault('verbosity', 0)
         kwargs.setdefault('no_commit', False)
         kwargs.setdefault('no_pull', False)
+        kwargs.setdefault('force', False)
 
         self.command.handle(*args, **kwargs)
 
@@ -36,7 +38,8 @@ class CommandTests(TestCase):
         self.mock_sync_project.delay.assert_called_with(
             active_project.pk,
             no_pull=False,
-            no_commit=False
+            no_commit=False,
+            force=False
         )
 
     def test_project_slugs(self):
@@ -50,7 +53,8 @@ class CommandTests(TestCase):
         self.mock_sync_project.delay.assert_called_with(
             handle_project.pk,
             no_pull=False,
-            no_commit=False
+            no_commit=False,
+            force=False
         )
 
     def test_no_matching_projects(self):
@@ -77,5 +81,6 @@ class CommandTests(TestCase):
         self.mock_sync_project.delay.assert_called_with(
             project.pk,
             no_pull=True,
-            no_commit=True
+            no_commit=True,
+            force=False
         )

--- a/pontoon/sync/tests/test_tasks.py
+++ b/pontoon/sync/tests/test_tasks.py
@@ -63,6 +63,17 @@ class SyncProjectTests(TestCase):
             CONTAINS('Skipping', self.db_project.slug)
         )
 
+    def test_no_changes_force(self):
+        """
+        If the database and VCS both have no changes, but force is true,
+        do not skip sync.
+        """
+        self.mock_pull_changes.return_value = False
+        self.mock_project_needs_sync.return_value = False
+
+        sync_project(self.db_project.pk, force=True)
+        assert_true(self.mock_perform_sync_project.called)
+
     def test_no_pull(self):
         """
         Don't call repo.pull if command.no_pull is True.


### PR DESCRIPTION
There's two commits here:

- Adds a `--force` parameter to `sync_projects` that bypasses the logic that skips repos with no changes. I needed this while attempting to profile the sync process so that I didn't have to keep making changes every time I ran sync.
- Adds the `CELERYD_MAX_TASKS_PER_CHILD` setting, which sets the number of tasks a celery worker can handle before being replaced by a new worker. The hope is that this will help rein in the amount of memory celery workers use (see the explanation and workaround sections from [this blog post](http://chase-seibert.github.io/blog/2013/08/03/diagnosing-memory-leaks-python.html) for my inspiration).

I'm still going to see if I can reduce our memory consumption but this may help get rid of the warnings, and we can configure the setting to be lower or higher if it affects our sync performance.

@mathjazz r?