### PR TITLE
Fix bug 1362929: Fix contributor timeline loading

### DIFF
--- a/pontoon/contributors/static/css/profile.css
+++ b/pontoon/contributors/static/css/profile.css
@@ -48,12 +48,6 @@
   padding-bottom: 8em;
 }
 
-#main .container > div:last-child {
-  margin: 0;
-  position: absolute;
-  width: 100%;
-}
-
 #main .tick {
   background: #272A2F;
   border: 4px solid #AAAAAA;


### PR DESCRIPTION
If the last child is positioned absolutely, the bottom of it can get cut off the viewport. That prevents the next batch of timeline items to load.

@jotes r?

