### PR TITLE
Fix bug 1225302: Add filter by translation author

### DIFF
--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -694,9 +694,60 @@ body > header aside p {
   box-sizing: border-box;
 }
 
+#filter .menu li.horizontal-separator {
+  background: transparent;
+  border-top: none;
+  color: #7BC876;
+  cursor: default;
+  font-size: 13px;
+  height: auto;
+  padding-top: 10px;
+  text-transform: uppercase;
+}
+
+#filter .menu li.horizontal-separator:first-child {
+  padding-top: 0;
+}
+
 #filter .menu li:not(.horizontal-separator) {
   padding: 4px 0 4px 30px;
   position: relative;
+}
+
+#filter .menu li.authors {
+  background: transparent;
+  cursor: default;
+  margin-bottom: -4px;
+  padding-left: 0;
+}
+
+#filter .menu li.authors ul {
+  max-height: 168px;
+  overflow: hidden;
+}
+
+#filter .menu li.authors li {
+  padding-left: 4px;
+  white-space: nowrap;
+}
+
+#filter .menu li.authors .author img {
+  vertical-align: top;
+}
+
+#filter .menu li.authors .author figcaption {
+  display: inline-block;
+  padding: 2px 4px;
+}
+
+#filter .menu li.authors .author .name {
+  color: #FFFFFF;
+  font-size: 16px;
+  padding-bottom: 4px;
+}
+
+#filter .menu li.authors .author .email {
+  color: #888888;
 }
 
 #filter .menu li .status {

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -437,9 +437,12 @@ $(function() {
 
   // Menu hover
   $('.menu').on('mouseenter', 'li, .static-links div', function () {
-    if ($(this).is('.static-links div') && !$('body').is('.translate')) {
+    // Ignore on nested menus and static links on dashborads
+    if ($(this).has('li').length ||
+        $(this).is('.static-links div') && !$('body').is('.translate')) {
       return false;
     }
+
     $('.menu li.hover, .static-links div').removeClass('hover');
     $(this).toggleClass('hover');
   });
@@ -638,18 +641,21 @@ $(function() {
   // General keyboard shortcuts
   $('html').unbind("keydown.pontoon").bind("keydown.pontoon", function (e) {
     function moveMenu(type) {
-      var options = (type === "up") ? ["first", "last", "prevAll"] :
-        ["last", "first", "nextAll"];
+      var options = (type === "up") ? ["first", "last", -1] :
+        ["last", "first", 1],
+          items = menu.find('li:visible:not(.horizontal-separator, :has(li))');
 
       if (hovered.length === 0 ||
-          menu.find('li:visible:' + options[0]).is('.hover')) {
+          menu.find('li:not(:has(li)):visible:' + options[0]).is('.hover')) {
         menu.find('li.hover').removeClass('hover');
-        menu.find('li:visible:' + options[1]).addClass('hover');
+        items[options[1]]().addClass('hover');
 
       } else {
-        menu.find('li.hover').removeClass('hover')
-          [options[2]](':visible:not(".horizontal-separator"):first')
-            .addClass('hover');
+        var current = menu.find('li.hover'),
+            next = items.index(current) + options[2];
+
+        current.removeClass('hover');
+        $(items.get(next)).addClass('hover');
       }
 
       if (menu.parent().is('.project, .part, .locale')) {
@@ -670,13 +676,13 @@ $(function() {
 
       // Up arrow
       if (key === 38) {
-        moveMenu("up");
+        moveMenu('up');
         return false;
       }
 
       // Down arrow
       if (key === 40) {
-        moveMenu("down");
+        moveMenu('down');
         return false;
       }
 

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -25,6 +25,7 @@ var Pontoon = (function (my) {
 
       var title = node.text(),
           selectorType = type;
+
       if (node.find('.email').length) {
         title = node.find('.email').text();
         selectorType = 'all';
@@ -3020,6 +3021,9 @@ window.onpopstate = function(e) {
 
     Pontoon.state = history.state;
 
+    Pontoon.authors = $('#server').data('authors');
+    Pontoon.updateAuthors();
+
     // Update search and filter
     Pontoon.setSearch(Pontoon.state.search);
     Pontoon.setFilter(Pontoon.state.filter);
@@ -3039,6 +3043,9 @@ Pontoon.attachMainHandlers();
 Pontoon.attachEntityListHandlers();
 Pontoon.attachEditorHandlers();
 Pontoon.attachBatchEditorHandlers();
+
+Pontoon.authors = $('#server').data('authors');
+Pontoon.updateAuthors();
 
 Pontoon.updateInitialState();
 Pontoon.initializePart();

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -17,6 +17,7 @@
      {% if user.profile and user.profile.force_suggestions %}data-force-suggestions="{{ user.profile.force_suggestions }}"{% endif %}
      {% if user.translated_locales %}data-user-translated-locales="{{ user.translated_locales|to_json() }}"{% endif %}
      {% if perms.base.can_manage %}data-manager="true"{% endif %}
+     {% if authors %}data-authors="{{ authors|to_json() }}"{% endif %}
      >
 </div>
 

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -146,15 +146,18 @@
         </div>
         <div class="menu">
           <ul>
-            <li class="all"><span class="status fa"></span>All</li>
-            <li class="missing"><span class="status fa"></span>Missing</li>
-            <li class="fuzzy"><span class="status fa"></span>Fuzzy</li>
-            <li class="suggested"><span class="status fa"></span>Suggested</li>
-            <li class="translated"><span class="status fa"></span>Translated</li>
-            <li class="horizontal-separator"></li>
-            <li class="untranslated"><span class="status fa"></span>Untranslated</li>
-            <li class="has-suggestions"><span class="status fa"></span>Has Suggestions</li>
-            <li class="unchanged"><span class="status fa"></span>Unchanged</li>
+            <li class="horizontal-separator">By Translation Status</li>
+            <li class="all" data-type="all"><span class="status fa"></span>All</li>
+            <li class="missing" data-type="missing"><span class="status fa"></span>Missing</li>
+            <li class="fuzzy" data-type="fuzzy"><span class="status fa"></span>Fuzzy</li>
+            <li class="suggested" data-type="suggested"><span class="status fa"></span>Suggested</li>
+            <li class="translated" data-type="translated"><span class="status fa"></span>Translated</li>
+            <li class="horizontal-separator for-authors">By Translation Author</li>
+            <li class="authors"><ul></ul></li>
+            <li class="horizontal-separator">Smart Filters</li>
+            <li class="untranslated" data-type="untranslated"><span class="status fa"></span>Untranslated</li>
+            <li class="unchanged" data-type="unchanged"><span class="status fa"></span>Unchanged</li>
+            <li class="has-suggestions" data-type="has-suggestions"><span class="status fa"></span>Has Suggestions</li>
           </ul>
         </div>
       </div>

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -234,6 +234,9 @@ def translate(request, locale, slug, part):
         .order_by('name')
     )
 
+    paths = [part] if part != 'all-resources' else None
+    authors = Translation.authors(locale, project, paths, serialize=True)
+
     return render(request, 'translate.html', {
         'download_form': forms.DownloadFileForm(),
         'upload_form': forms.UploadFileForm(),
@@ -242,6 +245,7 @@ def translate(request, locale, slug, part):
         'part': part,
         'project': project,
         'projects': projects,
+        'authors': authors,
     })
 
 

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -235,7 +235,7 @@ def translate(request, locale, slug, part):
     )
 
     paths = [part] if part != 'all-resources' else None
-    authors = Translation.authors(locale, project, paths, serialize=True)
+    authors = Translation.authors(locale, project, paths).serialize()
 
     return render(request, 'translate.html', {
         'download_form': forms.DownloadFileForm(),
@@ -419,7 +419,7 @@ def entities(request):
         return JsonResponse({
             'entities': Entity.map_entities(locale, entities),
             'stats': TranslatedResource.objects.stats(project, paths, locale),
-            'authors': Translation.authors(locale, project, paths, serialize=True),
+            'authors': Translation.authors(locale, project, paths).serialize(),
         }, safe=False)
 
     entities = Entity.for_project_locale(
@@ -475,7 +475,7 @@ def entities(request):
         'entities': Entity.map_entities(locale, entities_to_map, visible_entities),
         'has_next': has_next,
         'stats': TranslatedResource.objects.stats(project, paths, locale),
-        'authors': Translation.authors(locale, project, paths, serialize=True),
+        'authors': Translation.authors(locale, project, paths).serialize(),
     }, safe=False)
 
 
@@ -793,7 +793,7 @@ def update_translation(request):
                     'type': 'updated',
                     'translation': t.serialize(),
                     'stats': TranslatedResource.objects.stats(project, paths, l),
-                    'authors': Translation.authors(l, project, paths, serialize=True),
+                    'authors': Translation.authors(l, project, paths).serialize(),
                 })
 
             # If added by non-privileged user, unfuzzy it
@@ -818,7 +818,7 @@ def update_translation(request):
                         'type': 'updated',
                         'translation': t.serialize(),
                         'stats': TranslatedResource.objects.stats(project, paths, l),
-                        'authors': Translation.authors(l, project, paths, serialize=True),
+                        'authors': Translation.authors(l, project, paths).serialize(),
                     })
 
                 return JsonResponse({
@@ -859,7 +859,7 @@ def update_translation(request):
                 'type': 'added',
                 'translation': active.serialize(),
                 'stats': TranslatedResource.objects.stats(project, paths, l),
-                'authors': Translation.authors(l, project, paths, serialize=True),
+                'authors': Translation.authors(l, project, paths).serialize(),
             })
 
     # No translations saved yet
@@ -884,7 +884,7 @@ def update_translation(request):
             'type': 'saved',
             'translation': t.serialize(),
             'stats': TranslatedResource.objects.stats(project, paths, l),
-            'authors': Translation.authors(l, project, paths, serialize=True),
+            'authors': Translation.authors(l, project, paths).serialize(),
         })
 
 


### PR DESCRIPTION
@jotes r?

Authors are listed in the filter menu. Max height is set to fit 3 authors, then you need to scroll. If there aren't any translations submitted by Pontoon users, we don't show the filter. We update the authors list on translate page load, translation submission/deletion, batch operations and file upload.

I haven't found a much better UX solution for the authors selector. Filter menu is getting huge. Also, we'll be adding date/time (bug 1225305) and errors/checks (bug 1237667) filters, which will make it even bigger.

We should probably refactor filter UI as part of 1243115. We might also be able to merge it with the progress bar menu.