### PR TITLE
Ignore non-failure exceptions like Http404 and Permission Denied.

### DIFF
--- a/pontoon/base/middleware.py
+++ b/pontoon/base/middleware.py
@@ -1,0 +1,13 @@
+from django.core.exceptions import PermissionDenied
+from django.http import Http404
+
+from raygun4py.middleware.django import Provider
+
+
+class RaygunExceptionMiddleware(Provider):
+    def process_exception(self, request, exception):
+        # Ignore non-failure exceptions. We don't need to be notified
+        # of these.
+        if not isinstance(exception, (Http404, PermissionDenied)):
+            return (super(RaygunExceptionMiddleware, self)
+                    .process_exception(request, exception))

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -116,7 +116,7 @@ INSTALLED_APPS = (
 
 MIDDLEWARE_CLASSES = (
     'sslify.middleware.SSLifyMiddleware',
-    'raygun4py.middleware.django.Provider',
+    'pontoon.base.middleware.RaygunExceptionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',


### PR DESCRIPTION
If we still want notifications for excessive 404s we can configure a search in Papertrail.

@mathjazz r?