### PR TITLE
Prevent simultaneous save translation requests

### DIFF
--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -2151,7 +2151,11 @@ var Pontoon = (function (my) {
         submittedPluralForm = 0;
       }
 
-      return $.ajax({
+      if (self.XHRupdateOnServer) {
+        self.XHRupdateOnServer.abort();
+      }
+
+      self.XHRupdateOnServer = $.ajax({
         url: '/update/',
         type: 'POST',
         data: {
@@ -2173,6 +2177,11 @@ var Pontoon = (function (my) {
           }
         },
         error: function(error) {
+          // Skip if other request in progress
+          if (self.XHRupdateOnServer && self.XHRupdateOnServer.statusText === 'abort') {
+            return;
+          }
+
           if (error.status === 0) {
             // No connection -> use offline mode
             self.addToLocalStorage(entity, translation);


### PR DESCRIPTION
While we disable the save button while request is in progress, users
can still submit multiple translation update requests with their
keyboards. That can lead to stats inconsistency due to DB latency
in production. With this patch, it is now actively prevented.

@jotes r?