### PR TITLE
Strip whitespace to catch all IPs

### DIFF
--- a/pontoon/base/middleware.py
+++ b/pontoon/base/middleware.py
@@ -40,6 +40,8 @@ class BlockedIpMiddleware(object):
         except KeyError:
             ip = request.META['REMOTE_ADDR']
 
+        ip = ip.strip()
+
         # Block client IP addresses via settings variable BLOCKED_IPS
         if ip in settings.BLOCKED_IPS:
             return HttpResponseForbidden('<h1>Forbidden</h1>')


### PR DESCRIPTION
@jotes r?

I noticed we weren't catching all IPs during a ddos attempt.