### PR TITLE
Bug 1208171: Log sync timing to the database and display it.

### DIFF
--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -214,6 +214,15 @@ It's recommended to run this job once an hour. It commits any string changes in
 the database to the remote VCS servers associated with each project, and pulls
 down the latest changes to keep the database in sync.
 
+Sync Log Retention
+~~~~~~~~~~~~~~~~~~
+You may also optionally run the ``clear_old_sync_logs`` management command on a
+schedule to remove sync logs from the database that are over 90 days old:
+
+.. code-block:: bash
+
+   ./manage.py clear_old_sync_logs
+
 Database Migrations
 -------------------
 After deploying Pontoon for the first time, you must run the database

--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -91,3 +91,38 @@ def display_permissions(self):
         output = 'Can submit and approve translations for ' + locales
 
     return output
+
+
+@library.filter
+def format_datetime(value, format='full'):
+    if value is not None:
+        if format == 'full':
+            format = '%A, %B %d, %Y at %H:%M %Z'
+        elif format == 'date':
+            format = '%B %d, %Y'
+        elif format == 'time':
+            format = '%H:%M %Z'
+        return value.strftime(format)
+    else:
+        return '---'
+
+
+@library.filter
+def format_timedelta(value):
+    if value is not None:
+        parts = []
+        if value.days > 0:
+            parts.append('{0} days'.format(value.days))
+        minutes = value.seconds // 60
+        seconds = value.seconds % 60
+        if minutes > 0:
+            parts.append('{0} minutes'.format(minutes))
+        if seconds > 0:
+            parts.append('{0} seconds'.format(seconds))
+
+        if parts:
+            return ', '.join(parts)
+        else:
+            return '0 seconds'
+    else:
+        return '---'

--- a/pontoon/base/tests/test_helpers.py
+++ b/pontoon/base/tests/test_helpers.py
@@ -1,0 +1,44 @@
+from datetime import timedelta
+
+from django_nose.tools import assert_equal
+
+from pontoon.base.templatetags.helpers import format_datetime, format_timedelta
+from pontoon.base.tests import TestCase
+from pontoon.base.utils import aware_datetime
+
+
+class FormatDatetimeTests(TestCase):
+    def test_format_datetime_none(self):
+        assert_equal(format_datetime(None), '---')
+
+    def test_format_datetime_custom(self):
+        datetime = aware_datetime(2015, 1, 1, 5, 7)
+        assert_equal(format_datetime(datetime, '%H:%M'), '05:07')
+
+    def test_format_builtin(self):
+        """
+        Test that there exist built-in formats. We're not interested in
+        testing "all" of them, just that the capability exists.
+        """
+        with self.settings(TIME_ZONE='UTC'):
+            datetime = aware_datetime(2015, 1, 1, 5, 7)
+        assert_equal(format_datetime(datetime, 'time'), '05:07 UTC')
+
+
+class FormatTimedeltaTests(TestCase):
+    def test_format_timedelta_none(self):
+        assert_equal(format_timedelta(None), '---')
+
+    def test_format_timedelta_seconds(self):
+        assert_equal(format_timedelta(timedelta(seconds=5)), '5 seconds')
+
+    def test_format_timedelta_minutes(self):
+        duration = timedelta(minutes=1, seconds=7)
+        assert_equal(format_timedelta(duration), '1 minutes, 7 seconds')
+
+    def test_format_timedelta_days(self):
+        duration = timedelta(days=2, minutes=1, seconds=8)
+        assert_equal(format_timedelta(duration), '2 days, 1 minutes, 8 seconds')
+
+    def test_format_timedelta_0(self):
+        assert_equal(format_timedelta(timedelta(seconds=0)), '0 seconds')

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -247,6 +247,12 @@ PIPELINE_CSS = {
         ),
         'output_filename': 'css/project.min.css',
     },
