### PR TITLE
Bug 1280686: L20n UI for simple strings, multiline strings and traits

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -1716,19 +1716,14 @@ class Entity(DirtyFieldsMixin, models.Model):
 
         if translations:
             translation = sorted(translations, key=lambda k: (k.approved, k.date), reverse=True)[0]
-            return {
-                'fuzzy': translation.fuzzy,
-                'string': translation.string,
-                'approved': translation.approved,
-                'pk': translation.pk
-            }
+            return translation.serialize()
 
         else:
             return {
                 'fuzzy': False,
                 'string': None,
                 'approved': False,
-                'pk': None
+                'pk': None,
             }
 
     @classmethod

--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -1406,6 +1406,169 @@ body > header aside p {
   font-size: 15px;
 }
 
+.ftl-area {
+  background: #272A2F;
+  display: none;
+  height: 20%;
+  line-height: 22px;
+  min-height: 100px;
+  overflow: auto;
+  padding: 10px;
+  text-align: left;
+  width: 100%;
+
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+#source-pane .ftl-area {
+  background: transparent;
+  border: none;
+  display: none;
+  height: auto;
+  min-height: 0;
+  padding: 0;
+}
+
+.ftl-area button {
+  background: transparent;
+  border: none;
+  color: #7BC876;
+  font-size: 12px;
+  margin-left: 3px;
+  padding: 0;
+  text-align: right;
+  width: 24%;
+}
+
+.ftl-area button:hover {
+  color: #EBEBEB;
+}
+
+.ftl-area ul {
+  list-style: none;
+  margin: 0;
+  text-align: left;
+}
+
+.ftl-area section .id {
+  font-weight: 300;
+  border: 1px solid #5E6475;
+  background: transparent;
+  color: #FFFFFF;
+  display: inline-block;
+  font-weight: normal;
+  margin: 2px 5px 2px 0;
+  padding: 0 4px;
+  position: relative;
+  width: calc(25% - 5px);
+
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+.ftl-area section .id.built-in,
+.ftl-area .main-value .id {
+  color: #AAAAAA;
+}
+
+.ftl-area section .id .stress {
+  color: #7BC876;
+}
+
+.ftl-area section .id sub {
+  color: #7BC876;
+  float: right;
+  font-size: 11px;
+  margin-top: 4px;
+  text-transform: uppercase;
+}
+
+.ftl-area .main-value .id .remove {
+  margin: 0;
+  right: -1px;
+  top: 0;
+}
+
+.ftl-area section .value {
+  float: right;
+  background: #FFFFFF;
+  width: 75%;
+  padding: 0 4px;
+  margin: 2px 0;
+  line-height: 24px;
+
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+#source-pane .ftl-area section .value {
+  background: transparent;
+  color: white;
+  padding: 0;
+}
+
+.ftl-area .attributes .value#accesskey {
+  margin-right: 3px;
+  padding: 0 4px;
+  text-align: center;
+  text-transform: uppercase;
+  width: 24px;
+}
+
+.ftl-area .accesskeys {
+  display: inline-block;
+  float: right;
+  margin: 2px 0;
+  width: calc(75% - 27px);
+}
+
+.ftl-area .accesskeys div {
+  border: 1px solid #5E6475;
+  background: #4D5967;
+  cursor: pointer;
+  display: inline-block;
+  height: 22px;
+  margin-right: 3px;
+  text-align: center;
+  vertical-align: top;
+  width: 20px;
+}
+
+.ftl-area .accesskeys div.active,
+.ftl-area .accesskeys div:hover {
+  border-color: #7BC876;
+}
+
+#ftl-area .attributes .template {
+  display: none;
+}
+
+.ftl-area .attributes .custom-attribute .wrapper {
+  position: relative;
+  width: calc(25% - 5px);
+}
+
+.ftl-area .attributes .custom-attribute .wrapper .id {
+  line-height: 22px;
+  padding-right: 15px;
+  width: 100%;
+}
+
+.ftl-area section sub.remove {
+  color: #AAAAAA;
+  cursor: pointer;
+  font-size: 14px;
+  padding: 4px;
+  position: absolute;
+  right: 0;
+  top: 3px;
+}
+
+.ftl-area section sub.remove:hover {
+  color: #7BC876;
+}
+
 #plural-tabs ul li {
   display: none;
   text-align: center;
@@ -1473,6 +1636,21 @@ body > header aside p {
   bottom: 10px;
   position: absolute;
   right: 10px;
+}
+
+#editor #single #ftl {
+  display: none; /* TODO: Remove once source view support is implemented */
+  color: #AAAAAA;
+  float: left;
+  font-size: 18px;
+  font-weight: bold;
+  line-height: 0;
+  padding: 10px 5px 10px 0;
+}
+
+#editor #single #ftl.active,
+#editor #single #ftl:hover {
+  color: #7BC876;
 }
 
 #translation-length {
@@ -1552,8 +1730,12 @@ body > header aside p {
   border: none;
   color: #EBEBEB;
   height: 40px;
-  padding: 10px 5px;
+  padding: 10px 3px;
   text-transform: uppercase;
+}
+
+#editor #single > menu button#add-attribute {
+  display: none;
 }
 
 #editor #single > menu button[id^="save"],
