### PR TITLE
Bug 1382538 comments

### DIFF
--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -1,6 +1,7 @@
 /* Public functions used across different files */
 var Pontoon = (function (my) {
   const fluentParser = new FluentSyntax.FluentParser({ withSpans: false });
+  const fluentSerializer = new FluentSyntax.FluentSerializer();
 
   return $.extend(true, my, {
     fluent: {
@@ -277,7 +278,8 @@ var Pontoon = (function (my) {
           translation = ' = ' + translation;
         }
 
-        return entity.key + translation + '\n';
+        var content = entity.key + translation;
+        return fluentSerializer.serializeEntry(fluentParser.parseEntry(content));
       },
 
 

--- a/pontoon/sync/formats/ftl.py
+++ b/pontoon/sync/formats/ftl.py
@@ -80,6 +80,13 @@ class FTLResource(ParsedResource):
                 key = obj.id.name
                 translation = serializer.serialize_entry(obj)
 
+                # If syncing locale file
+                if source_resource:
+                    split = translation.split('\n' + key + ' = ')
+                    if len(split) > 1:
+                        serialized_comment = split[0] + '\n'
+                        translation = translation[len(serialized_comment):]
+
                 self.entities[key] = FTLEntity(
                     key,
                     translation,


### PR DESCRIPTION
@jotes r?

b0e65a3 Previously we stored translation with a comment on sync, and without a comment on submit. We no longer store comments as part of the FTL translation in the DB.

5a52470 is less ugly than 55f1f70 and also more powerful - it takes care of whitespaces surrounding placeables for example.