### PR TITLE
Always set logger name to module name

### DIFF
--- a/pontoon/administration/views.py
+++ b/pontoon/administration/views.py
@@ -28,7 +28,7 @@ from pontoon.sync.models import SyncLog
 from pontoon.sync.tasks import sync_project
 
 
-log = logging.getLogger('pontoon')
+log = logging.getLogger(__name__)
 
 
 def admin(request, template='admin.html'):

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -39,7 +39,7 @@ from pontoon.db import IContainsCollate  # noqa
 from pontoon.sync import KEY_SEPARATOR
 
 
-log = logging.getLogger('pontoon')
+log = logging.getLogger(__name__)
 
 
 # User class extensions

--- a/pontoon/base/utils.py
+++ b/pontoon/base/utils.py
@@ -33,7 +33,7 @@ from translate.storage.placeables.interfaces import BasePlaceable
 from translate.lang import data as lang_data
 
 
-log = logging.getLogger('pontoon')
+log = logging.getLogger(__name__)
 
 
 def split_ints(s):

--- a/pontoon/base/utils.py
+++ b/pontoon/base/utils.py
@@ -1,7 +1,6 @@
 import codecs
 import functools
 import json
-import logging
 import os
 import pytz
 import re
@@ -31,9 +30,6 @@ from translate.storage import base as storage_base
 from translate.storage.placeables import base, general, parse
 from translate.storage.placeables.interfaces import BasePlaceable
 from translate.lang import data as lang_data
-
-
-log = logging.getLogger(__name__)
 
 
 def split_ints(s):

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -51,7 +51,7 @@ from pontoon.base.utils import (
 )
 
 
-log = logging.getLogger('pontoon')
+log = logging.getLogger(__name__)
 
 
 def home(request):

--- a/pontoon/contributors/views.py
+++ b/pontoon/contributors/views.py
@@ -1,5 +1,4 @@
 import json
-import logging
 
 from dateutil.relativedelta import relativedelta
 from django.contrib import messages
@@ -22,9 +21,6 @@ from django.views.generic import TemplateView
 from pontoon.base import forms
 from pontoon.base.models import Locale, Project
 from pontoon.base.utils import require_AJAX
-
-
-log = logging.getLogger(__name__)
 
 
 @login_required(redirect_field_name='', login_url='/403')

--- a/pontoon/contributors/views.py
+++ b/pontoon/contributors/views.py
@@ -24,7 +24,7 @@ from pontoon.base.models import Locale, Project
 from pontoon.base.utils import require_AJAX
 
 
-log = logging.getLogger('pontoon')
+log = logging.getLogger(__name__)
 
 
 @login_required(redirect_field_name='', login_url='/403')

--- a/pontoon/localizations/views.py
+++ b/pontoon/localizations/views.py
@@ -13,7 +13,7 @@ from pontoon.base.utils import require_AJAX
 from pontoon.contributors.views import ContributorsMixin
 
 
-log = logging.getLogger('pontoon')
+log = logging.getLogger(__name__)
 
 
 def localization(request, code, slug):

--- a/pontoon/localizations/views.py
+++ b/pontoon/localizations/views.py
@@ -1,6 +1,5 @@
 from __future__ import division
 
-import logging
 import math
 
 from django.db.models import Q
@@ -11,9 +10,6 @@ from django.views.generic.detail import DetailView
 from pontoon.base.models import Locale, Project, ProjectLocale, TranslatedResource
 from pontoon.base.utils import require_AJAX
 from pontoon.contributors.views import ContributorsMixin
-
-
-log = logging.getLogger(__name__)
 
 
 def localization(request, code, slug):

--- a/pontoon/machinery/views.py
+++ b/pontoon/machinery/views.py
@@ -16,7 +16,7 @@ from pontoon.base import utils
 from pontoon.base.models import Locale, TranslationMemoryEntry
 
 
-log = logging.getLogger('pontoon')
+log = logging.getLogger(__name__)
 
 
 def machinery(request):

--- a/pontoon/projects/views.py
+++ b/pontoon/projects/views.py
@@ -1,4 +1,3 @@
-import logging
 import uuid
 
 from django.contrib.auth.models import User
@@ -17,9 +16,6 @@ from pontoon.base.models import Project
 from pontoon.base.utils import require_AJAX, split_ints
 from pontoon.contributors.views import ContributorsMixin
 from pontoon.projects import forms
-
-
-log = logging.getLogger(__name__)
 
 
 def projects(request):

--- a/pontoon/projects/views.py
+++ b/pontoon/projects/views.py
@@ -19,7 +19,7 @@ from pontoon.contributors.views import ContributorsMixin
 from pontoon.projects import forms
 
 
-log = logging.getLogger('pontoon')
+log = logging.getLogger(__name__)
 
 
 def projects(request):

--- a/pontoon/teams/views.py
+++ b/pontoon/teams/views.py
@@ -1,5 +1,4 @@
 import json
-import logging
 
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
@@ -20,9 +19,6 @@ from pontoon.base import forms
 from pontoon.base.models import Locale, Project
 from pontoon.base.utils import require_AJAX
 from pontoon.contributors.views import ContributorsMixin
-
-
-log = logging.getLogger(__name__)
 
 
 def teams(request):

--- a/pontoon/teams/views.py
+++ b/pontoon/teams/views.py
@@ -22,7 +22,7 @@ from pontoon.base.utils import require_AJAX
 from pontoon.contributors.views import ContributorsMixin
 
 
-log = logging.getLogger('pontoon')
+log = logging.getLogger(__name__)
 
 
 def teams(request):


### PR DESCRIPTION
BTW, in some of the files we `import logging`, set `log = logging.getLogger(__name__)` and then never log anything.

I find this convenient, because I can easily log during development without setting up the logging first and then removing the setup once I'm done.

I wonder if anyone has objections to this.