@@ -1563,7 +1745,7 @@ body > header aside p {
   color: #272A2F;
   font-weight: 600;
   margin-left: 10px;
-  padding: 10px 15px;
+  padding: 10px;
 }
 
 #editor #single > menu button[id^="save"].suggest {

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -1,0 +1,437 @@
+/* Public functions used across different files */
+var Pontoon = (function (my) {
+  return $.extend(true, my, {
+    fluent: {
+
+      /*
+       * Populate FTL translation area with existing data
+       */
+      renderEditor: function (translation) {
+        $('#ftl-area > .main-value').show().find('input').val('');
+        $('#ftl-area .attributes ul:first').empty();
+        $('#ftl-area > .main-value ul li:not(":first")').remove();
+
+        var self = this,
+            entity = Pontoon.getEditorEntity(),
+            isFTLplural = entity.isFTLplural,
+            translation = translation || entity.translation[0],
+            isTranslated = translation.pk,
+            entity_ast = FluentSyntax.parse(entity.original).body[0],
+            entityAttributes = [],
+            id, value;
+
+        var attributes = entity_ast.attributes;
+        if (isTranslated) {
+          var translation_ast = FluentSyntax.parse(translation.string).body[0];
+          attributes = translation_ast.attributes;
+        }
+
+        if (entity_ast.attributes) {
+          entityAttributes = $.map(entity_ast.attributes, function(item) {
+            return item.id.name;
+          });
+        }
+
+        // Plurals
+        if (isFTLplural) {
+          var pluralForms = $(Pontoon.locale.cldr_plurals).map(
+            function() {
+              return Pontoon.CLDR_PLURALS[this];
+            }
+          ).get();
+
+          $.each(pluralForms, function(i) {
+            var example = i === 3 ? 5 : i+1,
+                value = isTranslated ? self.serializePlaceables(translation_ast.value.elements[0].variants[i].value.elements) : '';
+            $('#ftl-area .main-value ul')
+              .append(
+                '<li class="clearfix">' +
+                  '<label class="id built-in" for="' + this + '">' +
+                    '<span>' + this + ' (e.g. </span><span class="stress">' + example + '</span>)<sub class="fa fa-remove remove" title="Remove"></sub>' +
+                  '</label>' +
+                  '<input class="value" id="' + this + '" type="text" value="' + value + '">' +
+                '</li>');
+          });
+
+          $('#entity-value').parents('li').hide();
+        }
+
+        // Attributes
+        if (!attributes) {
+          return;
+        }
+
+        $.each(attributes, function() {
+          id = this.id.name;
+          value = isTranslated ? this.value.elements[0].value : '';
+
+          var maxlength = label = input = cls = '';
+
+          if (id === 'accesskey') {
+            maxlength = '1';
+            input = '<div class="accesskeys"></div>';
+          }
+          input += '<input class="value" id="' + id + '" type="text" value="' + value + '" maxlength="' + maxlength + '">';
+
+          if ($.inArray(id, [entityAttributes])) {
+            label = '<label class="id" for="' + id + '">' +
+              '<span>' + id + '</span>' +
+            '</label>';
+
+          } else {
+            cls = ' class="custom-attribute clearfix"';
+            label = '<div class="wrapper">' +
+              '<input type="text" class="id" placeholder="enter-attribute-id" value="' + id + '">' +
+              '<sub class="fa fa-remove remove" title="Remove"></sub>' +
+            '</div>';
+          }
+
+          $('#ftl-area .attributes ul:first')
+            .append(
+              '<li' + cls + '>' +
+                label +
+                input +
+              '</li>');
+        });
+
+        // Update access keys presentaion
+        $('#ftl-area .attributes input').keyup();
+
+        // If no value in source string, no value in translation
+        if (!entity_ast.value) {
+          $('#ftl-area > .main-value').hide();
+        }
+
+        // Ignore editing for anonymous users
+        if (!Pontoon.user.id) {
+          $('#ftl-area input').prop('readonly', true);
+        }
+      },
+
+
+      /*
+       * Serialize value with placeables into a simple strings
+       */
+      serializePlaceables: function (elements) {
+        var translatedValue = '';
+
+        $.each(elements, function(i) {
+          if (this.type === 'TextElement') {
+            translatedValue += this.value;
+          } else if (this.type === 'ExternalArgument' || this.type === 'MessageReference') {
+            translatedValue += ('{' + this.id.name + '}');
+          }
+        });
+
+        return translatedValue;
+      },
+
+
+      /*
+       * Toggle FTL button
+       */
+      toggleButton: function () {
+        var entity = Pontoon.getEditorEntity();
+        $('#ftl').toggle(entity.format === 'ftl');
+      },
+
+
+      /*
+       * Toggle between standard and FTL translation editor
+       */
+      toggleEditor: function (activate) {
+        if (activate) {
+          $('#ftl-area').show();
+          // TODO: Uncomment once attributes are fully supported (defaults, removing, validation)
+          // $('#add-attribute').show();
+          $('#translation-length, #copy').hide();
+
+          $('#editor textarea').hide();
+          $('#ftl').addClass('active');
+
+          this.renderEditor();
+          $('#ftl-area input.value:visible:first').focus();
+
+        } else {
+          $('#ftl-area').hide();
+          // TODO: Uncomment once attributes are fully supported (defaults, removing, validation)
+          // $('#add-attribute').hide();
+          $('#translation-length, #copy').show();
+
+          $('#editor textarea').show().focus();
+          $('#ftl').removeClass('active');
+        }
+
+        Pontoon.moveCursorToBeginning();
+      },
+
+
+      /*
+       * Toggle between standard and FTL original string
+       */
+      toggleOriginal: function () {
+        var self = this,
+            entity = Pontoon.getEditorEntity();
+
+        if (entity.format !== 'ftl') {
+          return;
+        }
+
+        var ast = FluentSyntax.parse(entity.original).body[0],
+            original = '';
+
+        function renderOriginal(obj) {
+          if (entity.isFTLplural) {
+            var variants = ast.value.elements[0].variants;
+            $.each(variants, function() {
+              original += '<li><span class="id">' + (this.key.value || this.key.name) + '</span><span class="value">';
+              original += self.serializePlaceables(this.value.elements);
+              original += '</span></li>';
+            });
+
+          } else if (obj.attributes) {
+            var id, value;
+            $.each(obj.attributes, function() {
+              id = this.id.name;
+              value = this.value.elements[0].value;
+
+              $('#ftl-original .attributes ul')
+                .append(
+                  '<li>' +
+                    '<span class="id">' + id + '</span>' +
+                    '<span class="value">' + value + '</span>' +
+                  '</li>');
+            });
+          }
+        }
+
+        $('#ftl-original section ul').empty();
+
+        if (entity.isComplexFTL) {
+          $('#original').hide();
+          $('#ftl-original').show();
+
+          renderOriginal(ast);
+          $('#ftl-original .main-value ul').append(original);
+
+        } else {
+          $('#original').show();
+          $('#ftl-original').hide();
+        }
+      },
+
+
+      /*
+       * Get AST and any errors for the entity's translation
+       */
+      serializeTranslation: function(entity, translation) {
+        if (entity.format !== 'ftl') {
+          return translation;
+        }
+
+        if ($('#ftl').is('.active')) {
+          // Main value
+          var value = $('#ftl-area > .main-value input').val(),
+              attributes = '';
+
+          // Plurals
+          if (entity.isFTLplural) {
+            value = '{ ' + '$num ->';
+            var variants = $('#ftl-area .main-value li:visible');
+
+            variants.each(function(i) {
+              var id = $(this).find('.id span:first').html().split(' ')[0],
+                  val = $(this).find('.value').val(),
+                  def = (i === (variants.length - 1)) ? '*' : '';
+
+              if (id && val) {
+                value += '\n  ' + def + '[' + id + '] ' + val;
+              }
+            });
+
+            value += '\n  }';
+          }
+
+          // Attributes
+          $('#ftl-area .attributes ul:first li').each(function() {
+            var id = $(this).find('.id span').html() || $(this).find('.id').val(),
+                val = $(this).find('.value').val();
+
+            if (id && val) {
+              attributes += '\n  .' + id + ' = ' + val;
+            }
+          });
+
+          translation = (value ? ' = ' + value : '') + (attributes || '');
+
+        // Mark multiline strings with indent
+        } else if (translation.indexOf('\n') !== -1) {
+          translation = ' = \n  ' + translation.replace(/\n/g, '\n  ');
+
+        // Simple strings
+        } else {
+          translation = ' = ' + translation;
+        }
+
+        return entity.key + translation;
+      },
+
+
+      /*
+       * Get simplified preview of the FTL object
+       */
+      getSimplePreview: function(object, fallback, entity) {
+        var response = fallback;
+
+        if (entity.format === 'ftl') {
+          // Transfrom complex FTL-based strings into single-value strings
+          var source = object.original || object.string;
+
+          if (!source) {
+            return response;
+          }
+
+          ast = FluentSyntax.parse(source).body[0];
+
+          if (ast.value) {
+            response = ast.value.elements[0].value;
+
+          // Attributes
+          } else {
+            var attributes = ast.attributes;
+            if (attributes) {
+              response = attributes[0].value.elements[0].value;
+            }
+          }
+
+          // Plurals
+          if (ast.value && ast.value.elements && ast.value.elements[0].expression && ast.value.elements[0].variants) {
+            var variants = ast.value.elements[0].variants,
+                isFTLplural = variants.every(function(element) {
+                  var key = element.key.name,
+                      isPlural = Pontoon.CLDR_PLURALS.indexOf(key) !== -1,
+                      isInteger = element.key.type === 'NumberExpression';
+
+                  return isPlural || isInteger;
+                });
+
+            if (isFTLplural) {
+              response = variants[0].value.elements[0].value;
+              entity.isFTLplural = true;
+            }
+          }
+
+          // Mark complex strings
+          if (ast.attributes || (ast.value && ast.value.elements && ast.value.elements[0].expression && ast.value.elements[0].variants.length > 1)) {
+            object.isComplexFTL = true;
+
+          // Update entity and translation objects
+          } else {
+            if (object.hasOwnProperty('original')) {
+              object.original = object.marked = response;
+            } else if (object.hasOwnProperty('string')) {
+              object.string = response;
+            }
+          }
+        }
+
+        return response;
+      }
+
+    }
+  });
+}(Pontoon || {}));
+
+$(function() {
+
+  // Ignore editing for anonymous users
+  if (!Pontoon.user.id) {
+    return;
+  }
+
+  // Toggle FTL mode
+  $('#ftl').click(function (e) {
+    e.preventDefault();
+    Pontoon.fluent.toggleEditor(!$(this).is('.active'));
+  });
+
+  // Add attribute
+  $('#add-attribute').click(function (e) {
+    e.preventDefault();
+    $('#ftl-area .attributes ul:first').append($('#ftl-area .attributes .template li').clone());
+  });
+
+  // Remove attribute
+  $('#ftl-area section').on('click', 'sub.remove', function (e) {
+    e.preventDefault();
+    $(this).parents('li').remove();
+  });
+
+  // Generate access key list
+  $('#ftl-area .attributes').on('keyup', 'input:first', function() {
+    var active = $('.accesskeys').find('.active').html(),
+        unique = $(this).val().toUpperCase().split('').filter(function(item, i, ar) {
+          return ar.indexOf(item) === i;
+        });
+
+    $('.accesskeys').empty();
+
+    $.each(unique, function(i, v) {
+      $('.accesskeys').append('<div' + ((v === active) ? ' class="active"' : '') + '>' + v + '</div>');
+    });
+  });
+
+  // Select access key via click
+  $('#ftl-area .attributes').on('click', '.accesskeys div', function() {
+    var selected = $(this).is('.active');
+    $('.accesskeys div').removeClass('active');
+
+    if (!selected) {
+      $(this).addClass('active');
+    }
+
+    $('#accesskey').val($('.accesskeys div.active').html());
+  });
+
+  // Select access key via input
+  $('#ftl-area .attributes').on('keyup', '#accesskey', function() {
+    var accesskey = $(this).val().toUpperCase();
+
+    if (accesskey) {
+      $('.accesskeys div').removeClass('active');
+      $('.accesskeys div:contains("' + accesskey + '")').addClass('active');
+    }
+  });
+
+  // Clear translation area
+  $('#clear').click(function (e) {
+    e.preventDefault();
+
+    if ($('#ftl').is('.active')) {
+      var translation = {
+        pk: null,
+        string: ''
+      };
+
+      Pontoon.fluent.renderEditor(translation);
+      $('#ftl-area input.value:visible:first').focus();
+    }
+  });
+
+  // Copy helpers result to translation
+  $('#helpers section').on('click', 'li:not(".disabled")', function (e) {
+    e.preventDefault();
+
+    if ($('#ftl').is('.active')) {
+      var translation = {
+        pk: $(this).data('id'),
+        string: this.string
+      };
+
+      $('#translation').val(''); // Invalidate main copy from helpers action
+      Pontoon.fluent.renderEditor(translation);
+      $('#ftl-area input.value:visible:first').focus();
+    }
+  });
+
+});

