### PR TITLE
Fix untranslated filter

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -932,8 +932,8 @@ class EntityQuerySet(models.QuerySet):
         )
 
     def untranslated(self, locale):
-        return self.with_status_counts(locale).exclude(
-            Q(approved_count=F('expected_count')) | Q(fuzzy_count=F('expected_count')) | Q(suggested_count=F('expected_count'))
+        return self.with_status_counts(locale).filter(
+            Q(approved_count=0) & Q(fuzzy_count=0) & Q(suggested_count=0)
         )
 
     def fuzzy(self, locale):

--- a/pontoon/base/tests/test_models.py
+++ b/pontoon/base/tests/test_models.py
@@ -1194,8 +1194,11 @@ class EntityFilterTests(TestCase):
         )
         TranslationFactory.create(
             locale=self.locale,
-            entity=third_entity,
-            approved=True
+            entity=third_entity
+        )
+        TranslationFactory.create(
+            locale=self.locale,
+            entity=third_entity
         )
 
         assert_equal({second_entity}, set(Entity.objects.untranslated(self.locale)))


### PR DESCRIPTION
Entity is untranslated if it doesn't have a single (approved, fuzzy or
suggested) translation. Previously, entity with expected_count of 1 and
2 suggestions was also treated as untranslated.

@jotes r?