### PR TITLE
Switched pontoon-intro into official mozilla repo.

### DIFF
--- a/pontoon/base/migrations/0002_initial_data.py
+++ b/pontoon/base/migrations/0002_initial_data.py
@@ -17,7 +17,7 @@ def load_initial_data(apps, schema_editor):
         url=settings.SITE_URL + '/intro/',
         links=True,
         repository_type='git',
-        repository_url='https://github.com/mathjazz/pontoon-intro.git',
+        repository_url='https://github.com/mozilla/pontoon-intro.git',
         info_brief=('This is a demo website, used for demonstration purposes '
                     'only. You can translate on the website itself by double '
                     'clicking on page elements. Access to advanced features '


### PR DESCRIPTION
Hi @mathjazz, could you look at this? I remember that we talked @irc about this change quite a while ago.

I decided to modify a base migration because this won't change anything on your installation or production, but will affect only new contributors/fresh databases.