### PR TITLE
Properly log project syncs that skip sync completely.

### DIFF
--- a/pontoon/base/tests/test_utils.py
+++ b/pontoon/base/tests/test_utils.py
@@ -2,7 +2,12 @@ from django_nose.tools import assert_equal, assert_false, assert_is_none, assert
 
 from pontoon.base.tests import ProjectFactory, TestCase
 from pontoon.base.models import Project
-from pontoon.base.utils import extension_in, get_object_or_none
+from pontoon.base.utils import (
+    aware_datetime,
+    extension_in,
+    get_object_or_none,
+    latest_datetime,
+)
 
 
 class UtilsTests(TestCase):
@@ -21,3 +26,11 @@ class UtilsTests(TestCase):
         project = ProjectFactory.create(slug='exists')
         assert_is_none(get_object_or_none(Project, slug='does-not-exist'))
         assert_equal(get_object_or_none(Project, slug='exists'), project)
+
+    def test_latest_datetime(self):
+        larger = aware_datetime(2015, 1, 1)
+        smaller = aware_datetime(2014, 1, 1)
+
+        assert_is_none(latest_datetime([None, None, None]))
+        assert_equal(latest_datetime([None, larger]), larger)
+        assert_equal(latest_datetime([None, smaller, larger]), larger)

--- a/pontoon/base/utils.py
+++ b/pontoon/base/utils.py
@@ -496,3 +496,17 @@ def handle_upload_content(slug, code, part, f, user):
             changed_entities[key] = ChangedEntityLocale(entity=t.entity, locale=t.locale)
 
     ChangedEntityLocale.objects.bulk_create(changed_entities.values())
+
+
+def latest_datetime(datetimes):
+    """
+    Return the latest datetime in the given list of datetimes,
+    gracefully handling `None` values in the list. Returns `None` if all
+    values in the list are `None`.
+    """
+    if all(map(lambda d: d is None, datetimes)):
+        return None
+
+    min_datetime = timezone.make_aware(datetime.min)
+    datetimes = map(lambda d: d or min_datetime, datetimes)
+    return max(datetimes)

--- a/pontoon/sync/migrations/0003_auto_20151204_2343.py
+++ b/pontoon/sync/migrations/0003_auto_20151204_2343.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sync', '0002_auto_20151117_0029'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='projectsynclog',
+            name='skipped',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name='projectsynclog',
+            name='skipped_end_time',
+            field=models.DateTimeField(default=None, null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='repositorysynclog',
+            name='end_time',
+            field=models.DateTimeField(default=None, null=True, blank=True),
+        ),
+    ]

--- a/pontoon/sync/models.py
+++ b/pontoon/sync/models.py
@@ -4,6 +4,7 @@ from django.db.models import Max
 from django.utils import timezone
 
 from pontoon.base.models import Project, Repository
+from pontoon.base.utils import latest_datetime
 
 
 class BaseLog(models.Model):
@@ -27,7 +28,13 @@ class SyncLog(BaseLog):
             return None
         else:
             repo_logs = RepositorySyncLog.objects.filter(project_sync_log__sync_log=self)
-            return repo_logs.aggregate(Max('end_time'))['end_time__max']
+            repo_end = repo_logs.aggregate(Max('end_time'))['end_time__max']
+
+            skipped_end = self.project_sync_logs.aggregate(
+                Max('skipped_end_time')
+            )['skipped_end_time__max']
+
+            return latest_datetime([repo_end, skipped_end])
 
     @property
     def finished(self):
@@ -43,18 +50,41 @@ class ProjectSyncLog(BaseLog):
 
     start_time = models.DateTimeField(default=timezone.now)
 
+    skipped = models.BooleanField(default=False)
+    skipped_end_time = models.DateTimeField(default=None, blank=True, null=True)
+
     @property
     def end_time(self):
-        if not self.finished:
-            return None
-        else:
+        if self.skipped:
+            return self.skipped_end_time
+        elif self.finished:
             aggregate = (self.repository_sync_logs
                             .all()
                             .aggregate(Max('end_time')))
             return aggregate['end_time__max']
+        else:
+            return None
+
+    # Possible sync status'. May eventually become a model field.
+    IN_PROGRESS = 0
+    SKIPPED = 1
+    SYNCED = 2
+
+    @property
+    def status(self):
+        """Return a constant for the current status of this sync."""
+        if not self.finished:
+            return self.IN_PROGRESS
+        elif self.skipped:
+            return self.SKIPPED
+        else:
+            return self.SYNCED
 
     @property
     def finished(self):
+        if self.skipped:
+            return True
+
         repo_logs = self.repository_sync_logs.all()
         if len(repo_logs) != self.project.repositories.count():
             return False
@@ -68,7 +98,7 @@ class RepositorySyncLog(BaseLog):
     repository = models.ForeignKey(Repository)
 
     start_time = models.DateTimeField(default=timezone.now)
-    end_time = models.DateTimeField(default=timezone.now, blank=True, null=True)
+    end_time = models.DateTimeField(default=None, blank=True, null=True)
 
     @property
     def finished(self):

