### PR TITLE
Simplify locales list for superusers

### DIFF
--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -87,7 +87,10 @@ def display_permissions(self):
     output = 'Can make suggestions'
 
     if self.translated_locales:
-        locales = ', '.join(self.translated_locales)
+        if self.is_superuser:
+            locales = 'all locales'
+        else:
+            locales = ', '.join(self.translated_locales)
         output = 'Can submit and approve translations for ' + locales
 
     return output


### PR DESCRIPTION
Instead of listing all (100+) locales, simply put it as "all locales".

@jotes r?