### PR TITLE
Link Help to new documentation on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Pontoon enables localizers to translate web apps and web sites in place with
 context and spatial limitations right in front of them. A full list of extracted
 strings is also available, to help with strings that are hard to reach, e.g.
 error messages and the `<title>` tag.
-[Localizer Docs](https://developer.mozilla.org/docs/Mozilla/Localization/Localizing_with_Pontoon).
+[Localizer Docs](https://mozilla-l10n.github.io/localizer-documentation/tools/pontoon/).
 
 To enable localization of your site with Pontoon, include a script to overcome
 cross frame scripting, and Pontoon will autodetect strings. Or, to make the best

--- a/pontoon/base/templates/django/base.html
+++ b/pontoon/base/templates/django/base.html
@@ -75,7 +75,7 @@
                   {% endif %}
 
                   <li><a href="{% url 'pontoon.terms' %}"><i class="fa fa-legal fa-fw"></i>Terms of Use</a></li>
-                  <li><a href="https://developer.mozilla.org/en-US/docs/Localizing_with_Pontoon"><i class="fa fa-life-ring fa-fw"></i>Help</a></li>
+                  <li><a href="https://mozilla-l10n.github.io/localizer-documentation/tools/pontoon/"><i class="fa fa-life-ring fa-fw"></i>Help</a></li>
 
                   <li class="horizontal-separator"></li>
 

--- a/pontoon/base/templates/header.html
+++ b/pontoon/base/templates/header.html
@@ -30,7 +30,7 @@
               {{ Profile.top_menu() }}
 
               <li><a href="{{ url('pontoon.terms') }}"><i class="fa fa-legal fa-fw"></i>Terms of Use</a></li>
-              <li><a href="https://developer.mozilla.org/en-US/docs/Localizing_with_Pontoon"><i class="fa fa-life-ring fa-fw"></i>Help</a></li>
+              <li><a href="https://mozilla-l10n.github.io/localizer-documentation/tools/pontoon/"><i class="fa fa-life-ring fa-fw"></i>Help</a></li>
 
               <li class="horizontal-separator"></li>
 

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -115,7 +115,7 @@
             <li><a href="{{ url('pontoon.contributors') }}"><i class="fa fa-trophy fa-fw"></i>Top Contributors</a></li>
             <li><a href="{{ url('pontoon.machinery') }}"><i class="fa fa-search fa-fw"></i>Machinery</a></li>
             <li><a href="{{ url('pontoon.terms') }}"><i class="fa fa-legal fa-fw"></i>Terms of Use</a></li>
-            <li><a href="https://developer.mozilla.org/docs/Mozilla/Localization/Localizing_with_Pontoon"><i class="fa fa-life-ring fa-fw"></i>Help</a></li>
+            <li><a href="https://mozilla-l10n.github.io/localizer-documentation/tools/pontoon/"><i class="fa fa-life-ring fa-fw"></i>Help</a></li>
 
             <li class="horizontal-separator"></li>
 


### PR DESCRIPTION
New docs should be in good enough shape to replace the MDN page.