### PR TITLE
Fix bug 1200184: Allow translators to make suggestions

### DIFF
--- a/pontoon/base/migrations/0046_add_force_suggestions.py
+++ b/pontoon/base/migrations/0046_add_force_suggestions.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0045_remove_can_localize'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='userprofile',
+            name='svn_password',
+        ),
+        migrations.RemoveField(
+            model_name='userprofile',
+            name='svn_username',
+        ),
+        migrations.RemoveField(
+            model_name='userprofile',
+            name='transifex_password',
+        ),
+        migrations.RemoveField(
+            model_name='userprofile',
+            name='transifex_username',
+        ),
+        migrations.AddField(
+            model_name='userprofile',
+            name='force_suggestions',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -127,11 +127,8 @@ class UserProfile(models.Model):
     user = models.OneToOneField(User, related_name='profile')
 
     # Other fields here
-    transifex_username = models.CharField(max_length=40, blank=True)
-    transifex_password = models.CharField(max_length=128, blank=True)
-    svn_username = models.CharField(max_length=40, blank=True)
-    svn_password = models.CharField(max_length=128, blank=True)
     quality_checks = models.BooleanField(default=True)
+    force_suggestions = models.BooleanField(default=False)
 
 
 def validate_cldr(value):

--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -365,7 +365,7 @@ body > header .project.select {
 body > header #loading {
   display: none;
   float: left;
-  margin-right: 5px;
+  margin: 23px 5px 0 0;
 }
 
 body > header #loading.loader {
@@ -950,7 +950,7 @@ body > header aside p {
 }
 
 #plural-tabs ul li a {
-  display: inline-block;
+  display: block;
   padding: 10px;
 }
 
@@ -1040,6 +1040,26 @@ body > header aside p {
   font-weight: 600;
   margin-left: 10px;
   padding: 10px 15px;
+}
+
+#editor > menu button[id^="save"].suggest {
+  background: #4FC4F6;
+}
+
+#save:before {
+  content: "Save";
+}
+
+#save.suggest:before {
+  content: "Suggest";
+}
+
+#save-anyway:before {
+  content: "Save anyway";
+}
+
+#save-anyway.suggest:before {
+  content: "Suggest anyway";
 }
 
 #editor > menu button#leave-anyway {
@@ -1149,7 +1169,7 @@ body > header aside p {
   width: 22px;
 }
 
-#helpers > section ul li > header.localizer button,
+#helpers > section ul li > header.translator button,
 #helpers > section ul li > header.own button.delete,
 #helpers > section ul li.approved > header button.approve {
   display: inline-block;

