### PR TITLE
Bug 1243086 direct links

### DIFF
--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -586,11 +586,11 @@ label {
   height: 100%;
 }
 
-.select .menu ul li .chart span.approved {
+.select .menu ul li .chart span.translated {
   background: #7BC876;
 }
 
-.select .menu ul li .chart span.translated {
+.select .menu ul li .chart span.suggested {
   background: #4FC4F6;
 }
 
@@ -829,15 +829,15 @@ body > .container .about p a:visited {
   text-transform: uppercase;
 }
 
-.tooltip div.untranslated {
+.tooltip div.missing {
   border-color: #FD5F60;
 }
 
-.tooltip div.approved {
+.tooltip div.translated {
   border-color: #7BC876;
 }
 
-.tooltip div.translated {
+.tooltip div.suggested {
   border-color: #4FC4F6;
 }
 
@@ -907,11 +907,11 @@ img.rounded {
   width: 90px;
 }
 
-.details div.approved {
+.details div.translated {
   border-color: #7BC876;
 }
 
-.details div.translated {
+.details div.suggested {
   border-color: #4FC4F6;
 }
 
@@ -919,7 +919,7 @@ img.rounded {
   border-color: #FED271;
 }
 
-.details div.untranslated {
+.details div.missing {
   border-color: #FD5F60;
 }
 

--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -313,7 +313,7 @@ body > header .locale.select {
   content: "";
 }
 
-.translated .status:before {
+.suggested .status:before {
   color: #4FC4F6;
 }
 
@@ -321,11 +321,11 @@ body > header .locale.select {
   color: #FED271;
 }
 
-.approved .status:before {
+.translated .status:before {
   color: #7BC876;
 }
 
-.not-translated .status:before {
+.untranslated .status:before {
   color: #AAAAAA;
   content: "";
 }
@@ -810,8 +810,8 @@ body > header aside p {
   padding-left: 2%;
 }
 
-#entitylist > .wrapper > ul > li.approved p span.source-string,
 #entitylist > .wrapper > ul > li.translated p span.source-string,
+#entitylist > .wrapper > ul > li.suggested p span.source-string,
 #entitylist > .wrapper > ul > li.fuzzy p span.source-string,
 #entitylist > .wrapper > ul > li p span.translation-string:not(:empty) {
   display: inline-block;
@@ -1328,7 +1328,7 @@ p#sign-in-required > a#sidebar-signin {
 
 #helpers > section ul li > header.translator button,
 #helpers > section ul li > header.own button.delete,
-#helpers > section ul li.approved > header button.approve {
+#helpers > section ul li.translated > header button.approve {
   display: inline-block;
 }
 
@@ -1340,12 +1340,12 @@ p#sign-in-required > a#sidebar-signin {
   color: #FED271;
 }
 
-#helpers > section ul li.translated > header button.approve:before {
+#helpers > section ul li.suggested > header button.approve:before {
   color: #4FC4F6;
 }
 
 #helpers > section ul li > header button.approve:hover:before,
-#helpers > section ul li.approved > header button.approve:before {
+#helpers > section ul li.translated > header button.approve:before {
   color: #7BC876;
   content: "";
 }

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -453,10 +453,10 @@ $(function() {
         $('body').prepend(
           '<aside class="tooltip">' +
             '<div class="total">Total<span></span></div>' +
-            '<div class="approved">Translated<span></span></div>' +
-            '<div class="translated">Suggested<span></span></div>' +
+            '<div class="translated">Translated<span></span></div>' +
+            '<div class="suggested">Suggested<span></span></div>' +
             '<div class="fuzzy">Fuzzy<span></span></div>' +
-            '<div class="untranslated">Missing<span></span></div>' +
+            '<div class="missing">Missing<span></span></div>' +
           '</aside>');
       }
 
@@ -470,10 +470,10 @@ $(function() {
 
       $('.tooltip')
         .find('.total span').html(data.total_strings).end()
-        .find('.approved span').html(data.approved_strings).end()
-        .find('.translated span').html(data.translated_strings).end()
+        .find('.translated span').html(data.approved_strings).end()
+        .find('.suggested span').html(data.translated_strings).end()
         .find('.fuzzy span').html(data.fuzzy_strings).end()
-        .find('.untranslated span').html(untranslated_strings).end()
+        .find('.missing span').html(untranslated_strings).end()
         .css('left', left)
         .css('top', top)
         .show();

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -50,16 +50,16 @@
           <span class="number"></span>
         </div>
         <div class="details">
-          <div class="approved">
+          <div class="translated">
             <span>Translated</span>
             <p></p>
-          </div><div class="translated">
+          </div><div class="suggested">
             <span>Suggested</span>
             <p></p>
           </div><div class="fuzzy">
             <span>Fuzzy</span>
             <p></p>
-          </div><div class="untranslated">
+          </div><div class="missing">
             <span>Missing</span>
             <p></p>
           </div>
@@ -196,12 +196,12 @@
         <div class="menu">
           <ul>
             <li class="all"><span class="status fa"></span>All</li>
-            <li class="untranslated"><span class="status fa"></span>Missing</li>
+            <li class="missing"><span class="status fa"></span>Missing</li>
             <li class="fuzzy"><span class="status fa"></span>Fuzzy</li>
-            <li class="translated"><span class="status fa"></span>Suggested</li>
-            <li class="approved"><span class="status fa"></span>Translated</li>
+            <li class="suggested"><span class="status fa"></span>Suggested</li>
+            <li class="translated"><span class="status fa"></span>Translated</li>
             <li class="horizontal-separator"></li>
-            <li class="not-translated"><span class="status fa"></span>Untranslated</li>
+            <li class="untranslated"><span class="status fa"></span>Untranslated</li>
             <li class="has-suggestions"><span class="status fa"></span>Has Suggestions</li>
             <li class="unchanged"><span class="status fa"></span>Unchanged</li>
           </ul>

--- a/pontoon/base/templates/widgets/progress_chart.html
+++ b/pontoon/base/templates/widgets/progress_chart.html
@@ -3,8 +3,8 @@
 <span class="chart-wrapper">
   <a href="{{ link }}" class="clearfix">
     <span class="chart" data-chart="{{ chart|to_json }}">
-      <span class="approved" style="width:{{ chart.approved_share }}%;"></span>
-      <span class="translated" style="width:{{ chart.translated_share }}%;"></span>
+      <span class="translated" style="width:{{ chart.approved_share }}%;"></span>
+      <span class="suggested" style="width:{{ chart.translated_share }}%;"></span>
       <span class="fuzzy" style="width:{{ chart.fuzzy_share }}%;"></span>
     </span>
     <span class="percent">{{ chart.approved_percent }}%</span>

--- a/pontoon/base/tests/test_views.py
+++ b/pontoon/base/tests/test_views.py
@@ -429,13 +429,13 @@ class EntityViewTests(TestCase):
         Tests if right filter calls right method in the Entity manager.
         """
         filters = (
+            'missing',
+            'fuzzy',
+            'suggested',
             'translated',
             'untranslated',
-            'not-translated',
             'has-suggestions',
-            'approved',
-            'fuzzy',
-            'unchanged'
+            'unchanged',
         )
         for filter_ in filters:
             filter_name = filter_.replace('-', '_')
@@ -444,7 +444,7 @@ class EntityViewTests(TestCase):
                     'project': self.resource.project.slug,
                     'locale': self.locale.code,
                     'paths[]': [self.resource.path],
-                    'filterType': filter_,
+                    'filter': filter_,
                     'limit': 1,
                 }, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
                 assert_true(filter_mock.called)


### PR DESCRIPTION
This is a next iteration over #374, nicely crafted by @jotes.

**Fixed Bugs**
* [x] Inplace: impossible to open entity in the sidebar (JS error on click on the entity list)
* [x] Inplace: if search parameter in the URL, it's not used (all entities visible)
* [x] Inplace: if filter parameter in the URL without any match, `Not on the current page` visible
* [x] Inplace: if any URL parameter used, the sidebar opens without resizing the iframe
* [x] Out-of-context: If no matches found, sidebar not displayed and resized properly
* [x] Main menu is broken: when you click Go, `self.updateCurrentUrl is not a function`
* [x] Out-of-context -> inplace -> Entity selected inplace and in sidebar, but sidebar closed
* [x] `Can't load selected entity` if no match is not neccessary
* [x] Investigate use of `.visible` vs `.limited`
* [x] If specified entity not on the first page it's not properly appended
* [x] If requested entity on the page, it sometimes gets duplicated in the list, due to Paginator sorting issue

**New Features**
* [x] If Go clicked: reset filters (can't load selected entity if switching project anyways)
* [x] Filter and search should not trigger getEntities()` with changes in the main menu taken into account
* [x] Filters should use same names we use in the filter list (e.g. suggested instead of translated)
* [x] Make history (back/forward) work again, by only pushing state if it changes