### PR TITLE
Minimal main menu request

### DIFF
--- a/pontoon/base/static/css/search.css
+++ b/pontoon/base/static/css/search.css
@@ -8,7 +8,7 @@
   margin: 0;
   padding: 10px;
   text-align: left;
-  width: 232px;
+  width: 222px;
 }
 
 .locale.select .selector:before,

--- a/pontoon/base/templates/locale.html
+++ b/pontoon/base/templates/locale.html
@@ -11,7 +11,7 @@
      class="hidden"
      {% if csrf_token %}data-csrf="{{ csrf_token }}"{% endif %}
      data-locale="{{ locale.code }}"
-     data-locale-projects="{{ locale_projects or '' }}">
+     data-locale-projects="{{ locale.available_projects_list()|to_json }}">
 </div>
 {% endblock %}
 

--- a/pontoon/base/templates/locale_selector.html
+++ b/pontoon/base/templates/locale_selector.html
@@ -23,7 +23,24 @@
     <ul>
       {% for l in locales %}
       <li class="clearfix{% if l and l.chart %} filter{% endif %}">
-        <span class="language {{ l.code|lower }}"{% if locale %}{% for key, value in l.serialize().iteritems() %} data-{{ key }}="{{ value }}"{% endfor %}{% if locale == l %}data-details="{{ l.projects_parts_stats()|to_json }}"{% endif %}{% endif %}>{% if l and l.chart %}<a href="{% if project %}{{ url('pontoon.locale.project', l.code, project.slug) }}{% else %}{{ url('pontoon.locale', l.code) }}{% endif %}" class="clearfix">{% endif %}{{ l.name }}{% if l and l.chart %}</a>{% endif %}</span>
+        <span class="language {{ l.code|lower }}"
+        {% if locale %}
+          {% for key, value in l.serialize().iteritems() %}
+            data-{{ key }}="{{ value }}"
+          {% endfor %}
+          {% if locale == l %}
+            data-projects="{{ l.available_projects_list()|to_json }}"
+          {% endif %}
+        {% endif %}
+        >
+        {% if l and l.chart %}
+          <a href="{% if project %}{{ url('pontoon.locale.project', l.code, project.slug) }}{% else %}{{ url('pontoon.locale', l.code) }}{% endif %}" class="clearfix">
+        {% endif %}
+          {{ l.name }}
+        {% if l and l.chart %}
+          </a>
+        {% endif %}
+        </span>
         <span class="code">{% if l and l.chart %}<a class="code" href="{% if project %}{{ url('pontoon.locale.project', l.code, project.slug) }}{% else %}{{ url('pontoon.locale', l.code) }}{% endif %}" class="clearfix">{% endif %}{{ l.code }}{% if l and l.chart %}</a>{% endif %}</span>
         {% if not locale and l.chart %}
           {{ latest_activity.span(l.get_latest_activity(project|default(none))) }}

--- a/pontoon/base/templates/locale_selector.html
+++ b/pontoon/base/templates/locale_selector.html
@@ -24,7 +24,7 @@
       {% for l in locales %}
       <li class="clearfix{% if l and l.chart %} filter{% endif %}">
         <span class="language {{ l.code|lower }}"
-        {% if locale %}
+        {% if project and locale %}
           {% for key, value in l.serialize().iteritems() %}
             data-{{ key }}="{{ value }}"
           {% endfor %}

--- a/pontoon/base/templates/project_selector.html
+++ b/pontoon/base/templates/project_selector.html
@@ -28,11 +28,22 @@
       {% for p in projects %}
       <li class="clearfix"{% if project and project == p %} style="display: list-item;"{% endif %}>
         <span class="name"
-          {% for key, value in p.serialize().iteritems() %} data-{{ key }}="{{ value }}"{% endfor %}
+          {% for key, value in p.serialize().iteritems() %}
+            data-{{ key }}="{{ value }}"
+          {% endfor %}
+          {% if project and locale %}
+            {% if project == p %}
+              data-parts="{{ {locale.code: locale.parts_stats(p)}|to_json }}"
+            {% endif %}
+          {% endif %}
         >
