### PR TITLE
Vector version of Pontoon's logo

### DIFF
--- a/pontoon/base/static/img/logo.svg
+++ b/pontoon/base/static/img/logo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" shape-rendering="geometricPrecision"><path fill="#fff" d="m32 0h480v512h-480z"/><g fill="none"><path stroke="#272a2f" stroke-width="192" d="m192 512v-352h160v192h-160"/><path stroke="#7bc876" stroke-width="64" d="m192 512v-352h160v192h-160"/></g></svg>


### PR DESCRIPTION
This vector version is based on the logo.png file in the same folder. The file is derived from hand-crafted SVG source available pre request (because of its incompatibility with image editing programs).