### PR TITLE
Fix bug 1199489: delete obsolete translations

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -794,6 +794,11 @@ class Repository(models.Model):
         ordering = ['id']
 
 
+class ResourceQuerySet(models.QuerySet):
+    def asymmetric(self):
+        return self.filter(format__in=Resource.ASYMMETRIC_FORMATS)
+
+
 class Resource(models.Model):
     project = models.ForeignKey(Project, related_name='resources')
     path = models.TextField()  # Path to localization file
@@ -828,6 +833,8 @@ class Resource(models.Model):
     ALLOWED_EXTENSIONS = [f[0] for f in FORMAT_CHOICES] + SOURCE_EXTENSIONS
 
     ASYMMETRIC_FORMATS = ('dtd', 'properties', 'ini', 'inc', 'l20n')
+
+    objects = ResourceQuerySet.as_manager()
 
     @property
     def is_asymmetric(self):

--- a/pontoon/sync/core.py
+++ b/pontoon/sync/core.py
@@ -31,6 +31,8 @@ def sync_project(db_project, now):
         update_entities(db_project, vcs_project, changeset)
         changeset.execute()
 
+    return changeset.changes['obsolete_db']
+
 
 def serial_task(timeout, lock_key="", **celery_args):
     """


### PR DESCRIPTION
If translation is removed from the source file, we mark it as obsolete
in Pontoon. Now we also remove them from translated files in asymmetric
formats (they are removed on merge in symmetric ones), even if no other
changes have been made in those files (like translation added).

We do so by bringing a list of obsolete entities from the `sync_project`
task to `sync_project_repo` tasks and then marking `changed_resources` and
`locales_to_commit` properly so these files get updated and commited.