### PR TITLE
Load jquery.mark.js lib before the script that uses it

### DIFF
--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -328,10 +328,10 @@ PIPELINE_JS = {
         'source_filenames': (
             'js/jquery-ui.js',
             'js/jquery-ui-timepicker-addon.js',
+            'js/jquery.mark.js',
             'js/highstock.js',
             'js/translate.js',
             'js/request_projects.js',
-            'js/jquery.mark.js',
         ),
         'output_filename': 'js/translate.min.js',
     },


### PR DESCRIPTION
It's causing JS error in local development randomly:
`TypeError: item.unmark is not a function  translate.js:3306:7`

@jotes r?