### PR TITLE
Fixed urls for readthedocs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ localization and include all the neccessary tags.
 Service Documentation
 ---------------------
 Want to contribute to Pontoon or deploy your own instance? Check out the
-[Service Documentation](http://mozilla-pontoon.readthedocs.org/en/latest/).
+[Service Documentation](http://mozilla-pontoon.readthedocs.io/en/latest/).
 
 Get involved
 ------------

--- a/contribute.json
+++ b/contribute.json
@@ -7,7 +7,7 @@
     },
     "participate": {
         "home": "https://wiki.mozilla.org/Webdev/GetInvolved/pontoon.mozilla.org",
-        "docs": "http://mozilla-pontoon.readthedocs.org/",
+        "docs": "http://mozilla-pontoon.readthedocs.io/",
         "irc": "irc://irc.mozilla.org/#pontoon",
         "irc-contacts": [
             "mathjazz",

--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -197,7 +197,7 @@ RabbitMQ add-on:
    Again, you must attach the resource for RabbitMQ as ``RABBITMQ``. See the
    note in the Cache Add-ons section for details.
 
-.. _BROKER_URL: http://celery.readthedocs.org/en/latest/configuration.html#broker-url
+.. _BROKER_URL: http://celery.readthedocs.io/en/latest/configuration.html#broker-url
 
 Scheduled Jobs
 --------------


### PR DESCRIPTION
Hi @mathjazz,
I'm not sure if you had a time to the latest mail from readthedocs but it looks like we have all links into .io just because of the security concerns.