### PR TITLE
Standalone login fixes (was #528)

### DIFF
--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -482,10 +482,11 @@ $(function() {
   }
 
   // Sign in button action
-  $('#fxa-sign-in, #sidebar-signin').on('click', function(ev) {
+  $('#fxa-sign-in, #standalone-signin a, #sidebar-signin').on('click', function(ev) {
     var $this = $(this);
-
-    $this.prop('href', $this.prop('href') + '&next=' + getRedirectUrl());
+    var loginUrl = $this.prop('href'),
+        startSign = loginUrl.match(/\?/) ? '&': '?';
+    $this.prop('href', loginUrl + startSign + 'next=' + getRedirectUrl());
   });
 
   // Sign out button action

--- a/pontoon/base/templates/django/base.html
+++ b/pontoon/base/templates/django/base.html
@@ -48,7 +48,7 @@
         <li id="admin"{% if not perms.base.can_manage %} class="hidden"{% endif %}><a href="{% url "pontoon.admin" %}">Admin</a></li>
         {% if settings.DJANGO_LOGIN %}
             {% if not user.is_authenticated %}
-                <li id="standalone-sign-in"><a href="{% url 'standalone_login' %}">Sign in</a></li>
+                <li id="standalone-signin"><a href="{% url 'standalone_login' %}">Sign in</a></li>
             {% else %}
                 <li id="standalone-sign-out"><a href="{% url 'standalone_logout' %}" title="{{ user.email|nospam }}">Sign out</a></li>
             {% endif %}
@@ -71,7 +71,7 @@
 
     <!-- Javascript at the bottom for fast page loading -->
     {% providers_media_js %}
-    <script type="text/javascript" charset="utf-8" src="{% static 'js/main.js' %}">
-    </script>
+    <script type="text/javascript" charset="utf-8" src="{% static 'js/lib/jquery-1.11.1.min.js' %}"></script>
+    <script type="text/javascript" charset="utf-8" src="{% static 'js/main.js' %}"></script>
   </body>
 </html>

--- a/pontoon/base/templates/landing.html
+++ b/pontoon/base/templates/landing.html
@@ -20,7 +20,7 @@
             {% if user.is_authenticated() %}
               <li id="standalone-sign-out"><a href="{{ url('standalone_logout') }}" title="{{ user.email|nospam }}">Sign out</a></li>
             {% else %}
-              <li id="standalone-sign-in"><a id="standalone-sign-in" href="{{ url('standalone_login') }}">Sign in</a></li>
+              <li id="standalone-signin"><a href="{{ url('standalone_login') }}">Sign in</a></li>
             {% endif %}
           {% else %}
             {% if user.is_authenticated() %}

--- a/pontoon/base/templates/registration/login.html
+++ b/pontoon/base/templates/registration/login.html
@@ -14,12 +14,12 @@
 
 <form id="standalone-sign-in" method="POST" action="{{ request.path }}">
     <div class="clearfix">
-        <label for="username">Email</label> <br/>
+        <label for="id_username">Username</label> <br/>
         {{ form.username }}
         {{ form.username.errors }}
     </div>
     <div class="clearfix">
-        <label for="password">Password</label> <br/>
+        <label for="id_password">Password</label> <br/>
         {{ form.password }}
         {{ form.password.errors }}
     </div>

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -130,7 +130,7 @@
               {% if user.is_authenticated() %}
                 <li class="standalone-sign-out"><a href="{{ url('standalone_logout') }}"><i class="fa fa-sign-out fa-fw"></i> Sign Out</a></li>
               {% else %}
-                <li class="standalone-sign-in"><a id="standalone-sign-in" href="{{ url('standalone_login') }}"><i class="fa fa-sign-in fa-fw"></i>Sign in</a></li>
+                <li class="standalone-signin"><a href="{{ url('standalone_login') }}"><i class="fa fa-sign-in fa-fw"></i>Sign in</a></li>
               {% endif %}
             {% else %}
               {% if user.is_authenticated() %}
@@ -326,7 +326,14 @@
           <button id="clear" title="Clear Translation (Ctrl + Shift + Backspace)">Clear</button>
           <button id="save" title="Save Translation (Enter)"></button>
         {% else %}
-          <p id="sign-in-required"><a id="sidebar-signin" href="{{ provider_login_url(request) }}">Sign in</a> to translate.</p>
+          <p id="sign-in-required">
+            {% if settings.DJANGO_LOGIN %}
+              {% set login_url = url('standalone_login') %}
+            {% else %}
+              {% set login_url = provider_login_url(request) %}
+            {% endif %}
+            <a id="sidebar-signin" href="{{ login_url }}">Sign in</a> to translate.
+          </p>
         {% endif %}
       </menu>
 


### PR DESCRIPTION
* Rename label from email to username
* Load missing jQuery library
* Properly compose sign in URL
* Fix duplicate HTML IDs
* Use standalone login in translate view