### PR TITLE
Mark whitespace in diffs

### DIFF
--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -1425,6 +1425,7 @@ body > form,
 #helpers > section ul li > p ins,
 #helpers > section ul li > p del {
   border-radius: 2px;
+  white-space: pre-wrap;
 }
 
 #helpers > section ul li > p ins {


### PR DESCRIPTION
@jotes r?

Show diff doesn't show changes that contain regualr white space, e.g.:
https://pontoon.mozilla.org/fr/engagement/snippets/2017/jun2017.lang/?search=%23&string=165503

Markup is OK, it's a CSS bug.