### PR TITLE
Order entities by file path, and then order within the path

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -1423,7 +1423,7 @@ class Entity(DirtyFieldsMixin, models.Model):
         if exclude:
             entities = entities.exclude(pk__in=exclude)
 
-        return entities.distinct().order_by('order')
+        return entities.distinct().order_by('resource__path', 'order')
 
     @classmethod
     def map_entities(cls, locale, entities, visible_entities=None):
@@ -1458,7 +1458,7 @@ class Entity(DirtyFieldsMixin, models.Model):
                                  else True
             })
 
-        return sorted(entities_array, key=lambda k: k['order'])
+        return entities_array
 
 
 class ChangedEntityLocale(models.Model):

--- a/pontoon/base/tests/test_models.py
+++ b/pontoon/base/tests/test_models.py
@@ -784,9 +784,8 @@ class EntityTests(TestCase):
             string='First String'
         )
         entities = Entity.map_entities(self.locale, Entity.for_project_locale(self.project, self.locale))
-
-        assert_equal(entities[2]['original'], 'First String')
-        assert_equal(entities[3]['original'], 'Second String')
+        assert_equal(entities[1]['original'], 'First String')
+        assert_equal(entities[2]['original'], 'Second String')
 
     def test_for_project_locale_cleaned_key(self):
         """


### PR DESCRIPTION
@jotes r?

When All Resources are selected, we load entities by order within the
file, which means all entities that apear first in any of the project
files are loaded, followed by all "second" entities, etc.

From now on, we sort file path alphabetically like in the parts menu,
and then load entities from the first file, then second, etc.