### PR TITLE
Add gzip compression to django views.

### DIFF
--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -113,6 +113,7 @@ INSTALLED_APPS = (
 BLOCKED_IPS = os.environ.get('BLOCKED_IPS', '').split(',')
 
 MIDDLEWARE_CLASSES = (
+    'django.middleware.gzip.GZipMiddleware',
     'sslify.middleware.SSLifyMiddleware',
     'pontoon.base.middleware.RaygunExceptionMiddleware',
     'pontoon.base.middleware.BlockedIpMiddleware',


### PR DESCRIPTION
hi @mathjazz, I noticed that we don't use gzip for the django views.
More info at:
https://developers.google.com/speed/pagespeed/insights/?url=pontoon.mozilla.org