### PR TITLE
Use username instead of email as user identifier in URL

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -134,7 +134,9 @@ def user_role(self, locale):
 
 @property
 def user_profile_url(self):
-    return reverse('pontoon.contributor', kwargs={'email': self.email})
+    return reverse('pontoon.contributor.username', kwargs={
+        'username': self.username
+    })
 
 
 def user_gravatar_url(self, size):

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -325,7 +325,7 @@ var Pontoon = (function (my) {
                     '">' +
                     '<div class="info">' +
                       ((!this.email) ? '<span title="' + self.getApproveButtonTitle(this) + '">' + this.user + '</span>' :
-                        '<a href="/contributors/' + this.email + '" title="' + self.getApproveButtonTitle(this) + '">' + this.user + '</a>') +
+                        '<a href="/contributors/' + this.username + '" title="' + self.getApproveButtonTitle(this) + '">' + this.user + '</a>') +
                       '<time class="stress" datetime="' + this.date_iso + '">' + this.date + ' UTC</time>' +
                     '</div>' +
                     '<menu class="toolbar">' +

--- a/pontoon/base/templates/widgets/contributors.html
+++ b/pontoon/base/templates/widgets/contributors.html
@@ -26,7 +26,7 @@
       <tr>
         <td class="rank">{{ loop.index }}</td>
         <td class="contributor">
-          <a href="{{ url('pontoon.contributor', contributor.email)|nospam }}">
+          <a href="{{ url('pontoon.contributor.username', contributor.username) }}">
             <img class="rounded" src="{{ contributor.gravatar_url(44) }}">
             <p class="name">{{ contributor.display_name }}</p>
           </a>

--- a/pontoon/base/templates/widgets/latest_activity.html
+++ b/pontoon/base/templates/widgets/latest_activity.html
@@ -3,7 +3,7 @@
   {% if latest_activity.date %}
   <time datetime="{{ latest_activity.date.isoformat() }}">{{ latest_activity.date|naturaltime }}</time>
     {% if latest_activity.user %}
-    &bull; <a href="{{ url('pontoon.contributor', latest_activity.user.email)|nospam }}">{{ latest_activity.user.name_or_email|nospam }}</a>
+    &bull; <a href="{{ url('pontoon.contributor.username', latest_activity.user.username) }}">{{ latest_activity.user.name_or_email|nospam }}</a>
     {% endif %}
   {% else %}
   No activity yet

--- a/pontoon/base/urls.py
+++ b/pontoon/base/urls.py
@@ -28,6 +28,26 @@ urlpatterns = [
     url(r'^contributor/(?P<email>[\w.%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})/$',
         RedirectView.as_view(url="/contributors/%(email)s/", permanent=True)),
 
+    # List contributors
+    url(r'^contributors/$',
+        views.ContributorsView.as_view(),
+        name='pontoon.contributors'),
+
+    # Contributor profile by email
+    url(r'^contributors/(?P<email>[\w.%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})/$',
+        views.contributor_email,
+        name='pontoon.contributor.email'),
+
+    # Contributor profile by username
+    url(r'^contributors/(?P<username>\w+)/$',
+        views.contributor_username,
+        name='pontoon.contributor.username'),
+
+    # Current user profile
+    url(r'^profile/$',
+        views.profile,
+        name='pontoon.profile'),
+
     # API: Toogle user profile attribute
     url(r'^api/v1/user/(?P<email>[\w.%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})/$',
         views.toggle_user_profile_attribute,
@@ -91,21 +111,6 @@ urlpatterns = [
     url(r'^(?P<locale>[A-Za-z0-9\-\@\.]+)/(?P<slug>[\w-]+)/$',
         views.locale_project,
         name='pontoon.locale.project'),
-
-    # List contributors
-    url(r'^contributors/$',
-        views.ContributorsView.as_view(),
-        name='pontoon.contributors'),
-
-    # Contributor profile
-    url(r'^contributors/(?P<email>[\w.%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})/$',
-        views.contributor,
-        name='pontoon.contributor'),
-
-    # Current user profile
-    url(r'^profile/$',
-        views.profile,
-        name='pontoon.profile'),
 
     # Terminology Search
     url(r'^terminology/$',

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -252,12 +252,21 @@ def translate(request, locale, slug, part):
 @login_required(redirect_field_name='', login_url='/403')
 def profile(request):
     """Current user profile."""
-    return contributor(request, request.user.email)
+    return contributor(request, request.user)
 
 
-def contributor(request, email):
-    """Contributor profile."""
+def contributor_email(request, email):
     user = get_object_or_404(User, email=email)
+    return contributor(request, user)
+
+
+def contributor_username(request, username):
+    user = get_object_or_404(User, username=username)
+    return contributor(request, user)
+
+
+def contributor(request, user):
+    """Contributor profile."""
 
     # Exclude unchanged translations
     translations = (
@@ -646,6 +655,7 @@ def get_translation_history(request):
             "id": t.id,
             "user": "Imported" if u is None else u.name_or_email,
             "email": "" if u is None else u.email,
+            "username": "" if u is None else u.username,
             "translation": t.string,
             "date": t.date.strftime('%b %d, %Y %H:%M'),
             "date_iso": t.date.isoformat() + offset,


### PR DESCRIPTION
We use email addresses as user identifiers in contributor URLs, which is a bad idea, at least due to poor privacy respect and spam protection, making e.g the [top contributors](https://pontoon.mozilla.org/contributors/) page very spam-bot friendly.

This patch replaces email addresses with usernames, while keeping the old email-based URLs alive (to avoid breaking links and to help with manual URL entering).

@jotes r?