### PR TITLE
Switch back to latest upstream django-allauth

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -137,8 +137,8 @@ raygun4py==3.1.2 \
     --hash=sha256:ee32cc3c7b1320fc0312c2b3a904a810f61ba302c2bad6dec836bb19fbf68340
 django-cors-headers==1.1.0 \
     --hash=sha256:fcd96e2be47c8eef34c650e007a6d546e19e7ee61041b89edbbbbe7619aa3987
-https://bitbucket.org/mathjazz/django-allauth/get/0.25.3.zip#egg=django-allauth==0.25.3 \
-    --hash=sha256:6a9ab50aca6a996f1afb30e9d64260ce0e9ee4313b7c12971bdca4d5f92bde43
+django-allauth==0.28.0 \
+    --hash=sha256:135e42b2a6988de2e93729b9556ad6acf5bb8660ab5f3492d42aefc184a8aeb1
 python-openid==2.2.5 \
     --hash=sha256:92c51c3ecec846cbec4aeff11f9ff47303d4a63f93b0e6ac0ec02a091fed70ef \
     --hash=sha256:c2d133e47e0a7705c9272eef00d7a09c174f5bf17a127fed8e2c6499556cc782


### PR DESCRIPTION
The bug our fork fixes is now fixed upstream, let's move back to using the official branch.

@jotes r? Is there a reason why we were using a pretty old version - 0.25.2? Maybe because we started working on FxA support before 0.26.0 was release?

BTW, shall we also remove all social accounts with provider Persona?