+    'sync_logs': {
+        'source_filenames': (
+            'css/sync_logs.css',
+        ),
+        'output_filename': 'css/sync_logs.min.css',
+    },
     'translate': {
         'source_filenames': (
             'css/translate.css',
@@ -541,3 +547,5 @@ MICROSOFT_TERMINOLOGY_LOCALES = [
 EXCLUDE = os.environ.get('EXCLUDE', '').split(',')
 
 SYNC_TASK_TIMEOUT = 60 * 60  # 1 hour
+
+SYNC_LOG_RETENTION = 90  # days

--- a/pontoon/sync/management/commands/clear_old_sync_logs.py
+++ b/pontoon/sync/management/commands/clear_old_sync_logs.py
@@ -1,0 +1,17 @@
+from datetime import timedelta
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from pontoon.sync.models import SyncLog
+
+
+class Command(BaseCommand):
+    help = 'Delete sync logs that are older than settings.SYNC_LOG_RETENTION'
+
+    def handle(self, *args, **options):
+        delete_date = timezone.now() - timedelta(days=settings.SYNC_LOG_RETENTION)
+        (SyncLog.objects
+            .filter(start_time__lte=delete_date)
+            .delete())

--- a/pontoon/sync/migrations/0001_initial.py
+++ b/pontoon/sync/migrations/0001_initial.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0044_locale_translators'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ProjectSyncLog',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('start_time', models.DateTimeField(default=django.utils.timezone.now)),
+                ('project', models.ForeignKey(to='base.Project')),
+            ],
+        ),
+        migrations.CreateModel(
+            name='RepositorySyncLog',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('start_time', models.DateTimeField(default=django.utils.timezone.now)),
+                ('end_time', models.DateTimeField(default=django.utils.timezone.now)),
+                ('project_sync_log', models.ForeignKey(related_name='repository_sync_logs', to='sync.ProjectSyncLog')),
+                ('repository', models.ForeignKey(to='base.Repository')),
+            ],
+        ),
+        migrations.CreateModel(
+            name='SyncLog',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('start_time', models.DateTimeField(default=django.utils.timezone.now)),
+            ],
+        ),
+        migrations.AddField(
+            model_name='projectsynclog',
+            name='sync_log',
+            field=models.ForeignKey(related_name='project_sync_logs', to='sync.SyncLog'),
+        ),
+    ]

--- a/pontoon/sync/migrations/0002_auto_20151117_0029.py
+++ b/pontoon/sync/migrations/0002_auto_20151117_0029.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sync', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='repositorysynclog',
+            name='end_time',
+            field=models.DateTimeField(default=django.utils.timezone.now, null=True, blank=True),
+        ),
+    ]

--- a/pontoon/sync/models.py
+++ b/pontoon/sync/models.py
@@ -1,0 +1,75 @@
+from django.core.urlresolvers import reverse
+from django.db import models
+from django.db.models import Max
+from django.utils import timezone
+
+from pontoon.base.models import Project, Repository
+
+
+class BaseLog(models.Model):
+    @property
+    def duration(self):
+        if self.end_time is not None:
+            return self.end_time - self.start_time
+        else:
+            return None
+
+    class Meta:
+        abstract = True
+
+
+class SyncLog(BaseLog):
+    start_time = models.DateTimeField(default=timezone.now)
+
+    @property
+    def end_time(self):
+        if not self.finished:
+            return None
+        else:
+            repo_logs = RepositorySyncLog.objects.filter(project_sync_log__sync_log=self)
+            return repo_logs.aggregate(Max('end_time'))['end_time__max']
+
+    @property
+    def finished(self):
+        return all(log.finished for log in self.project_sync_logs.all())
+
+    def get_absolute_url(self):
+        return reverse('pontoon.sync.logs.details', kwargs={'sync_log_pk': self.pk})
+
+
+class ProjectSyncLog(BaseLog):
+    sync_log = models.ForeignKey(SyncLog, related_name='project_sync_logs')
+    project = models.ForeignKey(Project)
+
+    start_time = models.DateTimeField(default=timezone.now)
+
+    @property
+    def end_time(self):
+        if not self.finished:
+            return None
+        else:
+            aggregate = (self.repository_sync_logs
+                            .all()
+                            .aggregate(Max('end_time')))
+            return aggregate['end_time__max']
+
+    @property
+    def finished(self):
+        repo_logs = self.repository_sync_logs.all()
+        if len(repo_logs) != self.project.repositories.count():
+            return False
+        else:
+            return all(log.finished for log in repo_logs)
+
+
+class RepositorySyncLog(BaseLog):
+    project_sync_log = models.ForeignKey(ProjectSyncLog,
+                                         related_name='repository_sync_logs')
+    repository = models.ForeignKey(Repository)
+
+    start_time = models.DateTimeField(default=timezone.now)
+    end_time = models.DateTimeField(default=timezone.now, blank=True, null=True)
+
+    @property
+    def finished(self):
+        return self.end_time is not None

