### PR TITLE
Only download files we have translated resources for

### DIFF
--- a/pontoon/base/utils.py
+++ b/pontoon/base/utils.py
@@ -366,9 +366,9 @@ def get_download_content(slug, code, part):
     locale = get_object_or_404(Locale, code__iexact=code)
 
     # Download a ZIP of all files if project has > 1 and < 10 resources
-    isZipable = 1 < project.resources.count() < 10
+    resources = Resource.objects.filter(project=project, translatedresources__locale=locale)
+    isZipable = 1 < len(resources) < 10
     if isZipable:
-        resources = project.resources.all()
         s = StringIO.StringIO()
         zf = zipfile.ZipFile(s, "w")
 


### PR DESCRIPTION
Previously, if project had 4 .properties files and 1 .lang file, we
tried to download all files for all locales, even if the .lang file
was only enabled for a handful of them. Since the .lang file didn't
exist, download failed.

r=me