### PR TITLE
Download projects with few resources as ZIP

### DIFF
--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 import requests
 import xml.etree.ElementTree as ET
 import urllib
@@ -938,12 +937,11 @@ def download(request):
     except MultiValueDictKeyError:
         raise Http404
 
-    content, path = utils.get_download_content(slug, code, part)
+    content, filename = utils.get_download_content(slug, code, part)
 
     if not content:
         raise Http404
 
-    filename = os.path.basename(path)
     response = HttpResponse()
     response.content = content
     response['Content-Type'] = 'text/plain'


### PR DESCRIPTION
If project has mutiple resources, but less than 10, download all
files at once in a ZIP. Else, download separate files.

This wasn't tracked in bugzilla, it's a quick response to:
https://groups.google.com/forum/#!msg/mozilla.dev.l10n/aiJm4EH4s8w/V14iu-IUBwAJ

@jotes r?