### PR TITLE
Fix bug 1354812: Do not copy from helpers on Ctrl + Tab

### DIFF
--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -1651,7 +1651,7 @@ var Pontoon = (function (my) {
         }
 
         // Tab: Select suggestions
-        if (!$('.menu').is(':visible') && key === 9) {
+        if (!$('.menu').is(':visible') && key === 9 && !e.ctrlKey) {
 
           var section = $('#helpers section:visible'),
               index = section.find('li.suggestion.hover').index() + 1;


### PR DESCRIPTION
@jotes r?

I checked other keyboard shortcuts in Firefox with the `Tab` key and they are all combinations with `Ctrl`.