### PR TITLE
Fix bug 1219431: Adding translated word count to profile view

### DIFF
--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -291,6 +291,11 @@ body > header .project.select {
   content: "";
 }
 
+.words .status:before {
+  color: #44DDAA;
+  content: "";
+}
+
 .translated .status:before {
   color: #4FC4F6;
   content: "";
@@ -762,6 +767,7 @@ body > header aside p {
   padding-left: 2%;
 }
 
+#entitylist > .wrapper > ul > li.words p span.source-string,
 #entitylist > .wrapper > ul > li.approved p span.source-string,
 #entitylist > .wrapper > ul > li.translated p span.source-string,
 #entitylist > .wrapper > ul > li.fuzzy p span.source-string,

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -982,17 +982,36 @@ var Pontoon = (function (my) {
       });
     },
 
-
     /*
      * Update progress indicator and value
      */
     updateProgress: function () {
+
+      /*
+       * Count the number of words translated
+       */
+      function wordProgress () {
+        var entities = Pontoon.entities;
+        var entitiesLength = entities.length;
+        var wordCount = 0;
+        for (var entityIndex = 0; entityIndex < entitiesLength; entityIndex++) {
+          var entityString = entities[entityIndex].translation[0].string;
+          if (entityString !== null) {
+            var tempEntityString = entityString.split(' ');
+            wordCount += tempEntityString.length;
+          }
+        }
+        return wordCount;
+      }
+
       var all = $("#entitylist .entity").length,
           approved = $("#entitylist .entity.approved").length,
           translated = $("#entitylist .entity.translated").length,
           fuzzy = $("#entitylist .entity.fuzzy").length,
           untranslated = all - translated - approved - fuzzy,
+          words = wordProgress();
           fraction = {
+            words: words ? words / 1 : 0,
             approved: all ? approved / all : 0,
             translated: all ? translated / all : 0,
             fuzzy: all ? fuzzy / all : 0,
@@ -1031,6 +1050,7 @@ var Pontoon = (function (my) {
       // Update details in the menu
       $('#progress .menu').find('header span').html(all).end()
         .find('.details')
+          .find('.words p').html(words).end()
           .find('.approved p').html(approved).end()
           .find('.translated p').html(translated).end()
           .find('.fuzzy p').html(fuzzy).end()

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -50,6 +50,10 @@
           <span class="number"></span>
         </div>
         <div class="details">
+          <div class="words">
+            <span>Words</span>
+            <p></p>
+          </div>
           <div class="approved">
             <span>Translated</span>
             <p></p>

--- a/pontoon/base/templates/user.html
+++ b/pontoon/base/templates/user.html
@@ -52,6 +52,10 @@
 <ul class="notification"></ul>
 
 <div class="details">
+  <div class="words">
+    <span>Words Translated</span>
+    <p>{{ words }}</p>
+  </div>
   <div class="total">
     <span>Total</span>
     <p>{{ translations.count() }}</p>

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -264,10 +264,16 @@ def contributor(request, email):
 
     timeline.reverse()
 
+    words = 0
+
+    for translation in translations:
+        words += len(translation.string.split(' '))
+
     return render(request, 'user.html', {
         'contributor': user,
         'timeline': timeline,
         'translations': translations,
+        'words': words,
     })
 
 


### PR DESCRIPTION
I think this is a very naïve approach to show the word count, is there a better way of querying the QuerySet without iterating through all of them ? Also, should something similar be made for the `/contributors` view ? The top contributors view is passed a context of the `user` and `period`, How do I retrieve the other information from here ? @mathjazz 