### PR TITLE
Fix perpetual sync

### DIFF
--- a/pontoon/administration/vcs.py
+++ b/pontoon/administration/vcs.py
@@ -133,8 +133,7 @@ class CommitToRepository(object):
         return (' '.join([name, '<%s>' % user.email]))
 
     def nothing_to_commit(self):
-        text = 'Nothing to commit'
-        raise CommitToRepositoryException(unicode(text))
+        return log.warning('Nothing to commit')
 
 
 class CommitToGit(CommitToRepository):
@@ -167,7 +166,7 @@ class CommitToGit(CommitToRepository):
             raise CommitToRepositoryException(unicode(error))
 
         if 'Everything up-to-date' in error:
-            self.nothing_to_commit()
+            return self.nothing_to_commit()
 
         log.info(message)
 
@@ -196,7 +195,7 @@ class CommitToHg(CommitToRepository):
         push = ["hg", "push"]
         code, output, error = execute(push, path)
         if code == 1 and 'no changes found' in output:
-            self.nothing_to_commit()
+            return self.nothing_to_commit()
 
         if code != 0 and len(error):
             raise CommitToRepositoryException(unicode(error))
@@ -222,7 +221,7 @@ class CommitToSvn(CommitToRepository):
             raise CommitToRepositoryException(unicode(error))
 
         if not output and not error:
-            self.nothing_to_commit()
+            return self.nothing_to_commit()
 
         log.info(message)
 


### PR DESCRIPTION
@Osmose @jotes r?

I noticed several days ago that some projects sync constantly, even if
there are no changes neither on Pontoon nor on VCS side of things.

This is causing big problems because more and more projects are now
syncing perpetually, which makes sync in general and adding new locales
slow.

What went worng?

ChangedEntityLocales get rolled back on CommitToRepositoryException:
https://github.com/mozilla/pontoon/blob/master/pontoon/sync/tasks.py#L110

And CommitToRepositoryException is thrown if there's nothing to commit:
https://github.com/mozilla/pontoon/blob/master/pontoon/administration/vcs.py#L135

So we have a lot of ChangedEntityLocales instances that are already in
repository, and when we try to commit them, we remove them from the DB,
but than CommitToRepositoryException is thrown (Nothing to commit) and
the transaction gets roleld back, so they reappear in the DB.

Instead of throwing the exception, we now simply log "Nothing to commit".

If there's something generating potentially too many ChangedEntityLocales
instances, it still remaing a mistery to me. I'll test this cautiously on
production, project by project, because it's hard to test it locally.