### PR TITLE
Added sane way for handling events for the webdevelopers.

### DIFF
--- a/docs/dev/integration.rst
+++ b/docs/dev/integration.rst
@@ -1,0 +1,24 @@
+Integration
+===========
+
+The following is a list of mechanism that can help you to integrate your website/app
+with pontoon.
+
+Event-driven integration
+------------------------
+Pontoon exposes various events that can be handled jQuery callbacks.
+Following code will call an alert window when your page is called inside Pontoon Editor:
+
+.. code-block:: javascript
+
+   $(function() {
+     $(document).on('pontoonInit', function() {
+       alert('Hello world!');
+     });
+   });
+
+Supported jQuery Events
+---------------------------
+Pontoon exposes following events:
+* `pontoonInit` is called when the Pontoon is fully initialized and the Pontoon object is accessible for the javascript Api.
+* `pontoonSave` is executed after user saves new translation and Pontoon updates it on your site.

--- a/pontoon/base/static/js/pontoon.js
+++ b/pontoon/base/static/js/pontoon.js
@@ -505,6 +505,7 @@
             });
 
             stopEditing();
+            $.event.trigger('pontoonSave');
             break;
 
           case "BATCH-DELETE":
@@ -702,6 +703,7 @@
 
         loadJquery();
         window.removeEventListener("message", initizalize, false);
+        $.event.trigger('pontoonInit');
       }
     }
   }


### PR DESCRIPTION
Hi @mathjazz, could you look at this PoC?
Basically I wanted to create an interface for the webdevelopers to handle events that are sent by pontoon. I think this approach could be better than current state that forces user to create separate receiver for POST messages sent from a parent frame. This can be unsafe on the long run, because user can meet the unexpected issue with timing or unexpected changes in internal structure of pontoon.js that cause unexpected bugs.

This my initial idea how we could tackle this problem.  With a set of predefined events we create an safe interface which webdevelopers could use to integrate their sites with pontoon.