--- a/pontoon/sync/tasks.py
+++ b/pontoon/sync/tasks.py
@@ -62,6 +62,11 @@ def sync_project(self, project_pk, sync_log_pk, no_pull=False, no_commit=False, 
     # no Pontoon-side changes for this project, quit early.
     if not force and not repos_changed and not db_project.needs_sync:
         log.info('Skipping project {0}, no changes detected.'.format(db_project.slug))
+
+        project_sync_log.skipped = True
+        project_sync_log.skipped_end_time = timezone.now()
+        project_sync_log.save(update_fields=('skipped', 'skipped_end_time'))
+
         return
 
     perform_sync_project(db_project, now)
@@ -103,6 +108,8 @@ def sync_project_repo(self, project_pk, repo_pk, project_sync_log_pk, now,
     if len(repo.locales) < 1:
         log.warning('Could not sync repo `{0}`, no locales found within.'
                     .format(repo.url))
+        repo_sync_log.end_time = timezone.now()
+        repo_sync_log.save(update_fields=['end_time'])
         return
 
     vcs_project = VCSProject(db_project, locales=repo.locales)

--- a/pontoon/sync/templates/sync/log_details.html
+++ b/pontoon/sync/templates/sync/log_details.html
@@ -37,29 +37,32 @@
         <h2 class="project-name">Project: {{ project_log.project.name }}</h2>
 
         {% call details('sync-details project-details') %}
+          {{ detail_item('Status', project_log_status_string(project_log.status), class='status') }}
           {{ detail_item('Start', project_log.start_time|format_datetime('time'), class='start-time') }}
           {{ detail_item('End', project_log.end_time|format_datetime('time'), class='end-time') }}
           {{ detail_item('Duration', project_log.duration|format_timedelta, class='duration') }}
         {% endcall %}
 
-        <table class="repository-logs">
-          <tr class="repository-logs-header">
-            <th class="repository-logs-column">Repository URL</th>
-            <th class="repository-logs-column">Timing</th>
-          </tr>
-          {% for repo_log in repository_sync_logs[project_log] %}
-            <tr class="repository">
-              <td class="repository-url">{{ repo_log.repository.url }}</td>
-              <td class="repository-details">
-                {% call details('sync-details repository-details') %}
-                  {{ detail_item('Start', repo_log.start_time|format_datetime('time'), class='start-time') }}
-                  {{ detail_item('End', repo_log.end_time|format_datetime('time'), class='end-time') }}
-                  {{ detail_item('Duration', repo_log.duration|format_timedelta, class='duration') }}
-                {% endcall %}
-              </td>
+        {% if repository_sync_logs[project_log] %}
+          <table class="repository-logs">
+            <tr class="repository-logs-header">
+              <th class="repository-logs-column">Repository URL</th>
+              <th class="repository-logs-column">Timing</th>
             </tr>
-          {% endfor %}
-        </table>
+            {% for repo_log in repository_sync_logs[project_log] %}
+              <tr class="repository">
+                <td class="repository-url">{{ repo_log.repository.url }}</td>
+                <td class="repository-details">
+                  {% call details('sync-details repository-details') %}
+                    {{ detail_item('Start', repo_log.start_time|format_datetime('time'), class='start-time') }}
+                    {{ detail_item('End', repo_log.end_time|format_datetime('time'), class='end-time') }}
+                    {{ detail_item('Duration', repo_log.duration|format_timedelta, class='duration') }}
+                  {% endcall %}
+                </td>
+              </tr>
+            {% endfor %}
+          </table>
+        {% endif %}
       </section>
     {% endfor %}
   </div>

--- a/pontoon/sync/templatetags/helpers.py
+++ b/pontoon/sync/templatetags/helpers.py
@@ -1,0 +1,15 @@
+from django_jinja import library
+
+from pontoon.sync.models import ProjectSyncLog
+
+
+PROJECT_SYNC_LOG_STATUS = {
+    ProjectSyncLog.IN_PROGRESS: 'In-progress',
+    ProjectSyncLog.SKIPPED: 'Skipped',
+    ProjectSyncLog.SYNCED: 'Synced',
+}
+
+
+@library.global_function
+def project_log_status_string(status):
+    return PROJECT_SYNC_LOG_STATUS.get(status, '---')

--- a/pontoon/sync/tests/test_tasks.py
+++ b/pontoon/sync/tests/test_tasks.py
@@ -83,6 +83,9 @@ class SyncProjectTests(TestCase):
             CONTAINS('Skipping', self.db_project.slug)
         )
 
+        # When skipping, mark the project log properly.
+        assert_true(ProjectSyncLog.objects.get(project=self.db_project).skipped)
+
     def test_no_changes_force(self):
         """
         If the database and VCS both have no changes, but force is true,


### PR DESCRIPTION
Also logs end time for repo syncs that fail due to no locales being found within a repo.

This should fix most of the data issues with the sync logs. I'll hopefully come up with a separate PR implementing pagination.

@mathjazz r?