### PR TITLE
Make URLs case-sensitive

### DIFF
--- a/pontoon/base/utils.py
+++ b/pontoon/base/utils.py
@@ -42,7 +42,7 @@ def get_project_locale_from_request(request, locales):
 
     for a in accept:
         try:
-            return locales.get(code__iexact=a[0]).code
+            return locales.get(code=a[0]).code
         except:
             continue
 
@@ -377,7 +377,7 @@ def get_download_content(slug, code, part):
     from pontoon.base.models import Entity, Locale, Project, Resource
 
     project = get_object_or_404(Project, slug=slug)
-    locale = get_object_or_404(Locale, code__iexact=code)
+    locale = get_object_or_404(Locale, code=code)
 
     # Download a ZIP of all files if project has > 1 and < 10 resources
     resources = Resource.objects.filter(project=project, translatedresources__locale=locale)
@@ -493,7 +493,7 @@ def handle_upload_content(slug, code, part, f, user):
 
     relative_path = _get_relative_path_from_part(slug, part)
     project = get_object_or_404(Project, slug=slug)
-    locale = get_object_or_404(Locale, code__iexact=code)
+    locale = get_object_or_404(Locale, code=code)
     resource = get_object_or_404(Resource, project__slug=slug, path=relative_path)
 
     # Store uploaded file to a temporary file and parse it

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -88,7 +88,7 @@ def heroku_setup(request):
 
 def translate(request, locale, slug, part):
     """Translate view."""
-    locale = get_object_or_404(Locale, code__iexact=locale)
+    locale = get_object_or_404(Locale, code=locale)
     project = get_object_or_404(Project.objects.available(), slug=slug)
 
     if locale not in project.locales.all():
@@ -147,7 +147,7 @@ def entities(request):
         return HttpResponseBadRequest('Bad Request: {error}'.format(error=err))
 
     project = get_object_or_404(Project, slug=project)
-    locale = get_object_or_404(Locale, code__iexact=locale)
+    locale = get_object_or_404(Locale, code=locale)
 
     status = request.POST.get('status', '')
     extra = request.POST.get('extra', '')
@@ -364,7 +364,7 @@ def get_translations_from_other_locales(request):
         return HttpResponseBadRequest('Bad Request: {error}'.format(error=e))
 
     entity = get_object_or_404(Entity, pk=entity)
