### PR TITLE
Show non-requestable projects on team pages

### DIFF
--- a/pontoon/teams/views.py
+++ b/pontoon/teams/views.py
@@ -53,7 +53,7 @@ def ajax_projects(request, locale):
 
     projects = (
         Project.objects.available()
-        .filter(can_be_requested=True)
+        .filter(Q(locales=locale) | Q(can_be_requested=True))
         .prefetch_latest_translation(locale)
         .order_by('name')
     )


### PR DESCRIPTION
If a project cannot be requested by locales, we hide it from locales that have it enabled.

This patch fixes it.