### PR TITLE
Bug 1228770: Translation Page Links

### DIFF
--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -1939,6 +1939,12 @@ var Pontoon = (function (my) {
       $('.project .menu li .name[data-slug=' + this.project.slug + '], ' +
         '.locale .menu li .language[data-code=' + this.locale.code + ']')
         .parent().addClass('current').siblings().removeClass('current');
+      $('.static-links .current-team').parent().attr(
+        'href', '/' + this.locale.code);
+      $('.static-links .current-project').parent().attr(
+        'href', '/projects/' + this.project.slug);
+      $('.static-links .current-localization-project').parent().attr(
+        'href', '/' + this.locale.code + '/' + this.project.slug);
     },
 
 

--- a/pontoon/base/templates/locale_selector.html
+++ b/pontoon/base/templates/locale_selector.html
@@ -60,5 +60,20 @@
       {% endfor %}
       <li class="no-match">No results</li>
     </ul>
+
+    {% if part and locale %}
+    <div class="static-links">
+      <a href="{{ url('pontoon.teams') }}">
+        <div class="all-teams">
+          <span class="title">All Teams</span>
+        </div>
+      </a>
+      <a href="{{ url('pontoon.locale', locale.code) }}">
+        <div class="current-team">
+          <span class="title">Current Team</span>
+        </div>
+      </a>
+    </div>
+    {% endif %}
   </div>
 </div>

--- a/pontoon/base/templates/part_selector.html
+++ b/pontoon/base/templates/part_selector.html
@@ -53,6 +53,13 @@
         <span class="percent"></span>
       </div>
       {% if not part %}</a>{% endif %}
+      {% if part %}
+      <a href="{{ url('pontoon.locale.project', locale.code, project.slug) }}">
+        <div class="current-localization-project">
+          <span class="title">Current Localization Project</span>
+        </div>
+      </a>
+      {% endif %}
     </div>
   </div>
 </div>

--- a/pontoon/base/templates/project_selector.html
+++ b/pontoon/base/templates/project_selector.html
@@ -70,6 +70,24 @@
       {% endfor %}
       <li class="no-match">No results</li>
     </ul>
+
+    {% if part and locale %}
+    <div class="static-links">
+      <a href="{{ url('pontoon.projects') }}">
+        <div class="all-projects">
+          <span class="title">All Projects</span>
+        </div>
+      </a>
+      {% if project %}
+      <a href="{{ url('pontoon.project', project.slug) }}">
+        <div class="current-project">
+          <span class="title">Current Project</span>
+        </div>
+      </a>
+      {% endif %}
+    </div>
+    {% endif %}
+
     {% if locale and user.is_authenticated() %}
       <button id="request-projects">Requets new projects</button>
     {% endif %}

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -107,8 +107,6 @@
 
             <li class="horizontal-separator"></li>
 
-            <li><a href="{{ url('pontoon.teams') }}"><i class="fa fa-flag fa-fw"></i>Localization Teams</a></li>
-            <li><a href="{{ url('pontoon.projects') }}"><i class="fa fa-bar-chart-o fa-fw"></i>Project Overview</a></li>
             <li><a href="{{ url('pontoon.contributors') }}"><i class="fa fa-trophy fa-fw"></i>Top Contributors</a></li>
             <li><a href="{{ url('pontoon.search') }}"><i class="fa fa-search fa-fw"></i>Terminology Search</a></li>
             <li><a href="{{ url('pontoon.terms') }}"><i class="fa fa-legal fa-fw"></i>Terms of Use</a></li>


### PR DESCRIPTION
2. Add "All Projects" link to the Project menu, linking to /projects.
3. Remove Localization teams and Project Overview links from the Profile menu.
4. Add "Current Team" link to the Team menu, linking to /{team}.
5. Add "Current Project" link to the Project menu, linking to /{project}.
6. Add "Current Team - Project link to the Resources menu, linking to /{team}/{project}.

The label "Current Team - Project" looks strange, may be something like Project Overview?