### PR TITLE
Faster HG pull()

### DIFF
--- a/pontoon/administration/static/css/admin_project.css
+++ b/pontoon/administration/static/css/admin_project.css
@@ -124,7 +124,8 @@ form .button {
   width: 130px;
 }
 
-.controls .button.sync {
+.controls .button.sync,
+.controls .button.sync:hover {
   background: #F36;
   color: #272A2F;
   float: left;

--- a/pontoon/administration/static/js/admin_project.js
+++ b/pontoon/administration/static/js/admin_project.js
@@ -19,7 +19,7 @@ $(function() {
 
   // Submit form with Enter
   $('html').unbind("keydown.pontoon").bind("keydown.pontoon", function (e) {
-    if ($('input[type=text]:not("input[type=search]"):focus').length > 0) {
+    if ($('input[type=text]:focus').length > 0 || $('input[type=url]:focus').length > 0) {
       var key = e.keyCode || e.which;
       if (key === 13) { // Enter
         // A short delay to allow digest of autocomplete before submit


### PR DESCRIPTION
Instead of removing the entire repository folder and running `hg clone` on each sync, we try to do something similar as `git reset --hard`:
* discard uncommitted changes,
* delete untracked files,
* discard local commits.

We need two HG extensions to make this work. They are enabled inside each repo's `.hg/hgrc file` on each sync. The code to do that would be more elegant if we could enable the extensions in the system/user `hgrc` file, but I'm not sure where to put it. I tried [several paths](https://www.selenic.com/mercurial/hgrc.5.html), but none them actually enabled the extensions. Mercurial is installed via pip.

We currently clone ~200 HG repositories during each sync cycle. Quick test showed that this patch reduces the average repo `pull()` time from 5 to 2 seconds (except afer dyno restart of course). It's hard to predict how much time can this save us per sync cycle due to parallelization, but I'm hoping for a couple of minutes per sync cycle.

(Also including two other minor fixes I found along the way.)

@jotes r?
