### PR TITLE
Separated django login from heroku_demo.

### DIFF
--- a/docs/dev/install.rst
+++ b/docs/dev/install.rst
@@ -160,6 +160,8 @@ The following extra settings can be added to your ``.env`` file.
    Set your `Google Analytics key`_ to use Google Analytics.
 ``MOZILLIANS_API_KEY``
    Set your `Mozillians API key`_ to grant permission to Mozilla localizers.
+``DJANGO_LOGIN``
+   Set to True if you want to use the default Django login instead of Firefox Accounts. This will run allow you to log in via accounts created using `manage.py shell`.
 
 .. _Microsoft Translator API key: http://msdn.microsoft.com/en-us/library/hh454950
 .. _Google Analytics key: https://www.google.com/analytics/

--- a/pontoon/allauth_urls.py
+++ b/pontoon/allauth_urls.py
@@ -11,7 +11,7 @@ from allauth.compat import importlib
 from allauth.account import views as account_views
 from allauth.socialaccount import views as socialaccount_views, providers
 
-if settings.HEROKU_DEMO:
+if settings.DJANGO_LOGIN:
     urlpatterns = [
         url(r'^standalone-login/$', login, name='standalone_login'),
         url(r'^standalone-logout/$', logout, name='standalone_logout', kwargs={'next_page': '/'}),

--- a/pontoon/base/templates/django/base.html
+++ b/pontoon/base/templates/django/base.html
@@ -46,7 +46,7 @@
         <li><a href="{% url 'pontoon.terms' %}">Terms</a></li>
         <li><a href="https://developer.mozilla.org/en-US/docs/Localizing_with_Pontoon" target="_blank">Help</a></li>
         <li id="admin"{% if not perms.base.can_manage %} class="hidden"{% endif %}><a href="{% url "pontoon.admin" %}">Admin</a></li>
-        {% if settings.HEROKU_DEMO %}
+        {% if settings.DJANGO_LOGIN %}
             {% if not user.is_authenticated %}
                 <li id="standalone-sign-in"><a href="{% url 'standalone_login' %}">Sign in</a></li>
             {% else %}

--- a/pontoon/base/templates/landing.html
+++ b/pontoon/base/templates/landing.html
@@ -16,7 +16,7 @@
         <li><a href="{{ url('pontoon.terms') }}">Terms</a></li>
         <li><a href="https://developer.mozilla.org/docs/Mozilla/Localization/Localizing_with_Pontoon" target="_blank">Help</a></li>
         <li id="admin"{% if not perms.base.can_manage %} class="hidden"{% endif %}><a href="{{ url('pontoon.admin') }}">Admin</a></li>
-          {% if settings.HEROKU_DEMO %}
+          {% if settings.DJANGO_LOGIN %}
             {% if user.is_authenticated() %}
               <li id="standalone-sign-out"><a href="{{ url('standalone_logout') }}" title="{{ user.email|nospam }}">Sign out</a></li>
             {% else %}

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -125,7 +125,7 @@
             <li><a href="{{ url('pontoon.admin') }}">Admin</a></li>
             <li class="admin-current-project"><a href="">Admin &middot; Current Project</a></li>
             {% endif %}
-            {% if settings.HEROKU_DEMO %}
+            {% if settings.DJANGO_LOGIN %}
               {% if user.is_authenticated() %}
                 <li class="standalone-sign-out"><a href="{{ url('standalone_logout') }}"><i class="fa fa-sign-out fa-fw"></i> Sign Out</a></li>
               {% else %}

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -29,6 +29,8 @@ DEBUG = os.environ.get('DJANGO_DEBUG', 'False') != 'False'
 
 HEROKU_DEMO = os.environ.get('HEROKU_DEMO', 'False') != 'False'
 
+DJANGO_LOGIN = os.environ.get('DJANGO_LOGIN', 'False') != 'False' or HEROKU_DEMO
+
 ADMINS = MANAGERS = (
     (os.environ.get('ADMIN_NAME', ''),
      os.environ.get('ADMIN_EMAIL', '')),


### PR DESCRIPTION
@mathjazz I couldn't login via Fxa on my local/work machine. That's I decided to separate django login from the heroku demo.