### PR TITLE
Fix bug 1331710: Only privileged can flip suggestions

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -306,8 +306,12 @@ def contributed_translations(self):
 
 def can_translate(self, locale, project):
     """Check if user has suitable permissions to translate in given locale or project/locale."""
-    project_locale = ProjectLocale.objects.get(project=project, locale=locale)
 
+    # Locale managers can translate all projects
+    if locale.code in self.managed_locales:
+        return True
+
+    project_locale = ProjectLocale.objects.get(project=project, locale=locale)
     if project_locale.has_custom_translators:
         return self.has_perm('base.can_translate_project_locale', project_locale)
 

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -287,7 +287,7 @@
             <div class="menu">
               <ul>
                 {{ Checkbox.checkbox('Quality Checks', class='quality-checks', attribute='quality_checks', is_enabled=user.profile.quality_checks) }}
-                {% if user.translated_locales %}
+                {% if user.can_translate(project=project, locale=locale) %}
                 {{ Checkbox.checkbox('Make Suggestions', class='force-suggestions', attribute='force_suggestions', is_enabled=user.profile.force_suggestions) }}
                 {% endif %}
                 <li class="horizontal-separator"></li>


### PR DESCRIPTION
If the user doesn't have translator permission for the current project, she should not be able to turn Make suggestions toggle on/off from the translate view.

@jotes r?