--- a/pontoon/base/static/js/lib/fluent-syntax.js
+++ b/pontoon/base/static/js/lib/fluent-syntax.js
@@ -1,0 +1,1611 @@
+/* fluent-syntax@0.3.0 */
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+	typeof define === 'function' && define.amd ? define('fluent-syntax', ['exports'], factory) :
+	(factory((global.FluentSyntax = global.FluentSyntax || {})));
+}(this, (function (exports) { 'use strict';
+
+class Node {
+  constructor() {}
+}
+
+class Resource extends Node {
+  constructor(body = [], comment = null) {
+    super();
+    this.type = 'Resource';
+    this.body = body;
+    this.comment = comment;
+  }
+}
+
+class Entry extends Node {
+  constructor(span = null, annotations = []) {
+    super();
+    this.type = 'Entry';
+    this.span = span;
+    this.annotations = annotations;
+  }
+
+  addSpan(start, end) {
+    this.span = new Span(start, end);
+  }
+
+  addAnnotation(annot) {
+    this.annotations.push(annot);
+  }
+}
+
+class Message extends Entry {
+  constructor(
+    id, value = null, attributes = null, tags = null, comment = null,
+    span, annotations
+  ) {
+    super(span, annotations);
+    this.type = 'Message';
+    this.id = id;
+    this.value = value;
+    this.attributes = attributes;
+    this.tags = tags;
+    this.comment = comment;
+  }
+}
+
+class Pattern extends Node {
+  constructor(elements) {
+    super();
+    this.type = 'Pattern';
+    this.elements = elements;
+  }
+}
+
+class TextElement extends Node {
+  constructor(value) {
+    super();
+    this.type = 'TextElement';
+    this.value = value;
+  }
+}
+
+class Expression extends Node {
+  constructor() {
+    super();
+    this.type = 'Expression';
+  }
+}
+
+class StringExpression extends Expression {
+  constructor(value) {
+    super();
+    this.type = 'StringExpression';
+    this.value = value;
+  }
+}
+
+class NumberExpression extends Expression {
+  constructor(value) {
+    super();
+    this.type = 'NumberExpression';
+    this.value = value;
+  }
+}
+
+class MessageReference extends Expression {
+  constructor(id) {
+    super();
+    this.type = 'MessageReference';
+    this.id = id;
+  }
+}
+
+class ExternalArgument extends Expression {
+  constructor(id) {
+    super();
+    this.type = 'ExternalArgument';
+    this.id = id;
+  }
+}
+
+class SelectExpression extends Expression {
+  constructor(expression, variants) {
+    super();
+    this.type = 'SelectExpression';
+    this.expression = expression;
+    this.variants = variants;
+  }
+}
+
+class AttributeExpression extends Expression {
+  constructor(id, name) {
+    super();
+    this.type = 'AttributeExpression';
+    this.id = id;
+    this.name = name;
+  }
+}
+
+class VariantExpression extends Expression {
+  constructor(id, key) {
+    super();
+    this.type = 'VariantExpression';
+    this.id = id;
+    this.key = key;
+  }
+}
+
+class CallExpression extends Expression {
+  constructor(callee, args) {
+    super();
+    this.type = 'CallExpression';
+    this.callee = callee;
+    this.args = args;
+  }
+}
+
+class Attribute extends Node {
+  constructor(id, value) {
+    super();
+    this.type = 'Attribute';
+    this.id = id;
+    this.value = value;
+  }
+}
+
+class Tag extends Node {
+  constructor(name) {
+    super();
+    this.type = 'Tag';
+    this.name = name;
+  }
+}
+
+class Variant extends Node {
+  constructor(key, value, def = false) {
+    super();
+    this.type = 'Variant';
+    this.key = key;
+    this.value = value;
+    this.default = def;
+  }
+}
+
+class NamedArgument extends Node {
+  constructor(name, val) {
+    super();
+    this.type = 'NamedArgument';
+    this.name = name;
+    this.val = val;
+  }
+}
+
+class Identifier extends Node {
+  constructor(name) {
+    super();
+    this.type = 'Identifier';
+    this.name = name;
+  }
+}
+
+class Symbol$1 extends Identifier {
+  constructor(name) {
+    super(name);
+    this.type = 'Symbol';
+  }
+}
+
+class Comment extends Entry {
+  constructor(content, span, annotations) {
+    super(span, annotations);
+    this.type = 'Comment';
+    this.content = content;
+  }
+}
+
+class Section extends Entry {
+  constructor(name, comment = null, span, annotations) {
+    super(span, annotations);
+    this.type = 'Section';
+    this.name = name;
+    this.comment = comment;
+  }
+}
+
+class Function extends Identifier {
+  constructor(name) {
+    super(name);
+    this.type = 'Function';
+  }
+}
+
+class Junk extends Entry {
+  constructor(content, span, annotations) {
+    super(span, annotations);
+    this.type = 'Junk';
+    this.content = content;
+  }
+}
+
+class Span extends Node {
+  constructor(start, end) {
+    super();
+    this.type = 'Span';
+    this.start = start;
+    this.end = end;
+  }
+}
+
+class Annotation extends Node {
+  constructor(code, args = [], message) {
+    super();
+    this.type = 'Annotation';
+    this.code = code;
+    this.args = args;
+    this.message = message;
+  }
+
+  addSpan(start, end) {
+    this.span = new Span(start, end);
+  }
+}
+
+class ParserStream {
+  constructor(string) {
+    this.string = string;
+    this.iter = string[Symbol.iterator]();
+    this.buf = [];
+    this.peekIndex = 0;
+    this.index = 0;
+
+    this.iterEnd = false;
+    this.peekEnd = false;
+
+    this.ch = this.iter.next().value;
+  }
+
+  next() {
+    if (this.iterEnd) {
+      return undefined;
+    }
+
+    if (this.buf.length === 0) {
+      this.ch = this.iter.next().value;
+    } else {
+      this.ch = this.buf.shift();
+    }
+
+    this.index++;
+
+    if (this.ch === undefined) {
+      this.iterEnd = true;
+      this.peekEnd = true;
+    }
+
+    this.peekIndex = this.index;
+
+    return this.ch;
+  }
+
+  current() {
+    return this.ch;
+  }
+
+  currentIs(ch) {
+    return this.ch === ch;
+  }
+
+  currentPeek() {
+    if (this.peekEnd) {
+      return undefined;
+    }
+
+    const diff = this.peekIndex - this.index;
+
+    if (diff === 0) {
+      return this.ch;
+    }
+    return this.buf[diff - 1];
+  }
+
+  currentPeekIs(ch) {
+    return this.currentPeek() === ch;
+  }
+
+  peek() {
+    if (this.peekEnd) {
+      return undefined;
+    }
+
+    this.peekIndex += 1;
+
+    const diff = this.peekIndex - this.index;
+
+    if (diff > this.buf.length) {
+      const ch = this.iter.next().value;
+      if (ch !== undefined) {
+        this.buf.push(ch);
+      } else {
+        this.peekEnd = true;
+        return undefined;
+      }
+    }
+
+    return this.buf[diff - 1];
+  }
+
+  getIndex() {
+    return this.index;
+  }
+
+  getPeekIndex() {
+    return this.peekIndex;
+  }
+
+  peekCharIs(ch) {
+    if (this.peekEnd) {
+      return false;
+    }
+
+    const ret = this.peek();
+
+    this.peekIndex -= 1;
+
+    return ret === ch;
+  }
+
+  resetPeek() {
+    this.peekIndex = this.index;
+    this.peekEnd = this.iterEnd;
+  }
+
+  skipToPeek() {
+    const diff = this.peekIndex - this.index;
+
+    for (let i = 0; i < diff; i++) {
+      this.ch = this.buf.shift();
+    }
+
+    this.index = this.peekIndex;
+  }
+
+  getSlice(start, end) {
+    return this.string.substring(start, end);
+  }
+}
+
+class ParseError extends Error {
+  constructor(code, ...args) {
+    super();
+    this.code = code;
+    this.args = args;
+    this.message = getErrorMessage(code, args);
+  }
+}
+
+function getErrorMessage(code, args) {
+  switch (code) {
+    case 'E0001':
+      return 'Generic error';
+    case 'E0002':
+      return 'Expected an entry start';
+    case 'E0003': {
+      const [token] = args;
+      return `Expected token: "${token}"`;
+    }
+    case 'E0004': {
+      const [range] = args;
+      return `Expected a character from range: "${range}"`;
+    }
+    case 'E0005': {
+      const [id] = args;
+      return `Expected entry "${id}" to have a value, attributes or tags`;
+    }
+    case 'E0006': {
+      const [field] = args;
+      return `Expected field: "${field}"`;
+    }
+    case 'E0007':
+      return 'Keyword cannot end with a whitespace';
+    case 'E0008':
+      return 'Callee has to be a simple identifier';
+    case 'E0009':
+      return 'Key has to be a simple identifier';
+    case 'E0010':
+      return 'Expected one of the variants to be marked as default (*)';
+    case 'E0011':
+      return 'Expected at least one variant after "->"';
+    case 'E0012':
+      return 'Tags cannot be added to messages with attributes';
+    case 'E0013':
+      return 'Expected variant key';
+    case 'E0014':
+      return 'Expected literal';
+    case 'E0015':
+      return 'Only one variant can be marked as default (*)';
+    default:
+      return code;
+  }
+}
+
+/* eslint no-magic-numbers: "off" */
+
+class FTLParserStream extends ParserStream {
+  peekLineWS() {
+    let ch = this.currentPeek();
+    while (ch) {
+      if (ch !== ' ' && ch !== '\t') {
+        break;
+      }
+      ch = this.peek();
+    }
+  }
+
+  skipWSLines() {
+    while (true) {
+      this.peekLineWS();
+
+      if (this.currentPeek() === '\n') {
+        this.skipToPeek();
+        this.next();
+      } else {
+        this.resetPeek();
+        break;
+      }
+    }
+  }
+
+  skipLineWS() {
+    while (this.ch) {
+      if (this.ch !== ' ' && this.ch !== '\t') {
+        break;
+      }
+      this.next();
+    }
+  }
+
+  expectChar(ch) {
+    if (this.ch === ch) {
+      this.next();
+      return true;
+    }
+
+    if (ch === '\n') {
+      // Unicode Character 'SYMBOL FOR NEWLINE' (U+2424)
+      throw new ParseError('E0003', '\u2424');
+    }
+
+    throw new ParseError('E0003', ch);
+  }
+
+  takeCharIf(ch) {
+    if (this.ch === ch) {
+      this.next();
+      return true;
+    }
+    return false;
+  }
+
+  takeChar(f) {
+    const ch = this.ch;
+    if (ch !== undefined && f(ch)) {
+      this.next();
+      return ch;
+    }
+    return undefined;
+  }
+
+  isIDStart() {
+    if (this.ch === undefined) {
+      return false;
+    }
+
+    const cc = this.ch.charCodeAt(0);
+    return ((cc >= 97 && cc <= 122) || // a-z
+            (cc >= 65 && cc <= 90) ||  // A-Z
+             cc === 95);               // _
+  }
+
+  isNumberStart() {
+    const cc = this.ch.charCodeAt(0);
+    return ((cc >= 48 && cc <= 57) || cc === 45); // 0-9
+  }
+
+  isPeekNextLineIndented() {
+    if (!this.currentPeekIs('\n')) {
+      return false;
+    }
+
+    this.peek();
+
+    if (this.currentPeekIs(' ')) {
+      this.resetPeek();
+      return true;
+    }
+
+    this.resetPeek();
+    return false;
+  }
+
+  isPeekNextLineVariantStart() {
+    if (!this.currentPeekIs('\n')) {
+      return false;
+    }
+
+    this.peek();
+
+    const ptr = this.getPeekIndex();
+
+    this.peekLineWS();
+
+    if (this.getPeekIndex() - ptr === 0) {
+      this.resetPeek();
+      return false;
+    }
+
+    if (this.currentPeekIs('*')) {
+      this.peek();
+    }
+
+    if (this.currentPeekIs('[') && !this.peekCharIs('[')) {
+      this.resetPeek();
+      return true;
+    }
+    this.resetPeek();
+    return false;
+  }
+
+  isPeekNextLineAttributeStart() {
+    if (!this.currentPeekIs('\n')) {
+      return false;
+    }
+
+    this.peek();
+
+    const ptr = this.getPeekIndex();
+
+    this.peekLineWS();
+
+    if (this.getPeekIndex() - ptr === 0) {
+      this.resetPeek();
+      return false;
+    }
+
+    if (this.currentPeekIs('.')) {
+      this.resetPeek();
+      return true;
+    }
+
+    this.resetPeek();
+    return false;
+  }
+
+  isPeekNextLinePattern() {
+    if (!this.currentPeekIs('\n')) {
+      return false;
+    }
+
+    this.peek();
+
+    const ptr = this.getPeekIndex();
+
+    this.peekLineWS();
+
+    if (this.getPeekIndex() - ptr === 0) {
+      this.resetPeek();
+      return false;
+    }
+
+    if (this.currentPeekIs('}') ||
+        this.currentPeekIs('.') ||
+        this.currentPeekIs('#') ||
+        this.currentPeekIs('[') ||
+        this.currentPeekIs('*') ||
+        this.currentPeekIs('{')) {
+      this.resetPeek();
+      return false;
+    }
+
+    this.resetPeek();
+    return true;
+  }
+
+  isPeekNextLineTagStart() {
+    if (!this.currentPeekIs('\n')) {
+      return false;
+    }
+
+    this.peek();
+
+    const ptr = this.getPeekIndex();
+
+    this.peekLineWS();
+
+    if (this.getPeekIndex() - ptr === 0) {
+      this.resetPeek();
+      return false;
+    }
+
+    if (this.currentPeekIs('#')) {
+      this.resetPeek();
+      return true;
+    }
+
+    this.resetPeek();
+    return false;
+  }
+
+  skipToNextEntryStart() {
+    while (this.next()) {
+      if (this.currentIs('\n') && !this.peekCharIs('\n')) {
+        this.next();
+        if (this.ch === undefined || this.isIDStart() ||
+            (this.currentIs('/') && this.peekCharIs('/')) ||
+            (this.currentIs('[') && this.peekCharIs('['))) {
+          break;
+        }
+      }
+    }
+  }
+
+  takeIDStart() {
+    if (this.isIDStart()) {
+      const ret = this.ch;
+      this.next();
+      return ret;
+    }
+    throw new ParseError('E0004', 'a-zA-Z');
+  }
+
+  takeIDChar() {
+    const closure = ch => {
+      const cc = ch.charCodeAt(0);
+      return ((cc >= 97 && cc <= 122) || // a-z
+              (cc >= 65 && cc <= 90) || // A-Z
+              (cc >= 48 && cc <= 57) || // 0-9
+               cc === 95 || cc === 45);  // _-
+    };
+
+    return this.takeChar(closure);
+  }
+
+  takeSymbChar() {
+    const closure = ch => {
+      if (ch === undefined) {
+        return false;
+      }
+
+      const cc = ch.charCodeAt(0);
+      return ((cc >= 97 && cc <= 122) || // a-z
+              (cc >= 65 && cc <= 90) || // A-Z
+              (cc >= 48 && cc <= 57) || // 0-9
+               cc === 95 || cc === 45 || cc === 32);  // _-
+    };
+
+    return this.takeChar(closure);
+  }
+
+  takeDigit() {
+    const closure = ch => {
+      const cc = ch.charCodeAt(0);
+      return (cc >= 48 && cc <= 57); // 0-9
+    };
+
+    return this.takeChar(closure);
+  }
+}
+
+/*  eslint no-magic-numbers: [0]  */
+
+function parse(source) {
+  let comment = null;
+
+  const ps = new FTLParserStream(source);
+  ps.skipWSLines();
+
+  const entries = [];
+
+  while (ps.current()) {
+    const entry = getEntryOrJunk(ps);
+
+    if (entry.type === 'Comment' && entries.length === 0) {
+      comment = entry;
+    } else {
+      entries.push(entry);
+    }
+
+    ps.skipWSLines();
+  }
+
+  return new Resource(entries, comment);
+}
+
+function parseEntry(source) {
+  const ps = new FTLParserStream(source);
+  ps.skipWSLines();
+  return getEntryOrJunk(ps);
+}
+
+function getEntryOrJunk(ps) {
+  const entryStartPos = ps.getIndex();
+
+  try {
+    const entry = getEntry(ps);
+    entry.addSpan(entryStartPos, ps.getIndex());
+    return entry;
+  } catch (err) {
+    if (!(err instanceof ParseError)) {
+      throw err;
+    }
+
+    const annot = new Annotation(err.code, err.args, err.message);
+    annot.addSpan(ps.getIndex(), ps.getIndex());
+
+    ps.skipToNextEntryStart();
+    const nextEntryStart = ps.getIndex();
+
+    // Create a Junk instance
+    const slice = ps.getSlice(entryStartPos, nextEntryStart);
+    const junk = new Junk(slice);
+    junk.addSpan(entryStartPos, nextEntryStart);
+    junk.addAnnotation(annot);
+    return junk;
+  }
+}
+
+function getEntry(ps) {
+  let comment;
+
+  if (ps.currentIs('/')) {
+    comment = getComment(ps);
+  }
+
+  if (ps.currentIs('[')) {
+    return getSection(ps, comment);
+  }
+
+  if (ps.isIDStart()) {
+    return getMessage(ps, comment);
+  }
+
+  if (comment) {
+    return comment;
+  }
+  throw new ParseError('E0002');
+}
+
+function getComment(ps) {
+  ps.expectChar('/');
+  ps.expectChar('/');
+  ps.takeCharIf(' ');
+
+  let content = '';
+
+  while (true) {
+    let ch;
+    while ((ch = ps.takeChar(x => x !== '\n'))) {
+      content += ch;
+    }
+
+    ps.next();
+
+    if (ps.current() === '/') {
+      content += '\n';
+      ps.next();
+      ps.expectChar('/');
+      ps.takeCharIf(' ');
+    } else {
+      break;
+    }
+  }
+  return new Comment(content);
+}
+
+function getSection(ps, comment) {
+  ps.expectChar('[');
+  ps.expectChar('[');
+
+  ps.skipLineWS();
+
+  const symb = getSymbol(ps);
+
+  ps.skipLineWS();
+
+  ps.expectChar(']');
+  ps.expectChar(']');
+
+  ps.skipLineWS();
+
+  ps.expectChar('\n');
+
+  return new Section(symb, comment);
+}
+
+function getMessage(ps, comment) {
+  const id = getIdentifier(ps);
+
+  ps.skipLineWS();
+
+  let pattern;
+  let attrs;
+  let tags;
+
+  if (ps.currentIs('=')) {
+    ps.next();
+    ps.skipLineWS();
+
+    pattern = getPattern(ps);
+  }
+
+  if (ps.isPeekNextLineAttributeStart()) {
+    attrs = getAttributes(ps);
+  }
+
+  if (ps.isPeekNextLineTagStart()) {
+    if (attrs !== undefined) {
+      throw new ParseError('E0012');
+    }
+    tags = getTags(ps);
+  }
+
+  if (pattern === undefined && attrs === undefined && tags === undefined) {
+    throw new ParseError('E0005', id.name);
+  }
+
+  return new Message(id, pattern, attrs, tags, comment);
+}
+
+function getAttributes(ps) {
+  const attrs = [];
+
+  while (true) {
+    ps.expectChar('\n');
+    ps.skipLineWS();
+
+    ps.expectChar('.');
+
+    const key = getIdentifier(ps);
+
+    ps.skipLineWS();
+
+    ps.expectChar('=');
+
+    ps.skipLineWS();
+
+    const value = getPattern(ps);
+
+    if (value === undefined) {
+      throw new ParseError('E0006', 'value');
+    }
+
+    attrs.push(new Attribute(key, value));
+
+    if (!ps.isPeekNextLineAttributeStart()) {
+      break;
+    }
+  }
+  return attrs;
+}
+
+function getTags(ps) {
+  const tags = [];
+
+  while (true) {
+    ps.expectChar('\n');
+    ps.skipLineWS();
+
+    ps.expectChar('#');
+
+    const symbol = getSymbol(ps);
+
+    tags.push(new Tag(symbol));
+
+    if (!ps.isPeekNextLineTagStart()) {
+      break;
+    }
+  }
+  return tags;
+}
+
+function getIdentifier(ps) {
+  let name = '';
+
+  name += ps.takeIDStart();
+
+  let ch;
+  while ((ch = ps.takeIDChar())) {
+    name += ch;
+  }
+
+  return new Identifier(name);
+}
+
+function getVariantKey(ps) {
+  const ch = ps.current();
+
+  if (!ch) {
+    throw new ParseError('E0013');
+  }
+
+  const cc = ch.charCodeAt(0);
+
+  if ((cc >= 48 && cc <= 57) || cc === 45) { // 0-9, -
+    return getNumber(ps);
+  }
+
+  return getSymbol(ps);
+}
+
+function getVariants(ps) {
+  const variants = [];
+  let hasDefault = false;
+
+  while (true) {
+    let defaultIndex = false;
+
+    ps.expectChar('\n');
+    ps.skipLineWS();
+
+    if (ps.currentIs('*')) {
+      if (hasDefault) {
+        throw new ParseError('E0015');
+      }
+      ps.next();
+      defaultIndex = true;
+      hasDefault = true;
+    }
+
+    ps.expectChar('[');
+
+    const key = getVariantKey(ps);
+
+    ps.expectChar(']');
+
+    ps.skipLineWS();
+
+    const value = getPattern(ps);
+
+    if (!value) {
+      throw new ParseError('E0006', 'value');
+    }
+
+    variants.push(new Variant(key, value, defaultIndex));
+
+    if (!ps.isPeekNextLineVariantStart()) {
+      break;
+    }
+  }
+
+  if (!hasDefault) {
+    throw new ParseError('E0010');
+  }
+
+  return variants;
+}
+
+function getSymbol(ps) {
+  let name = '';
+
+  name += ps.takeIDStart();
+
+  while (true) {
+    const ch = ps.takeSymbChar();
+    if (ch) {
+      name += ch;
+    } else {
+      break;
+    }
+  }
+
+  return new Symbol$1(name.trimRight());
+}
+
+function getDigits(ps) {
+  let num = '';
+
+  let ch;
+  while ((ch = ps.takeDigit())) {
+    num += ch;
+  }
+
+  if (num.length === 0) {
+    throw new ParseError('E0004', '0-9');
+  }
+
+  return num;
+}
+
+function getNumber(ps) {
+  let num = '';
+
+  if (ps.currentIs('-')) {
+    num += '-';
+    ps.next();
+  }
+
+  num = `${num}${getDigits(ps)}`;
+
+  if (ps.currentIs('.')) {
+    num += '.';
+    ps.next();
+    num = `${num}${getDigits(ps)}`;
+  }
+
+  return new NumberExpression(num);
+}
+
+function getPattern(ps) {
+  let buffer = '';
+  const elements = [];
+  let firstLine = true;
+
+  let ch;
+  while ((ch = ps.current())) {
+    if (ch === '\n') {
+      if (firstLine && buffer.length !== 0) {
+        break;
+      }
+
+      if (!ps.isPeekNextLinePattern()) {
+        break;
+      }
+
+      ps.next();
+      ps.skipLineWS();
+
+      firstLine = false;
+
+      if (buffer.length !== 0) {
+        buffer += ch;
+      }
+      continue;
+    } else if (ch === '\\') {
+      const ch2 = ps.peek();
+      if (ch2 === '{' || ch2 === '"') {
+        buffer += ch2;
+      } else {
+        buffer += ch + ch2;
+      }
+      ps.next();
+    } else if (ch === '{') {
+      ps.next();
+
+      ps.skipLineWS();
+
+      if (buffer.length !== 0) {
+        elements.push(new TextElement(buffer));
+      }
+
+      buffer = '';
+
+      elements.push(getExpression(ps));
+
+      ps.expectChar('}');
+
+      continue;
+    } else {
+      buffer += ps.ch;
+    }
+    ps.next();
+  }
+
+  if (buffer.length !== 0) {
+    elements.push(new TextElement(buffer));
+  }
+
+  return new Pattern(elements);
+}
+
+function getExpression(ps) {
+  if (ps.isPeekNextLineVariantStart()) {
+    const variants = getVariants(ps);
+
+    ps.expectChar('\n');
+    ps.expectChar(' ');
+    ps.skipLineWS();
+
+    return new SelectExpression(null, variants);
+  }
+
+  const selector = getSelectorExpression(ps);
+
+  ps.skipLineWS();
+
+  if (ps.currentIs('-')) {
+    ps.peek();
+    if (!ps.currentPeekIs('>')) {
+      ps.resetPeek();
+    } else {
+      ps.next();
+      ps.next();
+
+      ps.skipLineWS();
+
+      const variants = getVariants(ps);
+
+      if (variants.length === 0) {
+        throw new ParseError('E0011');
+      }
+
+      ps.expectChar('\n');
+      ps.expectChar(' ');
+      ps.skipLineWS();
+
+      return new SelectExpression(selector, variants);
+    }
+  }
+
+  return selector;
+}
+
+function getSelectorExpression(ps) {
+  const literal = getLiteral(ps);
+
+  if (literal.type !== 'MessageReference') {
+    return literal;
+  }
+
+  const ch = ps.current();
+
+  if (ch === '.') {
+    ps.next();
+
+    const attr = getIdentifier(ps);
+    return new AttributeExpression(literal.id, attr);
+  }
+
+  if (ch === '[') {
+    ps.next();
+
+    const key = getVariantKey(ps);
+
+    ps.expectChar(']');
+
+    return new VariantExpression(literal.id, key);
+  }
+
+  if (ch === '(') {
+    ps.next();
+
+    const args = getCallArgs(ps);
+
+    ps.expectChar(')');
+
+    return new CallExpression(literal.id, args);
+  }
+
+  return literal;
+}
+
+function getCallArgs(ps) {
+  const args = [];
+
+  ps.skipLineWS();
+
+  while (true) {
+    if (ps.current() === ')') {
+      break;
+    }
+
+    const exp = getSelectorExpression(ps);
+
+    ps.skipLineWS();
+
+    if (ps.current() === ':') {
+      if (exp.type !== 'MessageReference') {
+        throw new ParseError('E0009');
+      }
+
+      ps.next();
+      ps.skipLineWS();
+
+      const val = getArgVal(ps);
+
+      args.push(new NamedArgument(exp.id, val));
+    } else {
+      args.push(exp);
+    }
+
+    ps.skipLineWS();
+
+    if (ps.current() === ',') {
+      ps.next();
+      ps.skipLineWS();
+      continue;
+    } else {
+      break;
+    }
+  }
+  return args;
+}
+
+function getArgVal(ps) {
+  if (ps.isNumberStart()) {
+    return getNumber(ps);
+  } else if (ps.currentIs('"')) {
+    return getString(ps);
+  }
+  throw new ParseError('E0006', 'value');
+}
+
+function getString(ps) {
+  let val = '';
+
+  ps.expectChar('"');
+
+  let ch;
+  while ((ch = ps.takeChar(x => x !== '"'))) {
+    val += ch;
+  }
+
+  ps.next();
+
+  return new StringExpression(val);
+
+}
+
+function getLiteral(ps) {
+  const ch = ps.current();
+
+  if (!ch) {
+    throw new ParseError('E0014');
+  }
+
+  if (ps.isNumberStart()) {
+    return getNumber(ps);
+  } else if (ch === '"') {
+    return getString(ps);
+  } else if (ch === '$') {
+    ps.next();
+    const name = getIdentifier(ps);
+    return new ExternalArgument(name);
+  }
+
+  const name = getIdentifier(ps);
+  return new MessageReference(name);
+}
+
+function indent(content) {
+  return content.split('\n').join('\n    ');
+}
+
+
+function containNewLine(elems) {
+  const withNewLine = elems.filter(
+    elem => (elem.type === 'TextElement' && elem.value.includes('\n'))
+  );
+  return !!withNewLine.length;
+}
+
+
+function serialize(resource, withJunk = false) {
+  const parts = [];
+
+  if (resource.comment) {
+    parts.push(
+      `${serializeComment(resource.comment)}\n\n`
+    );
+  }
+
+  for (const entry of resource.body) {
+    if (entry.types !== 'Junk' || withJunk) {
+      parts.push(serializeEntry(entry));
+    }
+  }
+
+  return parts.join('');
+}
+
+
+function serializeEntry(entry) {
+  switch (entry.type) {
+    case 'Message':
+      return serializeMessage(entry);
+    case 'Section':
+      return serializeSection(entry);
+    case 'Comment':
+      return serializeComment(entry);
+    case 'Junk':
+      return serializeJunk(entry);
+    default :
+      throw new Error(`Unknown entry type: ${entry.type}`);
+  }
+}
+
+
+function serializeComment(comment) {
+  return comment.content.split('\n').map(
+    line => `// ${line}`
+  ).join('\n');
+}
+
+
+function serializeSection(section) {
+  const name = serializeSymbol(section.name);
+
+  if (section.comment) {
+    const comment = serializeComment(section.comment);
+    return `\n\n${comment}\n[[ ${name} ]]\n\n`;
+  }
+
+  return `\n\n[[ ${name} ]]\n\n`;
+}
+
+
+function serializeJunk(junk) {
+  return junk.content;
+}
+
+
+function serializeMessage(message) {
+  const parts = [];
+
+  if (message.comment) {
+    parts.push(serializeComment(message.comment));
+    parts.push('\n');
+  }
+
+  parts.push(serializeIdentifier(message.id));
+
+  if (message.value) {
+    parts.push(' =');
+    parts.push(serializeValue(message.value));
+  }
+
+  if (message.tags) {
+    for (const tag of message.tags) {
+      parts.push(serializeTag(tag));
+    }
+  }
+
+  if (message.attributes) {
+    for (const attribute of message.attributes) {
+      parts.push(serializeAttribute(attribute));
+    }
+  }
+
+  parts.push('\n');
+  return parts.join('');
+}
+
+
+function serializeTag(tag) {
+  const name = serializeSymbol(tag.name);
+  return `\n    #${name}`;
+}
+
+
+function serializeAttribute(attribute) {
+  const id = serializeIdentifier(attribute.id);
+  const value = indent(serializeValue(attribute.value));
+  return `\n    .${id} =${value}`;
+}
+
+
+function serializeValue(pattern) {
+  const content = indent(serializePattern(pattern));
+  const multi = containNewLine(pattern.elements);
+
+  if (multi) {
+    return `\n    ${content}`;
+  }
+
+  return ` ${content}`;
+}
+
+
+function serializePattern(pattern) {
+  return pattern.elements.map(serializeElement).join('');
+}
+
+
+function serializeElement(element) {
+  switch (element.type) {
+    case 'TextElement':
+      return serializeTextElement(element);
+    case 'SelectExpression':
+      return `{${serializeSelectExpression(element)}}`;
+    default:
+      return `{ ${serializeExpression(element)} }`;
+  }
+}
+
+
+function serializeTextElement(text) {
+  return text.value;
+}
+
+
+function serializeExpression(expr) {
+  switch (expr.type) {
+    case 'StringExpression':
+      return serializeStringExpression(expr);
+    case 'NumberExpression':
+      return serializeNumberExpression(expr);
+    case 'MessageReference':
+      return serializeMessageReference(expr);
+    case 'ExternalArgument':
+      return serializeExternalArgument(expr);
+    case 'AttributeExpression':
+      return serializeAttributeExpression(expr);
+    case 'VariantExpression':
+      return serializeVariantExpression(expr);
+    case 'CallExpression':
+      return serializeCallExpression(expr);
+    default:
+      throw new Error(`Unknown expression type: ${expr.type}`);
+  }
+}
+
+
+function serializeStringExpression(expr) {
+  return `"${expr.value}"`;
+}
+
+
+function serializeNumberExpression(expr) {
+  return expr.value;
+}
+
+
+function serializeMessageReference(expr) {
+  return serializeIdentifier(expr.id);
+}
+
+
+function serializeExternalArgument(expr) {
+  return `$${serializeIdentifier(expr.id)}`;
+}
+
+
+function serializeSelectExpression(expr) {
+  const parts = [];
+
+  if (expr.expression) {
+    const selector = ` ${serializeExpression(expr.expression)} ->`;
+    parts.push(selector);
+  }
+
+  for (const variant of expr.variants) {
+    parts.push(serializeVariant(variant));
+  }
+
+  parts.push('\n');
+  return parts.join('');
+}
+
+
+function serializeVariant(variant) {
+  const key = serializeVariantKey(variant.key);
+  const value = indent(serializeValue(variant.value));
+
+  if (variant.default) {
+    return `\n   *[${key}]${value}`;
+  }
+
+  return `\n    [${key}]${value}`;
+}
+
+
+function serializeAttributeExpression(expr) {
+  const id = serializeIdentifier(expr.id);
+  const name = serializeIdentifier(expr.name);
+  return `${id}.${name}`;
+}
+
+
+function serializeVariantExpression(expr) {
+  const id = serializeIdentifier(expr.id);
+  const key = serializeVariantKey(expr.key);
+  return `${id}[${key}]`;
+}
+
+
+function serializeCallExpression(expr) {
+  const fun = serializeFunction(expr.callee);
+  const args = expr.args.map(serializeCallArgument).join(', ');
+  return `${fun}(${args})`;
+}
+
+
+function serializeCallArgument(arg) {
+  switch (arg.type) {
+    case 'NamedArgument':
+      return serializeNamedArgument(arg);
+    default:
+      return serializeExpression(arg);
+  }
+}
+
+
+function serializeNamedArgument(arg) {
+  const name = serializeIdentifier(arg.name);
+  const value = serializeArgumentValue(arg.val);
+  return `${name}: ${value}`;
+}
+
+
+function serializeArgumentValue(argval) {
+  switch (argval.type) {
+    case 'StringExpression':
+      return serializeStringExpression(argval);
+    case 'NumberExpression':
+      return serializeNumberExpression(argval);
+    default:
+      throw new Error(`Unknown argument type: ${argval.type}`);
+  }
+}
+
+
+function serializeIdentifier(identifier) {
+  return identifier.name;
+}
+
+
+function serializeSymbol(symbol) {
+  return symbol.name;
+}
+
+
+function serializeVariantKey(key) {
+  switch (key.type) {
+    case 'Symbol':
+      return serializeSymbol(key);
+    case 'NumberExpression':
+      return serializeNumberExpression(key);
+    default:
+      throw new Error(`Unknown variant key type: ${key.type}`);
+  }
+}
+
+
+function serializeFunction(fun) {
+  return fun.name;
+}
+
+function lineOffset(source, pos) {
+  // Substract 1 to get the offset.
+  return source.substring(0, pos).split('\n').length - 1;
+}
+
+function columnOffset(source, pos) {
+  const lastLineBreak = source.lastIndexOf('\n', pos);
+  return lastLineBreak === -1
+    ? pos
+    // Substracting two offsets gives length; substract 1 to get the offset.
+    : pos - lastLineBreak - 1;
+}
+
+exports.lineOffset = lineOffset;
+exports.columnOffset = columnOffset;
+exports.Resource = Resource;
+exports.Entry = Entry;
+exports.Message = Message;
+exports.Pattern = Pattern;
+exports.TextElement = TextElement;
+exports.Expression = Expression;
+exports.StringExpression = StringExpression;
+exports.NumberExpression = NumberExpression;
+exports.MessageReference = MessageReference;
+exports.ExternalArgument = ExternalArgument;
+exports.SelectExpression = SelectExpression;
+exports.AttributeExpression = AttributeExpression;
+exports.VariantExpression = VariantExpression;
+exports.CallExpression = CallExpression;
+exports.Attribute = Attribute;
+exports.Tag = Tag;
+exports.Variant = Variant;
+exports.NamedArgument = NamedArgument;
+exports.Identifier = Identifier;
+exports.Symbol = Symbol$1;
+exports.Comment = Comment;
+exports.Section = Section;
+exports.Function = Function;
+exports.Junk = Junk;
+exports.Span = Span;
+exports.Annotation = Annotation;
+exports.parse = parse;
+exports.parseEntry = parseEntry;
+exports.serialize = serialize;
+exports.serializeEntry = serializeEntry;
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+})));

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -251,7 +251,17 @@
 
       <div id="source-pane">
           <h2></h2>
