### PR TITLE
Fix UnboundLocalError on batch delete

### DIFF
--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -281,6 +281,7 @@ def batch_edit_translations(request):
     translation_pks.discard(None)
     translations = Translation.objects.filter(pk__in=translation_pks)
     latest_translation_pk = None
+    changed_translation_pks = []
 
     # Must be executed before translations set changes, which is why
     # we need to force evaluate QuerySets by wrapping them inside list()


### PR DESCRIPTION
Fixes an issue reported by @StoyanDimitrov.

r=me

```
File "/app/.heroku/python/lib/python2.7/site-packages/django/core/handlers/base.py", line 185, in _get_response
                  response = wrapped_callback(request, *callback_args, **callback_kwargs)

File "/app/.heroku/python/lib/python2.7/site-packages/newrelic-2.50.0.39/newrelic/hooks/framework_django.py", line 499, in wrapper
                  return wrapped(*args, **kwargs)

File "/app/.heroku/python/lib/python2.7/site-packages/django/contrib/auth/decorators.py", line 23, in _wrapped_view
                  return view_func(request, *args, **kwargs)

File "/app/.heroku/python/lib/python2.7/site-packages/django/views/decorators/http.py", line 40, in inner
              return func(request, *args, **kwargs)

File "/app/pontoon/base/utils.py", line 334, in wrap
          return f(request, *args, **kwargs)

File "/app/.heroku/python/lib/python2.7/site-packages/django/utils/decorators.py", line 185, in inner
                      return func(*args, **kwargs)

File "/app/pontoon/base/views.py", line 368, in batch_edit_translations
      ) for t in Translation.objects.filter(pk__in=changed_translation_pks).prefetch_related('entity')]
```