### PR TITLE
Fix bug 1235893: Don't approve suggestions on delete

### DIFF
--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -1161,7 +1161,7 @@ p#sign-in-required > a#sidebar-signin {
   cursor: pointer;
   padding-left: 10px;
   padding-right: 10px;
-  transition: all 0.2s ease-out;
+  transition: all 0.1s ease-out;
 }
 
 #helpers > section ul li.delete {


### PR DESCRIPTION
(Diff looks big because block alignment changed several times)

Do not automatically approve next translation when deleting the active
one. Not just when in suggest mode like the bug description suggests,
but in general.

Automatic approval is dangerous and from now on we require localizers
to explicitly approve one of the remaining suggestions. To avoid any
surprises.

@jotes r?