### PR TITLE
Prevent projects from disappearing on search in custom permissions selector

### DIFF
--- a/pontoon/base/static/css/manage_permissions.css
+++ b/pontoon/base/static/css/manage_permissions.css
@@ -193,3 +193,7 @@ h3 .remove-project .fa {
   color: #CCCCCC;
   cursor: pointer;
 }
+
+#project-selector .menu li:not(.limited) {
+  display: none;
+}

--- a/pontoon/base/static/js/manage_permissions.js
+++ b/pontoon/base/static/js/manage_permissions.js
@@ -106,7 +106,7 @@ $(function() {
     $permsForm.append(inputHidden('project-locale-' + $permsForm.data('index') + '-has_custom_translators', 1));
 
     // Update menu (must be above Copying Translators)
-    $(this).addClass('hidden');
+    $(this).addClass('hidden').removeClass('limited');
     if ($('#project-selector .menu li:not(".hidden")').length === 0) {
       $('#project-selector').addClass('hidden');
     }
@@ -129,7 +129,7 @@ $(function() {
     e.preventDefault();
 
     $('#project-selector').removeClass('hidden');
-    $("#project-selector li[data-slug='" + $permsForm.data('slug') + "']").removeClass('hidden');
+    $("#project-selector li[data-slug='" + $permsForm.data('slug') + "']").removeClass('hidden').addClass('limited');
 
     $permsForm.find('input[name$=has_custom_translators]').remove();
 

--- a/pontoon/base/templates/locale_permissions.html
+++ b/pontoon/base/templates/locale_permissions.html
@@ -79,7 +79,7 @@
                 </div>
                 <ul>
                     {% for pk, slug, name, all_users, translators, has_custom_translators in locale_projects %}
-                        <li data-slug="{{ slug }}" data-id="{{ pk }}" class="{% if has_custom_translators %}hidden{% endif %}">{{ name }}</li>
+                        <li data-slug="{{ slug }}" data-id="{{ pk }}" class="{% if has_custom_translators %}hidden{% else %}limited{% endif %}">{{ name }}</li>
                     {% endfor %}
                 </ul>
 


### PR DESCRIPTION
Steps to reproduce without the patch:
1. Go to /{locale}/permissions.
2. Add one project via project selector at the bottom.
3. Click on project selector again and start searching.
4. Clear search criteria.
5. Empty line appears in the project menu where selected project was displayed initially.

@jotes r?