### PR TITLE
Bug 1310510 - add virtualenv and fix CSP

### DIFF
--- a/docs/dev/install.rst
+++ b/docs/dev/install.rst
@@ -19,7 +19,7 @@ all the prerequisites using the following command:
 
    .. code-block:: bash
 
-      sudo apt install git python-pip nodejs-legacy npm postgresql postgresql-server-dev-9.5 postgresql-contrib-9.5 libxml2-dev libxslt1-dev python-dev libmemcached-dev
+      sudo apt install git python-pip nodejs-legacy npm postgresql postgresql-server-dev-9.5 postgresql-contrib-9.5 libxml2-dev libxslt1-dev python-dev libmemcached-dev virtualenv
 
 .. _Git: https://git-scm.com/
 .. _Python 2.7: https://www.python.org/
@@ -101,7 +101,7 @@ Installation
       python manage.py createsuperuser
 
    Make sure that the email address you use for the superuser account matches
-   the email that you will log in with via Persona.
+   the email that you will log in with via Firefox Accounts.
 
 7. Pull the latest strings from version control for the Pontoon Intro project
    (which is automatically created for you during the database migrations):

--- a/pontoon/settings/dev.py
+++ b/pontoon/settings/dev.py
@@ -20,3 +20,6 @@ MIDDLEWARE_CLASSES = base.MIDDLEWARE_CLASSES + (
 
 TEMPLATES = copy.copy(base.TEMPLATES)
 TEMPLATES[0]['OPTIONS']['match_regex'] = r'^(?!(admin|persona|debug_toolbar|registration|account|socialaccount)/).*\.(html|jinja)$'
+
+CSP_SCRIPT_SRC = base.CSP_SCRIPT_SRC + ('http://ajax.googleapis.com',)
+CSP_IMG_SRC = base.CSP_IMG_SRC + ('data:',)


### PR DESCRIPTION
1)We must modify django-debug-toolbar or add ajax.googleapis.com in CSP, because requirements-dev.txt contains django-debug-toolbar which needs access to ajax.googleapis.com
2)we need "data:" for base64 images. For example:
![2016-10-16_23-21-39 2](https://cloud.githubusercontent.com/assets/3993729/19420406/d2209082-93fb-11e6-9df3-0b88d450e582.png)
3)About Virtualenv
![2016-10-16_22-58-09](https://cloud.githubusercontent.com/assets/3993729/19420415/f089890c-93fb-11e6-9cfb-d55d562fc671.png)
