### PR TITLE
Add command for installation all the prerequisites if user is on Ubuntu 17.04.

### DIFF
--- a/docs/dev/install.rst
+++ b/docs/dev/install.rst
@@ -21,6 +21,12 @@ all the prerequisites using the following command:
 
       sudo apt install git python-pip nodejs-legacy npm postgresql postgresql-server-dev-9.5 postgresql-contrib-9.5 libxml2-dev libxslt1-dev python-dev libmemcached-dev virtualenv
 
+If you're on Ubuntu 17.04, you can install all the prerequisites using the following command:
+
+   .. code-block:: bash
+
+      sudo apt install git python-pip nodejs-legacy npm postgresql postgresql-server-dev-9.6 postgresql-contrib-9.6 libxml2-dev libxslt1-dev python-dev libmemcached-dev virtualenv
+
 .. _Git: https://git-scm.com/
 .. _Python 2.7: https://www.python.org/
 .. _pip: https://pip.pypa.io/en/stable/


### PR DESCRIPTION
As Ubuntu 17.04 use Postgresql 9.6, the previous command won't work so I added new and updated command.