### PR TITLE
Fix machinery CSS and JS Error

### DIFF
--- a/pontoon/machinery/static/css/machinery.css
+++ b/pontoon/machinery/static/css/machinery.css
@@ -76,12 +76,12 @@
   color: #7BC876;
 }
 
-.machinery li {
+#helpers .machinery li {
   padding-left: 5px;
   padding-right: 5px;
 }
 
-.machinery li:hover {
+#helpers .machinery li:hover {
   background: #333941;
   cursor: pointer;
 }

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -480,6 +480,7 @@ PIPELINE_JS = {
     },
     'machinery': {
         'source_filenames': (
+            'js/lib/diff.js',
             'js/lib/clipboard.min.js',
             'js/machinery.js',
         ),


### PR DESCRIPTION
Fixes:
* JS Error that prevents Translation Memory suggestions from appearing
* Too general CSS selector that affects the main menu by mistake

r=me