+
           <p id="original"></p>
+          <div id="ftl-original" class="ftl-area">
+            <section class="main-value">
+              <ul></ul>
+            </section>
+            <section class="attributes">
+              <ul></ul>
+            </section>
+          </div>
+
           <div id="metadata"></div>
           <div id="screenshots"></div>
       </div>
@@ -269,6 +279,31 @@
 
       <textarea {% if not user.is_authenticated() %} readonly {% endif %} id="translation" placeholder="Type translation and press Enter to save"></textarea>
 
+      <div id="ftl-area" class="ftl-area">
+        <section class="main-value">
+          <ul>
+            <li>
+              <label class="id" for="entity-value">
+                <span>Value</span>
+              </label>
+              <input type="text" id="entity-value" class="value" placeholder="Enter translation"></li>
+            </li>
+          </ul>
+        </section>
+        <section class="attributes">
+          <ul></ul>
+          <ul class="template">
+            <li class="custom-attribute clearfix">
+              <div class="wrapper">
+                <input type="text" class="id" placeholder="enter-attribute-id">
+                <sub class="fa fa-remove remove" title="Remove"></sub>
+              </div>
+              <input type="text" class="value" placeholder="Enter attribute value">
+            </li>
+          </ul>
+        </section>
+      </div>
+
       <menu>
         {% if user.is_authenticated() %}
           <div id="unsaved" class="warning-overlay">