--- a/pontoon/sync/static/css/sync_logs.css
+++ b/pontoon/sync/static/css/sync_logs.css
@@ -1,0 +1,139 @@
+/** @shared */
+#header {
+    margin: 10em 0 5em;
+}
+
+#header .title {
+    color: #7BC876;
+    font-size: 72px;
+    font-weight: 300;
+}
+
+/** @listing */
+.log-list {
+    color: #AAAAAA;
+    margin: 0 auto;
+    text-align: left;
+    width: 730px;
+}
+
+.log-list .log-list-column {
+    font-weight: bold;
+    padding: 0.4em;
+    text-transform: uppercase;
+}
+
+.sync-log .start-time,
+.sync-log .start-date,
+.sync-log .duration {
+    padding: 0.4em;
+    font-size: 14px;
+}
+
+.sync-log .start-time a {
+    color: #7BC876;
+}
+
+
+/** @details */
+.sync-details {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    list-style-type: none;
+    margin: 0;
+    padding: 1em;
+}
+
+.sync-details .detail-item {
+    flex: 1;
+    margin: 0 0.3em;
+}
+
+.sync-details .detail-label {
+    border: none;
+    color: #AAAAAA;
+    font-size: 12px;
+    margin: 0.5em 0;
+    text-transform: uppercase;
+}
+
+.sync-details .detail-value {
+    border: none;
+    font-size: 16px;
+}
+
+.command-details {
+    background: #333941;
+}
+
+.command-details .detail-item {
+    border-top: 4px solid;
+    flex: 0 0 250px;
+}
+
+.command-details .start-time {
+    border-color: #7BC876;
+}
+
+.command-details .end-time {
+    border-color: #4FC4F6;
+}
+
+.command-details .duration {
+    border-color: #FED271;
+}
+
+.project-details .start-time .detail-label,
+.repository-details .start-time .detail-label {
+    color: #7BC876;
+}
+
+.project-details .end-time .detail-label,
+.repository-details .end-time .detail-label {
+    color: #4FC4F6;
+}
+
+.project-details .duration .detail-label,
+.repository-details .duration .detail-label {
+    color: #FED271;
+}
+
+.project-logs {
+    width: 730px;
+    margin: 0 auto;
+}
+
+.project {
+    border: 1px solid #5C6172;
+    border-radius: 5px;
+    margin: 3em 0 0;
+    padding: 1em;
+}
+
+.project .project-name {
+    color: #AAAAAA;
+    font-size: 36px;
+    text-align: left;
+    text-transform: none;
+}
+
+.repository-logs {
+    list-style-type: none;
+    width: 100%;
+}
+
+.repository-logs .repository-logs-column {
+    color: #AAAAAA;
+    padding: 1em;
+    text-align: left;
+    text-transform: uppercase;
+}
+
+.repository .repository-url {
+    vertical-align: middle;
+}
+
+.repository:nth-child(even) {
+    background: #333941;
+}

