### PR TITLE
Link to https for Gravatar in profile page

### DIFF
--- a/pontoon/contributors/templates/contributors/profile.html
+++ b/pontoon/contributors/templates/contributors/profile.html
@@ -17,7 +17,7 @@
 
 {% block heading %}
 <section id="heading">
-  <a class="avatar" href="{% if my_profile %}http://gravatar.com/{% endif %}">
+  <a class="avatar" href="{% if my_profile %}https://gravatar.com/{% endif %}">
     {% if my_profile %}
       <div class="desc">Update profile picture</div>
     {% endif %}


### PR DESCRIPTION
Just noticed while writing doc: click on the profile picture takes you on the http version, and they don't redirect you automatically.