### PR TITLE
Added missing libmecached-dev package.

### DIFF
--- a/Aptfile
+++ b/Aptfile
@@ -1,2 +1,3 @@
 libsqlite3-dev
 subversion
+libmemcached-dev


### PR DESCRIPTION
Hi @mathjazz could you review? @davidascher had problems with the pylibmc because this package was missing.