### PR TITLE
Fix bug 1343631: Show translated string as translated

### DIFF
--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -2207,7 +2207,7 @@ var Pontoon = (function (my) {
           translation = entity.translation[0].string;
 
       entity.ui
-        .removeClass('translated suggested fuzzy partial')
+        .removeClass('translated suggested fuzzy missing partial')
         .addClass(status)
         .find('.translation-string')
           .html(self.markPlaceables(translation || ''));


### PR DESCRIPTION
If missing string gets translated, show it as translated when selected.

@jotes r?