### PR TITLE
Make translate view header always visible

### DIFF
--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -14,7 +14,7 @@ mark.placeable {
 }
 
 #project-load {
-  background: #272A2F;
+  background: #3F4752;
   display: table;
   height: 100%;
   overflow: hidden;
@@ -98,7 +98,6 @@ mark.placeable {
 
 body > header {
   background: #272A2F;
-  display: none;
   height: 60px;
   position: fixed;
   text-align: left;
@@ -107,25 +106,18 @@ body > header {
 }
 
 body > header > .container {
-  display: none;
   min-width: 800px;
-}
-
-body > header .loader {
-  color: #FFFFFF;
-  display: inline-block;
-  margin: 23px 16px;
 }
 
 #switch {
   background: transparent;
   border: none;
   color: #FFFFFF;
+  display: none;
   float: left;
   height: 60px;
   margin-left: 8px;
   padding: 0; /* Needed to prevent jumping on click */
-  transition: all 0.2s ease-out;
   width: 27px;
 }
 
@@ -290,6 +282,7 @@ body > header .project.select {
 
 #progress {
   cursor: pointer;
+  display: none;
   float: left;
   margin: 8px 5px 4px 0;
 }

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -1623,8 +1623,8 @@ var Pontoon = (function (my) {
       this.filterEntities('all');
       this.updateProgress();
 
+      $("#progress").show();
       $("#project-load").hide();
-      $("body > header > .container").show();
 
       // If 2-column layout opened by default, open first entity in the editor
       if (this.app.advanced) {
@@ -1691,8 +1691,6 @@ var Pontoon = (function (my) {
         case "READY":
           var advanced = false,
               websiteWidth = Pontoon.getProjectWidth();
-
-          $('body > header').show();
 
           if (websiteWidth) {
             var windowWidth = $(window).width(),
@@ -1971,7 +1969,6 @@ var Pontoon = (function (my) {
 
             // Projects without in place translation support
             } else {
-              $('body > header').show();
               $('#sidebar').addClass('advanced').css('width', '100%').show();
               $('#editor').addClass('opened');
 


### PR DESCRIPTION
Project loader now overlaps everything *but* the header (where all the
menus are). It also uses lighter background colors, so menus are visible
if openned while projects are loading.

@Osmose @jotes r?