### PR TITLE
Skip updating translations for missing entities.

### DIFF
--- a/pontoon/sync/exceptions.py
+++ b/pontoon/sync/exceptions.py
@@ -1,0 +1,2 @@
+class ParseError(RuntimeError):
+    """Exception to raise when parsing fails."""

--- a/pontoon/sync/formats/base.py
+++ b/pontoon/sync/formats/base.py
@@ -1,7 +1,3 @@
-class ParseError(RuntimeError):
-    """Exception to raise when parsing fails."""
-
-
 class ParsedResource(object):
     """
     Parent class for parsed resources as returned by parse.

--- a/pontoon/sync/formats/lang.py
+++ b/pontoon/sync/formats/lang.py
@@ -9,7 +9,8 @@ from parsimonious.exceptions import ParseError as ParsimoniousParseError, Visita
 from parsimonious.grammar import Grammar
 from parsimonious.nodes import NodeVisitor
 
-from pontoon.sync.formats.base import ParseError, ParsedResource
+from pontoon.sync.exceptions import ParseError
+from pontoon.sync.formats.base import ParsedResource
 from pontoon.sync.vcs_models import VCSTranslation
 
 

--- a/pontoon/sync/formats/po.py
+++ b/pontoon/sync/formats/po.py
@@ -9,7 +9,8 @@ import polib
 import sys
 
 from pontoon.sync import KEY_SEPARATOR
-from pontoon.sync.formats.base import ParseError, ParsedResource
+from pontoon.sync.exceptions import ParseError
+from pontoon.sync.formats.base import ParsedResource
 from pontoon.sync.vcs_models import VCSTranslation
 
 

--- a/pontoon/sync/tests/formats/test_lang.py
+++ b/pontoon/sync/tests/formats/test_lang.py
@@ -4,8 +4,8 @@ from textwrap import dedent
 from django_nose.tools import assert_equal, assert_raises
 
 from pontoon.base.tests import assert_attributes_equal, TestCase
+from pontoon.sync.exceptions import ParseError
 from pontoon.sync.formats import lang
-from pontoon.sync.formats.base import ParseError
 from pontoon.sync.tests.formats import FormatTestsMixin
 
 

--- a/pontoon/sync/tests/test_core.py
+++ b/pontoon/sync/tests/test_core.py
@@ -66,6 +66,19 @@ class UpdateTranslationsTests(FakeCheckoutTestCase):
             return update_translations(self.db_project, self.vcs_project,
                                        self.translated_locale, self.changeset)
 
+    def test_missing_entities(self):
+        """If either of the entities is missing, skip it."""
+        self.changeset.update_vcs_entity = Mock()
+        self.changeset.update_db_entity = Mock()
+
+        self.call_update_translations([
+            ('one', None, self.main_vcs_entity),
+            ('other', self.main_db_entity, None),
+            ('both', None, None),
+        ])
+        assert_false(self.changeset.update_vcs_entity.called)
+        assert_false(self.changeset.update_db_entity.called)
+
     def test_no_translation(self):
         """If no translation exists for a specific locale, skip it."""
         self.changeset.update_vcs_entity = Mock()

--- a/pontoon/sync/tests/test_vcs_models.py
+++ b/pontoon/sync/tests/test_vcs_models.py
@@ -11,7 +11,7 @@ from pontoon.base.tests import (
     RepositoryFactory,
     TestCase,
 )
-from pontoon.sync.formats.base import ParseError
+from pontoon.sync.exceptions import ParseError
 from pontoon.sync.tests import VCSEntityFactory, VCSTranslationFactory
 from pontoon.sync.vcs_models import VCSProject
 

--- a/pontoon/sync/vcs_models.py
+++ b/pontoon/sync/vcs_models.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 
 from pontoon.base import MOZILLA_REPOS
+from pontoon.sync.exceptions import ParseError
 from pontoon.sync.utils import (
     directory_contains_resources,
     is_resource,
@@ -59,9 +60,6 @@ class VCSProject(object):
         and allows tests that don't need to touch the resources to run
         with less mocking.
         """
-        # Avoid circular import; someday we should refactor to avoid.
-        from pontoon.sync.formats.base import ParseError
-
         resources = {}
         for path in self.relative_resource_paths():
             try:
@@ -181,8 +179,8 @@ class VCSResource(object):
             )
             try:
                 resource_file = formats.parse(resource_path, source_resource_path)
-            except IOError:
-                continue  # File doesn't exist, let's move on
+            except (IOError, ParseError):
+                continue  # File doesn't exist or is invalid, let's move on
 
             self.files[locale] = resource_file
             for translation in resource_file.translations:


### PR DESCRIPTION
If we don't have both a VCS entity and a DB entity, we can't do anything useful to update the translations for the entity, so we just skip them.

This fixes an issue we were running into when testing the new MasterFirefoxOS translation files. Since there are source files that may not exist in certain locales, we get `None` back for `vcs_translation` and hit an error, when really we should be skipping those.

@mathjazz r?