### PR TITLE
Bug 1382538: Store FTL translations with trailing newline

### DIFF
--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -277,7 +277,7 @@ var Pontoon = (function (my) {
           translation = ' = ' + translation;
         }
 
-        return entity.key + translation;
+        return entity.key + translation + '\n';
       },
 
 


### PR DESCRIPTION
That's because we need to serialize translations consistently with the python-fluent serializer. Otherwise translations get re-imported.

@jotes r?

(That's one inconsistency between Pontoon FTL serializer [ui2ftl] and python-fluent serializer. The other one is related to comments and is coming in a separate commit.)