-          {% if p and p.chart %}<a href="{% if locale %}{{ url('pontoon.locale.project', locale.code, p.slug) }}{% elif admin %}{{ url('pontoon.admin.project', p.slug) }}{% else %}{{ url('pontoon.project', p.slug) }}{% endif %}" class="clearfix">{% endif %}
-            {{ p.name }}
-          {% if p and p.chart %}</a>{% endif %}
+        {% if p and p.chart %}
+          <a href="{% if locale %}{{ url('pontoon.locale.project', locale.code, p.slug) }}{% elif admin %}{{ url('pontoon.admin.project', p.slug) }}{% else %}{{ url('pontoon.project', p.slug) }}{% endif %}" class="clearfix">
+        {% endif %}
+          {{ p.name }}
+        {% if p and p.chart %}
+          </a>
+        {% endif %}
         </span>
         {% if not project %}
           {{ latest_activity.span(p.get_latest_activity(locale|default(none))) }}

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -9,7 +9,6 @@
 <div id="server"
      class="hidden"
      data-site-url="{{ settings.SITE_URL }}"
-     {% if accept_language %}data-accept-language="{{ accept_language }}"{% endif %}
      {% if csrf_token %}data-csrf="{{ csrf_token }}"{% endif %}
      {% if user.email %}data-email="{{ user.email|nospam }}"{% endif %}
      {% if user.first_name %}data-name="{{ user.first_name }}"{% endif %}

--- a/pontoon/base/tests/test_models.py
+++ b/pontoon/base/tests/test_models.py
@@ -158,17 +158,17 @@ class LocalePartsTests(TestCase):
         EntityFactory.create(resource=self.resource)
         StatsFactory.create(resource=self.resource, locale=self.locale)
 
-    def test_projects_parts_stats_no_page_one_resource(self):
+    def test_parts_stats_no_page_one_resource(self):
         """
         Return resource paths and stats if no subpage and one resource defined.
         """
-        details = self.locale.projects_parts_stats().get(self.project.slug)
+        details = self.locale.parts_stats(self.project)
 
         assert_equal(len(details), 1)
         assert_equal(details[0]['resource__path'], '/main/path.po')
         assert_equal(details[0]['translated_count'], 0)
 
-    def test_projects_parts_stats_no_page_multiple_resources(self):
+    def test_parts_stats_no_page_multiple_resources(self):
         """
         Return resource paths and stats for locales resources are available for.
         """
@@ -180,8 +180,8 @@ class LocalePartsTests(TestCase):
         StatsFactory.create(resource=resource_other, locale=self.locale)
         StatsFactory.create(resource=resource_other, locale=self.locale_other)
 
-        details = self.locale.projects_parts_stats().get(self.project.slug)
-        details_other = self.locale_other.projects_parts_stats().get(self.project.slug)
+        details = self.locale.parts_stats(self.project)
+        details_other = self.locale_other.parts_stats(self.project)
 
         assert_equal(details[0]['resource__path'], '/main/path.po')
         assert_equal(details[0]['translated_count'], 0)
@@ -191,18 +191,18 @@ class LocalePartsTests(TestCase):
         assert_equal(details_other[0]['resource__path'], '/other/path.po')
         assert_equal(details_other[0]['translated_count'], 0)
 
-    def test_projects_parts_stats_pages_not_tied_to_resources(self):
+    def test_parts_stats_pages_not_tied_to_resources(self):
         """
         Return subpage name and stats.
         """
         SubpageFactory.create(project=self.project, name='Subpage')
 
-        details = self.locale.projects_parts_stats().get(self.project.slug)
+        details = self.locale.parts_stats(self.project)
 
         assert_equal(details[0]['resource__path'], 'Subpage')
         assert_equal(details[0]['translated_count'], 0)
 
-    def test_projects_parts_stats_pages_tied_to_resources(self):
+    def test_parts_stats_pages_tied_to_resources(self):
         """
         Return subpage name and stats for locales resources are available for.
         """
@@ -224,8 +224,8 @@ class LocalePartsTests(TestCase):
             resources=[resource_other]
         )
 
