### PR TITLE
Bug 1219212: Add ability to download translated resources

### DIFF
--- a/pontoon/administration/forms.py
+++ b/pontoon/administration/forms.py
@@ -22,5 +22,5 @@ SubpageInlineFormSet = inlineformset_factory(
 RepositoryInlineFormSet = inlineformset_factory(
     Project, Repository,
     extra=1,
-    fields=('type', 'url', 'source_repo'),
+    fields=('type', 'url', 'source_repo', 'permalink_prefix'),
 )

--- a/pontoon/administration/static/css/admin_project.css
+++ b/pontoon/administration/static/css/admin_project.css
@@ -280,6 +280,14 @@ form a.add-repo {
   padding: 0;
 }
 
+.repository .prefix-wrapper {
+  clear: both;
+}
+
+.repository .prefix-wrapper .prefix input[type=text] {
+  width: 100%;
+}
+
 .repository input[type=text] {
   width: 403px;
 }

--- a/pontoon/administration/templates/admin_project.html
+++ b/pontoon/administration/templates/admin_project.html
@@ -107,6 +107,12 @@
           {{ repo_form.DELETE }}
         </div>
       </section>
+      <section class="prefix-wrapper">
+        <div class="prefix">
+          {{ repo_form.permalink_prefix.label_tag() }}
+          {{ repo_form.permalink_prefix }}
+        </div>
+      </section>
       {{ repo_form.errors }}
     </div>
   {% endfor %}
@@ -126,6 +132,12 @@
       <div class="delete">
         {{ repo_formset.empty_form.DELETE.label_tag() }}
         {{ repo_formset.empty_form.DELETE }}
+      </div>
+    </section>
+    <section class="prefix-wrapper">
+      <div class="prefix">
+        {{ repo_formset.empty_form.permalink_prefix.label_tag() }}
+        {{ repo_formset.empty_form.permalink_prefix }}
       </div>
     </section>
     {{ repo_formset.empty_form.errors }}

--- a/pontoon/base/migrations/0047_repository_permalink_prefix.py
+++ b/pontoon/base/migrations/0047_repository_permalink_prefix.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0046_add_force_suggestions'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='repository',
+            name='permalink_prefix',
+            field=models.CharField(max_length=2000, verbose_name=b'Permalink prefix', blank=True),
+        ),
+    ]

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -21,7 +21,6 @@ from jsonfield import JSONField
 
 from pontoon.administration.vcs import commit_to_vcs, get_revision, update_from_vcs
 from pontoon.base import utils
-from pontoon.base.utils import get_object_or_none
 from pontoon.sync import KEY_SEPARATOR
 
 
@@ -444,7 +443,7 @@ class ProjectLocale(models.Model):
     @classmethod
     def get_latest_activity(cls, project, locale):
         """Get the latest activity within this project and locale."""
-        project_locale = get_object_or_none(ProjectLocale, project=project, locale=locale)
+        project_locale = utils.get_object_or_none(ProjectLocale, project=project, locale=locale)
         if project_locale is not None and project_locale.latest_translation is not None:
             return project_locale.latest_translation.latest_activity
         else:
@@ -476,6 +475,12 @@ class Repository(models.Model):
         choices=TYPE_CHOICES
     )
     url = models.CharField("URL", max_length=2000, blank=True)
+
+    """
+    Prefix of the resource URL, used for direct downloads. To form a full
+    URL, relative path must be appended.
+    """
+    permalink_prefix = models.CharField("Permalink prefix", max_length=2000, blank=True)
 
     """
     Mapping of locale codes to VCS revisions of each repo at the last
@@ -907,7 +912,7 @@ class Translation(DirtyFieldsMixin, models.Model):
             self.check_latest_translation(self.locale)
             self.check_latest_translation(stats)
 
-            project_locale = get_object_or_none(
+            project_locale = utils.get_object_or_none(
                 ProjectLocale,
                 project=self.entity.resource.project,
                 locale=self.locale

--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -478,26 +478,12 @@ body > header .notification li {
   display: block;
 }
 
-#profile .menu li.download.hover {
-  color: inherit;
-  cursor: inherit;
-  background: inherit;
-}
-
 #profile .menu li i.fa {
   margin: 0 8px 0 -2px;
 }
 
 #profile .menu li i.file-format {
-  font-weight: 300;
-  font-size: 13px;
   font-style: normal;
-}
-
-#profile .menu li i.file-format:hover {
-  border-color: #FFFFFF;
-  color: #FFFFFF;
-  cursor: pointer;
 }
 
 #profile.select .popup {
@@ -529,7 +515,6 @@ body > header .notification li {
   width: 60%;
 }
 
-#profile .menu li i.file-format,
 #hotkeys span {
   background: #3F4752;
   border: 1px solid #5E6475;

--- a/pontoon/base/static/js/pontoon.js
+++ b/pontoon/base/static/js/pontoon.js
@@ -568,29 +568,6 @@
             $("#context .mode").attr("label", message.value + " mode");
             break;
 
-          case "HTML":
-            $.ajax({
-              url: Pontoon.project.url,
-              success: function(data) {
-                var response = data,
-                    index = data.toLowerCase().indexOf("<head"),
-                    start = response.substring(0, index);
-                    inner = $("html").clone();
-                // Remove Pontoon-content
-                inner
-                  .find("link[href*='pontoon.css']").remove().end()
-                  .find("script[src*='pontoon']").remove().end()
-                  .find("script[src*='jquery.min.js']").remove().end()
-                  .find(".pontoon-remove").remove().end()
-                  .find(".pontoon-editable-toolbar").remove().end()
-                  .find("[contenteditable]").removeAttr("contenteditable").end()
-                  .find("body").removeAttr("contextmenu").end()
-                  .find("menu#context").remove();
-                postMessage("HTML", start + inner.html() + "\n</html>");
-              }
-            });
-            break;
-
           case "RESIZE":
             var toolbar = $('.pontoon-editable-toolbar'),
                 node = toolbar[0].target;

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -101,10 +101,7 @@
             <li class="horizontal-separator"></li>
             {% endif %}
 
-            <li class="download">Download
-              <i class="file-format html">HTML</i>
-              <i class="file-format json">JSON</i>
-            </li>
+            <li class="download">Download .<i class="file-format"></i></li>
 
             <li class="horizontal-separator"></li>
 

--- a/pontoon/sync/utils.py
+++ b/pontoon/sync/utils.py
@@ -60,3 +60,13 @@ def locale_directory_path(checkout_path, locale_code):
 
     raise IOError('Directory for locale `{0}` not found'.format(
                   locale_code or 'source'))
+
+
+def relative_source_path(path):
+    """
+    Return relative source resource path for the given relative locale
+    resource path. Source files for .po files are actually .pot.
+    """
+    if path.endswith('po'):
+        path += 't'
+    return path


### PR DESCRIPTION
This is first part of Bug 1219212: re-enabling resource download. When translating a resource, you can now download it from the profile menu, by clicking on the "Download FORMAT" link, where FORMAT is PO or DTD etc.

Since we don't have storage, this is how it works:
1) Pull source repository.
2) Get source (en-US) file - works for all formats.
3) Update file from DB.
4) Pass it to the user for download.

I left the code in the view, because I found myself in the import loop when moving it to utils.py. When we agree where should we put it and if the basic direction of this PR is correct, I should write some tests for get_download_content().

I tried to reuse as much sync code as possible. I also had to modify it a bit, but nothing serious. Given that all tests pass, I think we should be safe. I noticed VCSTranslation.update_from_db() is pretty slow and takes close to 20 seconds combined for the biggest file, but that's 2719 strings.

@Osmose @jotes r?