--- a/pontoon/sync/templates/sync/log_details.html
+++ b/pontoon/sync/templates/sync/log_details.html
@@ -1,0 +1,70 @@
+{% extends "landing.html" %}
+
+{% block title %}Pontoon &middot; Sync Log{% endblock %}
+
+{% block header %}
+  <header id="header">
+    <h1 class="title">Sync Log</h1>
+    {% if not sync_log.finished %}
+      <p class="in-progress">In-progress</p>
+    {% endif %}
+  </header>
+{% endblock %}
+
+{% macro details(class) -%}
+  <ol class="{{ class }}">
+    {{ caller() }}
+  </ol>
+{%- endmacro %}
+
+{% macro detail_item(label, value, class='') -%}
+  <li class="detail-item {{ class }}">
+    <div class="detail-label">{{ label }}</div>
+    <div class="detail-value">{{ value }}</div>
+  </li>
+{%- endmacro %}
+
+{% block middle %}
+  {% call details('sync-details command-details') %}
+    {{ detail_item('Start', sync_log.start_time|format_datetime, class='start-time') }}
+    {{ detail_item('End', sync_log.end_time|format_datetime, class='end-time') }}
+    {{ detail_item('Duration', sync_log.duration|format_timedelta, class='duration') }}
+  {% endcall %}
+
+  <div class="project-logs">
+    {% for project_log in project_sync_logs %}
+      <section class="project">
+        <h2 class="project-name">Project: {{ project_log.project.name }}</h2>
+
+        {% call details('sync-details project-details') %}
+          {{ detail_item('Start', project_log.start_time|format_datetime('time'), class='start-time') }}
+          {{ detail_item('End', project_log.end_time|format_datetime('time'), class='end-time') }}
+          {{ detail_item('Duration', project_log.duration|format_timedelta, class='duration') }}
+        {% endcall %}
+
+        <table class="repository-logs">
+          <tr class="repository-logs-header">
+            <th class="repository-logs-column">Repository URL</th>
+            <th class="repository-logs-column">Timing</th>
+          </tr>
+          {% for repo_log in repository_sync_logs[project_log] %}
+            <tr class="repository">
+              <td class="repository-url">{{ repo_log.repository.url }}</td>
+              <td class="repository-details">
+                {% call details('sync-details repository-details') %}
+                  {{ detail_item('Start', repo_log.start_time|format_datetime('time'), class='start-time') }}
+                  {{ detail_item('End', repo_log.end_time|format_datetime('time'), class='end-time') }}
+                  {{ detail_item('Duration', repo_log.duration|format_timedelta, class='duration') }}
+                {% endcall %}
+              </td>
+            </tr>
+          {% endfor %}
+        </table>
+      </section>
+    {% endfor %}
+  </div>
+{% endblock %}
+
+{% block extend_css %}
+  {% stylesheet 'sync_logs' %}
+{% endblock %}

--- a/pontoon/sync/templates/sync/log_list.html
+++ b/pontoon/sync/templates/sync/log_list.html
@@ -1,0 +1,36 @@
+{% extends "landing.html" %}
+
+{% block title %}Pontoon &middot; Sync Logs{% endblock %}
+
+{% block header %}
+  <header id="header">
+    <h1 class="title">Sync Logs</h1>
+  </header>
+{% endblock %}
+
+{% block middle %}
+  <table class="log-list">
+    <tr class="log-list-header">
+      <th class="log-list-column">Start Time</th>
+      <th class="log-list-column">Date</th>
+      <th class="log-list-column">Duration</th>
+    </tr>
+    {% for log in sync_logs %}
+      <tr class="sync-log">
+        <td class="start-time">
+          <a href="{{ log.get_absolute_url() }}">
+            {{ log.start_time|format_datetime('time') }}
+          </a>
+        </td>
+        <td class="start-date">
+          {{ log.start_time|format_datetime('date') }}
+        </td>
+        <td class="duration">{{ log.duration|format_timedelta }}</td>
+      </tr>
+    {% endfor %}
+  </table>
+{% endblock %}
+
+{% block extend_css %}
+  {% stylesheet 'sync_logs' %}
+{% endblock %}

--- a/pontoon/sync/tests/__init__.py
+++ b/pontoon/sync/tests/__init__.py
@@ -15,6 +15,7 @@ from pontoon.base.tests import (
 )
 from pontoon.base.utils import aware_datetime
 from pontoon.sync.changeset import ChangeSet
+from pontoon.sync.models import ProjectSyncLog, RepositorySyncLog, SyncLog
 from pontoon.sync.vcs_models import VCSEntity, VCSProject, VCSResource, VCSTranslation
 
 
@@ -42,6 +43,27 @@ class VCSTranslationFactory(factory.Factory):
 
     class Meta:
         model = VCSTranslation
