### PR TITLE
Fix bug 1292890: Sync stats if only resources changed in monolingual files

### DIFF
--- a/pontoon/sync/core.py
+++ b/pontoon/sync/core.py
@@ -32,7 +32,7 @@ def sync_project(db_project, now, full_scan=False):
         update_entities(db_project, vcs_project, changeset)
         changeset.execute()
 
-    return changeset.changes['obsolete_db'], removed_paths, added_paths
+    return changeset.changes, removed_paths, added_paths
 
 
 def serial_task(timeout, lock_key="", on_error=None, **celery_args):

--- a/pontoon/sync/vcs/models.py
+++ b/pontoon/sync/vcs/models.py
@@ -216,6 +216,7 @@ class VCSProject(object):
                     path=path, err=err
                 ))
 
+        log.info('Changed files: {resources}'.format(resources=resources.keys()))
         return resources
 
     @property


### PR DESCRIPTION
If only source files change in repo (e.g. when new strings are merged), we skip syncing translations. Which is the right thing to do, but as part of this we also skip updating stats. Which we shouldn't.

@jotes r?