### PR TITLE
Prefix element IDs in Fluent UI

### DIFF
--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -48,10 +48,10 @@ var Pontoon = (function (my) {
             $('#ftl-area .main-value ul')
               .append(
                 '<li class="clearfix">' +
-                  '<label class="id built-in" for="' + this + '">' +
+                  '<label class="id built-in" for="ftl-id-' + this + '">' +
                     '<span>' + this + ' (e.g. </span><span class="stress">' + example + '</span>)<sub class="fa fa-remove remove" title="Remove"></sub>' +
                   '</label>' +
-                  '<input class="value" id="' + this + '" type="text" value="' + value + '">' +
+                  '<input class="value" id="ftl-id-' + this + '" type="text" value="' + value + '">' +
                 '</li>');
           });
 
@@ -73,10 +73,10 @@ var Pontoon = (function (my) {
             maxlength = '1';
             input = '<div class="accesskeys"></div>';
           }
-          input += '<input class="value" id="' + id + '" type="text" value="' + value + '" maxlength="' + maxlength + '">';
+          input += '<input class="value" id="ftl-id-' + id + '" type="text" value="' + value + '" maxlength="' + maxlength + '">';
 
           if ($.inArray(id, [entityAttributes])) {
-            label = '<label class="id" for="' + id + '">' +
+            label = '<label class="id" for="ftl-id-' + id + '">' +
               '<span>' + id + '</span>' +
             '</label>';
 


### PR DESCRIPTION
@jotes r?

Instead of using attribute names as element IDs in Fluent UI, prefix them with `ftl-id-` to prevent Pontoon CSS and JS code having impact.

Without this fix, Pontoon can easily look like this (`title` attribute sets the input element ID to `title`, which has a rule in CSS):

![schermata 2017-07-19 alle 20 37 50](https://user-images.githubusercontent.com/626716/28386360-a140b7ae-6ccb-11e7-8f8a-81e77b4e763a.png)
