### PR TITLE
Disable in-place editing

### DIFF
--- a/pontoon/base/static/css/pontoon.css
+++ b/pontoon/base/static/css/pontoon.css
@@ -1,12 +1,10 @@
 .pontoon-hovered {
   outline: 1px dashed !important;
-}
-
-/* Prevent converting white-spaces at the beginning or
- * at the end of the node to &nbsp; and <br>
- */
-.pontoon-hovered[contenteditable=true] {
-  white-space: pre-wrap !important;
+  -webkit-user-select: none;
+  -khtml-user-select: none;
+  -moz-user-select: none;
+  -o-user-select: none;
+  user-select: none;
 }
 
 .pontoon-editable-toolbar {
@@ -37,11 +35,6 @@
 
 .pontoon-editable-toolbar .edit {
   background-image: url('../img/edit.png');
-}
-
-.pontoon-editable-toolbar .save {
-  background-image: url('../img/save.png');
-  display: none;
 }
 
 .pontoon-editable-toolbar .cancel {

--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -169,23 +169,6 @@ body > header > .container {
   min-width: 800px;
 }
 
-#switch {
-  background: transparent;
-  border: none;
-  color: #FFFFFF;
-  display: none;
-  float: left;
-  height: 60px;
-  margin-left: 8px;
-  padding: 0; /* Needed to prevent jumping on click */
-  width: 27px;
-}
-
-#switch.opened {
-  -webkit-transform: rotate(90deg);
-  transform: rotate(90deg);
-}
-
 .select {
   float: left;
   padding-left: 0;
@@ -556,7 +539,6 @@ body > header aside p {
   background: #3F4752;
   border-right: 1px solid #5E6475;
   bottom: 0;
-  display: none;
   overflow: hidden;
   position: fixed;
   top: 60px;
@@ -567,7 +549,6 @@ body > header aside p {
 }
 
 #sidebar.advanced {
-  display: block;
   width: 700px;
 }
 

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -25,8 +25,6 @@
 <!-- Main toolbar -->
 <header>
   <div class="container clearfix">
-    <button id="switch" class="fa fa-bars fa-2x"></button>
-
     {% include 'locale_selector.html' %}
 
     {% include 'project_selector.html' %}


### PR DESCRIPTION
Translating on the page itself is insufficient for various reasons:
* Original string is not always fully seen (e.g. if containing markup)
* Additional string details like comments and context are not visible
* Suggestions from history, machinery and other locales are not available
* Only the first plural form can be translated
* Features like Copy from original or Move to next string are missing

In addition to that, when translating in the page itself using the
contentEditable attribute, we were sometimes unable to fully control the
[markup that was submitted](https://github.com/mozilla/donate.mozilla.org/issues/1596).

From now on, sidebar is always open and strings can only be translated
in there, while it's still possible to select them on the page. The
sidebar switch icon (hamburger) is thus obsolete and has been removed.

Fix bug 1183819.

@jotes r?