### PR TITLE
Bug 1298610: Optimize syncing new locales

### DIFF
--- a/docs/dev/sync.rst
+++ b/docs/dev/sync.rst
@@ -20,13 +20,23 @@ Sync tasks are executed in parallel, using `Celery`_ to manage the worker queue.
 
 Syncing a Project
 -----------------
-Syncing an individual project consists of roughly the following steps:
+Syncing an individual project is split into two tasks. The first one is syncing
+source strings:
 
-- Pull the latest commit from version control.
-- Check for changes in VCS or in Pontoon, and if there are none, skip syncing
-  completely.
-- Find all the possible entities across all the resources for this project,
-  searching both the Pontoon database and VCS.
+- Pull latest changes of the source string repository from version control.
+- Check for changes in VCS and in Pontoon, and if there are no changes in VCS
+  and Pontoon and the project only uses one repository, skip syncing the
+  project completely.
+- If source repository has changed since the last sync, reflect any added,
+  changed or removed files in Pontoon.
+
+The seconds steps is syncing translations:
+
+- Pull latest changes of all project repositories from version control.
+- Check for changes in VCS and in Pontoon, and if there are no changes in VCS
+  and Pontoon, quit early.
+- If there are changes, identify which files have changed and find all their
+  entities, searching both the Pontoon database and VCS.
 - For each entity found, compare the VCS version to the Pontoon version (also
   known as the database version) and decide how to sync it. These changes are
   collected in a "Changeset" object.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,12 +5,14 @@ Pontoon is a web interface for translating text into other languages. Pontoon
 specializes in translating websites in-place, but can handle any project that
 uses one of the file formats it supports:
 
-- Gettext PO files
+- Gettext PO
 - XLIFF
-- Property files
+- FTL (L20n)
+- Properties
 - DTD
 - INI
-- .lang files
+- INC
+- .lang
 
 Pontoon pulls strings it needs to translate from an external source, and writes
 them back periodically. Typically these external sources are version control
@@ -20,8 +22,6 @@ sources include:
 - Git
 - Mercurial
 - Subversion
-- Remote file (pull only)
-- Transifex (pull only)
 
 Contents
 --------

--- a/pontoon/base/tests/test_models.py
+++ b/pontoon/base/tests/test_models.py
@@ -114,6 +114,7 @@ class ProjectTests(TestCase):
         project = ProjectFactory.create()
         assert_false(project.needs_sync)
 
