### PR TITLE
Adjust @require_AJAX decorator for New Relic use

### DIFF
--- a/pontoon/base/utils.py
+++ b/pontoon/base/utils.py
@@ -1,4 +1,5 @@
 import codecs
+import functools
 import json
 import logging
 import os
@@ -332,6 +333,7 @@ def require_AJAX(f):
     """
     AJAX request required decorator
     """
+    @functools.wraps(f)  # Required by New Relic
     def wrap(request, *args, **kwargs):
         if not request.is_ajax():
             return HttpResponseBadRequest('Bad Request: Request must be AJAX')


### PR DESCRIPTION
[Without this change](https://docs.newrelic.com/docs/agents/python-agent/supported-features/python-tips-tricks#decorators_and_introspection), New Relic groups all functions using @require_AJAX decorator into a single transaction, which makes it impossible to see how each of them performs. Most if not all AJAX views use this decorator (17 at the moment).