### PR TITLE
Fix Sign in link in translate view

### DIFF
--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -302,7 +302,7 @@
           <button id="clear" title="Clear Translation (Ctrl + Shift + Backspace)">Clear</button>
           <button id="save" title="Save Translation (Enter)"></button>
         {% else %}
-          <p id="sign-in-required"><a id="sidebar-signin" href="">Sign in</a> to translate.</p>
+          <p id="sign-in-required"><a id="sidebar-signin" href="{{ provider_login_url(request, "fxa") }}">Sign in</a> to translate.</p>
         {% endif %}
       </menu>
 


### PR DESCRIPTION
@jotes r?

We forgot to update this sign-in link. It's simpler to directly link to Firefox Account and that's sufficient, given that we'll drop Persona support in a month from now.