+        del project.unsynced_locales
         ProjectLocaleFactory.create(
             project=project,
             locale=LocaleFactory.create()

--- a/pontoon/sync/core.py
+++ b/pontoon/sync/core.py
@@ -1,7 +1,7 @@
 from functools import wraps
 import logging
 
-from collections import Counter, defaultdict
+from collections import Counter
 
 from celery import shared_task
 from django.contrib.auth.models import User
@@ -14,7 +14,6 @@ from pontoon.base.models import (
     Entity,
     Resource,
     TranslatedResource,
-    ChangedEntityLocale
 )
 from pontoon.sync.changeset import ChangeSet
 from pontoon.sync.vcs.models import VCSProject
@@ -23,7 +22,7 @@ from pontoon.sync.utils import locale_directory_path
 log = logging.getLogger(__name__)
 
 
-def sync_project(db_project, now, full_scan=False):
+def update_originals(db_project, now, full_scan=False):
     vcs_project = VCSProject(db_project, locales=[], full_scan=full_scan)
 
     with transaction.atomic():
@@ -82,23 +81,6 @@ def collect_entities(db_project, vcs_project):
         yield key, db_entities.get(key, None), vcs_entities.get(key, None)
 
 
-def get_changed_db_resources(db_project):
-    """
-    Returns a map of resource paths and their locales that where changed from the last sync.
-    """
-    resources = defaultdict(set)
-    changes = (
-        ChangedEntityLocale.objects
-            .filter(entity__resource__project=db_project)
-            .prefetch_related('locale', 'entity__resource')
-    )
-
-    for change in changes:
-        resources[change.entity.resource.path].add(change.locale)
-
-    return resources
-
-
 def update_entities(db_project, vcs_project, changeset):
     for key, db_entity, vcs_entity in collect_entities(db_project, vcs_project):
         if vcs_entity is None:
@@ -117,7 +99,7 @@ def update_entities(db_project, vcs_project, changeset):
 
 def update_resources(db_project, vcs_project):
     """Update the database on what resource files exist in VCS."""
-    log.debug('Scanning {}'.format(vcs_project.source_directory_path()))
+    log.debug('Scanning {}'.format(vcs_project.source_directory_path))
     _, vcs_removed_files = vcs_project.changed_source_files
 
     removed_resources = db_project.resources.filter(path__in=vcs_removed_files)
@@ -125,7 +107,7 @@ def update_resources(db_project, vcs_project):
 
     added_paths = []
 
-    log.debug('Removed paths: {}'.format(', '.join(removed_paths) or 'None'))
+    log.debug('Removed files: {}'.format(', '.join(removed_paths) or 'None'))
     removed_resources.delete()
 
     for relative_path, vcs_resource in vcs_project.resources.items():
@@ -137,22 +119,11 @@ def update_resources(db_project, vcs_project):
         if created:
             added_paths.append(relative_path)
 
-    log.debug('Added paths: {}'.format(', '.join(added_paths) or 'None'))
+    log.debug('Added files: {}'.format(', '.join(added_paths) or 'None'))
     return removed_paths, added_paths
 
 
 def update_translations(db_project, vcs_project, locale, changeset):
-    if not vcs_project.full_scan:
-        vcs = vcs_project.changed_files
-        db = get_changed_db_resources(db_project)
-
-        for path in set(vcs.keys() + db.keys()):
-            if path in vcs and path in db:
-                vcs[path] = set(list(vcs[path]) + list(db[path]))
-
-            else:
-                vcs[path] = vcs[path] if path in vcs else db[path]
-
     for key, db_entity, vcs_entity in collect_entities(db_project, vcs_project):
         # If we don't have both the db_entity and cs_entity we can't
         # do anything with the translations.
@@ -216,18 +187,15 @@ def entity_key(entity):
     return ':'.join([entity.resource.path, key])
 
 
-def pull_changes(db_project):
+def pull_changes(db_project, source_only=False):
     """
-    Update the local files with changes from the VCS. Returns
-    whether any of the updated repos have changed since the last
-    sync, based on the revision numbers.
-    Returns a tuple containing:
-    - if repository has changed.
-    - a map of revisions for each repository.
+    Update the local files with changes from the VCS. Returns True
+    if any of the updated repos have changed since the last sync.
     """
     changed = False
-    revisions = {}
-    for repo in db_project.repositories.all():
+    repositories = [db_project.source_repository] if source_only else db_project.repositories.all()
+
+    for repo in repositories:
         repo_revisions = repo.pull()
         # If any revision is None, we can't be sure if a change
         # happened or not, so we default to assuming it did.
@@ -235,9 +203,7 @@ def pull_changes(db_project):
         if unsure_change or repo_revisions != repo.last_synced_revisions:
             changed = True
 
-        revisions[repo.pk] = repo_revisions
-
-    return changed, revisions
+    return changed
 
 
 def commit_changes(db_project, vcs_project, changeset, locale):

--- a/pontoon/sync/models.py
+++ b/pontoon/sync/models.py
@@ -86,7 +86,7 @@ class ProjectSyncLog(BaseLog):
             return True
 
         repo_logs = self.repository_sync_logs.all()
-        sync_repos = self.project.repositories.exclude(source_repo=True)
+        sync_repos = self.project.translation_repositories()
         if len(repo_logs) != sync_repos.count():
             return False
         else:

--- a/pontoon/sync/tasks.py
+++ b/pontoon/sync/tasks.py
@@ -16,8 +16,8 @@ from pontoon.sync.changeset import ChangeSet
 from pontoon.sync.core import (
     commit_changes,
     pull_changes,
-    sync_project as perform_sync_project,
     serial_task,
+    update_originals,
     update_translated_resources,
     update_translations,
 )
@@ -46,7 +46,7 @@ def sync_project_error(error, *args, **kwargs):
     ).skip()
 
 
