### PR TITLE
Fix bug 1389882: Fix latest activity in Top Contributors

### DIFF
--- a/pontoon/contributors/templates/contributors/contributors.html
+++ b/pontoon/contributors/templates/contributors/contributors.html
@@ -44,7 +44,7 @@
           {{ HeadingInfo.details_item(
             title='Latest activity',
             class='latest-activity',
-            value=top_contributor.contributed_translations[0].date|naturaltime)
+            value=top_contributor.contributed_translations.latest('date').date|naturaltime)
           }}
         </ul>
 


### PR DESCRIPTION
@jotes r?

Instead of latest activity, we're showing the first activity.