### PR TITLE
Fix bug 1377830: Fix selecting all entities

### DIFF
--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -2118,12 +2118,15 @@ var Pontoon = (function (my) {
       self.allEntitiesSelected = true;
       $('#entitylist .entity:visible').addClass('selected');
 
-      // Fake selected entities count to prevent waiting for getEntities()
       self.selectedEntities = [];
       self.openBatchEditor(true);
 
       this.getEntities({pkOnly: true}).then(function(data) {
-        self.selectedEntities = data.entity_pks;
+        var locallySelectedEntities = self.getEntitiesIds('#entitylist .entity:visible.selected'),
+            mergedEntities = data.entity_pks.concat(locallySelectedEntities),
+            uniqueEntities = [...new Set(mergedEntities)];
+
+        self.selectedEntities = uniqueEntities;
         self.openBatchEditor();
       });
     },


### PR DESCRIPTION
Previously, when selecting all entities for mass actions, we loaded PKs
of all entities that match the selected criteria for the string list.
We have to do this, because we use paging and not all entites are loaded
in the string list.

The problem with this approach is that some strings could have changed
state since they were loaded in the string list. For example, if only
missing strings were filtered, and we translated them, Select all would
not return such strings.

Now we concatenate those strings returned from the server with the
selected strings on the client side.

@jotes r?