### PR TITLE
Fix bug 1395490: fix KeyError on sync

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -1005,8 +1005,7 @@ class Project(AggregatedStats):
             for locale in self.locales.all():
                 locale.aggregate_stats()
 
-    @property
-    def changed_resources(self):
+    def changed_resources(self, now):
         """
         Returns a map of resource paths and their locales
         that where changed from the last sync.
@@ -1014,7 +1013,7 @@ class Project(AggregatedStats):
         resources = defaultdict(set)
         changes = (
             ChangedEntityLocale.objects
-            .filter(entity__resource__project=self)
+            .filter(entity__resource__project=self, when__lte=now)
             .prefetch_related('locale', 'entity__resource')
         )
 

--- a/pontoon/sync/core.py
+++ b/pontoon/sync/core.py
@@ -284,7 +284,7 @@ def commit_changes(db_project, vcs_project, changeset, locale):
     repo.commit(commit_message, commit_author, locale_path)
 
 
-def get_changed_locales(db_project, locales):
+def get_changed_locales(db_project, locales, now):
     """
     Narrow down locales to the ones that have changed since the last sync by fetching latest
     repository commit hashes via API. For projects with many repositories, this is much faster
@@ -301,7 +301,8 @@ def get_changed_locales(db_project, locales):
 
     # If locale has changed in the DB, we need to sync it.
     changed_locale_pks = list(locales.filter(
-        changedentitylocale__entity__resource__project=db_project
+        changedentitylocale__entity__resource__project=db_project,
+        changedentitylocale__when__lte=now
     ).values_list('pk', flat=True))
 
     unchanged_locale_pks = []

--- a/pontoon/sync/tasks.py
+++ b/pontoon/sync/tasks.py
@@ -230,7 +230,7 @@ def sync_translations(
     # changed locales before the expensive VCS pull/clone operations. When performing full scan,
     # we still need to sync all locales.
     if not full_scan:
-        locales = get_changed_locales(db_project, locales)
+        locales = get_changed_locales(db_project, locales, now)
 
     # Pull VCS changes in case we're on a different worker than the one
     # sync started on.
@@ -275,6 +275,7 @@ def sync_translations(
 
     vcs_project = VCSProject(
         db_project,
+        now,
         locales=locales,
         repo_locales=repo_locales,
         obsolete_entities_paths=obsolete_entities_paths,


### PR DESCRIPTION
When detecting changed resources, only take into account changes made before the sync job started. Otherwise we might end up trying to sync locales we didn't pull files for, which will lead to KeyError in VCSResource constructor's for locale in locales loop. This is a regression from bug 1383252.

That same error is also thrown when a new locale is enabled for a project during sync - after the "pull phase". We fix it by checking that all locales identified as needing sync have been pulled. This is an old bug we never fixed.

Note: None of these two bugs is causing destructive changes: they break the project sync which then completes on the next run. However, if new source strings are added and the error occures, we hit bug 1383271.

@Pike Let me know if I finally overflooded you with r? requests.