### PR TITLE
Fix bug 1349330: Prevent too long translation submissions

### DIFF
--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -1661,6 +1661,14 @@ body > header aside p {
   padding: 9px 5px;
 }
 
+#translation-length .countdown {
+  display: none;
+}
+
+#translation-length .countdown .overflow {
+  color: #F36;
+}
+
 #editor #single > menu > .select {
   cursor: pointer;
   position: static; /* Avoid overlapping warning box */

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -122,6 +122,13 @@ var Pontoon = (function (my) {
     },
 
     /*
+     * Strip HTML tags from the given string
+     */
+    stripHTML: function (string) {
+      return $($.parseHTML(string)).text();
+    },
+
+    /*
      * Converts a number to a string containing commas every three digits
      */
     numberWithCommas: function (number) {

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -496,7 +496,7 @@ var Pontoon = (function (my) {
             splitComment = entity.comment;
         if (split[0].startsWith('MAX_LENGTH')) {
           try {
-            self.translationLengthLimit = parseInt(split[0].split('MAX_LENGTH: ')[1].split(' ')[0]);
+            self.translationLengthLimit = parseInt(split[0].split('MAX_LENGTH: ')[1].split(' ')[0], 10);
             splitComment = split.length > 1 ? entity.comment.substring(entity.comment.indexOf('\n') + 1) : '';
           } catch (e) {} // Catch unexpected comment structure
         }
@@ -1574,9 +1574,6 @@ var Pontoon = (function (my) {
           entity = self.getEditorEntity(),
           translation = $('#translation').val();
 
-      // Prevent double translation submissions
-      $(this).off('click.save');
-
       // Prevent empty translation submissions if not supported
       if (translation === '' &&
         ['properties', 'ini', 'dtd', 'ftl'].indexOf(entity.format) === -1) {
@@ -1589,6 +1586,9 @@ var Pontoon = (function (my) {
         self.endLoader('Translation too long.', 'error');
         return;
       }
+
+      // Prevent double translation submissions
+      $(this).off('click.save');
 
       self.updateOnServer(entity, translation, true);
     },

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -429,7 +429,21 @@ var Pontoon = (function (my) {
      * Update current translation length
      */
     updateCurrentTranslationLength: function () {
-      $('#translation-length .current-length').html($('#translation').val().length);
+      var limit = this.translationLengthLimit,
+          translation = $('#translation').val();
+
+      if (limit) {
+        var length = this.stripHTML(translation).length,
+            charactersLeft = limit - length;
+
+        $('#translation-length .characters-left')
+          .toggleClass('overflow', charactersLeft < 0)
+          .html(charactersLeft);
+
+      } else {
+        $('#translation-length .current-length')
+          .html(translation.length);
+      }
     },
 
 
@@ -469,18 +483,31 @@ var Pontoon = (function (my) {
      */
     openEditor: function (entity) {
       var self = this;
+      self.translationLengthLimit = null;
+
       $('#editor')[0].entity = entity;
 
-      // Metadata: comments, sources, keys
+      // Metadata: comment
       $('#metadata').empty();
       if (entity.comment) {
-        var comment = this.linkify(entity.comment);
-        if (comment === entity.comment) {
-          comment = this.doNotRender(entity.comment);
+
+        // Translation length limit
+        var split = entity.comment.split('\n'),
+            splitComment = entity.comment;
+        if (split[0].startsWith('MAX_LENGTH')) {
+          try {
+            self.translationLengthLimit = parseInt(split[0].split('MAX_LENGTH: ')[1].split(' ')[0]);
+            splitComment = split.length > 1 ? entity.comment.substring(entity.comment.indexOf('\n') + 1) : '';
+          } catch (e) {} // Catch unexpected comment structure
+        }
+
+        var comment = this.linkify(splitComment);
+        if (comment === splitComment) {
+          comment = this.doNotRender(splitComment);
         }
         self.appendMetaData('Comment', comment);
 
-        // Screenshots
+        // Screenshot
         $('#source-pane').removeClass().find('#screenshots').empty();
         $('#metadata').find('a').each(function() {
           var url = $(this).html();
@@ -491,9 +518,13 @@ var Pontoon = (function (my) {
           }
         });
       }
+
+      // Metadata: key
       if (entity.key) {
         self.appendMetaData('Context', entity.key);
       }
+
+      // Metadata: source
       if (entity.source) {
         if (typeof(entity.source) === 'object') {
           $.each(entity.source, function() {
@@ -503,6 +534,8 @@ var Pontoon = (function (my) {
           self.appendMetaData('Source', entity.source);
         }
       }
+
+      // Metadata: path
       if (entity.path) {
         var link = null,
             linkClass = null;
@@ -574,8 +607,13 @@ var Pontoon = (function (my) {
       // Length
       var original = entity['original' + this.isPluralized()].length;
 
+      // Toggle translation length display
+      $('#translation-length')
+        .find('.current-vs-original').toggle(!self.translationLengthLimit).end()
+        .find('.countdown').toggle(!!self.translationLengthLimit);
+
       // Need to show if sidebar opened by default
-      $('#translation-length').show().find('.original-length').html(original).end();
+      $('#translation-length').show().find('.original-length').html(original);
       self.moveCursorToBeginning();
       self.updateCurrentTranslationLength();
       self.updateCachedTranslation();
@@ -1533,19 +1571,26 @@ var Pontoon = (function (my) {
     saveTranslation: function (e) {
       e.preventDefault();
       var self = Pontoon,
-          entity = self.getEditorEntity();
+          entity = self.getEditorEntity(),
+          translation = $('#translation').val();
 
       // Prevent double translation submissions
       $(this).off('click.save');
 
-      var source = $('#translation').val();
-      if (source === '' &&
+      // Prevent empty translation submissions if not supported
+      if (translation === '' &&
         ['properties', 'ini', 'dtd', 'ftl'].indexOf(entity.format) === -1) {
           self.endLoader('Empty translations cannot be submitted.', 'error');
           return;
       }
 
-      self.updateOnServer(entity, source, true);
+      // Prevent too long translation submissions
+      if (self.translationLengthLimit && self.stripHTML(translation).length > self.translationLengthLimit) {
+        self.endLoader('Translation too long.', 'error');
+        return;
+      }
+
+      self.updateOnServer(entity, translation, true);
     },
 
 

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -359,7 +359,12 @@
           </div>
 
           <div id="translation-length">
-            <span class="current-length"></span>|<span class="original-length"></span>
+            <div class="current-vs-original">
+              <span class="current-length"></span>|<span class="original-length"></span>
+            </div>
+            <div class="countdown">
+              <span class="characters-left"></span>
+            </div>
           </div>
 
           <button id="add-attribute" title="Add attribute">+Attribute</button>


### PR DESCRIPTION
* Use string comments in .lang files to determine translation length limit
* If length limited, show character countdown
* If limit exceeded, prevent translation from being submitted
* Strip HTML tags when calculating string length
* Some code cleanups

@jotes r?

This fix is entirely frontend based, as we already mangle with comments in JS to present links and screenshots. We should file a bug to store this data in a more structured fashion on import.