### PR TITLE
No more red in latest activity column

### DIFF
--- a/pontoon/base/admin.py
+++ b/pontoon/base/admin.py
@@ -30,8 +30,8 @@ class UserAdmin(AuthUserAdmin):
 
 class LocaleAdmin(admin.ModelAdmin):
     search_fields = ['name', 'code']
-    list_display = ('pk', 'name', 'code', 'direction', 'script', 'population',
-                    'code', 'nplurals', 'plural_rule', 'cldr_plurals')
+    list_display = ('pk', 'name', 'code', 'script', 'direction', 'population',
+                    'cldr_plurals', 'nplurals', 'plural_rule')
     exclude = ('translators_group', 'managers_group')
     readonly_fields = AGGREGATED_STATS_FIELDS + ('latest_translation',)
 

--- a/pontoon/base/static/css/table.css
+++ b/pontoon/base/static/css/table.css
@@ -111,8 +111,6 @@ table.table {
 }
 
 .table .latest-activity time {
-  border-bottom: 1px dotted #F36;
-  padding: 0 1px;
   white-space: nowrap;
 }
 
@@ -147,7 +145,7 @@ table.table {
 }
 
 .table .latest-activity .tooltip .quote {
-  color: #f36;
+  color: #7BC876;
   font-size: 30px;
 }
 
@@ -159,6 +157,7 @@ table.table {
 
 .table .latest-activity .tooltip footer {
   color: #888888;
+  font-style: italic;
   height: 48px;
   margin-top: 10px;
   position: relative;
@@ -184,7 +183,7 @@ table.table {
 }
 
 .table .latest-activity .tooltip footer .translation-author {
-  color: #F36;
+  color: #7BC876;
 }
 
 .table .latest-activity .tooltip footer img {

--- a/pontoon/base/templates/widgets/heading_info.html
+++ b/pontoon/base/templates/widgets/heading_info.html
@@ -28,7 +28,7 @@
 <li class="deadline">
   <span class="title">Deadline</span>
   <span class="value">
-    <time datetime="{% if deadline %}{{ deadline.isoformat() }}{% endif %}" class="{{ deadline|date_status(complete) }}">{{ deadline|format_datetime('short_date', default='Not set') }}</time>
+    <time datetime="{% if deadline %}{{ deadline.isoformat() }}{% endif %}" class="{{ deadline|date_status(complete) }}">{{ deadline|format_datetime('short_date', default='―') }}</time>
   </span>
 </li>
 {% endmacro %}

--- a/pontoon/base/templates/widgets/latest_activity.html
+++ b/pontoon/base/templates/widgets/latest_activity.html
@@ -12,7 +12,7 @@
     {% endif %}
     <time datetime="{{ latest_activity.date.isoformat() }}" data-translation="{{ latest_activity.translation.string }}" data-action="{{ action }}" data-user-name="{{ user }}" data-user-avatar="{{ avatar }}">{{ latest_activity.date|naturaltime }}</time>
   {% else %}
-    <span class="not">No activity yet</span>
+    <span class="not">―</span>
   {% endif %}
 </span>
 {%- endmacro %}

--- a/pontoon/projects/templates/projects/widgets/project_list.html
+++ b/pontoon/projects/templates/projects/widgets/project_list.html
@@ -26,7 +26,7 @@
       </h3>
     </td>
     <td class="deadline">
-      <time datetime="{% if project.deadline %}{{ project.deadline.isoformat() }}{% endif %}" class="{{ project.deadline|date_status(chart.approved_percent == 100) }}">{{ project.deadline|format_datetime('short_date', default='Not set') }}</time>
+      <time datetime="{% if project.deadline %}{{ project.deadline.isoformat() }}{% endif %}" class="{{ project.deadline|date_status(chart.approved_percent == 100) }}">{{ project.deadline|format_datetime('short_date', default='―') }}</time>
     </td>
     <td class="priority">
       {% for n in range(5) %}


### PR DESCRIPTION
Red color implies errors, so we're replacing with "Pontoon green" in the latest activity column and removing the underline. "No activity yet" text has been replaced with &middot; to make it easier to distinguish from other entries. Also in the deadline column.

@MikkCZ @mastizada r?

Check it out on stage:
https://mozilla-pontoon-staging.herokuapp.com/projects/