### PR TITLE
Fix bug 1250303: Properly aggregate total strings

### DIFF
--- a/pontoon/base/templates/project_selector.html
+++ b/pontoon/base/templates/project_selector.html
@@ -39,7 +39,7 @@
           {% set chart = p.get_chart(locale|default(none)) %}
         {% endif %}
 
-        <li class="clearfix{% if chart != None %} limited{% endif %}"{% if project and project == p %} style="display: list-item;"{% endif %}>
+        <li class="clearfix{% if locale and p.slug in locale.available_projects_list() %} limited{% endif %}"{% if project and project == p %} style="display: list-item;"{% endif %}>
           <span class="name"
             {% for key, value in p.serialize().iteritems() %}
               data-{{ key }}="{{ value }}"

--- a/pontoon/sync/core.py
+++ b/pontoon/sync/core.py
@@ -103,6 +103,9 @@ def update_resources(db_project, vcs_project):
         # Calculate diffs to reduce DB queries
         total_strings_diff = len(vcs_resource.entities) - resource.total_strings
 
+        if total_strings_diff == 0:
+            continue
+
         # Resource
         resource.total_strings = F('total_strings') + total_strings_diff
         resource.save()


### PR DESCRIPTION
We have some issues with denormalized stats not being always in sync, see bug 1250303.

This fixes that and:
* Adds a little optimization to `update_resources()`.
* Displays projects in locale dashboard even if not imported yet.

@jotes r?