### PR TITLE
Use default Git branch instead of master

### DIFF
--- a/pontoon/sync/vcs/repositories.py
+++ b/pontoon/sync/vcs/repositories.py
@@ -36,7 +36,7 @@ class PullFromGit(PullFromRepository):
         execute(command, target)
 
         # Undo local changes
-        command = ["git", "reset", "--hard", "origin/master"]
+        command = ["git", "reset", "--hard", "HEAD"]
         code, output, error = execute(command, target)
 
         if code == 0:
@@ -154,7 +154,7 @@ class CommitToGit(CommitToRepository):
             raise CommitToRepositoryException(unicode(error))
 
         # Push
-        push = ["git", "push", self.url, 'master']
+        push = ["git", "push", self.url, 'HEAD']
         code, output, error = execute(push, path)
         if code != 0:
             raise CommitToRepositoryException(unicode(error))
@@ -330,7 +330,7 @@ class GitRepository(VCSRepository):
     @property
     def revision(self):
         code, output, error = self.execute(
-            ['git', 'rev-parse', 'master'],
+            ['git', 'rev-parse', 'HEAD'],
         )
         return output.strip() if code == 0 else None
 


### PR DESCRIPTION
We shouldn't be requiring Git repository branch name to be called master. We should use the default branch. We just got a request to enable a project that uses "develop" branch as default and wants it to be used by Pontoon.

Later on we could add a new Repository model property to specify a branch name in addition to current type and URL.

@jotes r?