### PR TITLE
Fix bug 1277367. Added "Access-Control-Allow-Origin: *" for pontoon.j…

### DIFF
--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -113,6 +113,7 @@ INSTALLED_APPS = (
     'pipeline',
     'session_csrf',
     'guardian',
+    'corsheaders',
 )
 
 BLOCKED_IPS = os.environ.get('BLOCKED_IPS', '').split(',')
@@ -122,6 +123,7 @@ MIDDLEWARE_CLASSES = (
     'sslify.middleware.SSLifyMiddleware',
     'pontoon.base.middleware.RaygunExceptionMiddleware',
     'pontoon.base.middleware.BlockedIpMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -548,3 +550,10 @@ BROKER_POOL_LIMIT = 1  # Limit to one connection per worker
 BROKER_CONNECTION_TIMEOUT = 30  # Give up connecting faster
 CELERY_RESULT_BACKEND = None  # We don't store results
 CELERY_SEND_EVENTS = False  # We aren't yet monitoring events
+
+# Settings related to the CORS mechanisms.
+# For the sake of integration with other sites,
+# some of javascript files (e.g. pontoon.js)
+# require Access-Control-Allow-Origin header to be set as '*'.
+CORS_ORIGIN_ALLOW_ALL = True
+CORS_URLS_REGEX = r'^/pontoon\.js$'

--- a/pontoon/urls.py
+++ b/pontoon/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import include, url
 from django.contrib import admin
 from django.contrib.auth.views import logout
 from django.views.generic import RedirectView, TemplateView
-
+from django.contrib.staticfiles.views import serve as staticfile
 from pontoon.intro.views import intro
 
 urlpatterns = [
@@ -51,8 +51,7 @@ urlpatterns = [
         RedirectView.as_view(url='/static/img/favicon.ico', permanent=True)),
 
     # Include script
-    url(r'^pontoon\.js$',
-        RedirectView.as_view(url='/static/js/pontoon.js', permanent=True)),
+    url(r'^pontoon\.js$', staticfile, kwargs=dict(path='js/pontoon.js', insecure=True)),
 
     # Main app: Must be at the end
     url(r'', include('pontoon.base.urls')),

--- a/requirements.txt
+++ b/requirements.txt
@@ -136,3 +136,5 @@ futures==3.0.4 \
     --hash=sha256:19485d83f7bd2151c0aeaf88fbba3ee50dadfb222ffc3b66a344ef4952b782a3
 raygun4py==3.1.2 \
     --hash=sha256:ee32cc3c7b1320fc0312c2b3a904a810f61ba302c2bad6dec836bb19fbf68340
+django-cors-headers==1.1.0 \
+    --hash=sha256:fcd96e2be47c8eef34c650e007a6d546e19e7ee61041b89edbbbbe7619aa3987


### PR DESCRIPTION
Hi @mathjazz  @lmorchard

Could you look at this patch?

I've tested this locally, but it seems to work.
```
curl -I -H 'ORIGIN: mozilla.org' http://localhost:8000/pontoon.js                                                                                                                                         
HTTP/1.0 301 Moved Permanently
Date: Thu, 02 Jun 2016 07:02:12 GMT
Server: WSGIServer/0.1 Python/2.7.11+
Access-Control-Allow-Origin: *
Vary: Cookie
X-Frame-Options: DENY
Content-Type: text/html; charset=utf-8
Location: /static/js/pontoon.js
Set-Cookie:  anoncsrf=k6h2VrfjNe8qzxqfzHgs7VUh3JwaSyj4; expires=Thu, 02-Jun-2016 09:02:12 GMT; httponly; Max-Age=7200; Path=/
% curl -I -H 'ORIGIN: mozilla.org' http://localhost:8000/                                                                                                                                                  
HTTP/1.0 200 OK
Date: Thu, 02 Jun 2016 07:02:17 GMT
Server: WSGIServer/0.1 Python/2.7.11+
Vary: Cookie, Accept-Encoding
X-Frame-Options: DENY
Content-Type: text/html; charset=utf-8
Set-Cookie:  anoncsrf=m1yd95CorqwlP0gBh9FISeiMeZLOnwxD; expires=Thu, 02-Jun-2016 09:02:17 GMT; httponly; Max-Age=7200; Path=/
```