### PR TITLE
Fix bug 1311295: support multiple locale repositories

### DIFF
--- a/pontoon/sync/models.py
+++ b/pontoon/sync/models.py
@@ -88,8 +88,7 @@ class ProjectSyncLog(BaseLog):
             return True
 
         repo_logs = self.repository_sync_logs.all()
-        sync_repos = self.project.translation_repositories()
-        if len(repo_logs) != sync_repos.count():
+        if len(repo_logs) != 1:
             return False
         else:
             return all(log.finished for log in repo_logs)

--- a/pontoon/sync/tasks.py
+++ b/pontoon/sync/tasks.py
@@ -210,6 +210,7 @@ def sync_translations(self, project_pk, project_sync_log_pk, now, project_change
     vcs_project = VCSProject(
         db_project,
         locales=locales,
+        repo_locales=repo_locales,
         obsolete_entities_paths=obsolete_entities_paths,
         new_paths=new_paths,
         full_scan=full_scan

--- a/pontoon/sync/tasks.py
+++ b/pontoon/sync/tasks.py
@@ -82,18 +82,15 @@ def sync_project(self, project_pk, sync_log_pk, locale=None, no_pull=False, no_c
 
     # Do not sync resources if locale specified
     if locale:
-        repo = locale.get_repository(db_project)
-        if repo:
-            sync_translations.delay(
-                project_pk,
-                repo.pk,
-                project_sync_log.pk,
-                now,
-                locale=locale,
-                no_pull=no_pull,
-                no_commit=no_commit,
-                full_scan=force
-            )
+        sync_translations.delay(
+            project_pk,
+            project_sync_log.pk,
+            now,
+            locale=locale,
+            no_pull=no_pull,
+            no_commit=no_commit,
+            full_scan=force
+        )
         return
 
     # Sync resources
@@ -103,19 +100,17 @@ def sync_project(self, project_pk, sync_log_pk, locale=None, no_pull=False, no_c
         return
 
     # Sync translations
-    for repo in db_project.translation_repositories():
-        sync_translations.delay(
-            project_pk,
-            repo.pk,
-            project_sync_log.pk,
-            now,
-            resource_changes['project_changes'],
-            resource_changes['obsolete_vcs_resources'],
-            resource_changes['new_paths'],
-            no_pull=no_pull,
-            no_commit=no_commit,
-            full_scan=force
-        )
+    sync_translations.delay(
+        project_pk,
+        project_sync_log.pk,
+        now,
+        resource_changes['project_changes'],
+        resource_changes['obsolete_vcs_resources'],
+        resource_changes['new_paths'],
+        no_pull=no_pull,
+        no_commit=no_commit,
+        full_scan=force
+    )
 
 
 def sync_resources(db_project, now, force, no_pull):
@@ -123,7 +118,7 @@ def sync_resources(db_project, now, force, no_pull):
     if no_pull:
         source_repo_changed = True  # Assume changed
     else:
-        source_repo_changed = pull_changes(db_project, source_only=True)
+        source_repo_changed, _ = pull_changes(db_project, source_only=True)
 
     # If the only repo hasn't changed since the last sync and there are
     # no Pontoon-side changes for this project, quit early.
@@ -153,19 +148,23 @@ def sync_resources(db_project, now, force, no_pull):
     }
 
 
-@serial_task(settings.SYNC_TASK_TIMEOUT, base=PontoonTask, lock_key='project={0},repo={1}', on_error=sync_translations_error)
-def sync_translations(self, project_pk, repo_pk, project_sync_log_pk, now, project_changes=None,
+@serial_task(settings.SYNC_TASK_TIMEOUT, base=PontoonTask, lock_key='project={0},translations', on_error=sync_translations_error)
+def sync_translations(self, project_pk, project_sync_log_pk, now, project_changes=None,
                       obsolete_vcs_resources=None, new_paths=None, locale=None, no_pull=False, no_commit=False,
                       full_scan=False):
     db_project = get_or_fail(Project, pk=project_pk,
         message='Could not sync project with pk={0}, not found.'.format(project_pk))
+
+    repos = db_project.translation_repositories()
+    repo_pk = repos[0].pk
     repo = get_or_fail(Repository, pk=repo_pk,
         message='Could not sync repo with pk={0}, not found.'.format(repo_pk))
+
     project_sync_log = get_or_fail(ProjectSyncLog, pk=project_sync_log_pk,
         message=('Could not sync project {0}, log with pk={1} not found.'
                  .format(db_project.slug, project_sync_log_pk)))
 
-    log.info('Syncing translations for repo: {}'.format(repo.url))
+    log.info('Syncing translations for project: {}'.format(db_project.slug))
 
     repo_sync_log = RepositorySyncLog.objects.create(
         project_sync_log=project_sync_log,
@@ -176,18 +175,18 @@ def sync_translations(self, project_pk, repo_pk, project_sync_log_pk, now, proje
     if locale:
         locales = [locale]
     else:
-        locales = repo.locales
+        locales = db_project.locales.all()
 
     if not locales:
-        log.info('Skipping repo `{0}` for project {1}, no locales to sync found within.'
-                  .format(repo.url, db_project.slug))
+        log.info('Skippig syncing translations for project {0}, no locales to sync found within.'
+                  .format(db_project.slug))
         repo_sync_log.end()
         return
 
     # Pull VCS changes in case we're on a different worker than the one
     # sync started on.
     if not no_pull:
-        repos_changed = pull_changes(db_project)
+        repos_changed, repo_locales = pull_changes(db_project)
 
     resources_changed = []
     obsolete_vcs_entities = []
@@ -234,9 +233,11 @@ def sync_translations(self, project_pk, repo_pk, project_sync_log_pk, now, proje
                                 update_locale_project_locale_stats(l, db_project)
                             db_project.aggregate_stats()
 
-                        log.info('Skipping repo `{0}` for project {1}, none of the locales has anything to sync.'
-                                 .format(repo.url, db_project.slug))
-                        repo.set_last_synced_revisions()
+                        log.info('Skippig syncing translations for project {0}, none of the locales has anything to sync.'
+                                 .format(db_project.slug))
+
+                        for r in repos:
+                            r.set_last_synced_revisions(locales=repo_locales[r.pk])
                         repo_sync_log.end()
                         return
 
@@ -310,12 +311,12 @@ def sync_translations(self, project_pk, repo_pk, project_sync_log_pk, now, proje
                 )
             )
 
-            failed_locales.add(locale)
+            failed_locales.add(locale.code)
 
     with transaction.atomic():
         db_project.aggregate_stats()
 
-    synced_locales = [locale.code for locale in (vcs_project.synced_locales - failed_locales)]
+    synced_locales = [locale.code for locale in vcs_project.synced_locales if locale.code not in failed_locales]
 
     if synced_locales:
         log.info('Synced translations for project {0} in locales {1}.'.format(
@@ -326,5 +327,8 @@ def sync_translations(self, project_pk, repo_pk, project_sync_log_pk, now, proje
             db_project.slug
         ))
 
-    repo.set_last_synced_revisions(exclude=failed_locales)
+    for r in repos:
+        r.set_last_synced_revisions(
+            locales=repo_locales[r.pk].exclude(code__in=failed_locales)
+        )
     repo_sync_log.end()

--- a/pontoon/sync/tests/test_core.py
+++ b/pontoon/sync/tests/test_core.py
@@ -294,7 +294,7 @@ class PullChangesTests(FakeCheckoutTestCase):
         mock_db_project.repositories.all.return_value = [self.repository]
         self.mock_repo_pull.return_value = {'single_locale': 'asdf'}
 
-        has_changed = pull_changes(self.db_project)
+        has_changed, _ = pull_changes(self.db_project)
         assert_true(has_changed)
 
     def test_unsure_changes(self):
@@ -306,7 +306,8 @@ class PullChangesTests(FakeCheckoutTestCase):
         self.repository.last_synced_revisions = {'single_locale': None}
         self.repository.save()
 
-        assert_true(pull_changes(self.db_project))
+        has_changed, _ = pull_changes(self.db_project)
+        assert_true(has_changed)
 
     def test_unchanged(self):
         """
@@ -316,5 +317,5 @@ class PullChangesTests(FakeCheckoutTestCase):
         self.mock_repo_pull.return_value = {'single_locale': 'asdf'}
         self.repository.last_synced_revisions = {'single_locale': 'asdf'}
         self.repository.save()
-        has_changed = pull_changes(self.db_project)
+        has_changed, _ = pull_changes(self.db_project)
         assert_false(has_changed)

--- a/pontoon/sync/tests/test_models.py
+++ b/pontoon/sync/tests/test_models.py
@@ -90,11 +90,8 @@ class ProjectSyncLogTests(TestCase):
         RepositorySyncLogFactory.create(project_sync_log=project_sync_log,
                                         repository=repo1,
                                         end_time=aware_datetime(2015, 1, 1))
-        RepositorySyncLogFactory.create(project_sync_log=project_sync_log,
-                                        repository=repo2,
-                                        end_time=aware_datetime(2015, 1, 2))
 
-        assert_equal(project_sync_log.end_time, aware_datetime(2015, 1, 2))
+        assert_equal(project_sync_log.end_time, aware_datetime(2015, 1, 1))
 
     def test_end_time_skipped(self):
         """

--- a/pontoon/sync/tests/test_tasks.py
+++ b/pontoon/sync/tests/test_tasks.py
@@ -1,7 +1,7 @@
 from django_nose.tools import assert_equal, assert_false, assert_raises, assert_true
 from mock import ANY, patch, PropertyMock
 
-from pontoon.base.models import ChangedEntityLocale, Project, Repository
+from pontoon.base.models import ChangedEntityLocale, Locale, Project, Repository
 from pontoon.base.tests import (
     ChangedEntityLocaleFactory,
     CONTAINS,
@@ -29,7 +29,8 @@ class SyncProjectTests(TestCase):
         self.sync_log = SyncLogFactory.create()
 
         self.mock_pull_changes = self.patch(
-            'pontoon.sync.tasks.pull_changes', return_value=True)
+            'pontoon.sync.tasks.pull_changes', return_value=[True, {}]
+        )
         self.mock_project_needs_sync = self.patch_object(
             Project, 'needs_sync', new_callable=PropertyMock, return_value=True)
 
@@ -65,7 +66,7 @@ class SyncProjectTests(TestCase):
         If the database has changes and VCS doesn't, skip syncing
         resources, but sync translations.
         """
-        self.mock_pull_changes.return_value = False
+        self.mock_pull_changes.return_value = [False, {}]
         self.mock_project_needs_sync.return_value = True
 
         with patch('pontoon.sync.tasks.log') as mock_log:
@@ -82,7 +83,7 @@ class SyncProjectTests(TestCase):
         If the database and the source repository both have no
         changes, and project has a single repository, skip sync.
         """
-        self.mock_pull_changes.return_value = False
+        self.mock_pull_changes.return_value = [False, {}]
         self.mock_project_needs_sync.return_value = False
 
         with patch('pontoon.sync.tasks.log') as mock_log:
@@ -101,7 +102,7 @@ class SyncProjectTests(TestCase):
         If the database and VCS both have no changes, but force is true,
         do not skip syncing resources.
         """
-        self.mock_pull_changes.return_value = False
+        self.mock_pull_changes.return_value = [False, {}]
         self.mock_project_needs_sync.return_value = False
 
         sync_project(self.db_project.pk, self.sync_log.pk, force=True)
@@ -116,15 +117,10 @@ class SyncProjectTests(TestCase):
 
     def test_create_project_log(self):
         assert_false(ProjectSyncLog.objects.exists())
-
-        repo = RepositoryFactory.create()
-        self.db_project.repositories = [repo]
-        self.db_project.save()
         sync_project(self.db_project.pk, self.sync_log.pk)
 
         log = ProjectSyncLog.objects.get(project=self.db_project)
-        assert_equal(self.mock_sync_translations.delay.call_args[0][1], repo.pk)
-        assert_equal(self.mock_sync_translations.delay.call_args[0][2], log.pk)
+        assert_equal(self.mock_sync_translations.delay.call_args[0][1], log.pk)
 
 
 class SyncTranslationsTests(FakeCheckoutTestCase):
@@ -133,7 +129,7 @@ class SyncTranslationsTests(FakeCheckoutTestCase):
         self.project_sync_log = ProjectSyncLogFactory.create()
 
         self.mock_pull_changes = self.patch(
-            'pontoon.sync.tasks.pull_changes', return_value=True)
+            'pontoon.sync.tasks.pull_changes', return_value=[True, {}])
         self.mock_commit_changes = self.patch('pontoon.sync.tasks.commit_changes')
         self.mock_repo_checkout_path = self.patch_object(
             Repository, 'checkout_path', new_callable=PropertyMock,
@@ -150,6 +146,10 @@ class SyncTranslationsTests(FakeCheckoutTestCase):
         before the sync started after handling it.
         """
         self.now = aware_datetime(1970, 1, 2)
+        self.mock_pull_changes.return_value = [True, {
+            self.repository.pk: Locale.objects.filter(pk=self.translated_locale.pk)
+        }]
+
         changed1, changed2, changed_after = ChangedEntityLocaleFactory.create_batch(3,
             locale=self.translated_locale,
             entity__resource=self.main_db_resource,
@@ -158,9 +158,8 @@ class SyncTranslationsTests(FakeCheckoutTestCase):
         changed_after.when = aware_datetime(1970, 1, 3)
         changed_after.save()
 
-        sync_translations(self.db_project.pk, self.repository.pk,
-                          self.project_sync_log.pk, self.now,
-                          self.mock_changes)
+        sync_translations(self.db_project.pk, self.project_sync_log.pk,
+                          self.now, self.mock_changes)
         with assert_raises(ChangedEntityLocale.DoesNotExist):
             changed1.refresh_from_db()
         with assert_raises(ChangedEntityLocale.DoesNotExist):
@@ -169,9 +168,11 @@ class SyncTranslationsTests(FakeCheckoutTestCase):
 
     def test_no_commit(self):
         """Don't call commit_changes if command.no_commit is True."""
-        sync_translations(self.db_project.pk, self.repository.pk,
-                          self.project_sync_log.pk, self.now,
-                          self.mock_changes, no_commit=True)
+        self.mock_pull_changes.return_value = [True, {
+            self.repository.pk: Locale.objects.filter(pk=self.translated_locale.pk)
+        }]
+        sync_translations(self.db_project.pk, self.project_sync_log.pk,
+                          self.now, self.mock_changes, no_commit=True)
         assert_false(self.mock_commit_changes.called)
 
     def test_remove_duplicate_approvals(self):
@@ -181,6 +182,9 @@ class SyncTranslationsTests(FakeCheckoutTestCase):
         # Trigger creation of new approved translation.
         self.main_vcs_translation.strings[None] = 'New Translated String'
         self.main_vcs_translation.fuzzy = False
+        self.mock_pull_changes.return_value = [True, {
+            self.repository.pk: Locale.objects.filter(pk=self.translated_locale.pk)
+        }]
 
         # Translation approved after the sync started simulates the race
         # where duplicate translations occur.
@@ -194,9 +198,8 @@ class SyncTranslationsTests(FakeCheckoutTestCase):
         ChangedEntityLocale.objects.filter(entity=self.main_db_entity).delete()
 
         with patch('pontoon.sync.tasks.VCSProject', return_value=self.vcs_project):
-            sync_translations(self.db_project.pk, self.repository.pk,
-                              self.project_sync_log.pk, self.now,
-                              self.mock_changes)
+            sync_translations(self.db_project.pk, self.project_sync_log.pk,
+                              self.now, self.mock_changes)
 
         # Only one translation should be approved: the duplicate_translation.
         assert_equal(self.main_db_entity.translation_set.filter(approved=True).count(), 1)
@@ -210,19 +213,21 @@ class SyncTranslationsTests(FakeCheckoutTestCase):
         assert_true(duplicate_translation.approved)
         assert_equal(duplicate_translation.approved_date, aware_datetime(1970, 1, 3))
 
-    def test_create_project_log(self):
+    def test_create_repository_log(self):
         assert_false(RepositorySyncLog.objects.exists())
 
         repo = RepositoryFactory.create()
         self.db_project.repositories = [repo]
         self.db_project.save()
+        self.mock_pull_changes.return_value = [True, {
+            repo.pk: Locale.objects.filter(pk=self.translated_locale.pk)
+        }]
 
-        sync_translations(self.db_project.pk, self.repository.pk,
-                          self.project_sync_log.pk, self.now,
-                          self.mock_changes)
+        sync_translations(self.db_project.pk, self.project_sync_log.pk,
+                          self.now, self.mock_changes)
 
-        log = RepositorySyncLog.objects.get(repository=self.repository)
-        assert_equal(log.repository, self.repository)
+        log = RepositorySyncLog.objects.get(repository=repo.pk)
+        assert_equal(log.repository, repo)
 
 
 class UserError(Exception):

--- a/pontoon/sync/vcs/repositories.py
+++ b/pontoon/sync/vcs/repositories.py
@@ -227,14 +227,8 @@ def execute(command, cwd=None, env=None):
 
 
 def update_from_vcs(repo_type, url, path):
-    try:
-        obj = globals()['PullFrom%s' % repo_type.capitalize()](url, path)
-        obj.pull()
-
-    except PullFromRepositoryException as e:
-        error = '%s Pull Error for %s: %s' % (repo_type.upper(), url, e)
-        log.debug(error)
-        raise Exception(error)
+    obj = globals()['PullFrom%s' % repo_type.capitalize()](url, path)
+    obj.pull()
 
 
 def commit_to_vcs(repo_type, path, message, user, url):


### PR DESCRIPTION
@jotes r?

This allows us to pull/push translations from/to different repositories per project. Currently we only support multiple repositories if one is used for source strings and the other for translations.

TODO:
- [x] Match locales to repositories when detecting changed files `repo.last_synced_revisions.keys()`?