@@ -283,6 +318,8 @@
             <ul></ul>
             <button id="save-anyway"></button>
           </div>
+
+          <button id="ftl" title="Toggle between simple and advanced FTL mode">FTL</button>
 
           <!-- Settings -->
           <div id="settings" class="select">
@@ -325,6 +362,7 @@
             <span class="current-length"></span>|<span class="original-length"></span>
           </div>
 
+          <button id="add-attribute" title="Add attribute">+Attribute</button>
           <button id="copy" title="Copy From Source (Ctrl + Shift + C)">Copy</button>
           <button id="clear" title="Clear Translation (Ctrl + Shift + Backspace)">Clear</button>
           <button id="save" title="Save Translation (Enter)"></button>
@@ -470,5 +508,7 @@
 {% endblock %}
 
 {% block extend_js %}
+  <!-- TODO: integrate into django-pipeline -->
+  <script type="text/javascript" src="{{ static('js/lib/fluent-syntax.js') }}"></script>
   {% javascript 'translate' %}
 {% endblock %}

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -403,19 +403,17 @@ def get_translation_history(request):
 
     for t in translations:
         u = t.user
-        payload.append({
-            "id": t.id,
+        translation_dict = t.serialize()
+        translation_dict.update({
             "user": "Imported" if u is None else u.name_or_email,
             "uid": "" if u is None else u.id,
             "username": "" if u is None else u.username,
-            "translation": t.string,
             "date": t.date.strftime('%b %d, %Y %H:%M'),
             "date_iso": t.date.isoformat() + offset,
-            "approved": t.approved,
             "approved_user": User.display_name_or_blank(t.approved_user),
             "unapproved_user": User.display_name_or_blank(t.unapproved_user),
-            "fuzzy": t.fuzzy,
         })
+        payload.append(translation_dict)
 
     return JsonResponse(payload, safe=False)
 

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -452,6 +452,7 @@ PIPELINE_JS = {
             'js/lib/jquery.mark.js',
             'js/lib/highstock.js',
             'js/lib/diff.js',
+            'js/fluent_interface.js',
             'js/translate.js',
         ),
         'output_filename': 'js/translate.min.js',

--- a/pontoon/sync/changeset.py
+++ b/pontoon/sync/changeset.py
@@ -149,7 +149,7 @@ class ChangeSet(object):
             # one timestamp per import, unlike timezone.now()
             'date_created': db_entity.date_created if db_entity else self.now,
             'order': vcs_entity.order,
-            'source': vcs_entity.source
+            'source': vcs_entity.source,
         }
 
     def send_notifications(self, new_entities):
@@ -337,7 +337,7 @@ class ChangeSet(object):
                 'key',
                 'comment',
                 'order',
-                'source'
+                'source',
             ])
 
     def bulk_create_translations(self):

