### PR TITLE
Bug 1216546 progressive load

### DIFF
--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -625,6 +625,10 @@ body > header aside p {
   width: 100%;
 }
 
+#entitylist .loading {
+  display: none;
+}
+
 .advanced #entitylist,
 .advanced #editor {
   width: 50%;

--- a/pontoon/base/static/js/pontoon.js
+++ b/pontoon/base/static/js/pontoon.js
@@ -110,7 +110,7 @@
        * Makes DOM nodes editable using contentEditable property
        *
        * entity Entity object
-       */ 
+       */
       function makeEditable(entity) {
         entity.body = true;
         $(entity.node).each(function() {
@@ -638,8 +638,8 @@
 
         if (target) {
           var top = target.getBoundingClientRect().top + window.scrollY,
-          toolbarTop = top - toolbar.outerHeight();
 
+          toolbarTop = top - toolbar.outerHeight();
           toolbar.css('top', toolbarTop);
         }
       });

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -184,7 +184,7 @@
     <div class="search-wrapper clearfix">
       <div class="icon fa fa-search"></div>
       <input id="search" type="search" autocomplete="off" placeholder="Search All" title="Search Strings (Alt + F)">
-      <div id="filter" class="select">
+      <div id="filter" class="select" data-current-filter="all">
         <div class="button selector all">
           <span class="status fa"></span>
           <span class="title">All</span>
@@ -209,6 +209,7 @@
       <h2 id="not-on-page">Not on the current page</h2>
       <ul class="uneditables"></ul>
       <h3 class="no-match"><div class="fa fa-exclamation-circle"></div>No results</h3>
+      <h3 class="loading"><div class="fa fa-exclamation-circle"></div>Loading entities</h3>
     </div>
   </div>
 

--- a/pontoon/base/tests/__init__.py
+++ b/pontoon/base/tests/__init__.py
@@ -137,6 +137,14 @@ class EntityFactory(DjangoModelFactory):
         model = Entity
 
 
+class PluralEntityFactory(DjangoModelFactory):
+    resource = SubFactory(ResourceFactory)
+    string = Sequence(lambda n: 'string {0}'.format(n))
+    string_plural = Sequence(lambda n: 'string plural {0}'.format(n))
+    class Meta:
+        model = Entity
+
+
 class ChangedEntityLocaleFactory(DjangoModelFactory):
     entity = SubFactory(EntityFactory)
     locale = SubFactory(LocaleFactory)

--- a/pontoon/base/tests/test_models.py
+++ b/pontoon/base/tests/test_models.py
@@ -25,6 +25,7 @@ from pontoon.base.tests import (
     EntityFactory,
     IdenticalTranslationFactory,
     LocaleFactory,
+    PluralEntityFactory,
     ProjectFactory,
     ProjectLocaleFactory,
     RepositoryFactory,
@@ -685,7 +686,7 @@ class EntityTests(TestCase):
         If paths not specified, return all project entities along with their
         translations for locale.
         """
-        entities = Entity.for_project_locale(self.project, self.locale)
+        entities = Entity.map_entities(self.locale, Entity.for_project_locale(self.project, self.locale))
 
         assert_equal(len(entities), 2)
         self.assert_serialized_entity(
@@ -727,7 +728,7 @@ class EntityTests(TestCase):
         with their translations for locale.
         """
         paths = ['other.lang']
-        entities = Entity.for_project_locale(self.project, self.locale, paths)
+        entities = Entity.map_entities(self.locale, Entity.for_project_locale(self.project, self.locale, paths))
 
         assert_equal(len(entities), 1)
         self.assert_serialized_entity(
@@ -740,7 +741,7 @@ class EntityTests(TestCase):
         locale.
         """
         subpages = [self.subpage.name]
-        entities = Entity.for_project_locale(self.project, self.locale, subpages)
+        entities = Entity.map_entities(self.locale, Entity.for_project_locale(self.project, self.locale, subpages))
 
         assert_equal(len(entities), 1)
         self.assert_serialized_entity(
@@ -750,7 +751,7 @@ class EntityTests(TestCase):
         """
         For pluralized strings, return all available plural forms.
         """
-        entities = Entity.for_project_locale(self.project, self.locale)
+        entities = Entity.map_entities(self.locale, Entity.for_project_locale(self.project, self.locale))
 
         assert_equal(entities[0]['original'], 'Source String')
         assert_equal(entities[0]['original_plural'], 'Plural Source String')
@@ -773,7 +774,7 @@ class EntityTests(TestCase):
             resource=self.main_resource,
             string='First String'
         )
-        entities = Entity.for_project_locale(self.project, self.locale)
+        entities = Entity.map_entities(self.locale, Entity.for_project_locale(self.project, self.locale))
 
         assert_equal(entities[2]['original'], 'First String')
         assert_equal(entities[3]['original'], 'Second String')
@@ -783,7 +784,7 @@ class EntityTests(TestCase):
         If key contais source string and Translate Toolkit separator,
         remove them.
         """
-        entities = Entity.for_project_locale(self.project, self.locale)
+        entities = Entity.map_entities(self.locale, Entity.for_project_locale(self.project, self.locale))
 
         assert_equal(entities[0]['key'], '')
         assert_equal(entities[1]['key'], 'Key')
@@ -1065,3 +1066,361 @@ class TranslationTests(TestCase):
             target=translation.string,
             locale=translation.locale
         )
+
+
+class EntityFilterTests(TestCase):
+    """
+    Tests all filters provided by the entity manager.
+    """
+    def setUp(self):
+        self.locale = LocaleFactory.create()
+        self.plural_locale = LocaleFactory.create(cldr_plurals='1,5')
+
+    def test_approved(self):
+        first_entity, second_entity, third_entity = EntityFactory.create_batch(3)
+        TranslationFactory.create(
+            locale=self.locale,
+            entity=first_entity,
+            approved=True
+        )
+        TranslationFactory.create(
+            locale=self.locale,
+            entity=second_entity,
+            fuzzy=True
+        )
+        TranslationFactory.create(
+            locale=self.locale,
+            entity=third_entity,
+            approved=True
+        )
+
+        assert_equal({first_entity, third_entity}, set(Entity.objects.approved(self.locale)))
+
+    def test_approved_plurals(self):
+        first_entity, second_entity, third_entity = PluralEntityFactory.create_batch(3)
+        TranslationFactory.create(
+            locale=self.plural_locale,
+            entity=first_entity,
+            approved=True,
+            plural_form=0
+        )
+        TranslationFactory.create(
+            locale=self.plural_locale,
+            entity=first_entity,
+            approved=True,
+            plural_form=1
+        )
+        TranslationFactory.create(
+            locale=self.plural_locale,
+            entity=second_entity,
+            approved=True,
+            plural_form=0
+        )
+        TranslationFactory.create(
+            locale=self.plural_locale,
+            entity=third_entity,
+            approved=True,
+            plural_form=0
+        )
+        TranslationFactory.create(
+            locale=self.plural_locale,
+            entity=third_entity,
+            approved=True,
+            plural_form=1
+        )
+
+        assert_equal({first_entity, third_entity},set(Entity.objects.approved(self.plural_locale)))
+
+    def test_fuzzy(self):
+        first_entity, second_entity, third_entity = EntityFactory.create_batch(3)
+        TranslationFactory.create(
+            locale=self.locale,
+            entity=first_entity,
+            fuzzy=True
+        )
+        TranslationFactory.create(
+            locale=self.locale,
+            entity=second_entity,
+            approved=True
+        )
+        TranslationFactory.create(
+            locale=self.locale,
+            entity=third_entity,
+            fuzzy=True
+        )
+
+        assert_equal({first_entity, third_entity}, set(Entity.objects.fuzzy(self.locale)))
+
+    def test_fuzzy_plurals(self):
+        first_entity, second_entity, third_entity = PluralEntityFactory.create_batch(3)
+        TranslationFactory.create(
+            locale=self.plural_locale,
+            entity=first_entity,
+            fuzzy=True,
+            plural_form=0
+        )
+        TranslationFactory.create(
+            locale=self.plural_locale,
+            entity=first_entity,
+            fuzzy=True,
+            plural_form=1
+        )
+        TranslationFactory.create(
+            locale=self.plural_locale,
+            entity=second_entity,
+            fuzzy=True,
+            plural_form=0
+        )
+        TranslationFactory.create(
+            locale=self.plural_locale,
+            entity=third_entity,
+            fuzzy=True,
+            plural_form=0
+        )
+        TranslationFactory.create(
+            locale=self.plural_locale,
+            entity=third_entity,
+            fuzzy=True,
+            plural_form=1
+        )
+
+        assert_equal({first_entity, third_entity}, set(Entity.objects.fuzzy(self.plural_locale)))
+
+    def test_untranslated(self):
+        first_entity, second_entity, third_entity = EntityFactory.create_batch(3)
+        TranslationFactory.create(
+            locale=self.locale,
+            entity=first_entity,
+            approved=True
+        )
+        TranslationFactory.create(
+            locale=self.locale,
+            entity=third_entity,
+            approved=True
+        )
+
+        assert_equal({second_entity}, set(Entity.objects.untranslated(self.locale)))
+
+    def test_not_translated(self):
+        first_entity, second_entity, third_entity = EntityFactory.create_batch(3)
+        TranslationFactory.create(
+            locale=self.locale,
+            entity=first_entity,
+            approved=True
+        )
+        TranslationFactory.create(
+            locale=self.locale,
+            entity=third_entity,
+            fuzzy=False,
+        )
+
+        assert_equal({second_entity, third_entity}, set(Entity.objects.not_translated(self.locale)))
+
+    def test_translated(self):
+        first_entity, second_entity, third_entity = EntityFactory.create_batch(3)
+        TranslationFactory.create(
+            locale=self.locale,
+            entity=second_entity,
+            approved=False,
+            fuzzy=False,
+        )
+        TranslationFactory.create(
+            locale=self.locale,
+            entity=third_entity,
+            approved=False,
+            fuzzy=False,
+        )
+
+        assert_equal({second_entity, third_entity}, set(Entity.objects.translated(self.locale)))
+
+    def test_unchanged(self):
+        first_entity, second_entity, third_entity = EntityFactory.create_batch(3, string='Unchanged string')
+        TranslationFactory.create(
+            locale=self.locale,
+            entity=first_entity,
+            approved=True,
+            string='Unchanged string'
+        )
+        TranslationFactory.create(
+            locale=self.locale,
+            entity=third_entity,
+            fuzzy=True,
+            string='Unchanged string'
+        )
+
+        assert_equal({first_entity, third_entity}, set(Entity.objects.unchanged(self.locale)))
+
+    def test_untranslated_plural(self):
+        first_entity, second_entity, third_entity = PluralEntityFactory.create_batch(3)
+        TranslationFactory.create(
+            locale=self.plural_locale,
+            entity=first_entity,
+            fuzzy=True,
+            plural_form=0,
+        )
+        TranslationFactory.create(
+            locale=self.plural_locale,
+            entity=first_entity,
+            fuzzy=True,
+            plural_form=1,
+        )
+        TranslationFactory.create(
+            locale=self.plural_locale,
+            entity=third_entity,
+            approved=True,
+            plural_form=0,
+        )
+        TranslationFactory.create(
+            locale=self.plural_locale,
+            entity=third_entity,
+            approved=True,
+            plural_form=1,
+        )
+
+        assert_equal({second_entity}, set(Entity.objects.untranslated(self.plural_locale)))
+
+    def test_not_translated_plural(self):
+        first_entity, second_entity, third_entity = PluralEntityFactory.create_batch(3)
+        TranslationFactory.create(
+            locale=self.plural_locale,
+            entity=first_entity,
+            approved=True,
+            plural_form=0,
+        )
+        TranslationFactory.create(
+            locale=self.plural_locale,
+            entity=first_entity,
+            fuzzy=True,
+            plural_form=1,
+        )
+        TranslationFactory.create(
+            locale=self.plural_locale,
+            entity=third_entity,
+            approved=True,
+            plural_form=0,
+        )
+        TranslationFactory.create(
+            locale=self.plural_locale,
+            entity=third_entity,
+            approved=True,
+            plural_form=1,
+        )
+
+        assert_equal({first_entity, second_entity}, set(Entity.objects.not_translated(self.plural_locale)))
+
+    def test_translated_plural(self):
+        first_entity, second_entity, third_entity = PluralEntityFactory.create_batch(3)
+        TranslationFactory.create(
+            locale=self.plural_locale,
+            entity=first_entity,
+            approved=False,
+            fuzzy=False,
+            plural_form=0,
+        )
+        TranslationFactory.create(
+            locale=self.plural_locale,
+            entity=first_entity,
+            approved=False,
+            fuzzy=False,
+            plural_form=1,
+        )
+        TranslationFactory.create(
+            locale=self.plural_locale,
+            entity=third_entity,
+            approved=False,
+            fuzzy=False,
+            plural_form=0,
+        )
+        TranslationFactory.create(
+            locale=self.plural_locale,
+            entity=third_entity,
+            approved=False,
+            fuzzy=False,
+            plural_form=1,
+        )
+
+        assert_equal({first_entity, third_entity}, set(Entity.objects.translated(self.plural_locale)))
+
+    def test_unchanged_plural(self):
+        first_entity, second_entity, third_entity = PluralEntityFactory.create_batch(3,
+            string='Unchanged string',
+            string_plural='Unchanged plural string'
+        )
+        TranslationFactory.create(
+            locale=self.plural_locale,
+            entity=first_entity,
+            approved=True,
+            plural_form=0,
+            string='Unchanged string'
+        )
+        TranslationFactory.create(
+            locale=self.plural_locale,
+            entity=first_entity,
+            approved=True,
+            plural_form=1,
+            string='Unchanged plural string'
+        )
+        TranslationFactory.create(
+            locale=self.plural_locale,
+            entity=third_entity,
+            fuzzy=True,
+            plural_form=0,
+            string='Unchanged string'
+        )
+        TranslationFactory.create(
+            locale=self.plural_locale,
+            entity=third_entity,
+            fuzzy=True,
+            plural_form=1,
+            string='Unchanged plural string'
+        )
+        assert_equal({first_entity, third_entity}, set(Entity.objects.unchanged(self.plural_locale)))
+
+    def test_has_suggestions_plural(self):
+        first_entity, second_entity, third_entity = PluralEntityFactory.create_batch(3,
+            string='Unchanged string',
+            string_plural='Unchanged plural string'
+        )
+        TranslationFactory.create(
+            locale=self.plural_locale,
+            entity=first_entity,
+            approved=True,
+            fuzzy=False,
+            plural_form=0
+        )
+        TranslationFactory.create(
+            locale=self.plural_locale,
+            entity=first_entity,
+            approved=True,
+            fuzzy=False,
+            plural_form=1,
+        )
+        TranslationFactory.create(
+            locale=self.plural_locale,
+            entity=first_entity,
+            approved=False,
+            fuzzy=False,
+            plural_form=2,
+        )
+        TranslationFactory.create(
+            locale=self.plural_locale,
+            entity=third_entity,
+            approved=True,
+            fuzzy=False,
+            plural_form=0,
+        )
+        TranslationFactory.create(
+            locale=self.plural_locale,
+            entity=third_entity,
+            approved=True,
+            fuzzy=False,
+            plural_form=1
+        )
+        TranslationFactory.create(
+            locale=self.plural_locale,
+            entity=third_entity,
+            approved=False,
+            fuzzy=False,
+            plural_form=2
+        )
+        assert_equal({first_entity, third_entity}, set(Entity.objects.has_suggestions(self.plural_locale)))

--- a/pontoon/base/tests/test_views.py
+++ b/pontoon/base/tests/test_views.py
@@ -4,12 +4,13 @@ from django.test import RequestFactory
 from django.utils.timezone import now
 
 from django_nose.tools import assert_equal, assert_true, assert_code
-from mock import patch
+from mock import patch, call
 
-from pontoon.base.models import Locale, Project
+from pontoon.base.models import Locale, Project, Entity, ProjectLocale, TranslatedResource
 from pontoon.base.utils import aware_datetime
 from pontoon.base.tests import (
     assert_json,
+    EntityFactory,
     LocaleFactory,
     ProjectFactory,
     ResourceFactory,
@@ -365,3 +366,90 @@ class TranslateMemoryTests(ViewTestCase):
         })
         assert_code(response, 200)
         assert_equal(response.content, '[]')
+
+
+class EntityViewTests(TestCase):
+    """
+    Tests related to the get_entity view.
+    """
+
+    def setUp(self):
+        self.resource = ResourceFactory.create()
+        self.locale = LocaleFactory.create()
+        ProjectLocale.objects.create(project=self.resource.project, locale=self.locale)
+        TranslatedResource.objects.create(resource=self.resource, locale=self.locale)
+        self.entities = EntityFactory.create_batch(3, resource=self.resource)
+        self.entities_pks = [e.pk for e in self.entities]
+
+    def test_inplace_mode(self):
+        """
+        Inplace mode of get_entites, should return all entities in a single batch.
+        """
+        response = self.client.post('/get-entities/', {
+            'project': self.resource.project.slug,
+            'locale': self.locale.code,
+            'paths[]': [self.resource.path],
+            'inplaceEditor': True,
+            # Inplace mode shouldn't respect paging or limiting page
+            'limit': 1,
+        }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+
+        assert_code(response, 200)
+        assert_equal(response.json()['has_next'], False)
+        assert_equal([e['pk'] for e in response.json()['entities']], self.entities_pks)
+
+    def test_entity_filters(self):
+        """
+        Tests if right filter calls right method in the Entity manager.
+        """
+        filters = (
+            'translated',
+            'untranslated',
+            'not-translated',
+            'has-suggestions',
+            'approved',
+            'fuzzy',
+            'unchanged'
+        )
+        for filter_ in filters:
+            filter_name = filter_.replace('-', '_')
+            with patch('pontoon.base.models.Entity.objects.{}'.format(filter_name), return_value=Entity.objects.all()) as filter_mock:
+                self.client.post('/get-entities/', {
+                    'project': self.resource.project.slug,
+                    'locale': self.locale.code,
+                    'paths[]': [self.resource.path],
+                    'filterType': filter_,
+                    'limit': 1,
+                }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+                assert_true(filter_mock.called)
+                assert_equal(filter_mock.call_args, call(self.locale))
+
+    def test_exclude_entities(self):
+        """
+        Excluded entities shouldn't returned by get_entities.
+        """
+        response = self.client.post('/get-entities/', {
+            'project': self.resource.project.slug,
+            'locale': self.locale.code,
+            'paths[]': [self.resource.path],
+            'excludeEntities[]': [self.entities[1].pk],
+            'limit': 1,
+        }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+
+        assert_code(response, 200)
+
+        assert_equal(response.json()['has_next'], True)
+        assert_equal([e['pk'] for e in response.json()['entities']], [self.entities[0].pk,])
+
+        response = self.client.post('/get-entities/', {
+            'project': self.resource.project.slug,
+            'locale': self.locale.code,
+            'paths[]': [self.resource.path],
+            'excludeEntities[]': [self.entities[0].pk, self.entities[1].pk],
+            'limit': 1,
+        }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+
+        assert_code(response, 200)
+
+        assert_equal(response.json()['has_next'], False)
+        assert_equal([e['pk'] for e in response.json()['entities']], [self.entities[2].pk])

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -9,12 +9,15 @@ import urllib
 
 from collections import defaultdict
 from dateutil.relativedelta import relativedelta
+from urlparse import parse_qs
+
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError, ImproperlyConfigured
 from django.core.mail import EmailMessage
+from django.core.paginator import Paginator, EmptyPage
 from django.core.validators import validate_comma_separated_integer_list
 from django.db import transaction, DataError
 from django.db.models import Count, F, Q
@@ -30,6 +33,7 @@ from django.http import (
 from django.shortcuts import get_object_or_404, render
 from django.utils import timezone
 from django.utils.datastructures import MultiValueDictKeyError
+from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from django.views.generic import TemplateView
 from django.views.generic.detail import DetailView
@@ -373,13 +377,16 @@ def locale_project_parts(request, locale, slug):
     return JsonResponse(locale.parts_stats(project), safe=False)
 
 
+@csrf_exempt
+@require_POST
 @require_AJAX
 def entities(request):
     """Get entities for the specified project, locale and paths."""
     try:
-        project = request.GET['project']
-        locale = request.GET['locale']
-        paths = json.loads(request.GET['paths'])
+        project = request.POST['project']
+        locale = request.POST['locale']
+        paths = request.POST.getlist('paths[]')
+        limit = int(request.POST.get('limit', 40))
     except (MultiValueDictKeyError, ValueError) as e:
         return HttpResponseBadRequest('Bad Request: {error}'.format(error=e))
 
@@ -387,11 +394,41 @@ def entities(request):
     locale = get_object_or_404(Locale, code__iexact=locale)
 
     search = None
-    if request.GET.get('keyword', None):
-        search = request.GET
+    if request.POST.get('search', None):
+        search = {k: v[0] for k, v in parse_qs(request.POST.get('search', '')).items()}
 
-    entities = Entity.for_project_locale(project, locale, paths, search)
-    return JsonResponse(entities, safe=False)
+    filter_type = request.POST.get('filterType', '')
+    filter_search = request.POST.get('filterSearch', '')
+
+    # In-context view requires loading of all entities
+    if request.POST.get('inplaceEditor', None):
+        entities = Entity.for_project_locale(project, locale, paths, search)
+        return JsonResponse({
+            'entities': Entity.map_entities(locale, entities),
+            'has_next': False,
+            'stats': TranslatedResource.objects.stats(paths, locale),
+        }, safe=False)
+
+    # In out-of-context view, paginate entities
+    else:
+        exclude_entities = request.POST.getlist('excludeEntities[]', [])
+        entities = Entity.for_project_locale(project, locale, paths, search, exclude_entities,
+            filter_type, filter_search)
+        paginator = Paginator(entities, limit)
+
+        try:
+            entities_page = paginator.page(1)
+        except EmptyPage:
+            return JsonResponse({
+                'has_next': False,
+                'stats': {},
+            })
+
+        return JsonResponse({
+            'entities': Entity.map_entities(locale, entities_page.object_list),
+            'has_next': entities_page.has_next(),
+            'stats': TranslatedResource.objects.stats(paths, locale),
+        }, safe=False)
 
 
 @require_AJAX
@@ -463,6 +500,7 @@ def delete_translation(request):
     """Delete given translation."""
     try:
         t = request.POST['translation']
+        paths = request.POST.getlist('paths[]')
     except MultiValueDictKeyError as e:
         return HttpResponseBadRequest('Bad Request: {error}'.format(error=e))
 
@@ -482,7 +520,9 @@ def delete_translation(request):
 
     translation.delete()
 
-    return HttpResponse('ok')
+    return JsonResponse({
+        'stats': TranslatedResource.objects.stats(paths, translation.locale)
+        })
 
 
 @anonymous_csrf_exempt
@@ -499,6 +539,7 @@ def update_translation(request):
         original = request.POST['original']
         ignore_check = request.POST['ignore_check']
         approve = json.loads(request.POST['approve'])
+        paths = request.POST.getlist('paths[]')
     except MultiValueDictKeyError as e:
         return HttpResponseBadRequest('Bad Request: {error}'.format(error=e))
 
@@ -585,6 +626,7 @@ def update_translation(request):
                 return JsonResponse({
                     'type': 'updated',
                     'translation': t.serialize(),
+                    'stats': TranslatedResource.objects.stats(paths, l),
                 })
 
             # If added by non-privileged user, unfuzzy it
@@ -608,6 +650,7 @@ def update_translation(request):
                     return JsonResponse({
                         'type': 'updated',
                         'translation': t.serialize(),
+                        'stats': TranslatedResource.objects.stats(paths, l),
                     })
 
                 return HttpResponse("Same translation already exists.")
@@ -644,6 +687,7 @@ def update_translation(request):
             return JsonResponse({
                 'type': 'added',
                 'translation': active.serialize(),
+                'stats': TranslatedResource.objects.stats(paths, l)
             })
 
     # No translations saved yet
@@ -667,6 +711,7 @@ def update_translation(request):
         return JsonResponse({
             'type': 'saved',
             'translation': t.serialize(),
+            'stats': TranslatedResource.objects.resource_locale_path(paths, l)
         })
 
 
@@ -1032,3 +1077,4 @@ def request_projects(request, locale):
 def get_csrf(request):
     """Get CSRF token."""
     return HttpResponse(request.csrf_token)
+


### PR DESCRIPTION
TODO list:
Backend:
- [x] translations_count is not doing what it should.
- [x] Search has to search by more than just the source string.

Frontend:
- [x] Progress bar only shows the status of the first 40 loaded entities instead of all.
- [x] 'No results' never appears when searching or filtering entities.
- [x] When you scroll to the bottom, 'Loading entities' starts jumping (showing and hiding) and several requests are made. You also need to wait for that to complete before you can scroll back up.
- [x] Translated filter is still not doing what it should. It's returning entities containing both, suggestions and approved translations. It should only display entities with blue checkmark icons. Also, it behaves differently if you select filter multiple times in a row. What I don't understand is why after page load and simple filter selection (Suggested) get-entities request puts the first 40 displayed entities on the excludeEntities list.
- [x]  Tests are failing.
- [x]  Progress bar is still off. I haven't checked the code, but numbers don't compute. It might be related to the translated filter issue descirbed above, because translated entities aren't calculated properly. It doesn't update on add/delete/approve translation. I'm also concerned if moving the logic to backend is a good idea, because it makes at least 4 big DB queries (and additional XmlHttpRequest) every time a translation is saved/deleted/approved.
- [x] On homepage (or any project with in-place l10n support), the normal (out of context) view is loaded first, which then jumps to in-place view with the iframe.
- [x] Progress doesn't get updated when you delete a translation.
- [x] On scroll to bottom, sometimes "Loading entities" title is always visible - it doesn't disappear. (Maybe when resource file contains just above 40 entities?)
- [x] On scroll to bottom, sometimes not all entities are loaded. They only load after you select Filter - All.
- [x] I go to http://localhost:8000/sl/firefox-os/apps/bluetooth/bluetooth.properties/ with 28 translated and 1 suggested string. I select Suggested filter to only show the one suggested translation. I switch to http://localhost:8000/sl/firefox-os/apps/bluetooth/manifest.properties/ and I get all 4 suggested translations available inside the entire firefox-os project (even if none of them belongs to the manifest.properties file). If I select All from the filte menu, I still see 4 suggested strings and 4 strings that actually belong to the manifest.properties file.