-    locales = entity.resource.project.locales.exclude(code__iexact=locale)
+    locales = entity.resource.project.locales.exclude(code=locale)
     plural_form = None if entity.string_plural == "" else 0
 
     translations = Translation.objects.filter(
@@ -389,7 +389,7 @@ def get_translation_history(request):
         return HttpResponseBadRequest('Bad Request: {error}'.format(error=e))
 
     entity = get_object_or_404(Entity, pk=entity)
-    locale = get_object_or_404(Locale, code__iexact=locale)
+    locale = get_object_or_404(Locale, code=locale)
 
     translations = Translation.objects.filter(entity=entity, locale=locale)
     if plural_form != "-1":
@@ -514,7 +514,7 @@ def update_translation(request):
         return HttpResponse("error")
 
     try:
-        l = Locale.objects.get(code__iexact=locale)
+        l = Locale.objects.get(code=locale)
     except Locale.DoesNotExist as error:
         log.error(str(error))
         return HttpResponse("error")

--- a/pontoon/localizations/views.py
+++ b/pontoon/localizations/views.py
@@ -18,7 +18,7 @@ log = logging.getLogger('pontoon')
 
 def localization(request, code, slug):
     """Locale-project overview."""
-    locale = get_object_or_404(Locale, code__iexact=code)
+    locale = get_object_or_404(Locale, code=code)
     project = get_object_or_404(Project.objects.available(), slug=slug)
     project_locale = get_object_or_404(ProjectLocale, locale=locale, project=project)
 
@@ -35,7 +35,7 @@ def localization(request, code, slug):
 @require_AJAX
 def ajax_resources(request, code, slug):
     """Resources tab."""
-    locale = get_object_or_404(Locale, code__iexact=code)
+    locale = get_object_or_404(Locale, code=code)
     project = get_object_or_404(
         Project.objects.available().prefetch_related('subpage_set'),
         slug=slug
@@ -88,7 +88,7 @@ class LocalizationContributorsView(ContributorsMixin, DetailView):
     def get_object(self):
         return get_object_or_404(
             ProjectLocale,
-            locale__code__iexact=self.kwargs['code'],
+            locale__code=self.kwargs['code'],
             project__slug=self.kwargs['slug']
         )
 

--- a/pontoon/machinery/views.py
+++ b/pontoon/machinery/views.py
@@ -23,7 +23,7 @@ def machinery(request):
         request, Locale.objects) or 'en-GB'
 
     return render(request, 'machinery/machinery.html', {
-        'locale': Locale.objects.get(code__iexact=locale),
+        'locale': Locale.objects.get(code=locale),
         'locales': Locale.objects.all(),
     })
 
@@ -38,7 +38,7 @@ def translation_memory(request):
         return HttpResponseBadRequest('Bad Request: {error}'.format(error=e))
 
     max_results = 5
-    locale = get_object_or_404(Locale, code__iexact=locale)
+    locale = get_object_or_404(Locale, code=locale)
     entries = TranslationMemoryEntry.objects.minimum_levenshtein_ratio(text).filter(locale=locale)
 
     # Exclude existing entity

--- a/pontoon/teams/views.py
+++ b/pontoon/teams/views.py
@@ -39,7 +39,7 @@ def teams(request):
 
 def team(request, locale):
     """Team dashboard."""
-    locale = get_object_or_404(Locale, code__iexact=locale)
+    locale = get_object_or_404(Locale, code=locale)
 
     return render(request, 'teams/team.html', {
         'locale': locale,
@@ -49,7 +49,7 @@ def team(request, locale):
 @require_AJAX
 def ajax_projects(request, locale):
     """Projects tab."""
-    locale = get_object_or_404(Locale, code__iexact=locale)
+    locale = get_object_or_404(Locale, code=locale)
 
     projects = (
         Project.objects.available()
@@ -70,7 +70,7 @@ def ajax_projects(request, locale):
 @require_AJAX
 def ajax_info(request, locale):
     """Info tab."""
-    locale = get_object_or_404(Locale, code__iexact=locale)
+    locale = get_object_or_404(Locale, code=locale)
 
     return render(request, 'teams/includes/info.html', {
         'locale': locale,
@@ -80,7 +80,7 @@ def ajax_info(request, locale):
 @permission_required_or_403('base.can_manage_locale', (Locale, 'code', 'locale'))
 @transaction.atomic
 def ajax_permissions(request, locale):
-    l = get_object_or_404(Locale, code__iexact=locale)
+    l = get_object_or_404(Locale, code=locale)
     project_locales = l.project_locale.available()
 
     if request.method == 'POST':
@@ -129,7 +129,7 @@ def ajax_permissions(request, locale):
 def request_projects(request, locale):
     """Request projects to be added to locale."""
     slug_list = request.POST.getlist('projects[]')
-    locale = get_object_or_404(Locale, code__iexact=locale)
+    locale = get_object_or_404(Locale, code=locale)
 
     # Validate projects
     project_list = (
@@ -172,7 +172,7 @@ class LocaleContributorsView(ContributorsMixin, DetailView):
     """
     template_name = 'teams/includes/contributors.html'
     model = Locale
-    slug_field = 'code__iexact'
+    slug_field = 'code'
     slug_url_kwarg = 'code'
 
     def get_context_object_name(self, obj):


### PR DESCRIPTION
We currently allow case-insensitive locale codes in URLs, but only on server side (and without any redirects). Which means some of our pages are broken:
https://pontoon.mozilla.org/bn-bd/              

And some are more broken:
https://pontoon.mozilla.org/bn-bd/pontoon-intro/

OTOH, we require project slugs to be case-sensitive.

Let's make all URL parameters case-sensitive, which menas we'll simply 404 for the examples above.

@jotes r?