### PR TITLE
Fix bug 1344658: optimize authors and time range

### DIFF
--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -685,7 +685,13 @@ body > header aside p {
   padding-right: 5px;
 }
 
+#filter .menu li.horizontal-separator.for-time-range,
+#filter .menu li.horizontal-separator.for-authors {
+  display: none;
+}
+
 #filter .menu li.time-range {
+  display: none;
   padding: 4px 0;
 }
 

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -23,8 +23,6 @@
      {% if user.translated_locales %}data-user-translated-locales="{{ user.translated_locales|to_json() }}"{% endif %}
      {% if user.translated_projects %}data-user-translated-projects="{{ user.translated_projects|to_json() }}"{% endif %}
      {% if perms.base.can_manage_project %}data-manager="true"{% endif %}
-     data-authors="{{ authors|to_json() }}"
-     data-counts-per-minute="{{ counts_per_minute|to_json() }}"
      {% if user.is_authenticated() %}
       data-display-name="{{ user.name_or_email }}"
       {% if user.profile.locales_order %}

--- a/pontoon/base/urls.py
+++ b/pontoon/base/urls.py
@@ -33,11 +33,17 @@ urlpatterns = [
         views.locale_project_parts,
         name='pontoon.locale.project.parts'),
 
+    # AJAX: Get authors and time range data
+    url(r'^(?P<locale>[A-Za-z0-9\-\@\.]+)/(?P<slug>[\w-]+)/(?P<part>.+)/authors-and-time-range/$',
+        views.authors_and_time_range,
+        name='pontoon.authors.and.time.range'),
+
     # Translate project
     url(r'^(?P<locale>[A-Za-z0-9\-\@\.]+)/(?P<slug>[\w-]+)/(?P<part>.+)/$',
         views.translate,
         name='pontoon.translate'),
 
+    # Download translation memory
     url(r'^(?P<locale>[A-Za-z0-9\-\@\.]+)/(?P<slug>[\w-]+)/(?P<filename>.+)\.tmx$',
         views.download_translation_memory,
         name='pontoon.download_tmx'),

--- a/pontoon/base/utils.py
+++ b/pontoon/base/utils.py
@@ -578,7 +578,7 @@ def latest_datetime(datetimes):
 
 def parse_time_interval(interval):
     """
-    Return start and end time objects from time interval string n the format
+    Return start and end time objects from time interval string in the format
     %d%m%Y%H%M-%d%m%Y%H%M. Also, increase interval by one minute due to
     truncation to a minute in Translation.counts_per_minute QuerySet.
     """


### PR DESCRIPTION
Instead of updating a list of authors and the time range in the filter menu on any event that can change them, we do it when the filter menu is opened.

This has the biggest impact on saving and deleting translations. Together with 242de20c42663d8a0476cb1081deaae4df3b4312, those two tasks should be at least 80% faster.

It also speeds up loading of the translate page and entities.

@jotes r?