### PR TITLE
Fix failing Translation Memory count test

### DIFF
--- a/pontoon/base/tests/test_views.py
+++ b/pontoon/base/tests/test_views.py
@@ -224,7 +224,6 @@ class TranslateMemoryTests(ViewTestCase):
         result = response.json()
         src_string = result[0].pop('source')
 
-        assert_equal(len(result), 1)
         assert_true(src_string in ('abaa', 'aaab', 'aaab'))
         assert_equal(
             result,

--- a/pontoon/base/tests/test_views.py
+++ b/pontoon/base/tests/test_views.py
@@ -220,7 +220,20 @@ class TranslateMemoryTests(ViewTestCase):
             'pk': memory_entry.entity.pk,
             'locale': memory_entry.locale.code
         })
-        assert_equal(response.json()[0]['count'], 3)
+
+        result = response.json()
+        src_string = result[0].pop('source')
+
+        assert_equal(len(result), 1)
+        assert_true(src_string in ('abaa', 'aaab', 'aaab'))
+        assert_equal(
+            result,
+            [{
+                u'count': 3,
+                u'quality': 75.0,
+                u'target': u'ccc',
+            }]
+        )
 
     def test_exclude_entity(self):
         """

--- a/pontoon/base/tests/test_views.py
+++ b/pontoon/base/tests/test_views.py
@@ -220,10 +220,7 @@ class TranslateMemoryTests(ViewTestCase):
             'pk': memory_entry.entity.pk,
             'locale': memory_entry.locale.code
         })
-        assert_json(response, [{u'count': 3,
-                     u'quality': 75.0,
-                     u'source': u'abaa',
-                     u'target': u'ccc'}])
+        assert_equal(response.json()[0]['count'], 3)
 
     def test_exclude_entity(self):
         """


### PR DESCRIPTION
We now only compare the count instead of the entire response, in which the selected source parameter can vary between different environments.

The error started showing on Travis after https://github.com/mozilla/pontoon/commit/393f618223437946c836f954560d68a88c754983#diff-d32c42d35421a86de5df6a6b90db1703 was merged.

@Pike is this the fix you had in mind?

