### PR TITLE
Update translated resources when skipping locales

### DIFF
--- a/pontoon/sync/core.py
+++ b/pontoon/sync/core.py
@@ -174,7 +174,7 @@ def update_translations(db_project, vcs_project, locale, changeset):
             changeset.update_db_entity(locale, db_entity, vcs_entity)
 
 
-def update_translated_resources(db_project, vcs_project, changeset, locale):
+def update_translated_resources(db_project, vcs_project, locale):
     """Update the TranslatedResource entries in the database."""
     for resource in db_project.resources.all():
         # We only want to create/update the TranslatedResource object if the

--- a/pontoon/sync/tasks.py
+++ b/pontoon/sync/tasks.py
@@ -195,14 +195,17 @@ def sync_project_repo(self, project_pk, repo_pk, project_sync_log_pk, now, proje
                 # Skip locales that have nothing to sync
                 if vcs_project.synced_locales and locale not in vcs_project.synced_locales:
                     if db_project_changed or obsolete_vcs_resources:
+                        update_translated_resources(db_project, vcs_project, locale)
                         update_locale_project_locale_stats(locale, db_project)
+                        log.debug('Skipping locale `{0}` for project {1}, nothing to sync.'
+                                  .format(locale.code, db_project.slug))
                     continue
 
                 changeset = ChangeSet(db_project, vcs_project, now, obsolete_vcs_entities, obsolete_vcs_resources)
                 update_translations(db_project, vcs_project, locale, changeset)
                 changeset.execute()
 
-                update_translated_resources(db_project, vcs_project, changeset, locale)
+                update_translated_resources(db_project, vcs_project, locale)
 
                 # Skip if none of the locales has anything to sync
                 # VCSProject.synced_locales is set on a first call to
@@ -211,6 +214,7 @@ def sync_project_repo(self, project_pk, repo_pk, project_sync_log_pk, now, proje
                 if len(vcs_project.synced_locales) == 0:
                     if db_project_changed or obsolete_vcs_resources:
                         for l in locales:
+                            update_translated_resources(db_project, vcs_project, l)
                             update_locale_project_locale_stats(l, db_project)
                         db_project.aggregate_stats()
 

--- a/pontoon/sync/tests/test_core.py
+++ b/pontoon/sync/tests/test_core.py
@@ -139,7 +139,7 @@ class UpdateTranslatedResourcesTests(FakeCheckoutTestCase):
         available in the current locale.
         """
         update_translated_resources(self.db_project, self.vcs_project,
-                             self.changeset, self.translated_locale)
+                                    self.translated_locale)
 
         assert_true(TranslatedResource.objects.filter(
             resource=self.main_db_resource, locale=self.translated_locale
@@ -162,7 +162,7 @@ class UpdateTranslatedResourcesTests(FakeCheckoutTestCase):
             is_asymmetric.return_value = True
 
             update_translated_resources(self.db_project, self.vcs_project,
-                                 self.changeset, self.translated_locale)
+                                        self.translated_locale)
 
             assert_true(TranslatedResource.objects.filter(
                 resource=self.main_db_resource, locale=self.translated_locale
@@ -182,7 +182,7 @@ class UpdateTranslatedResourcesTests(FakeCheckoutTestCase):
         even if the inactive locale has a resource.
         """
         update_translated_resources(self.db_project, self.vcs_project,
-                             self.changeset, self.translated_locale)
+                                    self.translated_locale)
 
         assert_true(TranslatedResource.objects.filter(
             resource=self.main_db_resource, locale=self.translated_locale


### PR DESCRIPTION
This is even simpler than it looks: if we skip locale sync, but the resources have been changed, we need to update translated resources anyways to update the total_strings count.

Also remove unused argument from the `update_translated_resources()` function and update tests.

@jotes r?