### PR TITLE
Show notifications at the bottom

### DIFF
--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -862,7 +862,7 @@ tfoot td a {
   left: 0;
   margin: 0;
   position: fixed;
-  top: -60px;
+  bottom: -60px;
   width: 100%;
   z-index: 100;
 }

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -57,7 +57,7 @@ var Pontoon = (function (my) {
      */
     closeNotification: function () {
       $('.notification').animate({
-        top: '-60px',
+        bottom: '-60px',
       }, {
         duration: 200
       }, function() {
@@ -78,7 +78,7 @@ var Pontoon = (function (my) {
           .html('<li class="' + (type || '') + '">' + text + '</li>')
           .removeClass('hide')
           .animate({
-            top: 0,
+            bottom: 0,
           }, {
             duration: 200
           });


### PR DESCRIPTION
Move notifications bar to the bottom of the screen. On top of the page it covers the header and the main menu in the translate view, preventing it from being used while the notification is presented. It will be slightly less visible, but it covers big enough area to attract user's attention.

@jotes r?