+
+
+class SyncLogFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = SyncLog
+
+
+class ProjectSyncLogFactory(factory.DjangoModelFactory):
+    sync_log = factory.SubFactory(SyncLogFactory)
+    project = factory.SubFactory(ProjectFactory)
+
+    class Meta:
+        model = ProjectSyncLog
+
+
+class RepositorySyncLogFactory(factory.DjangoModelFactory):
+    project_sync_log = factory.SubFactory(ProjectSyncLogFactory)
+    repository = factory.SubFactory(RepositoryFactory)
+
+    class Meta:
+        model = RepositorySyncLog
 
 
 class FakeCheckoutTestCase(TestCase):

--- a/pontoon/sync/tests/test_models.py
+++ b/pontoon/sync/tests/test_models.py
@@ -1,0 +1,110 @@
+from django_nose.tools import assert_equal, assert_false, assert_is_none, assert_true
+
+from pontoon.base.tests import ProjectFactory, RepositoryFactory, TestCase
+from pontoon.base.utils import aware_datetime
+from pontoon.sync.tests import (
+    ProjectSyncLogFactory,
+    RepositorySyncLogFactory,
+    SyncLogFactory,
+)
+
+
+class SyncLogTests(TestCase):
+    def test_end_time_unfinished(self):
+        """If a job is unfinished, it's end_time is None."""
+        sync_log = SyncLogFactory.create()
+
+        # Create repo without existing log so sync is unfinished.
+        repo = RepositoryFactory.create()
+        ProjectSyncLogFactory.create(sync_log=sync_log, project__repositories=[repo])
+
+        assert_is_none(sync_log.end_time)
+
+    def test_end_time(self):
+        """
+        Return the latest end time among repo sync logs for this log.
+        """
+        sync_log = SyncLogFactory.create()
+        RepositorySyncLogFactory.create(project_sync_log__sync_log=sync_log,
+                                        end_time=aware_datetime(2015, 1, 1))
+        RepositorySyncLogFactory.create(project_sync_log__sync_log=sync_log,
+                                        end_time=aware_datetime(2015, 1, 2))
+
+        assert_equal(sync_log.end_time, aware_datetime(2015, 1, 2))
+
+    def test_finished(self):
+        sync_log = SyncLogFactory.create()
+
+        # Create repo without existing log so sync is unfinished.
+        repo = RepositoryFactory.create()
+        project_sync_log = ProjectSyncLogFactory.create(
+            sync_log=sync_log, project__repositories=[repo])
+
+        # Sync isn't finished until all repos are finished.
+        assert_false(sync_log.finished)
+
+        repo_log = RepositorySyncLogFactory.create(
+            repository=repo,
+            project_sync_log=project_sync_log,
+            start_time=aware_datetime(2015, 1, 1),
+            end_time=None
+        )
+        assert_false(sync_log.finished)
+
+        repo_log.end_time = aware_datetime(2015, 1, 2)
+        repo_log.save()
+        assert_true(sync_log.finished)
+
+
+class ProjectSyncLogTests(TestCase):
+    def test_end_time_unfinished(self):
+        """If a sync is unfinished, it's end_time is None."""
+        repo = RepositoryFactory.create()
+        project_sync_log = ProjectSyncLogFactory.create(project__repositories=[repo])
+        assert_is_none(project_sync_log.end_time)
+
+    def test_end_time(self):
+        """
+        Return the latest end time among repo sync logs for this log.
+        """
+        project = ProjectFactory.create(repositories=[])
+        repo1, repo2 = RepositoryFactory.create_batch(2, project=project)
+        project_sync_log = ProjectSyncLogFactory.create(project=project)
+
+        RepositorySyncLogFactory.create(project_sync_log=project_sync_log,
+                                        repository=repo1,
+                                        end_time=aware_datetime(2015, 1, 1))
+        RepositorySyncLogFactory.create(project_sync_log=project_sync_log,
+                                        repository=repo2,
+                                        end_time=aware_datetime(2015, 1, 2))
+
+        assert_equal(project_sync_log.end_time, aware_datetime(2015, 1, 2))
+
+    def test_finished(self):
+        repo = RepositoryFactory.create()
+        project_sync_log = ProjectSyncLogFactory.create(project__repositories=[repo])
+
+        # Sync isn't finished until all repos are finished.
+        assert_false(project_sync_log.finished)
+
+        repo_log = RepositorySyncLogFactory.create(
+            repository=repo,
+            project_sync_log=project_sync_log,
+            start_time=aware_datetime(2015, 1, 1),
+            end_time=None
+        )
+        assert_false(project_sync_log.finished)
+
+        repo_log.end_time = aware_datetime(2015, 1, 2)
+        repo_log.save()
+        assert_true(project_sync_log.finished)
+
+
+class RepositorySyncLogTests(TestCase):
+    def test_finished(self):
+        log = RepositorySyncLogFactory.create(end_time=None)
+        assert_false(log.finished)
+
+        log.end_time = aware_datetime(2015, 1, 1)
+        log.save()
+        assert_true(log.finished)