--- a/pontoon/sync/formats/ftl.py
+++ b/pontoon/sync/formats/ftl.py
@@ -5,8 +5,9 @@ import copy
 import logging
 import os
 
-from ftl.format.parser import FTLParser, ParseContext, L10nError
-from ftl.format.serializer import FTLSerializer
+from fluent.syntax import ast
+from fluent.syntax import parser
+from fluent.syntax import serializer
 
 from pontoon.sync import SyncError
 from pontoon.sync.formats.base import ParsedResource
@@ -15,12 +16,12 @@ from pontoon.sync.vcs.models import VCSTranslation
 log = logging.getLogger(__name__)
 
 
-class L20NEntity(VCSTranslation):
+class FTLEntity(VCSTranslation):
     """
-    Represents entities in l20n (without its attributes).
+    Represents entities in FTL (without its attributes).
     """
     def __init__(self, key, source_string, source_string_plural, strings, comments=None, order=None):
-        super(L20NEntity, self).__init__(
+        super(FTLEntity, self).__init__(
             key=key,
             source_string=source_string,
             source_string_plural=source_string_plural,
@@ -31,10 +32,10 @@ class L20NEntity(VCSTranslation):
         )
 
     def __repr__(self):
-        return '<L20NEntity {key}>'.format(key=self.key.encode('utf-8'))
+        return '<FTLEntity {key}>'.format(key=self.key.encode('utf-8'))
 
 
-class L20NResource(ParsedResource):
+class FTLResource(ParsedResource):
     def __init__(self, path, locale, source_resource=None):
         self.path = path
         self.locale = locale
@@ -45,7 +46,7 @@ class L20NResource(ParsedResource):
         # Copy entities from the source_resource if it's available.
         if source_resource:
             for key, entity in source_resource.entities.items():
-                self.entities[key] = L20NEntity(
+                self.entities[key] = FTLEntity(
                     entity.key,
                     '',
                     '',
@@ -56,7 +57,7 @@ class L20NResource(ParsedResource):
 
         try:
             with codecs.open(path, 'r', 'utf-8') as resource:
-                self.structure = FTLParser().parseResource(resource.read())
+                self.structure = parser.parse(resource.read())
         except IOError:
             # If the file doesn't exist, but we have a source resource,
             # we can keep going, we'll just not have any translations.
@@ -66,29 +67,26 @@ class L20NResource(ParsedResource):
                 raise
 
         def get_comment(obj):
-            return [obj['comment']['content']] if obj['comment'] else []
+            return [obj.comment.content] if obj.comment else []
 
-        def parse_entity(obj, section_comment=[]):
-            translation = FTLSerializer().dumpEntity(obj).split('=', 1)[1].lstrip(' ')
-            self.entities[obj['id']['name']] = L20NEntity(
-                obj['id']['name'],
-                translation,
-                '',
-                {None: translation},
-                section_comment + get_comment(obj),
-                self.order
-            )
-            self.order += 1
+        section_comment = None
+        for obj in self.structure.body:
+            if type(obj) == ast.Message:
+                key = obj.id.name
+                translation = serializer.serialize_message(obj)
 
-        for obj in self.structure[0]['body']:
-            if obj['type'] == 'Entity':
-                parse_entity(obj)
+                self.entities[key] = FTLEntity(
+                    key,
+                    translation,
+                    '',
+                    {None: translation},
+                    (section_comment or []) + get_comment(obj),
+                    self.order
+                )
+                self.order += 1
 
-            elif obj['type'] == 'Section':
+            elif type(obj) == ast.Section:
                 section_comment = get_comment(obj)
-                for obj in obj['body']:
-                    if obj['type'] == 'Entity':
-                        parse_entity(obj, section_comment)
 
     @property
     def translations(self):
@@ -101,50 +99,25 @@ class L20NResource(ParsedResource):
         resource.
         """
         if not self.source_resource:
-            raise SyncError('Cannot save l20n resource {0}: No source resource given.'
+            raise SyncError('Cannot save FTL resource {0}: No source resource given.'
                             .format(self.path))
 
         with codecs.open(self.source_resource.path, 'r', 'utf-8') as resource:
-            structure = FTLParser().parseResource(resource.read())
+            structure = parser.parse(resource.read())
 
-        def serialize_entity(obj, entities):
-            entity_id = obj['id']['name']
-            translations = self.entities[entity_id].strings
-
-            if translations:
-                source = translations[None]
-                key = self.entities[entity_id].key
-
-		# TODO: Make serialization less fragile
-                try:
-                    entity = ParseContext(key + '=' + source).getEntity().toJSON()
-                except L10nError:
-                    log.info('FTL serialization erorr in file {0}, locale {1}, key {2}'.format(self.path, self.locale, key))
-                    raise
-
-                obj['value'] = entity['value']
-                obj['traits'] = entity['traits']
-            else:
-                index = entities.index(obj)
-                del entities[index]
-
-        entities = structure[0]['body']
+        entities = structure.body
 
         # Use list() to iterate over a copy, leaving original free to modify
         for obj in list(entities):
-            if obj['type'] == 'Entity':
-                serialize_entity(obj, entities)
-
-            elif obj['type'] == 'Section':
+            if type(obj) == ast.Message:
                 index = entities.index(obj)
-                section = entities[index]['body']
+                entity = self.entities[obj.id.name]
 
-                for obj in list(section):
-                    if obj['type'] == 'Entity':
-                        serialize_entity(obj, section)
-
-                # Remove section if empty
-                if len(section) == 0:
+                if entity.strings:
+                    message = parser.parse_entry(entity.strings[None])
+                    message.comment = obj.comment
+                    entities[index] = message
+                else:
                     del entities[index]
 
         # Create parent directory if it doesn't exist.
@@ -154,13 +127,13 @@ class L20NResource(ParsedResource):
             pass  # Already exists, phew!
 
         with codecs.open(self.path, 'w+', 'utf-8') as f:
-            f.write(FTLSerializer().serialize(structure[0]))
+            f.write(serializer.serialize(structure))
             log.debug('Saved file: %s', self.path)
 
 
 def parse(path, source_path=None, locale=None):
     if source_path is not None:
-        source_resource = L20NResource(source_path, locale)
+        source_resource = FTLResource(source_path, locale)
     else:
         source_resource = None
-    return L20NResource(path, locale, source_resource)
+    return FTLResource(path, locale, source_resource)

--- a/pontoon/sync/tests/test_vcs_models.py
+++ b/pontoon/sync/tests/test_vcs_models.py
@@ -178,6 +178,7 @@ class VCSProjectTests(TestCase):
                 ['/root/templates/foo.pot']
             )
 
+
 class VCSEntityTests(TestCase):
     def test_has_translation_for(self):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,8 +37,8 @@ py-bcrypt==0.3 \
     --hash=sha256:af12f99454e895e9e430c75723c3b9419c0bccd0ea77803662d6a9ac56f6425b
 pyasn1==0.1.7 \
     --hash=sha256:e4f81d53c533f6bd9526b047f047f7b101c24ab17339c1a7ad8f98b25c101eab
-https://github.com/l20n/python-l20n/archive/b229ff0.zip#egg=l20n==0.2 \
-    --hash=sha256:fce3395034b16e8d01ef1ee9d8d67de9536a4d1c8b30a9fc335f668b7beb72d8
+https://github.com/projectfluent/python-fluent/archive/c51965d.zip#egg=fluent==0.3 \
+    --hash=sha256:0b319d9d6e054d2c0b924366a170dd95221a4c232581c4ce525c9923c7ca6e06
 requests==2.6.2 \
     --hash=sha256:8f0f56813f82d0c27d9578221268ac9af48f076c71ee69693305ceca6ca355bd \
     --hash=sha256:0577249d4b6c4b11fd97c28037e98664bfaa0559022fee7bcef6b752a106e505


### PR DESCRIPTION
This is the first attempt at implementing UI for the advanced L20n patterns.

**It brings:**

- More robust `FTL` file format parsing and serialization.
- Support for all patterns used in Test Pilot project, which is already enabled:
  - Simple strings.
  - Multiline strings.
  - Attributes.
- Special interface for localizing access keys.
- Special interface for localizing plurals.
- Basic error handling of translations.

**TODO:**

- [x] If user not logged in, inputs must be uneditable.
- [x] Copy and Clear not working in FTL mode.
- [x] Update editor on delete, copy from helpers, approve.
- [x] Building l20n.js on Heroku fails.

**Not covered by this PR:**

- Selectors (remaining examples in the `demo.ftl` file).
- More advanced error handling, resembling http://l20n.github.io/tinker/.