-        details = self.locale.projects_parts_stats().get(self.project.slug)
-        details_other = self.locale_other.projects_parts_stats().get(self.project.slug)
+        details = self.locale.parts_stats(self.project)
+        details_other = self.locale_other.parts_stats(self.project)
 
         assert_equal(details[0]['resource__path'], 'Other Subpage')
         assert_equal(details[0]['translated_count'], 0)

--- a/pontoon/base/tests/test_views.py
+++ b/pontoon/base/tests/test_views.py
@@ -234,9 +234,9 @@ class LocaleProjectTests(ViewTestCase):
         translation = TranslationFactory.create(entity__resource=resource, locale=locale)
         StatsFactory.create(resource=resource, locale=locale, latest_translation=translation)
 
-        with patch.object(Locale, 'projects_parts_stats') as mock_projects_parts_stats, \
+        with patch.object(Locale, 'parts_stats') as mock_parts_stats, \
                 patch('pontoon.base.views.render') as mock_render:
-            mock_projects_parts_stats.return_value = [
+            mock_parts_stats.return_value = [
                 {'resource__path': 'has/stats.po'},
                 {'resource__path': 'no/stats.po'}
             ]

--- a/pontoon/base/urls.py
+++ b/pontoon/base/urls.py
@@ -45,9 +45,9 @@ urlpatterns = patterns(
         RedirectView.as_view(url="/%(locale)s/", permanent=True)),
 
     # AJAX: Get locale details
-    url(r'^teams/(?P<locale>[A-Za-z0-9\-\@\.]+)/details/$',
-        views.get_locale_details,
-        name='pontoon.locale.details'),
+    url(r'^teams/(?P<locale>[A-Za-z0-9\-\@\.]+)/projects/$',
+        views.locale_projects,
+        name='pontoon.locale.projects'),
 
     # List all imported projects
     url(r'^projects/$',
@@ -78,6 +78,11 @@ urlpatterns = patterns(
     url(r'^(?P<locale>[A-Za-z0-9\-\@\.]+)/manage/$',
         views.locale_manage,
         name='pontoon.locale.manage'),
+
+    # AJAX: Request project to be added to locale
+    url(r'^(?P<locale>[A-Za-z0-9\-\@\.]+)/(?P<slug>[\w-]+)/parts/$',
+        views.locale_project_parts,
+        name='pontoon.locale.project.parts'),
 
     # Translate project
     url(r'^(?P<locale>[A-Za-z0-9\-\@\.]+)/(?P<slug>[\w-]+)/(?P<part>.+)/$',

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -177,7 +177,7 @@ def locale_project(request, locale, slug):
         .select_related('resource', 'latest_translation')
     )
     stats = {s.resource.path: s for s in stats_qs}
-    parts = l.projects_parts_stats(project)
+    parts = l.parts_stats(project)
 
     for part in parts:
         stat = stats.get(part['resource__path'], None)
@@ -333,13 +333,20 @@ def search(request):
 
 
 @require_AJAX
-def get_locale_details(request, locale):
-    """Get locale projects with their pages/paths and stats."""
+def locale_projects(request, locale):
+    """Get active projects for locale."""
     locale = get_object_or_404(Locale, code=locale)
 
-    return JsonResponse({
-        "details": locale.projects_parts_stats(),
-    })
+    return JsonResponse(locale.available_projects_list(), safe=False)
+
+
+@require_AJAX
+def locale_project_parts(request, locale, slug):
+    """Get locale-project pages/paths with stats."""
+    locale = get_object_or_404(Locale, code=locale)
+    project = get_object_or_404(Project, slug=slug)
+
+    return JsonResponse(locale.parts_stats(project), safe=False)
 
 
 @require_AJAX


### PR DESCRIPTION
It turns out #329 caused much longer translate page loads on stage for locales with many projects enabled. So instead of loading all projects, parts and stats data for locale, we now only load parts and stats for current project-locale combination.

That means changing selection in locale and project menu triggers AJAX request to get data for the part menu if not already available.

I've also made a step forward WRT code reuse.

@jotes r?