### PR TITLE
Fix bug 1384846: Fix diff view for FTL strings

### DIFF
--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -269,7 +269,7 @@ var Pontoon = (function (my) {
         success: function(data) {
           if (data.length) {
             $.each(data, function(i) {
-              var baseString = self.fluent.getSimplePreview(this, data[0].string, entity);
+              var baseString = self.fluent.getSimplePreview(data[0], data[0].string, entity),
                   translationString = self.fluent.getSimplePreview(this, this.string, entity);
 
               list.append(


### PR DESCRIPTION
This worked for all formats except for FTL, because getSimplePreview()
returns the fallback value for them, which is passed as the second
argument.

For FTL strings we need to generate their presentation using their
source, which is passed as the first argument. Since the same argument
was passed for the base string and the translate string, the diff
was always empty.

@jotes r?