### PR TITLE
Bug 1382773 and related Fluent UI bugfixes

### DIFF
--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -261,7 +261,7 @@ var Pontoon = (function (my) {
 
           // Plurals
           if (entity.isFTLplural) {
-            value = '{ ' + '$num ->';
+            value = '';
             var variants = $('#ftl-area .main-value li:visible');
 
             variants.each(function(i) {
@@ -274,7 +274,9 @@ var Pontoon = (function (my) {
               }
             });
 
-            value += '\n  }';
+            if (value) {
+              value = '{ $num ->' + value + '\n  }';
+            }
           }
 
           // Attributes

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -43,9 +43,23 @@ var Pontoon = (function (my) {
             }
           ).get();
 
-          $.each(pluralForms, function(i) {
-            var example = i === 3 ? 5 : i+1,
-                value = isTranslated ? self.serializePlaceables(translation_ast.value.elements[0].variants[i].value.elements) : '';
+          if (translation_ast) {
+            var variants = translation_ast.value.elements[0].variants;
+          }
+
+          $.each(pluralForms, function(pluralForm) {
+            var value = '',
+                example = pluralForm === 3 ? 5 : pluralForm + 1;
+
+            if (translation_ast) {
+              for (var i = 0; i < variants.length; i++) {
+                if (variants[i].key.name === this.toString()) {
+                  value = self.serializePlaceables(variants[i].value.elements);
+                  break;
+                }
+              }
+            }
+
             $('#ftl-area .main-value ul')
               .append(
                 '<li class="clearfix">' +

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -47,9 +47,12 @@ var Pontoon = (function (my) {
             var variants = translation_ast.value.elements[0].variants;
           }
 
+          if (!Pontoon.locale.examples) {
+            Pontoon.generateLocalePluralExamples();
+          }
+
           $.each(pluralForms, function(pluralForm) {
-            var value = '',
-                example = pluralForm === 3 ? 5 : pluralForm + 1;
+            var value = '';
 
             if (translation_ast) {
               for (var i = 0; i < variants.length; i++) {
@@ -64,7 +67,7 @@ var Pontoon = (function (my) {
               .append(
                 '<li class="clearfix">' +
                   '<label class="id built-in" for="ftl-id-' + this + '">' +
-                    '<span>' + this + ' (e.g. </span><span class="stress">' + example + '</span>)<sub class="fa fa-remove remove" title="Remove"></sub>' +
+                    '<span>' + this + ' (e.g. </span><span class="stress">' + Pontoon.locale.examples[pluralForm] + '</span>)<sub class="fa fa-remove remove" title="Remove"></sub>' +
                   '</label>' +
                   '<input class="value" id="ftl-id-' + this + '" type="text" value="' + value + '">' +
                 '</li>');

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -209,6 +209,9 @@ var Pontoon = (function (my) {
         var self = this,
             entity = Pontoon.getEditorEntity();
 
+        $('#original').show();
+        $('#ftl-original').hide();
+
         if (entity.format !== 'ftl') {
           return;
         }
@@ -255,10 +258,6 @@ var Pontoon = (function (my) {
 
           renderOriginal(ast);
           $('#ftl-original .main-value ul').append(original);
-
-        } else {
-          $('#original').show();
-          $('#ftl-original').hide();
         }
       },
 

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -301,11 +301,26 @@ var Pontoon = (function (my) {
         }
 
         var content = entity.key + translation,
-            ast = fluentParser.parseEntry(content);
+            ast = fluentParser.parseEntry(content),
+            entityAst = fluentParser.parseEntry(entity.original),
+            error = null;
 
+        // Parse error
         if (ast.type === 'Junk') {
+          error = ast.annotations[0].message;
+
+        // TODO: Should be removed by bug 1237667
+        // Detect missing values
+        } else if (entityAst && ast && entityAst.value && !ast.value) {
+          error = "Please make sure to fill in the value";
+        // Detect missing attributes
+        } else if (entityAst.attributes && ast.attributes && entityAst.attributes.length !== ast.attributes.length) {
+          error = "Please make sure to fill in all the attributes";
+        }
+
+        if (error) {
           return {
-            error: ast.annotations[0].message
+            error: error
           };
         }
 

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -262,17 +262,27 @@ var Pontoon = (function (my) {
           // Plurals
           if (entity.isFTLplural) {
             value = '';
-            var variants = $('#ftl-area .main-value li:visible');
+            var variants = $('#ftl-area .main-value li:visible'),
+                nonEmptyVariants = [],
+                def = '';
 
             variants.each(function(i) {
               var id = $(this).find('.id span:first').html().split(' ')[0],
-                  val = $(this).find('.value').val(),
-                  def = (i === (variants.length - 1)) ? '*' : '';
+                  val = $(this).find('.value').val();
 
               if (id && val) {
-                value += '\n  ' + def + '[' + id + '] ' + val;
+                nonEmptyVariants.push('[' + id + '] ' + val);
               }
             });
+
+            for (var i = 0; i < nonEmptyVariants.length; i++) {
+              // Mark the last variant as default
+              // TODO: Should be removed by bug 1237667
+              if (i === nonEmptyVariants.length - 1) {
+                def = '*';
+              }
+              value += '\n  ' + def + nonEmptyVariants[i];
+            }
 
             if (value) {
               value = '{ $num ->' + value + '\n  }';

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -298,8 +298,16 @@ var Pontoon = (function (my) {
           translation = ' = ' + translation;
         }
 
-        var content = entity.key + translation;
-        return fluentSerializer.serializeEntry(fluentParser.parseEntry(content));
+        var content = entity.key + translation,
+            ast = fluentParser.parseEntry(content);
+
+        if (ast.type === 'Junk') {
+          return {
+            error: ast.annotations[0].message
+          };
+        }
+
+        return fluentSerializer.serializeEntry(ast);
       },
 
 

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -78,7 +78,7 @@ var Pontoon = (function (my) {
 
         // Main Value
         } else if (translation_ast && translation_ast.value) {
-          $('#ftl-area > .main-value #entity-value').val(translation_ast.value.elements[0].value);
+          $('#ftl-area > .main-value #entity-value').val(self.serializePlaceables(translation_ast.value.elements));
         }
 
         // Attributes
@@ -88,7 +88,7 @@ var Pontoon = (function (my) {
 
         $.each(attributes, function() {
           id = this.id.name;
-          value = isTranslated ? this.value.elements[0].value : '';
+          value = isTranslated ? self.serializePlaceables(this.value.elements) : '';
 
           var maxlength = label = input = cls = '';
 

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -485,6 +485,30 @@ var Pontoon = (function (my) {
 
 
     /*
+     * Get example number for each plural form based on locale plural rule
+     */
+    generateLocalePluralExamples: function () {
+      var self = this;
+      var examples = self.locale.examples = {};
+      var nplurals = self.locale.nplurals;
+      var n = 0;
+
+      if (nplurals === 2) {
+        examples = {0: 1, 1: 2};
+
+      } else {
+        while (Object.keys(examples).length < nplurals) {
+          var rule = eval(self.locale.plural_rule);
+          if (!examples[rule]) {
+            examples[rule] = n;
+          }
+          n++;
+        }
+      }
+    },
+
+
+    /*
      * Open translation editor in the main UI
      *
      * entity Entity
@@ -572,29 +596,13 @@ var Pontoon = (function (my) {
 
         var nplurals = this.locale.nplurals;
         if (nplurals > 1) {
-
-          // Get example number for each plural form based on locale plural rule
           if (!this.locale.examples) {
-            var examples = this.locale.examples = {},
-                n = 0;
-
-            if (nplurals === 2) {
-              examples = {0: 1, 1: 2};
-
-            } else {
-              while (Object.keys(examples).length < nplurals) {
-                var rule = eval(this.locale.plural_rule);
-                if (!examples[rule]) {
-                  examples[rule] = n;
-                }
-                n++;
-              }
-            }
+            self.generateLocalePluralExamples();
 
             $.each(this.locale.cldr_plurals, function(i) {
               $('#plural-tabs li:eq(' + i + ') a')
                 .find('span').html(self.CLDR_PLURALS[this]).end()
-                .find('sup').html(examples[i]);
+                .find('sup').html(self.locale.examples[i]);
             });
           }
           $('#plural-tabs li:lt(' + nplurals + ')').css('display', 'table-cell');

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -2081,7 +2081,7 @@ var Pontoon = (function (my) {
                   // Make newest alternative translation active
                   if (next.length) {
                     next.click();
-                    var newTranslation = $('#translation').val();
+                    var newTranslation = self.fluent.serializeTranslation(entity, $('#translation').val());
 
                     if (entity.body && pluralForm === 0) {
                       self.postMessage("SAVE", {


### PR DESCRIPTION
This patch brings several bugfixes related to working with FTL translations:
* Prevent submitting translations that produce parse errors.
* Prevent submitting translations that miss values and attributes if the exist in the source.
* Do not break the plurals UI if not all plural forms translated.
* Properly display placeables in attributes and main value.

@jotes r? It's not a big patch, but it still might be easier to review this on a commit-by-commit basis.

Note: I'm planning to rewrite most of this code as part of bug 1362072.