### PR TITLE
Bug 1383252: Reduce the number of hg clone operations

### DIFF
--- a/pontoon/base/admin.py
+++ b/pontoon/base/admin.py
@@ -96,7 +96,8 @@ class RepositoryInline(admin.TabularInline):
     model = models.Repository
     extra = 0
     verbose_name_plural = 'Repositories'
-    fields = ('type', 'url', 'branch', 'website', 'permalink_prefix', 'last_synced_revisions', 'source_repo',)
+    fields = ('type', 'url', 'branch', 'website', 'permalink_prefix', 'last_synced_revisions',
+              'source_repo',)
 
 
 class SubpageInline(admin.TabularInline):

--- a/pontoon/sync/tests/test_core.py
+++ b/pontoon/sync/tests/test_core.py
@@ -317,5 +317,5 @@ class PullChangesTests(FakeCheckoutTestCase):
         self.mock_repo_pull.return_value = {'single_locale': 'asdf'}
         self.repository.last_synced_revisions = {'single_locale': 'asdf'}
         self.repository.save()
-        has_changed, _ = pull_changes(self.db_project)
+        has_changed, _ = pull_changes(self.db_project, locales=self.db_project.locales.all())
         assert_false(has_changed)

--- a/pontoon/sync/tests/test_tasks.py
+++ b/pontoon/sync/tests/test_tasks.py
@@ -81,7 +81,7 @@ class SyncProjectTests(TestCase):
         sync_project(self.db_project.pk, self.sync_log.pk)
         assert_false(self.mock_update_originals.called)
         mock_log.info.assert_called_with(
-            CONTAINS('Skipping syncing resources', self.db_project.slug)
+            CONTAINS('Skipping syncing sources', self.db_project.slug)
         )
 
     def test_no_changes_skip(self):

--- a/pontoon/sync/vcs/models.py
+++ b/pontoon/sync/vcs/models.py
@@ -146,7 +146,11 @@ class VCSProject(object):
         files = {}
 
         # VCS changes
-        for repo in self.db_project.translation_repositories():
+        repos = self.db_project.translation_repositories()
+        if self.repo_locales:
+            repos = repos.filter(pk__in=self.repo_locales.keys())
+
+        for repo in repos:
             if repo.multi_locale:
                 locales = (
                     self.repo_locales[repo.pk] if self.repo_locales


### PR DESCRIPTION
This is 3 things and it's better to look at them commit by commit:

1. Purely cosmetic. But it helps a little with the following ones.
2. If `sync_projects` is ran with the `--locale` parameter, we only sync the specified locale, but we also pull repositories for all other locales within the project. And rely on that fact in a few places. This anomaly is now gone, which and helps with the final commit.
3. The actual bugfix. More info in commit description.