### PR TITLE
Fix bug 1363164: Show read notifications in popup

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -333,6 +333,18 @@ def can_translate(self, locale, project):
     return self.has_perm('base.can_translate_locale', locale)
 
 
+@property
+def menu_notifications(self):
+    """A list of notifications to display in the notifications menu."""
+    unread_count = self.notifications.unread().count()
+    count = settings.NOTIFICATIONS_MAX_COUNT
+
+    if unread_count > count:
+        count = unread_count
+
+    return self.notifications.all()[:count]
+
+
 User.add_to_class('profile_url', user_profile_url)
 User.add_to_class('gravatar_url', user_gravatar_url)
 User.add_to_class('name_or_email', user_name_or_email)
@@ -349,6 +361,7 @@ User.add_to_class('objects', UserCustomManager.from_queryset(UserQuerySet)())
 User.add_to_class('contributed_translations', contributed_translations)
 User.add_to_class('top_contributed_locale', top_contributed_locale)
 User.add_to_class('can_translate', can_translate)
+User.add_to_class('menu_notifications', menu_notifications)
 
 
 class UserProfile(models.Model):

--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -1011,6 +1011,10 @@ header .right .select .menu {
   padding: 0;
 }
 
+.notifications .menu ul.notification-list li.notification-item[data-unread="true"] {
+  background: #3F4752;
+}
+
 .notifications .menu li.notification-item span {
   float: none;
 }

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -52,7 +52,7 @@ var Pontoon = (function (my) {
         url: '/notifications/mark-all-as-read/',
         success: function() {
           $('#notifications.unread .button .icon').animate({color: '#4D5967'}, 1000);
-          var unreadNotifications = $('#main.notifications .right-column li.notification-item[data-unread="true"]');
+          var unreadNotifications = $('.notifications .menu ul.notification-list li.notification-item[data-unread="true"]');
 
           unreadNotifications.animate({backgroundColor: 'transparent'}, 1000, function() {
             // Remove inline style and unread mark to make hover work again

--- a/pontoon/contributors/static/css/notifications.css
+++ b/pontoon/contributors/static/css/notifications.css
@@ -2,10 +2,6 @@
   max-height: none;
 }
 
-.right-column li.notification-item[data-unread="true"] {
-  background: #3F4752;
-}
-
 /* No notifications */
 #main.no .left-column {
   display: none;

--- a/pontoon/contributors/templates/contributors/widgets/notifications_menu.html
+++ b/pontoon/contributors/templates/contributors/widgets/notifications_menu.html
@@ -1,14 +1,19 @@
 {% macro menu() %}
 {% if user.is_authenticated() %}
+
 {% set unread_notifications = user.notifications.unread() %}
-<div id="notifications" class="notifications select{% if unread_notifications|length > 0 %} unread{% endif %}">
+{% set unread_notifications_count = unread_notifications.count() %}
+{% set limit = 7 %}
+{% set notifications_to_display_count = unread_notifications_count if unread_notifications_count > limit else limit %}
+
+<div id="notifications" class="notifications select{% if unread_notifications_count > 0 %} unread{% endif %}">
 
   <div class="button selector">
     <i class="icon fa fa-bell-o fa-fw"></i>
   </div>
 
   <div class="menu">
-    {{ list(notifications=unread_notifications) }}
+    {{ list(notifications=user.notifications.all()[:notifications_to_display_count]) }}
 
     <ul>
       <li class="horizontal-separator"></li>
@@ -17,6 +22,7 @@
   </div>
 
 </div>
+
 {% endif %}
 {% endmacro %}
 

--- a/pontoon/contributors/templates/contributors/widgets/notifications_menu.html
+++ b/pontoon/contributors/templates/contributors/widgets/notifications_menu.html
@@ -6,7 +6,7 @@
 {% set limit = 7 %}
 {% set notifications_to_display_count = unread_notifications_count if unread_notifications_count > limit else limit %}
 
-<div id="notifications" class="notifications select{% if unread_notifications_count > 0 %} unread{% endif %}">
+<div id="notifications" class="notifications select{% if unread_notifications %} unread{% endif %}">
 
   <div class="button selector">
     <i class="icon fa fa-bell-o fa-fw"></i>

--- a/pontoon/contributors/templates/contributors/widgets/notifications_menu.html
+++ b/pontoon/contributors/templates/contributors/widgets/notifications_menu.html
@@ -1,19 +1,14 @@
 {% macro menu() %}
 {% if user.is_authenticated() %}
 
-{% set unread_notifications = user.notifications.unread() %}
-{% set unread_notifications_count = unread_notifications.count() %}
-{% set limit = 7 %}
-{% set notifications_to_display_count = unread_notifications_count if unread_notifications_count > limit else limit %}
-
-<div id="notifications" class="notifications select{% if unread_notifications %} unread{% endif %}">
+<div id="notifications" class="notifications select{% if user.notifications.unread() %} unread{% endif %}">
 
   <div class="button selector">
     <i class="icon fa fa-bell-o fa-fw"></i>
   </div>
 
   <div class="menu">
-    {{ list(notifications=user.notifications.all()[:notifications_to_display_count]) }}
+    {{ list(notifications=user.menu_notifications) }}
 
     <ul>
       <li class="horizontal-separator"></li>

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -790,3 +790,6 @@ else:
 # Attach extra arguments passed to notify.send(...) to the .data attribute
 # of the Notification object.
 NOTIFICATIONS_USE_JSONFIELD = True
+
+# Maximum number of read notifications to display in the notifications menu
+NOTIFICATIONS_MAX_COUNT = 7


### PR DESCRIPTION
In notifications popup, always show the latest 7 notifications, including the unread. If there are more than 7 unread notifications, show all.

@jotes r?