### PR TITLE
Fix bug 1316171: JS_TRUSTED_ORIGINS can be loaded from ENV.

### DIFF
--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -679,6 +679,9 @@ SOCIALACCOUNT_PROVIDERS = {
 }
 
 # Defined all trusted origins that will be returned in pontoon.js file.
-JS_TRUSTED_ORIGINS = [
-    SITE_URL,
-]
+if os.environ.get('JS_TRUSTED_ORIGINS'):
+    JS_TRUSTED_ORIGINS = os.environ.get('JS_TRUSTED_ORIGINS').split(',')
+else:
+    JS_TRUSTED_ORIGINS = [
+        SITE_URL,
+    ]


### PR DESCRIPTION
@mathjazz I think this can be helpful on the production or even on the staging.