### PR TITLE
Bug 1377099 - Make search faster.

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -2028,8 +2028,15 @@ class Entity(DirtyFieldsMixin, models.Model):
             search_query = (search, locale.db_collation)
             entities = (
                 Entity.objects.filter(
-                    Q(translation__string__icontains_collate=search_query, translation__locale=locale) | Q(string__icontains=search) | Q(string_plural__icontains=search) | Q(comment__icontains=search) | Q(key__icontains=search),
-                    pk__in=entities
+                    (
+                        Q(translation__string__icontains_collate=search_query) |
+                        Q(string__icontains=search) |
+                        Q(string_plural__icontains=search) |
+                        Q(comment__icontains=search) |
+                        Q(key__icontains=search)
+                    ),
+                    pk__in=entities,
+                    translation__locale=locale,
                 )
                 .distinct()
             )

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -2031,8 +2031,7 @@ class Entity(DirtyFieldsMixin, models.Model):
                     translation__string__icontains_collate=search_query,
                     translation__locale=locale,
                 )
-                .distinct()
-                .values_list('id')
+                .values_list('id', flat=True)
             )
             entity_matches = (
                 entities.filter(
@@ -2041,13 +2040,10 @@ class Entity(DirtyFieldsMixin, models.Model):
                     Q(comment__icontains=search) |
                     Q(key__icontains=search)
                 )
-                .distinct()
-                .values_list('id')
+                .values_list('id', flat=True)
             )
             entities = Entity.objects.filter(
-                pk__in=set(
-                    e[0] for e in list(translation_matches) + list(entity_matches)
-                )
+                pk__in=set(list(translation_matches) + list(entity_matches))
             )
 
         entities = entities.prefetch_resources_translations(locale)


### PR DESCRIPTION
We join the entity table with the translation table in order to search, but that join is done for all the translations, where we only care about translations for the locale the user is looking at. This commit moves the filter on the locale up in the WHERE clause, allowing the database to optimize the join, leading to a faster search time.