### PR TITLE
Initial version of translation memory.

### DIFF
--- a/pontoon/base/migrations/0048_translationmemoryentry.py
+++ b/pontoon/base/migrations/0048_translationmemoryentry.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.db.models.deletion
+
+from django.contrib.postgres.operations import CreateExtension
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0047_repository_permalink_prefix'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='TranslationMemoryEntry',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('source', models.TextField()),
+                ('target', models.TextField()),
+                ('entity', models.ForeignKey(on_delete=django.db.models.deletion.SET_NULL, to='base.Entity', null=True)),
+                ('locale', models.ForeignKey(to='base.Locale')),
+                ('translation', models.ForeignKey(related_name='memory_entries', on_delete=django.db.models.deletion.SET_NULL, to='base.Translation', null=True)),
+            ],
+        ),
+        CreateExtension('fuzzystrmatch'),
+        migrations.RunSQL('CREATE INDEX source_length_idx ON base_translationmemoryentry(CHAR_LENGTH(source))',
+                          'DROP INDEX source_length_idx'),
+    ]

--- a/pontoon/base/migrations/0049_create_translation_memory_entries.py
+++ b/pontoon/base/migrations/0049_create_translation_memory_entries.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def create_translation_memory_entries(apps, schema):
+    Translation = apps.get_model('base', 'Translation')
+    TranslationMemoryEntry = apps.get_model('base', 'TranslationMemoryEntry')
+    def get_memory_entry(translation):
+        return TranslationMemoryEntry(
+            entity_id=translation['entity_id'],
+            source=translation['entity__string'],
+            target=translation['string'],
+            locale_id=translation['locale_id'],
+            translation_id=translation['pk'],
+        )
+    translations = (
+        Translation.objects.filter(approved=True, fuzzy=False)
+          .filter(models.Q(plural_form__isnull=True) | models.Q(plural_form=0))
+          .prefetch_related('entity')
+          .values('pk', 'entity_id', 'entity__string', 'string', 'locale_id')
+    )
+    TranslationMemoryEntry.objects.bulk_create(map(get_memory_entry, translations), 1000)
+
+
+def remove_translation_memory_entries(apps, schema):
+    TranslationMemoryEntry = apps.get_model('base', 'TranslationMemoryEntry')
+    TranslationMemoryEntry.objects.all().delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('base', '0048_translationmemoryentry'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_translation_memory_entries, remove_translation_memory_entries)
+    ]

--- a/pontoon/base/tests/__init__.py
+++ b/pontoon/base/tests/__init__.py
@@ -1,3 +1,4 @@
+import json
 import os
 import tempfile
 
@@ -23,6 +24,7 @@ from pontoon.base.models import (
     Stats,
     Subpage,
     Translation,
+    TranslationMemoryEntry
 )
 
 
@@ -158,6 +160,16 @@ class IdenticalTranslationFactory(TranslationFactory):
     entity = SubFactory(EntityFactory, string=SelfAttribute('..string'))
 
 
+class TranslationMemoryFactory(DjangoModelFactory):
+    source = Sequence(lambda n: 'source {0}'.format(n))
+    target = Sequence(lambda n: 'target {0}'.format(n))
+    entity = SubFactory(EntityFactory, string=SelfAttribute('..source'))
+    locale = SubFactory(LocaleFactory)
+
+    class Meta:
+        model = TranslationMemoryEntry
+
+
 class StatsFactory(DjangoModelFactory):
     resource = SubFactory(ResourceFactory)
     locale = SubFactory(LocaleFactory)
@@ -266,3 +278,10 @@ def create_tempfile(contents):
     with os.fdopen(fd, 'w') as f:
         f.write(contents)
     return path
+
+
+def assert_json(response, expected_obj):
+    """
+    Checks if response contains a expected json object.
+    """
+    assert_equal(json.loads(response.content), expected_obj)

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -1,12 +1,11 @@
 import json
-import Levenshtein
 import logging
-import math
 import os
 import requests
 import xml.etree.ElementTree as ET
 import urllib
 
+from collections import defaultdict
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.contrib import messages
@@ -33,7 +32,6 @@ from django.views.decorators.http import require_POST
 from django.views.generic import TemplateView
 from django.views.generic.detail import DetailView
 from guardian.decorators import permission_required_or_403
-from operator import itemgetter
 
 from pontoon.base import forms
 from pontoon.base import utils
