### PR TITLE
Fix bug 1278826: filter partially translated pluralized strings as missing

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -1087,7 +1087,7 @@ class EntityQuerySet(models.QuerySet):
 
     def missing(self, locale):
         return self.with_status_counts(locale).filter(
-            Q(approved_count=0) & Q(fuzzy_count=0) & Q(suggested_count=0)
+            Q(approved_count__lt=F('expected_count')) & Q(fuzzy_count__lt=F('expected_count')) & Q(suggested_count__lt=F('expected_count'))
         )
 
     def fuzzy(self, locale):

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -1880,6 +1880,8 @@ var Pontoon = (function (my) {
 
     /*
      * Update progress indicator and value
+     *
+     * entity If provided, also update the parts menu
      */
     updateProgress: function (entity) {
       var self = this,


### PR DESCRIPTION
This fixes the missing filter to also include partially translated pluralized strings.

@jotes r?