--- a/pontoon/base/static/css/user.css
+++ b/pontoon/base/static/css/user.css
@@ -113,7 +113,7 @@
 
 .info li.check-box {
   cursor: pointer;
-  display: inline-block;
+  display: table;
 }
 
 .details {

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -525,23 +525,37 @@ $(function() {
         .find('section.' + section).show();
   });
 
-  // Toggle quality checks
-  $('.check-box.quality-checks').click(function() {
+  // Toggle user profile attribute
+  $('.check-box').click(function() {
     var self = $(this);
     Pontoon.startLoader();
 
     $.ajax({
-      url: '/quality-checks-switch/',
+      url: '/api/v1/user/' + Pontoon.user.email + '/',
       type: 'POST',
       data: {
-        csrfmiddlewaretoken: $('#server').data('csrf')
+        csrfmiddlewaretoken: $('#server').data('csrf'),
+        attribute: self.data('attribute'),
+        value: !self.is('.enabled')
       },
       success: function(data) {
         if (data === 'ok') {
           self.toggleClass('enabled');
-          var status = self.is('.enabled') ? 'enabled' : 'disabled';
-          Pontoon.endLoader('Quality checks ' + status + '.');
+          var is_enabled = self.is('.enabled'),
+              status = is_enabled ? 'enabled' : 'disabled';
+
+          Pontoon.endLoader(self.text() + ' ' + status + '.');
           $('.notification').addClass('menu-open');
+
+          if (self.is('.force-suggestions')) {
+            Pontoon.user.forceSuggestions = is_enabled;
+            Pontoon.postMessage("UPDATE-ATTRIBUTE", {
+              object: 'user',
+              attribute: 'forceSuggestions',
+              value: is_enabled
+            });
+            $('[id^="save"]').toggleClass('suggest', is_enabled);
+          }
         }
       },
       error: function() {

--- a/pontoon/base/static/js/pontoon.js
+++ b/pontoon/base/static/js/pontoon.js
@@ -39,7 +39,7 @@
               entity = element.entity,
               content = $(element).html();
 
-          if (Pontoon.user.localizer || !entity.translation[0].approved) {
+          if ((Pontoon.user.isTranslator && !Pontoon.user.forceSuggestions) || !entity.translation[0].approved) {
             entity.translation[0].string = content;
             $(entity.node).each(function() {
               this.html(content);
@@ -594,6 +594,14 @@
               left = node.getBoundingClientRect().left + window.scrollX;
               toolbar.css('left', left);
             }
+            break;
+
+          case "UPDATE-ATTRIBUTE":
+            var object = message.value.object,
+                attribute = message.value.attribute,
+                value = message.value.value;
+
+            Pontoon[object][attribute] = value;
             break;
 
           }

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -148,7 +148,7 @@ var Pontoon = (function (my) {
                 (this.approved ? ' class="approved"' : '') +
                 'title="Click to copy">' +
                   '<header class="clearfix' +
-                    ((self.user.localizer) ? ' localizer' :
+                    ((self.user.isTranslator) ? ' translator' :
                       ((self.user.email === this.email && !this.approved) ?
                         ' own' : '')) +
                     '">' +
@@ -194,6 +194,22 @@ var Pontoon = (function (my) {
      */
     appendMetaData: function (title, text) {
       $('#metadata').append('<p><span class="title">' + title + '</span>' + text + '</p>');
+    },
+
+
+    /*
+     * Update current translation length
+     */
+    updateCurrentTranslationLength: function () {
+      $('#translation-length .current-length').html($('#translation').val().length);
+    },
+
+
+    /*
+     * Update cached translation, needed for unsaved changes check
+     */
+    updateCachedTranslation: function () {
+      this.cachedTranslation = $('#translation').val();
     },
 
 
@@ -284,10 +300,10 @@ var Pontoon = (function (my) {
           translationString = entity.translation[0].string,
           translation = translationString ? translationString.length : 0;
 
-      $('#translation-length')
-        .show() // Needed if sidebar opened by default
-        .find('.original-length').html(original).end()
-        .find('.current-length').html(translation);
+      // Need to show if sidebar opened by default
+      $('#translation-length').show().find('.original-length').html(original).end();
+      self.updateCurrentTranslationLength();
+      self.updateCachedTranslation();
 
       // Update entity list
       $("#entitylist .hovered").removeClass('hovered');
@@ -350,11 +366,10 @@ var Pontoon = (function (my) {
         return callback();
       }
 
-      var pluralForm = this.getPluralForm(true),
-          translation = entity.translation[pluralForm].string,
-          source = $('#translation').val();
+      var before = this.cachedTranslation,
+          after = $('#translation').val();
 
-      if ((translation !== null) && (translation !== source)) {
+      if ((before !== null) && (before !== after)) {
         $('#unsaved').show();
         $("#translation").focus();
         this.checkUnsavedChangesCallback = callback;
@@ -640,9 +655,9 @@ var Pontoon = (function (my) {
         $('#original').html(marked);
 
         $('#translation').val(source).focus();
-        $('#translation-length')
-          .find('.original-length').html(original.length).end()
-          .find('.current-length').html($('#translation').val().length);
+        $('#translation-length .original-length').html(original.length);
+        self.updateCurrentTranslationLength();
+        self.updateCachedTranslation();
 
         $('#quality:visible .cancel').click();
         $("#helpers nav .active a").click();
@@ -739,9 +754,7 @@ var Pontoon = (function (my) {
 
       // Update length (keydown is triggered too early)
       }).unbind("input propertychange").bind("input propertychange", function (e) {
-        var length = $('#translation').val().length;
-        $('#translation-length .current-length').html(length);
-
+        self.updateCurrentTranslationLength();
         $('.warning-overlay:visible .cancel').click();
       });
 
@@ -775,7 +788,8 @@ var Pontoon = (function (my) {
             source = original;
 
         $('#translation').val(source).focus();
-        $('#translation-length .current-length').html(source.length);
+        self.updateCurrentTranslationLength();
+        self.updateCachedTranslation();
       });
 
       // Clear translation area
@@ -784,7 +798,8 @@ var Pontoon = (function (my) {
         e.preventDefault();
 
         $('#translation').val('').focus();
-        $('#translation-length .current-length').html('0');
+        self.updateCurrentTranslationLength();
+        self.updateCachedTranslation();
       });
 
       // Do not change anything when cancelled
@@ -885,7 +900,8 @@ var Pontoon = (function (my) {
         var translation = $(this).find('.translation').text(),
             source = translation;
         $('#translation').val(source).focus();
-        $('#translation-length .current-length').html(source.length);
+        self.updateCurrentTranslationLength();
+        self.updateCachedTranslation();
 
         $('.warning-overlay:visible .cancel').click();
       });
@@ -944,7 +960,7 @@ var Pontoon = (function (my) {
                       entity.translation[pluralForm].string = translation;
                       entity.ui.find('.translation-string')
                         .html(self.doNotRender(translation));
-                      if (self.user.localizer) {
+                      if (self.user.isTranslator) {
                         next.addClass('approved');
                         if (entity.body) {
                           self.postMessage("SAVE", entity.translation[0].string);
@@ -1158,10 +1174,11 @@ var Pontoon = (function (my) {
 
           var pf = self.getPluralForm(true);
           entity.translation[pf] = data.translation;
+          self.cachedTranslation = translation;
           self.updateEntityUI(entity);
 
           // Update translation, including in place if possible
-          if (!inplace && entity.body && (self.user.localizer ||
+          if (!inplace && entity.body && (self.user.isTranslator ||
               !entity.translation[pf].approved)) {
             self.postMessage("SAVE", {
               translation: translation,
@@ -1237,7 +1254,7 @@ var Pontoon = (function (my) {
             var data = {
               type: "added",
               translation: {
-                approved: self.user.localizer,
+                approved: self.user.isTranslator,
                 fuzzy: false,
                 string: translation
               }
@@ -1464,8 +1481,10 @@ var Pontoon = (function (my) {
         e.preventDefault();
         e.stopPropagation();
 
-        var data = self.pushState();
-        self.initialize();
+        self.checkUnsavedChanges(function() {
+          var data = self.pushState();
+          self.initialize();
+        });
       });
 
       // Profile menu
@@ -1488,7 +1507,7 @@ var Pontoon = (function (my) {
           } else if ($(this).is(".hotkeys")) {
             $('#hotkeys').show();
 
-          } else if ($(this).is(".quality-checks")) {
+          } else if ($(this).is('.check-box')) {
             e.stopPropagation();
           }
         });
@@ -1551,6 +1570,14 @@ var Pontoon = (function (my) {
           .bind('mouseup', { initial: data }, mouseUpHandler);
       });
 
+    },
+
+
+    /*
+     * Update save buttons based on user permissions and settings
+     */
+    updateSaveButtons: function () {
+      $('[id^="save"]').toggleClass('suggest', !this.user.isTranslator || this.user.forceSuggestions);
     },
 
 
@@ -1619,6 +1646,7 @@ var Pontoon = (function (my) {
       this.updateMainMenu();
       this.updateProjectInfo();
       this.updateProfileMenu();
+      this.updateSaveButtons();
       this.renderEntityList();
       this.filterEntities('all');
       this.updateProgress();
@@ -1885,7 +1913,7 @@ var Pontoon = (function (my) {
     createObject: function (advanced, projectWindow) {
       var self = this;
 
-      function isLocalizer(translatedLocales) {
+      function isTranslator(translatedLocales) {
         if (translatedLocales) {
           return translatedLocales.indexOf(self.locale.code) > -1;
         }
@@ -1910,15 +1938,8 @@ var Pontoon = (function (my) {
       };
 
       this.part = $('.part .selector').attr('title');
-
       this.locale = self.getLocaleData();
-
-      this.user = {
-        email: $('#server').data('email') || '',
-        name: $('#server').data('name') || '',
-        localizer: isLocalizer($('#server').data('user-translated-locales')),
-        manager: $('#server').data('manager')
-      };
+      this.user.isTranslator = isTranslator($('#server').data('user-translated-locales'));
     },
 
 
@@ -2097,21 +2118,28 @@ var Pontoon = (function (my) {
 
 /* Main code */
 $(function() {
-  Pontoon.attachMainHandlers();
-  Pontoon.attachEditorHandlers();
-
   window.onpopstate = function(e) {
-    // Update main menu
-    $('.project .menu li [data-slug="' + e.state.project + '"]').parent().click();
-    $('.locale .menu li .language.' + e.state.locale.toLowerCase()).parent().click();
-    if (e.state.paths) {
-      Pontoon.updatePartSelector(e.state.paths);
-    }
-    // TODO: update search
+    if (e.state) {
+      // Update main menu
+      $('.project .menu li [data-slug="' + e.state.project + '"]').parent().click();
+      $('.locale .menu li .language.' + e.state.locale.toLowerCase()).parent().click();
+      if (e.state.paths) {
+        Pontoon.updatePartSelector(e.state.paths);
+      }
 
-    Pontoon.initialize();
+      Pontoon.initialize();
+    }
   };
 
+  Pontoon.user = {
+    email: $('#server').data('email') || '',
+    name: $('#server').data('name') || '',
+    forceSuggestions: $('#server').data('force-suggestions') === 'True' ? true : false,
+    manager: $('#server').data('manager')
+  };
+
+  Pontoon.attachMainHandlers();
+  Pontoon.attachEditorHandlers();
   Pontoon.pushState();
   Pontoon.initialize();
 });

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% import "widgets/checkbox.html" as Checkbox %}
+
 {% block class %}translate{% endblock %}
 
 {% block content %}
@@ -11,6 +13,7 @@
      {% if csrf_token %}data-csrf="{{ csrf_token }}"{% endif %}
      {% if user.email %}data-email="{{ user.email }}"{% endif %}
      {% if user.first_name %}data-name="{{ user.first_name }}"{% endif %}
+     {% if user.profile and user.profile.force_suggestions %}data-force-suggestions="{{ user.profile.force_suggestions }}"{% endif %}
      {% if user.translated_locales %}data-user-translated-locales="{{ user.translated_locales|to_json() }}"{% endif %}
      {% if perms.base.can_manage %}data-manager="true"{% endif %}
      >
@@ -91,7 +94,10 @@
           <ul>
             {% if user.is_authenticated() %}
             <li><a href="{{ url('pontoon.profile') }}"><i class="fa fa-user fa-fw"></i>View profile</a></li>
-            <li class="quality-checks check-box{% if user.profile.quality_checks %} enabled{% endif %}"><i class="fa fa-fw"></i>Quality checks</li>
+            {{ Checkbox.checkbox('Quality checks', class='quality-checks', attribute='quality_checks', is_enabled=user.profile.quality_checks) }}
+              {% if user.translated_locales %}
+              {{ Checkbox.checkbox('Make suggestions', class='force-suggestions', attribute='force_suggestions', is_enabled=user.profile.force_suggestions) }}
+              {% endif %}
             <li class="horizontal-separator"></li>
             {% endif %}
 
@@ -245,7 +251,7 @@
         <a href="#" class="cancel">&times;</a>
         <h2>The following checks have failed</h2>
         <ul></ul>
-        <button id="save-anyway">Save anyway</button>
+        <button id="save-anyway"></button>
       </div>
       <div id="translation-length">
         <span class="current-length"></span>|<span class="original-length"></span>
@@ -253,7 +259,7 @@
       <button id="copy">Copy</button>
       <button id="clear">Clear</button>
       <button id="cancel">Cancel</button>
-      <button id="save">Save</button>
+      <button id="save"></button>
     </menu>
 
     <div id="helpers" class="tabs">

--- a/pontoon/base/templates/user.html
+++ b/pontoon/base/templates/user.html
@@ -1,5 +1,7 @@
 {% extends "landing.html" %}
 
+{% import "widgets/checkbox.html" as Checkbox %}
+
 {% block title %}Pontoon &middot; {% if contributor.first_name %}{{ contributor.first_name }}{% else %}{{ contributor.email }}{% endif %}{% endblock %}
 
 {% block class %}user{% endblock %}
@@ -39,7 +41,10 @@
   <li><span class="fa fa-fw fa-envelope"></span><a href="mailto:{{ contributor.email }}">{{ contributor.email }}</a></li>
   <li><span class="fa fa-fw fa-lock"></span>{{ contributor|display_permissions() }}</li>
   {% if user.is_authenticated() and user.email == contributor.email %}
-  <li class="check-box quality-checks{% if user.profile.quality_checks %} enabled{% endif %}"><span class="fa fa-fw"></span>Quality checks</li>
+  {{ Checkbox.checkbox('Quality checks', class='quality-checks', attribute='quality_checks', is_enabled=user.profile.quality_checks) }}
+    {% if user.translated_locales %}
+    {{ Checkbox.checkbox('Force suggestions', class='force-suggestions', attribute='force_suggestions', is_enabled=user.profile.force_suggestions) }}
+    {% endif %}
   {% endif %}
 </ul>
 

--- a/pontoon/base/templates/widgets/checkbox.html
+++ b/pontoon/base/templates/widgets/checkbox.html
@@ -1,0 +1,3 @@
+{% macro checkbox(label, class, attribute, is_enabled=False) %}
+<li class="check-box {{ class }}{% if is_enabled %} enabled{% endif %}" data-attribute="{{ attribute }}"><i class="fa fa-fw"></i>{{ label }}</li>
+{% endmacro %}

--- a/pontoon/base/urls.py
+++ b/pontoon/base/urls.py
@@ -30,6 +30,11 @@ urlpatterns = patterns(
     url(r'^contributor/(?P<email>[\w.%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})/$',
         RedirectView.as_view(url="/contributors/%(email)s/", permanent=True)),
 
+    # API: Toogle user profile attribute
+    url(r'^api/v1/user/(?P<email>[\w.%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})/$',
+        views.toggle_user_profile_attribute,
+        name='pontoon.toggle_user_profile_attribute'),
+
     # List all active localization teams
     url(r'^teams/$',
         views.locales,
@@ -55,7 +60,8 @@ urlpatterns = patterns(
         name='pontoon.project.contributors'),
 
     # AJAX: Get project details
-    url(r'^projects/(?P<slug>[\w-]+)/details/$', views.get_project_details,
+    url(r'^projects/(?P<slug>[\w-]+)/details/$',
+        views.get_project_details,
         name='pontoon.project.details'),
 
     # List team contributors
@@ -129,8 +135,6 @@ urlpatterns = patterns(
         name='pontoon.other_locales'),
     url(r'^download/', views.download,
         name='pontoon.download'),
-    url(r'^quality-checks-switch/', views.quality_checks_switch,
-        name='pontoon.quality_checks_switch'),
     url(r'^request-locale/', views.request_locale,
         name='pontoon.request_locale'),
     url(r'^save-user-name/', views.save_user_name,


### PR DESCRIPTION
Uses different title (Suggest) and color (blue) for Save button if
user make suggestions (either because they don't have translator
privileges or because they explicitly force to make suggestions in
preferences).

Other minor fixes and improvements I *had* to make:
* Remove obsolete user profile fields
* Fix notification loader position on translate page
* Make entire plural tab area clickable
* Fix unsaved changes warning when adding suggestions
* Check for unsaved changed when clicking Go button
* Fix Safari error with onpopstate event, triggered on first page load

@Osmose @jotes r?