### PR TITLE
Optimize latest activity DB requests

### DIFF
--- a/pontoon/base/tests/test_models.py
+++ b/pontoon/base/tests/test_models.py
@@ -808,7 +808,7 @@ class LocaleTests(TestCase):
         locale = LocaleFactory.create(latest_translation=None)
         assert_is_none(locale.get_latest_activity())
 
-    def test_get_latest_activity_with_locale(self):
+    def test_get_latest_activity_with_project(self):
         """
         If a locale is given, defer to
         ProjectLocale.get_latest_activity.
@@ -819,7 +819,7 @@ class LocaleTests(TestCase):
         with patch.object(ProjectLocale, 'get_latest_activity') as mock_get_latest_activity:
             mock_get_latest_activity.return_value = 'latest'
             assert_equal(locale.get_latest_activity(project=project), 'latest')
-            mock_get_latest_activity.assert_called_with(project, locale)
+            mock_get_latest_activity.assert_called_with(locale, project)
 
     def test_translators_group(self):
         """


### PR DESCRIPTION
I realized `Project.objects.select_related('latest_translation')` is never used, because `p.get_latest_activity(locale)` actually ends up accessing `latest_translation` property of the `ProjectLocale` object (not `Project`).

So this PR collects the appropriate data and sends it to the template. It reduces DB requests by 40% on the locale page.

@Osmose @jotes Before I do something similar on the project page, I wonder if there's a more elegant way of doing this.

For more context, I noticed this while preparing for https://bugzilla.mozilla.org/show_bug.cgi?id=1214392.