### PR TITLE
Removed support for django-sha2

### DIFF
--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -47,10 +47,6 @@ STATIC_HOST = os.environ.get('STATIC_HOST', '')
 SESSION_COOKIE_HTTPONLY = os.environ.get('SESSION_COOKIE_HTTPONLY', 'True') != 'False'
 SESSION_COOKIE_SECURE = os.environ.get('SESSION_COOKIE_SECURE', 'True') != 'False'
 
-HMAC_KEYS = {
-    'hmac-key': os.environ['HMAC_KEY'],
-}
-
 SITE_URL = os.environ.get('SITE_URL', 'http://localhost:8000')
 BROWSERID_AUDIENCES = [SITE_URL]
 
@@ -389,17 +385,15 @@ ALLOWED_HOSTS = lazy(_allowed_hosts, list)()
 # Any other hasher in the list can be used for existing passwords.
 # Playdoh ships with Bcrypt+HMAC by default because it's the most secure.
 # To use bcrypt, fill in a secret HMAC key in your local settings.
-BASE_PASSWORD_HASHERS = (
-    'django_sha2.hashers.BcryptHMACCombinedPasswordVerifier',
-    'django_sha2.hashers.SHA512PasswordHasher',
-    'django_sha2.hashers.SHA256PasswordHasher',
+PASSWORD_HASHERS = (
+    'django.contrib.auth.hashers.PBKDF2PasswordHasher',
+    'django.contrib.auth.hashers.PBKDF2SHA1PasswordHasher',
+    'django.contrib.auth.hashers.BCryptSHA256PasswordHasher',
+    'django.contrib.auth.hashers.BCryptPasswordHasher',
     'django.contrib.auth.hashers.SHA1PasswordHasher',
     'django.contrib.auth.hashers.MD5PasswordHasher',
     'django.contrib.auth.hashers.UnsaltedMD5PasswordHasher',
 )
-
-from django_sha2 import get_password_hashers
-PASSWORD_HASHERS = get_password_hashers(BASE_PASSWORD_HASHERS, HMAC_KEYS)
 
 ## Logging
 LOGGING = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,8 +15,6 @@ diff-match-patch==20121119 \
     --hash=sha256:9dba5611fbf27893347349fd51cc1911cb403682a7163373adacc565d11e2e4c
 django-session-csrf==0.5 \
     --hash=sha256:44e4639ec057a6b6a9dddb869d4e3a4818fc9278ec490cce39aef08440592a93
-django-sha2==0.4 \
-    --hash=sha256:b06a86451a99d6c26bfa65082999dbf658e087e596e9292cce688b53eabaaada
 mock==1.3.0 \
     --hash=sha256:3f573a18be94de886d1191f27c168427ef693e8dcfcecf95b170577b2eb69cbb
 pbr==1.6.0 \


### PR DESCRIPTION
Hi, @mathjazz? Could you review this patch? This change definetely would require additional testing on your local environment before deployment on production.