### PR TITLE
Only raise Http404 when content is None

### DIFF
--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -1118,7 +1118,7 @@ def download(request):
 
     content, filename = utils.get_download_content(slug, code, part)
 
-    if not content:
+    if content is None:
         raise Http404
 
     response = HttpResponse()


### PR DESCRIPTION
There are valid scenarios when `content` can be an empty string.  For instance,
this may happen when there hasn't been any translations made to the file that's
supposed to be downloaded.

@mathjazz r?