### PR TITLE
Add postgresql-contrib to apted packages

### DIFF
--- a/docs/dev/install.rst
+++ b/docs/dev/install.rst
@@ -19,7 +19,7 @@ all the prerequisites using the following command:
 
    .. code-block:: bash
 
-      sudo apt install git python-pip nodejs-legacy npm postgresql postgresql-server-dev-9.5 libxml2-dev libxslt1-dev python-dev libmemcached-dev
+      sudo apt install git python-pip nodejs-legacy npm postgresql postgresql-server-dev-9.5 postgresql-contrib-9.5 libxml2-dev libxslt1-dev python-dev libmemcached-dev
 
 .. _Git: https://git-scm.com/
 .. _Python 2.7: https://www.python.org/


### PR DESCRIPTION
Without installing contrib explicitly, I run into this stacktrace (Linux Mint 18):

> Applying base.0048_translationmemoryentry...Traceback (most recent call last):
>   File "manage.py", line 20, in <module>
>     execute_from_command_line(sys.argv)
>   File "/home/michal/repos/pontoon/venv/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 353, in execute_from_command_line
>     utility.execute()
>   File "/home/michal/repos/pontoon/venv/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 345, in execute
>     self.fetch_command(subcommand).run_from_argv(self.argv)
>   File "/home/michal/repos/pontoon/venv/local/lib/python2.7/site-packages/django/core/management/base.py", line 348, in run_from_argv
>     self.execute(*args, **cmd_options)
>   File "/home/michal/repos/pontoon/venv/local/lib/python2.7/site-packages/django/core/management/base.py", line 399, in execute
>     output = self.handle(*args, **options)
>   File "/home/michal/repos/pontoon/venv/local/lib/python2.7/site-packages/django/core/management/commands/migrate.py", line 200, in handle
>     executor.migrate(targets, plan, fake=fake, fake_initial=fake_initial)
>   File "/home/michal/repos/pontoon/venv/local/lib/python2.7/site-packages/django/db/migrations/executor.py", line 92, in migrate
>     self._migrate_all_forwards(plan, full_plan, fake=fake, fake_initial=fake_initial)
>   File "/home/michal/repos/pontoon/venv/local/lib/python2.7/site-packages/django/db/migrations/executor.py", line 121, in _migrate_all_forwards
>     state = self.apply_migration(state, migration, fake=fake, fake_initial=fake_initial)
>   File "/home/michal/repos/pontoon/venv/local/lib/python2.7/site-packages/django/db/migrations/executor.py", line 198, in apply_migration
>     state = migration.apply(state, schema_editor)
>   File "/home/michal/repos/pontoon/venv/local/lib/python2.7/site-packages/django/db/migrations/migration.py", line 123, in apply
>     operation.database_forwards(self.app_label, schema_editor, old_state, project_state)
>   File "/home/michal/repos/pontoon/venv/local/lib/python2.7/site-packages/django/contrib/postgres/operations.py", line 17, in database_forwards
>     schema_editor.execute("CREATE EXTENSION IF NOT EXISTS %s" % self.name)
>   File "/home/michal/repos/pontoon/venv/local/lib/python2.7/site-packages/django/db/backends/base/schema.py", line 110, in execute
>     cursor.execute(sql, params)
>   File "/home/michal/repos/pontoon/venv/local/lib/python2.7/site-packages/django/db/backends/utils.py", line 79, in execute
>     return super(CursorDebugWrapper, self).execute(sql, params)
>   File "/home/michal/repos/pontoon/venv/local/lib/python2.7/site-packages/django/db/backends/utils.py", line 64, in execute
>     return self.cursor.execute(sql, params)
>   File "/home/michal/repos/pontoon/venv/local/lib/python2.7/site-packages/django/db/utils.py", line 95, in __exit__
>     six.reraise(dj_exc_type, dj_exc_value, traceback)
>   File "/home/michal/repos/pontoon/venv/local/lib/python2.7/site-packages/django/db/backends/utils.py", line 64, in execute
>     return self.cursor.execute(sql, params)
> django.db.utils.OperationalError: could not open extension control file "/usr/share/postgresql/9.5/extension/fuzzystrmatch.control"