@@ -46,6 +44,7 @@ from pontoon.base.models import (
     Resource,
     Stats,
     Translation,
+    TranslationMemoryEntry,
     UserProfile,
     get_locales_with_project_stats,
     get_locales_with_stats,
@@ -686,80 +685,42 @@ def update_translation(request):
 
 
 def translation_memory(request):
-    """Get translations from internal translations."""
+    """Get translations from internal translations memory."""
     try:
         text = request.GET['text']
         locale = request.GET['locale']
         pk = request.GET['pk']
     except MultiValueDictKeyError as e:
         log.error(str(e))
-        return HttpResponse("error")
+        return HttpResponse('error')
 
     try:
         locale = Locale.objects.get(code__iexact=locale)
     except Locale.DoesNotExist as e:
         log.error(e)
-        return HttpResponse("error")
+        return HttpResponse('error')
 
-    min_quality = 0.7
     max_results = 5
-    length = len(text)
-    min_dist = math.ceil(max(length * min_quality, 2))
-    max_dist = math.floor(min(length / min_quality, 1000))
-
-    # Only check entities with similar length
-    entities = Entity.objects.all().extra(
-        where=["CHAR_LENGTH(string) BETWEEN %s AND %s" % (min_dist, max_dist)])
+    entries = TranslationMemoryEntry.objects.minimum_levenshtein_ratio(text).filter(locale=locale)
 
     # Exclude existing entity
     if pk:
-        entities = entities.exclude(pk=pk)
+        entries = entries.exclude(entity__pk=pk)
 
-    translations = {}
+    entries = entries.values('source', 'target', 'quality').order_by('-quality')
+    suggestions = defaultdict(lambda: {'count': 0, 'quality': 0})
 
-    for e in entities:
-        source = e.string
-        quality = Levenshtein.ratio(text, source)
+    for entry in entries:
+        if entry['target'] not in suggestions or entry['quality'] > suggestions[entry['target']]['quality']:
+            suggestions[entry['target']].update(entry)
+        suggestions[entry['target']]['count'] += 1
 
-        if quality > min_quality:
-            plural_form = None if e.string_plural == "" else 0
-            translation = get_translation(
-                entity=e, locale=locale, fuzzy=False, plural_form=plural_form)
-
-            if translation.string != '' or translation.pk is not None:
-                count = 1
-                quality = quality * 100
-
-                if translation.string in translations:
-                    existing = translations[translation.string]
-                    count = existing['count'] + 1
-
-                    # Store data for best match among equal translations only
-                    if quality < existing['quality']:
-                        quality = existing['quality']
-                        source = existing['source']
-
-                translations[translation.string] = {
-                    'source': source,
-                    'quality': quality,
-                    'count': count,
-                }
-
-    if len(translations) > 0:
-        # Sort by translation count
-        t = sorted(translations.iteritems(), key=itemgetter(1), reverse=True)
-        translations_array = []
-
-        for a, b in t[:max_results]:
-            b["target"] = a
-            translations_array.append(b)
-
+    if len(suggestions) > 0:
         return JsonResponse({
-            'translations': translations_array
+            'translations': sorted(suggestions.values(), key=lambda e: e['count'], reverse=True)[:max_results],
         })
-
     else:
-        return HttpResponse("no")
+        return HttpResponse('no')
 
 
 def machine_translation(request):

--- a/pontoon/sync/changeset.py
+++ b/pontoon/sync/changeset.py
@@ -6,6 +6,7 @@ from pontoon.base.models import (
     Entity,
     Locale,
     Translation,
+    TranslationMemoryEntry
 )
 from pontoon.base.utils import match_attr
 
@@ -233,6 +234,14 @@ class ChangeSet(object):
 
     def bulk_create_translations(self):
         Translation.objects.bulk_create(self.translations_to_create)
+        memory_entries = [TranslationMemoryEntry(
+            source=t.entity.string,
+            target=t.string,
+            locale_id=t.locale_id,
+            entity_id=t.entity.pk,
+            translation_id=t.pk
+        ) for t in self.translations_to_create if t.plural_form in (None, 0)]
+        TranslationMemoryEntry.objects.bulk_create(memory_entries)
 
     def bulk_update_translations(self):
         if len(self.translations_to_update) > 0:

--- a/pylama.ini
+++ b/pylama.ini
@@ -1,6 +1,8 @@
 [pylama]
 linters = pyflakes
 
+[pylama:media/projects/*]
+skip = 1
 
 [pylama:*/pontoon-intro/]
 skip = 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,9 +53,6 @@ pyasn1==0.1.7
 # sha256: -Shql53l7vyjxaNVruygX0ba58QwixjgBOTdKvfX7Sk
 https://github.com/l20n/python-l20n/archive/4e32a8d.zip#egg=python-l20n
 
-# sha256: wTEccb61tu7OpLuiAKYmMx72cRA1dEi-R7ob_jxKowU
-python-Levenshtein==0.11.2
-
 # sha256: NYsFoMJgXBXPgzfRcBbrla_qrQfJAN-cLN524hlKklg
 # sha256: PhW0FsmiA5waUSCLLNO7T_15bNGeYBsdJlevy3fD3JA
 pytz==2015.2


### PR DESCRIPTION
Hi @mathjazz @Osmose,
I've had very hard time with porting translation memory to elasticsearch. However, i can't say that anything was wrong with ES. I just don't know ES stack enough to make it work in reasonable time now. However, i'll definetely try again in future.
After first breakdown I decided to try with postgresql and in the end, it was a lot easier.
I've added new dependency which adds support pg_trgm. However, official version on Pypi can't support migrations in django 1.8.4. I've created PR to the upstream and i'm waiting for reaction of the owner of the package.
I would really like to hear your initial comments and suggestions.

