### PR TITLE
Filters optimization for non-PO projects

### DIFF
--- a/pontoon/base/tests/test_models.py
+++ b/pontoon/base/tests/test_models.py
@@ -1230,7 +1230,7 @@ class EntityFilterTests(TestCase):
 
         assert_equal(
             {first_entity, third_entity},
-            set(Entity.objects.with_status_counts(self.locale).filter(Entity.objects.translated()))
+            set(Entity.objects.with_status_counts(self.locale).filter(Entity.objects.translated(self.locale, False)))
         )
 
     def test_translated_plurals(self):
@@ -1268,7 +1268,7 @@ class EntityFilterTests(TestCase):
 
         assert_equal(
             {first_entity, third_entity},
-            set(Entity.objects.with_status_counts(self.plural_locale).filter(Entity.objects.translated()))
+            set(Entity.objects.with_status_counts(self.plural_locale).filter(Entity.objects.translated(self.locale, False)))
         )
 
     def test_fuzzy(self):
@@ -1291,7 +1291,7 @@ class EntityFilterTests(TestCase):
 
         assert_equal(
             {first_entity, third_entity},
-            set(Entity.objects.with_status_counts(self.locale).filter(Entity.objects.fuzzy()))
+            set(Entity.objects.with_status_counts(self.locale).filter(Entity.objects.fuzzy(self.locale, False)))
         )
 
     def test_fuzzy_plurals(self):
@@ -1329,7 +1329,7 @@ class EntityFilterTests(TestCase):
 
         assert_equal(
             {first_entity, third_entity},
-            set(Entity.objects.with_status_counts(self.plural_locale).filter(Entity.objects.fuzzy()))
+            set(Entity.objects.with_status_counts(self.plural_locale).filter(Entity.objects.fuzzy(self.locale, False)))
         )
 
     def test_missing(self):
@@ -1350,7 +1350,7 @@ class EntityFilterTests(TestCase):
 
         assert_equal(
             {second_entity},
-            set(Entity.objects.with_status_counts(self.locale).filter(Entity.objects.missing()))
+            set(Entity.objects.with_status_counts(self.locale).filter(Entity.objects.missing(self.locale, False)))
         )
 
     def test_partially_translated_plurals(self):
@@ -1379,7 +1379,7 @@ class EntityFilterTests(TestCase):
 
         assert_equal(
             {second_entity, third_entity},
-            set(Entity.objects.with_status_counts(self.plural_locale).filter(Entity.objects.missing()))
+            set(Entity.objects.with_status_counts(self.plural_locale).filter(Entity.objects.missing(self.locale, False)))
         )
 
     def test_suggested(self):
@@ -1399,7 +1399,7 @@ class EntityFilterTests(TestCase):
 
         assert_equal(
             {second_entity, third_entity},
-            set(Entity.objects.with_status_counts(self.locale).filter(Entity.objects.suggested()))
+            set(Entity.objects.with_status_counts(self.locale).filter(Entity.objects.suggested(self.locale, False)))
         )
 
     def test_unchanged(self):
@@ -1422,7 +1422,7 @@ class EntityFilterTests(TestCase):
 
         assert_equal(
             {first_entity, third_entity},
-            set(Entity.objects.with_status_counts(self.locale).filter(Entity.objects.unchanged()))
+            set(Entity.objects.with_status_counts(self.locale).filter(Entity.objects.unchanged(self.locale, False)))
         )
 
     def test_missing_plural(self):
@@ -1454,7 +1454,7 @@ class EntityFilterTests(TestCase):
 
         assert_equal(
             {second_entity},
-            set(Entity.objects.with_status_counts(self.plural_locale).filter(Entity.objects.missing()))
+            set(Entity.objects.with_status_counts(self.plural_locale).filter(Entity.objects.missing(self.locale, False)))
         )
 
     def test_suggested_plural(self):
@@ -1490,7 +1490,7 @@ class EntityFilterTests(TestCase):
 
         assert_equal(
             {first_entity, third_entity},
-            set(Entity.objects.with_status_counts(self.plural_locale).filter(Entity.objects.suggested()))
+            set(Entity.objects.with_status_counts(self.plural_locale).filter(Entity.objects.suggested(self.locale, False)))
         )
 
     def test_unchanged_plural(self):
@@ -1529,7 +1529,7 @@ class EntityFilterTests(TestCase):
         )
         assert_equal(
             {first_entity, third_entity},
-            set(Entity.objects.with_status_counts(self.plural_locale).filter(Entity.objects.unchanged()))
+            set(Entity.objects.with_status_counts(self.plural_locale).filter(Entity.objects.unchanged(self.locale, False)))
         )
 
     def test_has_suggestions_plural(self):
@@ -1568,7 +1568,7 @@ class EntityFilterTests(TestCase):
         )
         assert_equal(
             {first_entity, third_entity},
-            set(Entity.objects.with_status_counts(self.plural_locale).filter(Entity.objects.has_suggestions()))
+            set(Entity.objects.with_status_counts(self.plural_locale).filter(Entity.objects.has_suggestions(self.locale, False)))
         )
 
     def test_rejected_plural(self):
@@ -1627,7 +1627,7 @@ class EntityFilterTests(TestCase):
         )
         assert_equal(
             {second_entity, third_entity},
-            set(Entity.objects.with_status_counts(self.plural_locale).filter(Entity.objects.rejected()))
+            set(Entity.objects.with_status_counts(self.plural_locale).filter(Entity.objects.rejected(self.locale, False)))
         )
 
     def test_combined_filters(self):

--- a/pontoon/base/tests/test_views.py
+++ b/pontoon/base/tests/test_views.py
@@ -313,7 +313,7 @@ class EntityViewTests(TestCase):
             else:
                 params['status'] = filter_
 
-            with patch('pontoon.base.models.Entity.objects.{}'.format(filter_name), return_value=getattr(Entity.objects, filter_name)()) as filter_mock:
+            with patch('pontoon.base.models.Entity.objects.{}'.format(filter_name), return_value=getattr(Entity.objects, filter_name)(self.locale, False)) as filter_mock:
                 self.client.ajax_post('/get-entities/', params)
                 assert_true(filter_mock.called)
 


### PR DESCRIPTION
Our model has two drawbacks that make it hard (slow) to filter and search strings:

1. Most filters need to identify an *active translation* (approved or latest suggestion) for the string, and there's no easy (fast) way of retrieving active translations from the model.

2. For projects using .po files we store translations for different plural forms as different Translation model instances, which makes it even harder to retrieve active translations: we need to retrieve one for each plural form supported for a locale. To circumvent that we use `with_status_counts` annotations, but that slows things down even further.

This PR solves the issue #2 for non-PO projects. That's currently 26 out of 33 projects enabled in Pontoon. The number also includes our biggest projects in terms of number of source strings, which perform slower when filtering.

It's a quick and dirty hack, meant to reduce the number of Request timeouts we're seeing after we moved locales from Pootle to Pontoon. It's deployed on stage ATM. Applying status and extra filters feels noticably faster than on production. DB was restored from a few days old production backup. 

Note that this is only a temporary hack before we come up with a proper solution for bug 1377099.

Pinging @adngdb and @jotes for feedback.