-def sync_project_repo_error(error, *args, **kwargs):
+def sync_translations_error(error, *args, **kwargs):
     RepositorySyncLog.objects.create(
         project_sync_log=ProjectSyncLog.objects.get(pk=args[2]),
         repository=Repository.objects.get(pk=args[1]),
@@ -80,24 +80,11 @@ def sync_project(self, project_pk, sync_log_pk, locale=None, no_pull=False, no_c
         start_time=now
     )
 
-    # We have to cache changed files before last revision is overriden by pull
-    if no_pull:
-        repos_changed = True  # Assume changed.
-    else:
-        repos_changed, _ = pull_changes(db_project)
-
-    # If the repos haven't changed since the last sync and there are
-    # no Pontoon-side changes for this project, quit early.
-    if not force and not repos_changed and not db_project.needs_sync:
-        log.info('Skipping project {0}, no changes detected.'.format(db_project.slug))
-        project_sync_log.skip()
-        return
-
     # Do not sync resources if locale specified
     if locale:
         repo = locale.get_repository(db_project)
         if repo:
-            sync_project_repo.delay(
+            sync_translations.delay(
                 project_pk,
                 repo.pk,
                 project_sync_log.pk,
@@ -107,38 +94,66 @@ def sync_project(self, project_pk, sync_log_pk, locale=None, no_pull=False, no_c
                 no_commit=no_commit,
                 full_scan=force
             )
+        return
 
+    # Sync resources
+    resource_changes = sync_resources(db_project, now, force, no_pull)
+    if not resource_changes:
+        project_sync_log.skip()
+        return
+
+    # Sync translations
+    for repo in db_project.translation_repositories():
+        sync_translations.delay(
+            project_pk,
+            repo.pk,
+            project_sync_log.pk,
+            now,
+            resource_changes['project_changes'],
+            resource_changes['obsolete_vcs_resources'],
+            resource_changes['new_paths'],
+            no_pull=no_pull,
+            no_commit=no_commit,
+            full_scan=force
+        )
+
+
+def sync_resources(db_project, now, force, no_pull):
+    # Pull source repository
+    if no_pull:
+        source_repo_changed = True  # Assume changed
     else:
+        source_repo_changed = pull_changes(db_project, source_only=True)
+
+    # If the only repo hasn't changed since the last sync and there are
+    # no Pontoon-side changes for this project, quit early.
+    if not force and not db_project.needs_sync and not source_repo_changed and db_project.has_single_repo:
+        log.info('Skipping project {0}, no changes detected.'.format(db_project.slug))
+        return False
+
+    if force or source_repo_changed:
         try:
-            project_changes, obsolete_vcs_resources, new_paths = perform_sync_project(db_project, now, full_scan=force)
-        except MissingSourceDirectoryError, e:
+            project_changes, obsolete_vcs_resources, new_paths = update_originals(db_project, now, full_scan=force)
+        except MissingSourceDirectoryError as e:
             log.error(e)
-            project_sync_log.skip()
-            return
+            return False
 
         log.info('Synced resources for project {0}.'.format(db_project.slug))
+        db_project.source_repository.set_last_synced_revisions()
 
-        # No need to sync translations if it's a source repository
-        for repo in db_project.repositories.exclude(source_repo=True):
-            sync_project_repo.delay(
-                project_pk,
-                repo.pk,
-                project_sync_log.pk,
-                now,
-                project_changes,
-                obsolete_vcs_resources,
-                new_paths,
-                no_pull=no_pull,
-                no_commit=no_commit,
-                full_scan=force
-            )
+    else:
+        project_changes, obsolete_vcs_resources, new_paths = None, None, None
+        log.info('Skipping syncing resources for project {0}, no changes detected.'.format(db_project.slug))
 
-        for repo in db_project.repositories.filter(source_repo=True):
-            repo.set_last_synced_revisions()
+    return {
+        'project_changes': project_changes,
+        'obsolete_vcs_resources': obsolete_vcs_resources,
+        'new_paths': new_paths,
+    }
 
 
-@serial_task(settings.SYNC_TASK_TIMEOUT, base=PontoonTask, lock_key='project={0},repo={1}', on_error=sync_project_repo_error)
-def sync_project_repo(self, project_pk, repo_pk, project_sync_log_pk, now, project_changes=None,
+@serial_task(settings.SYNC_TASK_TIMEOUT, base=PontoonTask, lock_key='project={0},repo={1}', on_error=sync_translations_error)
+def sync_translations(self, project_pk, repo_pk, project_sync_log_pk, now, project_changes=None,
                       obsolete_vcs_resources=None, new_paths=None, locale=None, no_pull=False, no_commit=False,
                       full_scan=False):
     db_project = get_or_fail(Project, pk=project_pk,
@@ -148,7 +163,8 @@ def sync_project_repo(self, project_pk, repo_pk, project_sync_log_pk, now, proje
     project_sync_log = get_or_fail(ProjectSyncLog, pk=project_sync_log_pk,
         message=('Could not sync project {0}, log with pk={1} not found.'
                  .format(db_project.slug, project_sync_log_pk)))
-    log.info('Syncing repo: {}'.format(repo.url))
+
+    log.info('Syncing translations for repo: {}'.format(repo.url))
 
     repo_sync_log = RepositorySyncLog.objects.create(
         project_sync_log=project_sync_log,
@@ -156,29 +172,39 @@ def sync_project_repo(self, project_pk, repo_pk, project_sync_log_pk, now, proje
         start_time=timezone.now()
     )
 
-    # Pull VCS changes in case we're on a different worker than the one
-    # sync started on.
-    if not no_pull:
-        pull_changes(db_project)
-
     if locale:
         locales = [locale]
     else:
         locales = repo.locales
 
-    # Cannot skip earlier - repo.locales is only available after pull_changes()
     if not locales:
-        log.debug('Skipping repo `{0}` for project {1}, no locales to sync found within.'
+        log.info('Skipping repo `{0}` for project {1}, no locales to sync found within.'
                   .format(repo.url, db_project.slug))
         repo_sync_log.end()
         return
 
-    db_project_changed = (
-        project_changes['update_db'] +
-        project_changes['obsolete_db'] +
-        project_changes['create_db']
-    )
-    obsolete_vcs_entities = project_changes['obsolete_db']
+    # Pull VCS changes in case we're on a different worker than the one
+    # sync started on.
+    if not no_pull:
+        repos_changed = pull_changes(db_project)
+
+    # If none of the repos has changed since the last sync and there are
+    # no Pontoon-side changes for this project, quit early.
+    if not full_scan and not db_project.needs_sync and not repos_changed:
+        log.info('Skipping project {0}, no changes detected.'.format(db_project.slug))
+        repo_sync_log.end()
+        return
+
+    db_project_changed = []
+    obsolete_vcs_entities = []
+    if project_changes:
+        db_project_changed = (
+            project_changes['update_db'] +
+            project_changes['obsolete_db'] +
+            project_changes['create_db']
+        )
+        obsolete_vcs_entities = project_changes['obsolete_db']
+
     obsolete_entities_paths = Resource.objects.obsolete_entities_paths(obsolete_vcs_entities) if obsolete_vcs_entities else None
 
     vcs_project = VCSProject(
@@ -192,25 +218,11 @@ def sync_project_repo(self, project_pk, repo_pk, project_sync_log_pk, now, proje
     for locale in locales:
         try:
             with transaction.atomic():
-                # Skip locales that have nothing to sync
-                if vcs_project.synced_locales and locale not in vcs_project.synced_locales:
-                    if db_project_changed or obsolete_vcs_resources:
-                        update_translated_resources(db_project, vcs_project, locale)
-                        update_locale_project_locale_stats(locale, db_project)
-                        log.debug('Skipping locale `{0}` for project {1}, nothing to sync.'
-                                  .format(locale.code, db_project.slug))
-                    continue
+                # Sets VCSProject.synced_locales, needed to skip early
+                if not vcs_project.synced_locales:
+                    vcs_project.resources
 
-                changeset = ChangeSet(db_project, vcs_project, now, obsolete_vcs_entities, obsolete_vcs_resources)
-                update_translations(db_project, vcs_project, locale, changeset)
-                changeset.execute()
-
-                update_translated_resources(db_project, vcs_project, locale)
-
-                # Skip if none of the locales has anything to sync
-                # VCSProject.synced_locales is set on a first call to
-                # VCSProject.resources, which is set in
-                # pontoon.sync.core.update_translated_resources()
+                # Skip all locales if none of the them has anything to sync
                 if len(vcs_project.synced_locales) == 0:
                     if db_project_changed or obsolete_vcs_resources:
                         for l in locales:
@@ -223,6 +235,19 @@ def sync_project_repo(self, project_pk, repo_pk, project_sync_log_pk, now, proje
                     repo_sync_log.end()
                     return
 
+                # Skip locales that have nothing to sync
+                if vcs_project.synced_locales and locale not in vcs_project.synced_locales:
+                    if db_project_changed or obsolete_vcs_resources:
+                        update_translated_resources(db_project, vcs_project, locale)
+                        update_locale_project_locale_stats(locale, db_project)
+                        log.debug('Skipping locale `{0}` for project {1}, no changes detected.'
+                                  .format(locale.code, db_project.slug))
+                    continue
+
+                changeset = ChangeSet(db_project, vcs_project, now, obsolete_vcs_entities, obsolete_vcs_resources)
+                update_translations(db_project, vcs_project, locale, changeset)
+                changeset.execute()
+                update_translated_resources(db_project, vcs_project, locale)
                 update_locale_project_locale_stats(locale, db_project)
 
                 # Clear out the "has_changed" markers now that we've finished

--- a/pontoon/sync/tests/test_changeset.py
+++ b/pontoon/sync/tests/test_changeset.py
@@ -103,7 +103,7 @@ class ChangeSetTests(FakeCheckoutTestCase):
         """Create new entity in the database."""
         self.main_db_entity.delete()
 
-        self.main_vcs_entity.key = 'string-key'
+        self.main_vcs_entity.key = 'Source String'
         self.main_vcs_entity.comments = ['first comment', 'second']
         self.main_vcs_entity.order = 7
         self.main_vcs_translation.fuzzy = False
@@ -120,7 +120,7 @@ class ChangeSetTests(FakeCheckoutTestCase):
             new_entity,
             resource=self.main_db_resource,
             string='Source String',
-            key='string-key',
+            key='Source String',
             comment='first comment\nsecond',
             order=7,
             string_plural='plural string',
@@ -155,7 +155,7 @@ class ChangeSetTests(FakeCheckoutTestCase):
         self.main_db_translation.extra = {}
         self.main_db_translation.save()
 
-        self.main_vcs_entity.key = 'string-key'
+        self.main_vcs_entity.key = 'Source String'
         self.main_vcs_entity.comments = ['first comment', 'second']
         self.main_vcs_entity.order = 7
         self.main_vcs_entity.string_plural = 'plural string'
@@ -169,7 +169,7 @@ class ChangeSetTests(FakeCheckoutTestCase):
         self.main_db_entity.refresh_from_db()
         assert_attributes_equal(
             self.main_db_entity,
-            key='string-key',
+            key='Source String',
             comment='first comment\nsecond',
             order=7,
             string_plural='plural string',

--- a/pontoon/sync/tests/test_core.py
+++ b/pontoon/sync/tests/test_core.py
@@ -288,20 +288,14 @@ class PullChangesTests(FakeCheckoutTestCase):
     def test_basic(self):
         """
         Pull_changes should call repo.pull for each repo for the
-        project, save the return value to repo.last_synced_revisions,
-        and return whether any changes happened in VCS.
+        project and return whether any changes happened in VCS.
         """
         mock_db_project = MagicMock()
         mock_db_project.repositories.all.return_value = [self.repository]
         self.mock_repo_pull.return_value = {'single_locale': 'asdf'}
 
-        has_changed, revisions = pull_changes(self.db_project)
+        has_changed = pull_changes(self.db_project)
         assert_true(has_changed)
-        assert_equal(revisions, {self.repository.pk: {'single_locale': 'asdf'}})
-        self.repository.last_synced_revisions = revisions[self.repository.pk]
-        self.repository.save()
-        self.repository.refresh_from_db()
-        assert_equal(self.repository.last_synced_revisions, {'single_locale': 'asdf'})
 
     def test_unsure_changes(self):
         """
@@ -322,5 +316,5 @@ class PullChangesTests(FakeCheckoutTestCase):
         self.mock_repo_pull.return_value = {'single_locale': 'asdf'}
         self.repository.last_synced_revisions = {'single_locale': 'asdf'}
         self.repository.save()
-        has_changed, _ = pull_changes(self.db_project)
+        has_changed = pull_changes(self.db_project)
         assert_false(has_changed)

--- a/pontoon/sync/tests/test_models.py
+++ b/pontoon/sync/tests/test_models.py
@@ -81,7 +81,7 @@ class ProjectSyncLogTests(TestCase):
         Return the latest end time among repo sync logs for this log.
         """
         project = ProjectFactory.create(repositories=[])
-        repo1, repo2 = RepositoryFactory.create_batch(2, project=project)
+        source_repo, repo1, repo2 = RepositoryFactory.create_batch(3, project=project)
         project_sync_log = ProjectSyncLogFactory.create(project=project)
 
         RepositorySyncLogFactory.create(project_sync_log=project_sync_log,

--- a/pontoon/sync/tests/test_tasks.py
+++ b/pontoon/sync/tests/test_tasks.py
@@ -13,7 +13,7 @@ from pontoon.base.tests import (
 from pontoon.base.utils import aware_datetime
 from pontoon.sync.core import serial_task
 from pontoon.sync.models import ProjectSyncLog, RepositorySyncLog, SyncLog
-from pontoon.sync.tasks import sync_project, sync_project_repo
+from pontoon.sync.tasks import sync_project, sync_translations
 from pontoon.sync.tests import (
     FAKE_CHECKOUT_PATH,
     FakeCheckoutTestCase,
@@ -29,12 +29,13 @@ class SyncProjectTests(TestCase):
         self.sync_log = SyncLogFactory.create()
 
         self.mock_pull_changes = self.patch(
-            'pontoon.sync.tasks.pull_changes', return_value=(True, {}))
+            'pontoon.sync.tasks.pull_changes', return_value=True)
         self.mock_project_needs_sync = self.patch_object(
             Project, 'needs_sync', new_callable=PropertyMock, return_value=True)
-        self.mock_sync_project_repo = self.patch('pontoon.sync.tasks.sync_project_repo')
 
-        self.mock_perform_sync_project = self.patch('pontoon.sync.tasks.perform_sync_project', return_value=[[], [], []])
+        self.mock_sync_translations = self.patch('pontoon.sync.tasks.sync_translations')
+
+        self.mock_update_originals = self.patch('pontoon.sync.tasks.update_originals', return_value=[[], [], []])
 
         self.mock_source_directory_path = self.patch('pontoon.sync.vcs.models.VCSProject.source_directory_path',
                                                             return_value=self.repository.checkout_path)
@@ -47,7 +48,7 @@ class SyncProjectTests(TestCase):
             with assert_raises(Project.DoesNotExist):
                 sync_project(99999, self.sync_log.pk)
             mock_log.error.assert_called_with(CONTAINS('99999'))
-            assert_false(self.mock_perform_sync_project.called)
+            assert_false(self.mock_update_originals.called)
 
     def test_missing_log(self):
         """
@@ -57,33 +58,39 @@ class SyncProjectTests(TestCase):
             with assert_raises(SyncLog.DoesNotExist):
                 sync_project(self.db_project.pk, 99999)
             mock_log.error.assert_called_with(CONTAINS('99999'))
-            assert_false(self.mock_perform_sync_project.called)
+            assert_false(self.mock_update_originals.called)
 
     def test_db_changed_no_repo_changed(self):
         """
-        If the database has changes and VCS doesn't, do not skip syncing
-        the project.
+        If the database has changes and VCS doesn't, skip syncing
+        resources, but sync translations.
         """
-        self.mock_pull_changes.return_value = (False, {})
+        self.mock_pull_changes.return_value = False
         self.mock_project_needs_sync.return_value = True
 
+        with patch('pontoon.sync.tasks.log') as mock_log:
+            sync_project(self.db_project.pk, self.sync_log.pk)
+
         sync_project(self.db_project.pk, self.sync_log.pk)
-        assert_true(self.mock_perform_sync_project.called)
+        assert_false(self.mock_update_originals.called)
+        mock_log.info.assert_called_with(
+            CONTAINS('Skipping syncing resources', self.db_project.slug)
+        )
 
     def test_no_changes_skip(self):
         """
-        If the database and VCS both have no changes, skip sync and log
-        a message.
+        If the database and the source repository both have no
+        changes, and project has a single repository, skip sync.
         """
-        self.mock_pull_changes.return_value = (False, {})
+        self.mock_pull_changes.return_value = False
         self.mock_project_needs_sync.return_value = False
 
         with patch('pontoon.sync.tasks.log') as mock_log:
             sync_project(self.db_project.pk, self.sync_log.pk)
 
-        assert_false(self.mock_perform_sync_project.called)
+        assert_false(self.mock_update_originals.called)
         mock_log.info.assert_called_with(
-            CONTAINS('Skipping', self.db_project.slug)
+            CONTAINS('Skipping project', self.db_project.slug)
         )
 
         # When skipping, mark the project log properly.
@@ -92,13 +99,13 @@ class SyncProjectTests(TestCase):
     def test_no_changes_force(self):
         """
         If the database and VCS both have no changes, but force is true,
-        do not skip sync.
+        do not skip syncing resources.
         """
-        self.mock_pull_changes.return_value = (False, {})
+        self.mock_pull_changes.return_value = False
         self.mock_project_needs_sync.return_value = False
 
         sync_project(self.db_project.pk, self.sync_log.pk, force=True)
-        assert_true(self.mock_perform_sync_project.called)
+        assert_true(self.mock_update_originals.called)
 
     def test_no_pull(self):
         """
@@ -116,17 +123,17 @@ class SyncProjectTests(TestCase):
         sync_project(self.db_project.pk, self.sync_log.pk)
 
         log = ProjectSyncLog.objects.get(project=self.db_project)
-        assert_equal(self.mock_sync_project_repo.delay.call_args[0][1], repo.pk)
-        assert_equal(self.mock_sync_project_repo.delay.call_args[0][2], log.pk)
+        assert_equal(self.mock_sync_translations.delay.call_args[0][1], repo.pk)
+        assert_equal(self.mock_sync_translations.delay.call_args[0][2], log.pk)
 
 
-class SyncProjectRepoTests(FakeCheckoutTestCase):
+class SyncTranslationsTests(FakeCheckoutTestCase):
     def setUp(self):
-        super(SyncProjectRepoTests, self).setUp()
+        super(SyncTranslationsTests, self).setUp()
         self.project_sync_log = ProjectSyncLogFactory.create()
 
         self.mock_pull_changes = self.patch(
-            'pontoon.sync.tasks.pull_changes', return_value=(True, {}))
+            'pontoon.sync.tasks.pull_changes', return_value=True)
         self.mock_commit_changes = self.patch('pontoon.sync.tasks.commit_changes')
         self.mock_repo_checkout_path = self.patch_object(
             Repository, 'checkout_path', new_callable=PropertyMock,
@@ -151,7 +158,7 @@ class SyncProjectRepoTests(FakeCheckoutTestCase):
         changed_after.when = aware_datetime(1970, 1, 3)
         changed_after.save()
 
-        sync_project_repo(self.db_project.pk, self.repository.pk,
+        sync_translations(self.db_project.pk, self.repository.pk,
                           self.project_sync_log.pk, self.now,
                           self.mock_changes)
         with assert_raises(ChangedEntityLocale.DoesNotExist):
@@ -162,7 +169,7 @@ class SyncProjectRepoTests(FakeCheckoutTestCase):
 
     def test_no_commit(self):
         """Don't call commit_changes if command.no_commit is True."""
-        sync_project_repo(self.db_project.pk, self.repository.pk,
+        sync_translations(self.db_project.pk, self.repository.pk,
                           self.project_sync_log.pk, self.now,
                           self.mock_changes, no_commit=True)
         assert_false(self.mock_commit_changes.called)
@@ -187,7 +194,7 @@ class SyncProjectRepoTests(FakeCheckoutTestCase):
         ChangedEntityLocale.objects.filter(entity=self.main_db_entity).delete()
 
         with patch('pontoon.sync.tasks.VCSProject', return_value=self.vcs_project):
-            sync_project_repo(self.db_project.pk, self.repository.pk,
+            sync_translations(self.db_project.pk, self.repository.pk,
                               self.project_sync_log.pk, self.now,
                               self.mock_changes)
 
@@ -210,7 +217,7 @@ class SyncProjectRepoTests(FakeCheckoutTestCase):
         self.db_project.repositories = [repo]
         self.db_project.save()
 
-        sync_project_repo(self.db_project.pk, self.repository.pk,
+        sync_translations(self.db_project.pk, self.repository.pk,
                           self.project_sync_log.pk, self.now,
                           self.mock_changes)
 

--- a/pontoon/sync/tests/test_vcs_models.py
+++ b/pontoon/sync/tests/test_vcs_models.py
@@ -40,16 +40,16 @@ class VCSProjectTests(TestCase):
         self.vcs_project = VCSProject(self.project)
 
     def test_relative_resource_paths(self):
-        self.vcs_project.source_directory_path = Mock(return_value='/root/')
-        self.vcs_project.resources_for_path = Mock(return_value=[
-            '/root/foo.po',
-            '/root/meh/bar.po'
-        ])
+        with patch.object(VCSProject, 'source_directory_path', new_callable=PropertyMock, return_value='/root/'):
+            self.vcs_project.resources_for_path = Mock(return_value=[
+                '/root/foo.po',
+                '/root/meh/bar.po'
+            ])
 
-        assert_equal(
-            list(self.vcs_project.relative_resource_paths()),
-            ['foo.po', 'meh/bar.po']
-        )
+            assert_equal(
+                list(self.vcs_project.relative_resource_paths()),
+                ['foo.po', 'meh/bar.po']
+            )
 
     def test_relative_resource_paths_pot(self):
         """
@@ -57,16 +57,16 @@ class VCSProjectTests(TestCase):
         relative paths are used within non-source locales that do not
         have .pot files.
         """
-        self.vcs_project.source_directory_path = Mock(return_value='/root/')
-        self.vcs_project.resources_for_path = Mock(return_value=[
-            '/root/foo.pot',
-            '/root/meh/bar.pot'
-        ])
+        with patch.object(VCSProject, 'source_directory_path', new_callable=PropertyMock, return_value='/root/'):
+            self.vcs_project.resources_for_path = Mock(return_value=[
+                '/root/foo.pot',
+                '/root/meh/bar.pot'
+            ])
 
-        assert_equal(
-            list(self.vcs_project.relative_resource_paths()),
-            ['foo.po', 'meh/bar.po']
-        )
+            assert_equal(
+                list(self.vcs_project.relative_resource_paths()),
+                ['foo.po', 'meh/bar.po']
+            )
 
     def test_source_directory_path_no_resource(self):
         """
@@ -77,7 +77,7 @@ class VCSProjectTests(TestCase):
         self.mock_checkout_path.return_value = checkout_path
 
         assert_equal(
-            self.vcs_project.source_directory_path(),
+            self.vcs_project.source_directory_path,
             os.path.join(checkout_path, 'real_resources', 'templates')
         )
 
@@ -90,7 +90,7 @@ class VCSProjectTests(TestCase):
         self.mock_checkout_path.return_value = checkout_path
 
         assert_equal(
-            self.vcs_project.source_directory_path(),
+            self.vcs_project.source_directory_path,
             os.path.join(checkout_path, 'templates')
         )
 
@@ -103,7 +103,7 @@ class VCSProjectTests(TestCase):
         self.mock_checkout_path.return_value = checkout_path
 
         assert_equal(
-            self.vcs_project.source_directory_path(),
+            self.vcs_project.source_directory_path,
             os.path.join(checkout_path, 'en-US')
         )
 
@@ -116,7 +116,7 @@ class VCSProjectTests(TestCase):
         self.mock_checkout_path.return_value = checkout_path
 
         assert_equal(
-            self.vcs_project.source_directory_path(),
+            self.vcs_project.source_directory_path,
             os.path.join(checkout_path, 'en')  # en has pot files in it
         )
 

--- a/pontoon/sync/vcs/repositories.py
+++ b/pontoon/sync/vcs/repositories.py
@@ -357,10 +357,14 @@ class HgRepository(VCSRepository):
         )
         return output.strip() if code == 0 else None
 
+    def _strip(self, rev):
+        "Ignore trailing + in revision number. It marks local changes."
+        return rev.rstrip('+')
+
     def get_changed_files(self, path, from_revision, statuses=None):
         statuses = statuses or ('A', 'M')
         code, output, error = self.execute(
-            ['hg', 'status', '-a', '-m', '-r', '--rev={}'.format(from_revision), '--rev=tip'],
+            ['hg', 'status', '-a', '-m', '-r', '--rev={}'.format(self._strip(from_revision)), '--rev=tip'],
             cwd=path
         )
         if code == 0:
@@ -369,7 +373,7 @@ class HgRepository(VCSRepository):
         return []
 
     def get_removed_files(self, path, from_revision):
-        return self.get_changed_files(path, from_revision, ('R',))
+        return self.get_changed_files(path, self._strip(from_revision), ('R',))
 
 
 # TODO: Tie these to the same constants that the Repository model uses.


### PR DESCRIPTION
This optimization affects all project repository types, fixes some bugs and hopefully makes code more readable. It's particularly noticeable on projects that use multiple repositories and when adding new locales or entire projects.

**Optimizations**
* When syncing resources, only check out source repositories (currently we check out all repositories twice: during resources and during translation sync). 3f939b2
* If no changes detected in source repository, skip syncing resources (currently we sync resources even if only translations need to be synced). 3f939b2
* Acknowledge changed files when syncing resources (currently if resources need to be synced, we sync all resources). 871cb88
* Optimize changed files detection by 90% using @cached_property. 3f83b32
* Do not detect all following files detected as changed when one detected as chanegd. Over 90% optimization for small syncs on big projects. cd6fdaf
* 80 % faster execute_update_db(), commonly the slowest function on syncing translations, mostly noticable when adding new locales or projects. 8c8fd31
* Skip syncing translations as early as possible. Avoids syncing first project locale even if not needed. 9407d86

**Code improvements**
* Return Project.source_repository and Repository.locales even if repository not checked out (needed above). b5125c1 163d99c
* Use `translation_repositories()` instead of `.exclude(source_repo=True)`, which doesn't exclude source repositories not marked with the `source_repo` flag. 3f83b32
* `VCSProject.changed_files` now also includes DB changes. 73406bd
* Changed some function names for better readability. bf01222 56af5fc
* Ignore trailing + in HG revision number (caused by local changes) to avoid hg: parse error, preventing changes to be detected. 8ecfcd8

@jotes r?