### PR TITLE
Bug 1219212: Add ability to UPLOAD translated resources

### DIFF
--- a/pontoon/base/forms.py
+++ b/pontoon/base/forms.py
@@ -1,0 +1,44 @@
+import os
+
+from django import forms
+from pontoon.sync.formats import SUPPORTED_FORMAT_PARSERS
+
+
+class DownloadFileForm(forms.Form):
+    slug = forms.CharField()
+    code = forms.CharField()
+    part = forms.CharField()
+
+
+class UploadFileForm(DownloadFileForm):
+    uploadfile = forms.FileField()
+
+    def clean(self):
+        cleaned_data = super(UploadFileForm, self).clean()
+        part = cleaned_data.get("part")
+        uploadfile = cleaned_data.get("uploadfile")
+
+        if uploadfile:
+            limit = 5000
+
+            # File size validation
+            if uploadfile.size > limit * 1000:
+                current = round(uploadfile.size/1000)
+                message = (
+                    'Upload failed. Keep filesize under {limit} kB. Your upload: {current} kB.'
+                    .format(limit=limit, current=current)
+                )
+                raise forms.ValidationError(message)
+
+            # File format validation
+            if part:
+                file_extension = os.path.splitext(uploadfile.name)[1].lower()
+                part_extension = os.path.splitext(part)[1].lower()
+
+                # For now, skip if uploading file while using subpages
+                if part_extension in SUPPORTED_FORMAT_PARSERS.keys() and part_extension != file_extension:
+                    message = (
+                        'Upload failed. File format not supported. Use {supported}.'
+                        .format(supported=part_extension)
+                    )
+                    raise forms.ValidationError(message)

--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -69,6 +69,11 @@ mark.placeable {
   display: none;
 }
 
+#download-file,
+#upload-file {
+  top: 100000px;
+}
+
 /*
  * SpinKit
  * https://github.com/tobiasahlin/SpinKit/blob/master/LICENSE
@@ -478,12 +483,12 @@ body > header .notification li {
   display: block;
 }
 
-#profile .menu li i.fa {
-  margin: 0 8px 0 -2px;
+#profile .menu li.upload {
+  margin-top: 1px;
 }
 
-#profile .menu li i.file-format {
-  font-style: normal;
+#profile .menu li i.fa {
+  margin: 0 8px 0 -2px;
 }
 
 #profile.select .popup {

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -3,33 +3,8 @@ var Pontoon = (function (my) {
   return $.extend(true, my, {
 
     /*
-     * Download resource file. Not possible with AJAX.
+     * Get suggestions from other locales
      */
