### PR TITLE
Bug 1382538: Properly remove comments in FTL translations

### DIFF
--- a/pontoon/sync/formats/ftl.py
+++ b/pontoon/sync/formats/ftl.py
@@ -78,14 +78,12 @@ class FTLResource(ParsedResource):
         for obj in self.structure.body:
             if type(obj) == ast.Message:
                 key = obj.id.name
-                translation = serializer.serialize_entry(obj)
 
-                # If syncing locale file
+                # Do not store translation comments in the database
                 if source_resource:
-                    split = translation.split('\n' + key + ' = ')
-                    if len(split) > 1:
-                        serialized_comment = split[0] + '\n'
-                        translation = translation[len(serialized_comment):]
+                    obj.comment = None
+
+                translation = serializer.serialize_entry(obj)
 
                 self.entities[key] = FTLEntity(
                     key,


### PR DESCRIPTION
We don't store translation comments in the DB, at least for now. The way we strip them from the translation is hideous. This patch fixes this.

All this should become easier when we'll be able to store AST in the DB instead of the serialized string.