### PR TITLE
Bug 1278826 - Text overflow in two places

### DIFF
--- a/pontoon/base/static/css/user.css
+++ b/pontoon/base/static/css/user.css
@@ -248,6 +248,7 @@
   font-size: 16px;
   margin: -1em 0 0 2em;
   line-height: 1.6;
+  word-wrap: break-word;
 }
 
 #timeline .label {


### PR DESCRIPTION
I see first part of this bug only in Webkit browsers. Commit fixes it.
Possible fix of second one:
1)consider such strings as untranslated, left span with class "translation-string" emply
2)add class for parent "half_translated", and assign "source-string" width 49% if parent has class "half_translated"