### PR TITLE
Bug 1214411: Skip repo sync if locales have nothing to sync

### DIFF
--- a/pontoon/sync/vcs/models.py
+++ b/pontoon/sync/vcs/models.py
@@ -27,7 +27,7 @@ log = logging.getLogger(__name__)
 
 class MissingSourceRepository(Exception):
     """
-    Exception is called when project can't find the repository
+    Raised when project can't find the repository
     which contains source files.
     """
 
@@ -142,6 +142,7 @@ class VCSProject(object):
                 for path, locale_path, locale in filter(None, map(lambda x: self.get_path_info(x, repo), changed_files)):
                     path = path[len(locale_path):].lstrip(os.sep)
                     files.setdefault(path, []).append(locale)
+
         return files
 
 


### PR DESCRIPTION
I noticed the following sync messages in the logs:
"Synced translations for project firefox-aurora in locales ."

It occurs if repo changes, but none of the locale files is affected, e.g. if a readme file changes in the repo.

From now on, as soon as we detect there aren't any changes in translation files, we skip the repo sync.

@jotes r?