### PR TITLE
Fix bug 1216516: Load all helper requests at once

### DIFF
--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -1168,7 +1168,7 @@ body > .container {
 .tabs nav ul li a {
   display: inline-block;
   outline: none;
-  padding: 10px;
+  padding: 10px 5px;
   width: 100%;
 
   -moz-box-sizing: border-box;

--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -939,7 +939,7 @@ body > header aside p {
   color: #CCCCCC;
 }
 
-#editor nav li a > span > span {
+#editor nav li a > span > .fa {
   left: 0;
   position: absolute;
   right: 0;
@@ -948,8 +948,20 @@ body > header aside p {
   visibility: hidden;
 }
 
-#editor nav li a.loading > span > span {
+#editor nav li a.loading > span > .fa {
   visibility: visible;
+}
+
+#editor nav li a > span > .count {
+  background: #3F4752;
+  border-radius: 3px;
+  color: #4FC4F6;
+  padding: 0 5px;
+}
+
+#editor nav li.active a > span > .count,
+#editor nav li:hover a > span > .count {
+  background: #4D5967;
 }
 
 #editor nav li a > span {
@@ -958,6 +970,10 @@ body > header aside p {
 
 #editor nav li a.loading > span {
   visibility: hidden;
+}
+
+#editor nav li a.loading[href="#machinery"] span.count {
+  visibility: visible;
 }
 
 #editor textarea {
@@ -1134,25 +1150,16 @@ p#sign-in-required > a#sidebar-signin {
   top: 43px;
 }
 
-#helpers > section.custom-search .search-wrapper {
+#helpers > section.machinery .search-wrapper {
   margin: 0 10px 10px;
 }
 
-#helpers > section.custom-search .icon {
+#helpers > section.machinery .icon {
   left: 2px;
   right: auto;
 }
 
-#helpers > section.custom-search.loading .icon,
-#helpers > section.custom-search .icon.fa-cog {
-  display: none;
-}
-
-#helpers > section.custom-search.loading .icon.fa-cog {
-  display: block;
-}
-
-#helpers > section.custom-search input[type=search] {
+#helpers > section.machinery input[type=search] {
   background: transparent;
   padding: 10px 10px 5px 25px;
 }

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -148,21 +148,8 @@ var Pontoon = (function (my) {
           loader = loader || 'helpers li a[href="#machinery"]',
           ul = $('#' + tab_id).find('ul').empty(),
           tab = $('#' + loader).addClass('loading'),
-          requests = 0;
-
-      function complete(jqXHR, status) {
-        if (status !== "abort") {
-          requests--;
-          if (requests === 0) {
-            tab.removeClass('loading');
-            if (ul.find('li').length === 0) {
-              ul.append('<li class="disabled">' +
-                '<p>No translations available.</p>' +
-              '</li>');
-            }
-          }
-        }
-      }
+          requests = 0,
+          count = 0;
 
       function append(data) {
         var title = loader !== 'search' ? ' title="Copy Into Translation (Tab)"' : '';
@@ -188,6 +175,8 @@ var Pontoon = (function (my) {
           return (valA < valB) ? 1 : (valA > valB) ? -1 : 0;
         });
         ul.append(listitems);
+
+        count++;
       }
 
       function error(error) {
@@ -197,9 +186,26 @@ var Pontoon = (function (my) {
           if (ul.find('li').length === 0) {
             self.noConnectionError(ul);
           }
-          tab.removeClass('loading');
         }
       }
+
+      function complete(jqXHR, status) {
+        if (status !== "abort") {
+          requests--;
+          tab.find('.count').html(count).toggle(count !== 0);
+          if (requests === 0) {
+            tab.removeClass('loading');
+            if (ul.find('li').length === 0) {
+              ul.append('<li class="disabled">' +
+                '<p>No translations available.</p>' +
+              '</li>');
+            }
+          }
+        }
+      }
+
+      // Reset count
+      tab.find('.count').html('').hide();
 
       // Translation memory
       requests++;

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -270,10 +270,28 @@
     <div id="helpers" class="tabs">
       <nav>
         <ul>
-          <li class="active"><a href="#history"><span>History<span class="fa fa-cog fa-lg fa-spin"></span></span></a></li>
-          <li><a href="#machinery"><span>Machinery<span class="fa fa-cog fa-lg fa-spin"></span></span></a></li>
-          <li><a href="#other-locales"><span>Locales<span class="fa fa-cog fa-lg fa-spin"></span></span></a></li>
-          <li><a href="#custom-search"><span>Search<span class="fa fa-cog fa-lg fa-spin"></span></span></a></li>
+          <li class="active">
+            <a href="#history">
+              <span>History
+                <span class="fa fa-cog fa-lg fa-spin"></span>
+                <span class="count"></span>
+              </span>
+            </a>
+          </li><li>
+            <a href="#machinery">
+              <span>Machinery
+                <span class="fa fa-cog fa-lg fa-spin"></span>
+                <span class="count"></span>
+              </span>
+            </a>
+          </li><li>
+            <a href="#other-locales">
+              <span>Locales
+                <span class="fa fa-cog fa-lg fa-spin"></span>
+                <span class="count"></span>
+              </span>
+            </a>
+          </li>
         </ul>
       </nav>
 
@@ -282,19 +300,14 @@
       </section>
 
       <section class="machinery">
+        <div class="search-wrapper clearfix">
+          <div class="icon fa fa-search"></div>
+          <input type="search" autocomplete="off" placeholder="Type to search machinery">
+        </div>
         <ul></ul>
       </section>
 
       <section class="other-locales">
-        <ul></ul>
-      </section>
-
-      <section class="custom-search">
-        <div class="search-wrapper clearfix">
-          <div class="icon fa fa-search"></div>
-          <div class="icon fa fa-cog fa-spin"></div>
-          <input type="search" autocomplete="off" placeholder="Type keyword and press Enter to search">
-        </div>
         <ul></ul>
       </section>
     </div>


### PR DESCRIPTION
Loads all helper requests (history + machinery + locales) at once and displays a number of results in a tab.

@jotes r?