### PR TITLE
Fix bug 1278826 - incorrect stats, filters and UI

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -1541,6 +1541,7 @@ class TranslatedResource(AggregatedStats):
         fuzzy = translations.filter(fuzzy=True).count()
 
         # Plural
+        half_translated = 0
         nplurals = locale.nplurals or 1
         for e in translated_entities.exclude(string_plural=''):
             translations = Translation.objects.filter(entity=e, locale=locale)
@@ -1548,8 +1549,10 @@ class TranslatedResource(AggregatedStats):
                 approved += 1
             elif translations.filter(fuzzy=True).count() == nplurals:
                 fuzzy += 1
+            else:
+                half_translated += 1
 
-        translated = max(translated_entities.count() - approved - fuzzy, 0)
+        translated = max(translated_entities.count() - approved - fuzzy - half_translated, 0)
 
         if not save:
             self.total_strings = resource.total_strings


### PR DESCRIPTION
A half-translated string is a string which has plular forms but not all forms translated.

- [ ] Fix stats when half-translated string is shown as suggested but not missing (maybe we need to add filter in condition nevertheless it works in this way)

- [ ] Fix missing filter that can't catch half-translated strings

- [ ] Fix breaking UI by half-translated strings