### PR TITLE
Fix bug 1218801: Speedup homepage

### DIFF
--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -1,3 +1,12 @@
+/* Must be available immediately */
+// Add case insensitive :contains-like selector to jQuery (search)
+$.expr[':'].containsi = function(a, i, m) {
+  return (a.textContent || a.innerText || '')
+    .toUpperCase().indexOf(m[3].toUpperCase()) >= 0;
+};
+
+
+
 /* Public functions used across different files */
 var Pontoon = (function (my) {
   return $.extend(true, my, {
@@ -425,12 +434,6 @@ $(function() {
   }).on('mouseleave', 'li .chart-wrapper', function () {
     $('.tooltip:visible').remove();
   });
-
-  // Add case insensitive :contains-like selector to jQuery (search)
-  $.expr[':'].containsi = function(a, i, m) {
-    return (a.textContent || a.innerText || '')
-      .toUpperCase().indexOf(m[3].toUpperCase()) >= 0;
-  };
 
   // Profile menu
   // Register handlers to prep django-browserid before binding menu.

--- a/pontoon/base/static/js/pontoon.js
+++ b/pontoon/base/static/js/pontoon.js
@@ -657,21 +657,14 @@
       if (entities.length > 0) {
 
         if (entities[0].format === 'properties' && $('[data-l10n-id]').length) {
-          var localized = false;
+          loadEntitiesL10nJs();
+
+          // If webL10n localized event triggered, retranslate using Pontoon translations
           window.addEventListener("localized", function() {
-            if (!localized) {
-              if (!document.webL10n || document.webL10n.getReadyState() === 'complete') {
-                localized = true;
-                loadEntitiesL10nJs();
-              }
-            }
-          }, false);
-          // Fallback: in case the event is never triggered
-          setTimeout(function() {
-            if (!localized) {
+            if (!document.webL10n || document.webL10n.getReadyState() === 'complete') {
               loadEntitiesL10nJs();
             }
-          }, 1000);
+          }, false);
 
         } else {
           var hooks = false;
@@ -784,7 +777,13 @@
       url = url.substring(url.indexOf(split) + split.length);
       paths.push(url);
     }
-
-    postMessage("READY", paths, null, "*");
   }
 })();
+
+var appWindow = window.opener || ((window !== window.top) ? window.top : undefined);
+if (appWindow) {
+  appWindow.postMessage(JSON.stringify({
+    type: 'READY',
+    value: []
+  }), '*');
+}

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -318,7 +318,7 @@
 </aside>
 
 <!-- Website placeholder + iframe fix: prevent iframes from capturing the mousemove events during a drag -->
-<iframe id="source"></iframe>
+<iframe id="source"{% if project.pk == 1 and part != 'search' %} src="{{ project.url }}"{% endif %}></iframe>
 <div id="iframe-cover"></div>
 
 <!-- No results -->

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -264,7 +264,6 @@ PIPELINE_CSS = {
         'source_filenames': (
             'css/bootstrap.min.css',
             'css/agency.css',
-            'css/font-awesome.min.css',
         ),
         'output_filename': 'css/intro.min.css',
     },


### PR DESCRIPTION
* Remove 1 second setTimeout on .properties detection
* Preload iframe on homepage
* Do not wait for iframe to load before getting entities
* Optimize intro page (fix bug 1179017)
* Focus webpage when loaded
* Load translate.js code instantly, without waiting for page to load

@jotes r?