### PR TITLE
Fix chart calculations

### DIFF
--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import json
 import logging
 import os

--- a/pontoon/localizations/views.py
+++ b/pontoon/localizations/views.py
@@ -1,3 +1,5 @@
+from __future__ import division
+
 import logging
 import math
 


### PR DESCRIPTION
As part of the `pontoon.base` app split, we forgot to move the `from __future__ import division` to `pontoon.localizations` app.

This explains the difference in how division works without the import:
https://mail.python.org/pipermail/tutor/2008-March/060886.html

@jotes r?