### PR TITLE
Fix updating parts menu for subpages

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -311,9 +311,10 @@ class Locale(AggregatedStats):
 
     def parts_stats(self, project):
         """Get locale-project pages/paths with stats."""
-        def get_details(translatedresources):
-            return translatedresources.order_by('resource__path').values(
+        def get_details(parts):
+            return parts.order_by('title').values(
                 'url',
+                'title',
                 'resource__path',
                 'resource__total_strings',
                 'fuzzy_strings',
@@ -332,7 +333,10 @@ class Locale(AggregatedStats):
         # If subpages aren't defined,
         # return resource paths with corresponding stats
         if len(pages) == 0:
-            details = get_details(translatedresources.annotate(url=F('resource__project__url')))
+            details = get_details(translatedresources.annotate(
+                title=F('resource__path'),
+                url=F('resource__project__url')
+            ))
 
         # If project has defined subpages, return their names with
         # corresponding project stats. If subpages have defined resources,
@@ -343,7 +347,8 @@ class Locale(AggregatedStats):
                 details = get_details(
                     # List only subpages, whose resources are available for locale
                     pages.filter(resources__translatedresources__locale=self).annotate(
-                        resource__path=F('name'),
+                        title=F('name'),
+                        resource__path=F('resources__path'),
                         resource__total_strings=F('resources__total_strings'),
                         fuzzy_strings=F('resources__translatedresources__fuzzy_strings'),
                         translated_strings=F('resources__translatedresources__translated_strings'),
@@ -354,7 +359,8 @@ class Locale(AggregatedStats):
             else:
                 details = get_details(
                     pages.annotate(
-                        resource__path=F('name'),
+                        title=F('name'),
+                        resource__path=F('project__resources__path'),
                         resource__total_strings=F('project__resources__total_strings'),
                         fuzzy_strings=F('project__resources__translatedresources__fuzzy_strings'),
                         translated_strings=F('project__resources__translatedresources__translated_strings'),

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -1382,11 +1382,11 @@ var Pontoon = (function (my) {
       var locale = this.getSelectedLocale(),
           parts = this.getProjectData('parts')[locale],
           currentPart = this.getSelectedPart();
-          part = $.grep(parts, function (e) { return e.resource__path === currentPart; });
+          part = $.grep(parts, function (e) { return e.title === currentPart; });
 
       // Fallback if selected part not available for the selected locale & project
       if (!part.length) {
-        this.updatePartSelector(parts[0].resource__path);
+        this.updatePartSelector(parts[0].title);
       }
 
       // Switch to Resources tab
@@ -1511,7 +1511,7 @@ var Pontoon = (function (my) {
         menu.find('li:not(".no-match")').remove();
         $(parts).each(function() {
           var cls = '',
-              title = this.resource__path,
+              title = this.title,
               percent = '0%';
 
           if (currentProject && currentLocale && self.part === title) {
@@ -2182,7 +2182,7 @@ var Pontoon = (function (my) {
           part = this.getSelectedPart(),
           availableParts = this.getProjectData('parts')[locale],
           matchingParts = $.grep(availableParts, function (e) {
-            return e.resource__path === part;
+            return e.title === part;
           });
 
       if (!matchingParts.length) {
@@ -2207,7 +2207,7 @@ var Pontoon = (function (my) {
       // Fallback to first available part if no matches found (mistyped URL)
       if (requestedPart) {
         this.updateCurrentPart();
-        paths = this.currentPart.resource__path;
+        paths = this.currentPart.title;
         this.updatePartSelector(paths);
         postfix = paths + '/';
       }

--- a/pontoon/base/templates/part_selector.html
+++ b/pontoon/base/templates/part_selector.html
@@ -36,11 +36,11 @@
       <ul>
         {% if not part %}
         {% for p in parts %}
-          {% set link = url('pontoon.translate', locale.code, project.slug, p.resource__path) %}
+          {% set link = url('pontoon.translate', locale.code, project.slug, p.title) %}
           <li class="clearfix">
             <span class="name">
               <a href="{{ link }}" class="clearfix">
-                {{ p.resource__path }}
+                {{ p.title }}
               </a>
             </span>
 

--- a/pontoon/base/tests/test_models.py
+++ b/pontoon/base/tests/test_models.py
@@ -165,7 +165,7 @@ class LocalePartsTests(TestCase):
         details = self.locale.parts_stats(self.project)
 
         assert_equal(len(details), 1)
-        assert_equal(details[0]['resource__path'], '/main/path.po')
+        assert_equal(details[0]['title'], '/main/path.po')
         assert_equal(details[0]['translated_strings'], 0)
 
     def test_parts_stats_no_page_multiple_resources(self):
@@ -183,12 +183,12 @@ class LocalePartsTests(TestCase):
         details = self.locale.parts_stats(self.project)
         details_other = self.locale_other.parts_stats(self.project)
 
-        assert_equal(details[0]['resource__path'], '/main/path.po')
+        assert_equal(details[0]['title'], '/main/path.po')
         assert_equal(details[0]['translated_strings'], 0)
-        assert_equal(details[1]['resource__path'], '/other/path.po')
+        assert_equal(details[1]['title'], '/other/path.po')
         assert_equal(details[1]['translated_strings'], 0)
         assert_equal(len(details_other), 1)
-        assert_equal(details_other[0]['resource__path'], '/other/path.po')
+        assert_equal(details_other[0]['title'], '/other/path.po')
         assert_equal(details_other[0]['translated_strings'], 0)
 
     def test_parts_stats_pages_not_tied_to_resources(self):
@@ -199,7 +199,7 @@ class LocalePartsTests(TestCase):
 
         details = self.locale.parts_stats(self.project)
 
-        assert_equal(details[0]['resource__path'], 'Subpage')
+        assert_equal(details[0]['title'], 'Subpage')
         assert_equal(details[0]['translated_strings'], 0)
 
     def test_parts_stats_pages_tied_to_resources(self):
@@ -227,11 +227,11 @@ class LocalePartsTests(TestCase):
         details = self.locale.parts_stats(self.project)
         details_other = self.locale_other.parts_stats(self.project)
 
-        assert_equal(details[0]['resource__path'], 'Other Subpage')
+        assert_equal(details[0]['title'], 'Other Subpage')
         assert_equal(details[0]['translated_strings'], 0)
-        assert_equal(details[1]['resource__path'], 'Subpage')
+        assert_equal(details[1]['title'], 'Subpage')
         assert_equal(details[1]['translated_strings'], 0)
-        assert_equal(details_other[0]['resource__path'], 'Other Subpage')
+        assert_equal(details_other[0]['title'], 'Other Subpage')
         assert_equal(details_other[0]['translated_strings'], 0)
 
 

--- a/pontoon/base/tests/test_views.py
+++ b/pontoon/base/tests/test_views.py
@@ -238,6 +238,7 @@ class LocaleProjectTests(ViewTestCase):
                 patch('pontoon.base.views.render') as mock_render:
             mock_parts_stats.return_value = [
                 {
+                    'title': 'has/stats.po',
                     'resource__path': 'has/stats.po',
                     'resource__total_strings': 1,
                     'approved_strings': 0,
@@ -245,6 +246,7 @@ class LocaleProjectTests(ViewTestCase):
                     'fuzzy_strings': 0,
                 },
                 {
+                    'title': 'no/stats.po',
                     'resource__path': 'no/stats.po',
                     'resource__total_strings': 1,
                     'approved_strings': 0,
@@ -258,6 +260,7 @@ class LocaleProjectTests(ViewTestCase):
             assert_equal(ctx['parts'], [
                 {
                     'latest_activity': translation,
+                    'title': 'has/stats.po',
                     'resource__path': 'has/stats.po',
                     'resource__total_strings': 1,
                     'approved_strings': 0,
@@ -276,6 +279,7 @@ class LocaleProjectTests(ViewTestCase):
                 },
                 {
                     'latest_activity': None,
+                    'title': 'no/stats.po',
                     'resource__path': 'no/stats.po',
                     'resource__total_strings': 1,
                     'approved_strings': 0,

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -186,7 +186,7 @@ def locale_project(request, locale, slug):
     parts = l.parts_stats(project)
 
     for part in parts:
-        stat = translatedresources.get(part['resource__path'], None)
+        stat = translatedresources.get(part['title'], None)
         part['latest_activity'] = stat.latest_translation if stat else None
 
         part['chart'] = {


### PR DESCRIPTION
By renaming `resource__path` attribute (holding resource paths and subpage
names) to `title` and adding a new `resource__path` attribute holding
resource paths only.

@jotes r?