### PR TITLE
Fix team selector width

### DIFF
--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -655,14 +655,6 @@ tfoot td a {
   padding-right: 50px;
 }
 
-.locale.select .menu ul li span.language {
-  width: 140px;
-}
-
-.locale.select .menu ul li span.code {
-  width: 80px;
-}
-
 .select .menu ul li {
   cursor: pointer;
 }


### PR DESCRIPTION
There's no reason to set fixed width of the `.language` and `.code` elements within the team selector menu. In fact, it makes longer language names break into multiple lines sometimes.

r=me