### PR TITLE
Speed up sync log listing

### DIFF
--- a/pontoon/sync/tests/test_models.py
+++ b/pontoon/sync/tests/test_models.py
@@ -62,10 +62,13 @@ class SyncLogTests(TestCase):
             start_time=aware_datetime(2015, 1, 1),
             end_time=None
         )
+        del sync_log.finished
         assert_false(sync_log.finished)
 
         repo_log.end_time = aware_datetime(2015, 1, 2)
         repo_log.save()
+
+        del sync_log.finished
         assert_true(sync_log.finished)
 
 
@@ -122,6 +125,9 @@ class ProjectSyncLogTests(TestCase):
             start_time=aware_datetime(2015, 1, 1),
             end_time=aware_datetime(2015, 1, 1, 1),
         )
+
+        del project_sync_log.finished
+        del project_sync_log.status
         assert_equal(project_sync_log.status, ProjectSyncLog.SYNCED)
 
         # Skipped projects are just "skipped".
@@ -129,6 +135,7 @@ class ProjectSyncLogTests(TestCase):
             project__repositories=[repo],
             skipped=True,
         )
+
         assert_equal(skipped_log.status, ProjectSyncLog.SKIPPED)
 
     def test_finished(self):
@@ -144,10 +151,14 @@ class ProjectSyncLogTests(TestCase):
             start_time=aware_datetime(2015, 1, 1),
             end_time=None
         )
+
+        del project_sync_log.finished
         assert_false(project_sync_log.finished)
 
         repo_log.end_time = aware_datetime(2015, 1, 2)
         repo_log.save()
+
+        del project_sync_log.finished
         assert_true(project_sync_log.finished)
 
     def test_finished_skipped(self):
@@ -163,4 +174,6 @@ class RepositorySyncLogTests(TestCase):
 
         log.end_time = aware_datetime(2015, 1, 1)
         log.save()
+
+        del log.finished
         assert_true(log.finished)


### PR DESCRIPTION
Loading /sync page is slow. This should speed it by ~80%.

The main trick is in not calling `SyncLog.finished` property.

@jotes r?