### PR TITLE
Use script name in CSS selector instead of locale codes

### DIFF
--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -219,8 +219,7 @@ button {  width: auto; overflow: visible; }
 /* COMMON */
 
 /* Bug 1351813 */
-[lang="ar"],
-[lang="fa"] {
+[data-script="Arabic"] {
     font-size: 1.1em;
 }
 

--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -1402,8 +1402,7 @@ body > header aside p {
   box-sizing: border-box;
 }
 
-#editor textarea[lang="ar"],
-#editor textarea[lang="fa"] {
+#editor textarea[data-script="Arabic"] {
   font-size: 15px;
 }
 

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -253,7 +253,7 @@ var Pontoon = (function (my) {
               '</ul>' +
             '</header>' +
             '<p class="original">' + self.doNotRender(data.original || '') + '</p>' +
-            '<p class="translation" dir="' + self.locale.direction + '" lang="' + self.locale.code + '">' +
+            '<p class="translation" dir="' + self.locale.direction + '" lang="' + self.locale.code + '" data-script="' + self.locale.script + '">' +
               self.markPlaceables(data.translation) +
             '</p>' +
             '<p class="translation-clipboard">' +

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -36,7 +36,7 @@ var Pontoon = (function (my) {
         '<span class="status fa' + (self.user.canTranslate() ? '' : ' unselectable') + '"></span>' +
         '<p class="string-wrapper">' +
           '<span class="source-string">' + source_string + '</span>' +
-          '<span class="translation-string' + openSans + '" dir="' + self.locale.direction + '" lang="' + self.locale.code + '">' +
+          '<span class="translation-string' + openSans + '" dir="' + self.locale.direction + '" lang="' + self.locale.code + '" data-script="' + self.locale.script + '">' +
             self.markPlaceables(entity.translation[0].string || '') +
           '</span>' +
         '</p>' +
@@ -133,7 +133,7 @@ var Pontoon = (function (my) {
             $.each(data, function() {
               list.append('<li class="suggestion" title="Copy Into Translation (Tab)">' +
                 '<header>' + this.locale__name + '<span class="stress">' + this.locale__code + '</span></header>' +
-                '<p class="translation" dir="' + this.locale__direction + '" lang="' + this.locale__code + '">' +
+                '<p class="translation" dir="' + this.locale__direction + '" lang="' + this.locale__code + '" data-script="' + this.locale__script + '">' +
                   self.markPlaceables(this.string) +
                 '</p>' +
                 '<p class="translation-clipboard">' +
@@ -272,10 +272,10 @@ var Pontoon = (function (my) {
                       ((self.user.id && (self.user.id === this.uid) || self.user.canTranslate()) ? '<button class="delete fa" title="Delete"></button>' : '') +
                     '</menu>' +
                   '</header>' +
-                  '<p class="translation" dir="' + self.locale.direction + '" lang="' + self.locale.code + '">' +
+                  '<p class="translation" dir="' + self.locale.direction + '" lang="' + self.locale.code + '" data-script="' + self.locale.script + '">' +
                     self.markPlaceables(this.translation) +
                   '</p>' +
-                  '<p class="translation-diff" dir="' + self.locale.direction + '" lang="' + self.locale.code + '">' +
+                  '<p class="translation-diff" dir="' + self.locale.direction + '" lang="' + self.locale.code + '" data-script="' + self.locale.script + '">' +
                     ((i > 0) ? self.diff(data[0].translation, this.translation) : self.markPlaceables(this.translation)) +
                   '</p>' +
                   '<p class="translation-clipboard">' +
@@ -2784,7 +2784,8 @@ var Pontoon = (function (my) {
     updateTextareaAttributes: function () {
       $('#translation')
         .attr('dir', this.locale.direction)
-        .attr('lang', this.locale.code);
+        .attr('lang', this.locale.code)
+        .attr('data-script', this.locale.script);
     },
 
 

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -374,7 +374,9 @@ def get_translations_from_other_locales(request):
         approved=True
     ).order_by('locale__name')
 
-    payload = list(translations.values('locale__code', 'locale__name', 'locale__direction', 'string'))
+    payload = list(translations.values(
+        'locale__code', 'locale__name', 'locale__direction', 'locale__script', 'string'
+    ))
     return JsonResponse(payload, safe=False)
 
 

--- a/pontoon/contributors/static/css/profile.css
+++ b/pontoon/contributors/static/css/profile.css
@@ -142,8 +142,7 @@
   margin-right: 2em;
 }
 
-#main .content p[lang="ar"],
-#main .content p[lang="fa"] {
+#main .content p[data-script="Arabic"] {
   font-size: 18px;
 }
 

--- a/pontoon/contributors/templates/contributors/includes/timeline.html
+++ b/pontoon/contributors/templates/contributors/includes/timeline.html
@@ -23,7 +23,7 @@
         {% if event.translation %}
         {% set direction = event.translation.locale.direction %}
         <div class="fa fa-2x quote {% if direction == 'ltr' %}fa-quote-left{% else %}fa-quote-right{% endif %}"></div>
-        <p dir="{{ direction }}" lang="{{ event.translation.locale.code }}">{{ event.translation.string }}</p>
+        <p dir="{{ direction }}" lang="{{ event.translation.locale.code }}" data-script="{{ event.translation.locale.script }}">{{ event.translation.string }}</p>
         {% endif %}
         <div class="label clearfix {{ event.type }}">
             <figure>


### PR DESCRIPTION
Just to make it more robust, we don't hardcode Arabic locale codes anymore.

@jotes r?