--- a/pontoon/sync/urls.py
+++ b/pontoon/sync/urls.py
@@ -1,0 +1,13 @@
+from django.conf.urls import patterns, url
+
+from pontoon.sync import views
+
+
+urlpatterns = patterns(
+    '',
+
+    url(r'^sync/log/$', views.sync_log_list, name='pontoon.sync.logs.list'),
+
+    url(r'^sync/log/(?P<sync_log_pk>\d+)/', views.sync_log_details,
+        name='pontoon.sync.logs.details'),
+)

--- a/pontoon/sync/views.py
+++ b/pontoon/sync/views.py
@@ -1,0 +1,30 @@
+from django.shortcuts import get_object_or_404, render
+
+from pontoon.sync.models import SyncLog
+
+
+def sync_log_list(request):
+    return render(request, 'sync/log_list.html', {
+        'sync_logs': SyncLog.objects.order_by('-start_time'),
+    })
+
+
+def sync_log_details(request, sync_log_pk):
+    # Prefetch for the end_time
+    queryset = SyncLog.objects.prefetch_related(
+        'project_sync_logs__repository_sync_logs__repository',
+        'project_sync_logs__project__repositories',
+    )
+
+    sync_log = get_object_or_404(queryset, pk=sync_log_pk)
+    project_sync_logs = sync_log.project_sync_logs.all()
+    repository_sync_logs = {
+        project_log: project_log.repository_sync_logs.all()
+        for project_log in project_sync_logs
+    }
+
+    return render(request, 'sync/log_details.html', {
+        'sync_log': sync_log,
+        'project_sync_logs': project_sync_logs,
+        'repository_sync_logs': repository_sync_logs,
+    })

--- a/pontoon/urls.py
+++ b/pontoon/urls.py
@@ -21,6 +21,9 @@ urlpatterns = patterns('',
     # Django admin
     (r'^a/', include(admin.site.urls)),
 
+    # Sync views
+    (r'', include('pontoon.sync.urls')),
+
     # Test project: Pontoon Intro
     url(r'^intro/$', 'pontoon.intro.views.intro'),
 


### PR DESCRIPTION
This is sort've in-progress but I think is sufficiently useful to merge now (plus I need to focus on different things for a while and thus won't really be able to improve this soon).

This adds some models for storing timing data about sync jobs in the database, and some views to view the data. The pages are public but not linked anywhere on the site, so we can use them and play around with them without bugging users. The data itself isn't sensitive so having the page public isn't an issue.

There are some known bugs that I haven't handled that I don't think are blockers:

- The big one, projects that are skipped due to a lack of changes have no timing data, which I think causes the entire run to not have an end time. This should be fixed with a followup PR soon, but I may not get to it for a while.
- If a job fails with an error, it is listed as "In-progress" forever.
- The views aren't smart at all about in-progress jobs, don't auto-update, etc.
- The changes aren't 100% well tested as I expect them to evolve a bunch before we settle into the logging that we want.
- Source repos are shown as having taken 0 seconds to sync.

Even with all this I think it will significantly improve our current method of verbose logging and human work to get sync times.

@mathjazz @jotes r?