### PR TITLE
Remove helper animations

### DIFF
--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -1349,24 +1349,9 @@ body > header aside p {
   color: #CCCCCC;
 }
 
-#editor nav li a > span > .fa {
-  left: 0;
-  position: absolute;
-  right: 0;
-  top: 2px;
-  vertical-align: 0;
-  /* Bug 1312228: Stop tab loading animations when not needed to avoid high CPU usage */
-  display: none;
-  visibility: hidden;
-}
-
-#editor nav li a.loading > span > .fa {
-  display: block;
-  visibility: visible;
-}
-
 #editor nav li a > span > .count {
   background: #3F4752;
+  display: none;
   margin-left: 0;
 }
 
@@ -1377,18 +1362,6 @@ body > header aside p {
 
 #editor nav li a > span > .count > .preferred {
   color: #7BC876;
-}
-
-#editor nav li a > span {
-  position: relative;
-}
-
-#editor nav li a.loading > span {
-  visibility: hidden;
-}
-
-#editor nav li a.loading[href="#machinery"] span.count {
-  visibility: visible;
 }
 
 #editor textarea {

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -268,10 +268,12 @@ var Pontoon = (function (my) {
       var self = this,
           loader = loader || 'helpers li a[href="#machinery"]',
           ul = $('#helpers > .machinery').children('ul').empty(),
-          tab = $('#' + loader).addClass('loading'),
+          tab = $('#' + loader).addClass('loading'), // .loading class used on the /machinery page
           requests = 0,
           count = 0,
           sourcesMap = {};
+
+      self.NProgressUnbind();
 
       function append(data) {
         var title = loader !== 'search' ? ' title="Copy Into Translation (Tab)"' : ' title="Copy to clipboard"',
@@ -378,10 +380,11 @@ var Pontoon = (function (my) {
       function complete(jqXHR, status) {
         if (status !== "abort") {
           requests--;
-          tab.find('.count').html(count).toggle(count !== 0);
+          tab.find('.count').html(count).show();
           if (requests === 0) {
             tab.removeClass('loading');
             if (ul.children('li').length === 0) {
+              tab.find('.count').hide();
               ul.append('<li class="disabled">' +
                 '<p>No translations available.</p>' +
               '</li>');
@@ -389,9 +392,6 @@ var Pontoon = (function (my) {
           }
         }
       }
-
-      // Reset count
-      tab.find('.count').html('').hide();
 
       // Translation memory
       requests++;
@@ -560,8 +560,9 @@ var Pontoon = (function (my) {
           });
         }
       }).error(error).complete(complete);
-    }
 
+      self.NProgressBind();
+    }
   });
 }(Pontoon || {}));
 

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -120,11 +120,13 @@ var Pontoon = (function (my) {
     getOtherLocales: function (entity) {
       var self = this,
           list = $('#helpers .other-locales ul').empty(),
-          tab = $('#helpers a[href="#other-locales"]').addClass('loading'),
+          tab = $('#helpers a[href="#other-locales"]'),
           count = '',
           preferred = 0,
           remaining = 0,
           localesOrder = self.user.localesOrder;
+
+      self.NProgressUnbind();
 
       if (self.XHRgetOtherLocales) {
         self.XHRgetOtherLocales.abort();
@@ -203,7 +205,7 @@ var Pontoon = (function (my) {
           }
         },
         complete: function() {
-          tab.removeClass('loading')
+          tab
             .find('.count')
               .find('.preferred').html(preferred).toggle(preferred > 0).end()
               .find('.plus').html('+').toggle(preferred > 0 && remaining > 0).end()
@@ -211,6 +213,8 @@ var Pontoon = (function (my) {
               .toggle(count !== '');
         }
       });
+
+      self.NProgressBind();
     },
 
 
@@ -252,8 +256,10 @@ var Pontoon = (function (my) {
     getHistory: function (entity) {
       var self = this,
           list = $('#helpers .history ul').empty(),
-          tab = $('#helpers a[href="#history"]').addClass('loading'),
+          tab = $('#helpers a[href="#history"]'),
           count = '';
+
+      self.NProgressUnbind();
 
       if (self.XHRgetHistory) {
         self.XHRgetHistory.abort();
@@ -321,10 +327,11 @@ var Pontoon = (function (my) {
           }
         },
         complete: function() {
-          tab.removeClass('loading')
-            .find('.count').html(count).toggle(count !== '');
+          tab.find('.count').html(count).toggle(count !== '');
         }
       });
+
+      self.NProgressBind();
     },
 
 

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -388,21 +388,18 @@
             <li class="active">
               <a href="#history" title="Translation history">
                 <span>History
-                  <span class="fa fa-cog fa-lg fa-spin"></span>
                   <span class="count"></span>
                 </span>
               </a>
             </li><li>
               <a href="#machinery" title="Translation memory, machine translation & terminology">
                 <span>Machinery
-                  <span class="fa fa-cog fa-lg fa-spin"></span>
                   <span class="count"></span>
                 </span>
               </a>
             </li><li>
               <a href="#other-locales" title="Translations to other languages">
                 <span>Locales
-                  <span class="fa fa-cog fa-lg fa-spin"></span>
                   <span class="count"><span class="preferred"></span><span class="plus"></span><span class="remaining"></span></span>
                 </span>
               </a>


### PR DESCRIPTION
This PR is good for two reasons:

1. It removes more lines than adds.
2. It removes loading animations in the helper tabs (history, machinery, locales), including the horizontal progress bar (`self.NProgressUnbind()`), which makes Pontoon feel lighter while navigating between strings.