### PR TITLE
fix comment for contribute.json in urls.py

### DIFF
--- a/pontoon/urls.py
+++ b/pontoon/urls.py
@@ -41,7 +41,7 @@ urlpatterns = [
     # Robots.txt
     url(r'^robots.txt$', TemplateView.as_view(template_name='robots.txt', content_type='text/plain')),
 
-    # Robots.txt
+    # contribute.json
     url(r'^contribute.json$', TemplateView.as_view(template_name='contribute.json', content_type='text/plain')),
 
     # Favicon


### PR DESCRIPTION
While digging up how pontoon implements contribute.json, I found a copy-n-paste bug.

Easy enough?