-    download: function () {
-      var params = {
-          slug: this.project.slug,
-          code: this.locale.code,
-          path: this.part,
-          csrfmiddlewaretoken: $('#server').data('csrf')
-      };
-
-      var post = $('<form>', {
-        method: 'POST',
-        action: '/download/'
-      });
-
-      for (var key in params) {
-        $('<input>', {
-          type: 'hidden',
-          name: key,
-          value: params[key]
-        }).appendTo(post);
-      }
-
-      post.appendTo('body').submit().remove();
-    },
-
-
     getOtherLocales: function (entity) {
       var self = this,
           list = $('#helpers .other-locales ul').empty(),
@@ -1319,6 +1294,19 @@ var Pontoon = (function (my) {
 
 
     /*
+     * Update download/upload form fields with translation project data
+     */
+    updateFormFields: function (form) {
+      var self = this;
+
+      form
+        .find('#id_slug').val(self.project.slug).end()
+        .find('#id_code').val(self.locale.code).end()
+        .find('#id_part').val(self.part);
+    },
+
+
+    /*
      * Attach event handlers to main toolbar elements
      */
     attachMainHandlers: function () {
@@ -1517,6 +1505,8 @@ var Pontoon = (function (my) {
           var data = self.pushState();
           self.initialize();
         });
+
+        self.closeNotification();
       });
 
       // Profile menu
@@ -1537,7 +1527,11 @@ var Pontoon = (function (my) {
             });
 
           } else if ($(this).is('.download')) {
-            self.download();
+            self.updateFormFields($('form#download-file'));
+            $('form#download-file').submit();
+
+          } else if ($(this).is(".upload")) {
+            $('#id_uploadfile').click();
 
           } else if ($(this).is(".hotkeys")) {
             $('#hotkeys').show();
@@ -1594,6 +1588,11 @@ var Pontoon = (function (my) {
           .bind('mouseup', { initial: data }, mouseUpHandler);
       });
 
+      // File upload
+      $('#id_uploadfile').change(function() {
+        self.updateFormFields($('form#upload-file'));
+        $('form#upload-file').submit();
+      });
     },
 
 
@@ -1606,11 +1605,11 @@ var Pontoon = (function (my) {
 
 
     /*
-     * Update links in the profile menu
+     * Update profile menu links and contents
      */
     updateProfileMenu: function () {
       $('#profile .admin-current-project a').attr('href', '/admin/projects/' + this.project.slug + '/');
-      $('#profile .download .file-format').html(this.entities[0].format.toUpperCase());
+      $('#profile .upload').toggle(history.state.paths && this.user.isTranslator);
     },
 
 

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -101,7 +101,8 @@
             <li class="horizontal-separator"></li>
             {% endif %}
 
-            <li class="download">Download .<i class="file-format"></i></li>
+            <li class="download"><i class="fa fa-cloud-download fa-fw"></i>Download Translations</i></li>
+            <li class="upload"><i class="fa fa-cloud-upload fa-fw"></i>Upload Translations</li>
 
             <li class="horizontal-separator"></li>
 
@@ -120,7 +121,7 @@
             {% endif %}
 
             {% if user.is_authenticated() %}
-            <li class="sign-out"><a href="{{ url('signout') }}"><i class="fa fa-sign-out fa-fw"></i>Sign out</a></li>
+            <li class="sign-out"><a href="{{ url('signout') }}"><i class="fa fa-sign-out fa-fw"></i>Sign Out</a></li>
             {% else %}
             <li class="sign-in"><i class="fa fa-sign-in fa-fw"></i>Sign in</li>
             {% endif %}
@@ -322,6 +323,21 @@
     <div class="text">"640K ought to be enough for anybody."</div>
   </div>
 </div>
+
+<form id="download-file" method="POST" action="{{ url('pontoon.download') }}">
+    <input type="hidden" value="{{ csrf_token }}" name="csrfmiddlewaretoken">
+    {{ download_form.slug }}
+    {{ download_form.code }}
+    {{ download_form.part }}
+</form>
+
+<form id="upload-file" method="POST" action="{{ url('pontoon.upload') }}" enctype="multipart/form-data">
+    <input type="hidden" value="{{ csrf_token }}" name="csrfmiddlewaretoken">
+    {{ upload_form.slug }}
+    {{ upload_form.code }}
+    {{ upload_form.part }}
+    {{ upload_form.uploadfile }}
+</form>
 {% endblock %}
 
 {% block extend_css %}

--- a/pontoon/base/urls.py
+++ b/pontoon/base/urls.py
@@ -131,6 +131,8 @@ urlpatterns = patterns(
         name='pontoon.other_locales'),
     url(r'^download/', views.download,
         name='pontoon.download'),
+    url(r'^upload/', views.upload,
+        name='pontoon.upload'),
     url(r'^request-locale/', views.request_locale,
         name='pontoon.request_locale'),
     url(r'^save-user-name/', views.save_user_name,


### PR DESCRIPTION
This is based on #280, so look at 6853f0c only.

It adds the ability to upload translations for the currently translated resource (disabled on search and for non-translators).

To update translations in the DB, I reused the sync code. There shouldn't be any problems it upload is performed during sync, because it's same as if translations were manually submitted.

TODO (can wait until next release):
- I can't wait to get my hands dirty with drag & drop upload and fancy progress bars.
- Enable upload to anyone and add suggestions if user not translator or forces suggestions.

@Osmose @jotes r?