### PR TITLE
Latest activity

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -1861,7 +1861,7 @@ class TranslationQuerySet(models.QuerySet):
         translations = self.filter(string__contains=find)
 
         if translations.count() == 0:
-            return translations
+            return translations, None
 
         # Empty translations produced by replace might not be always allowed
         forbidden = (
@@ -1887,8 +1887,8 @@ class TranslationQuerySet(models.QuerySet):
         translations.update(approved=False, approved_user=None, approved_date=None)
 
         # Create new translations
-        Translation.objects.bulk_create(translations_to_create)
-        return translations
+        new_translations = Translation.objects.bulk_create(translations_to_create)
+        return translations, new_translations[-1].pk
 
     def authors(self):
         """

--- a/pontoon/base/templates/widgets/latest_activity.html
+++ b/pontoon/base/templates/widgets/latest_activity.html
@@ -1,4 +1,4 @@
-{% macro span(latest_activity, resource='all-resources') -%}
+{% macro span(latest_activity) -%}
 <span class="latest">
   {% if latest_activity.date %}
     {% if latest_activity.user %}

--- a/pontoon/base/utils.py
+++ b/pontoon/base/utils.py
@@ -553,6 +553,10 @@ def handle_upload_content(slug, code, part, f, user):
 
     ChangedEntityLocale.objects.bulk_create(changed_entities.values())
 
+    # Update latest translation
+    if changeset.translations_to_create:
+        changeset.translations_to_create[-1].update_latest_translation()
+
 
 def latest_datetime(datetimes):
     """

--- a/pontoon/localizations/templates/localizations/widgets/resource_list.html
+++ b/pontoon/localizations/templates/localizations/widgets/resource_list.html
@@ -21,7 +21,7 @@
       </h4>
     </td>
     <td class="latest-activity">
-      {{ LatestActivity.span(latest_activity, resource=resource.title) }}
+      {{ LatestActivity.span(latest_activity) }}
     </td>
     <td class="progress">
       {{ ProgressChart.span(chart, chart_link, link_parameter) }}


### PR DESCRIPTION
We don't set latest activity on batch editing actions and changes made via file upload.

We also don't show latest activity data for projects with subpages.

This patch fixes all of that.

@jotes r?