### PR TITLE
Allow searching by locale code in team list

### DIFF
--- a/pontoon/base/static/js/table.js
+++ b/pontoon/base/static/js/table.js
@@ -74,12 +74,12 @@ var Pontoon = (function (my) {
               list = $(this).data('list') || '.table-sort tbody',
               // Selector of the list item element, relative to list
               item = $(this).data('item') || 'tr',
-              // Optional selector to match filter query against
-              filter = $(this).data('filter') || ' td:first-child';
+              // Selector of the list item element's child to match filter query against
+              filter = $(this).data('filter') || 'td:first-child';
 
           $(list)
-            .find(item + '.limited').show().end()
-            .find(item + '.limited' + filter + ':not(":containsi(\'' + $(field).val() + '\')")').parents(item).hide();
+            .find(item + '.limited').hide().end()
+            .find(item + '.limited ' + filter + ':containsi("' + $(field).val() + '")').parents(item).show();
         });
       }(),
 

--- a/pontoon/projects/templates/projects/includes/teams.html
+++ b/pontoon/projects/templates/projects/includes/teams.html
@@ -4,7 +4,7 @@
   <menu class="controls">
     <div class="search-wrapper small clearfix">
       <div class="icon fa fa-search"></div>
-      <input class="table-filter" type="search" autocomplete="off" autofocus placeholder="Filter teams">
+      <input class="table-filter" type="search" autocomplete="off" autofocus placeholder="Filter teams" data-filter="td:nth-child(-n+2)">
     </div>
   </menu>
 

--- a/pontoon/teams/templates/teams/teams.html
+++ b/pontoon/teams/templates/teams/teams.html
@@ -60,7 +60,7 @@
     <menu class="controls">
       <div class="search-wrapper clearfix">
         <div class="icon fa fa-search"></div>
-        <input class="table-filter" type="search" autocomplete="off" autofocus placeholder="Filter teams">
+        <input class="table-filter" type="search" autocomplete="off" autofocus placeholder="Filter teams" data-filter="td:nth-child(-n+2)">
       </div>
     </menu>
 


### PR DESCRIPTION
One should be able to search by locale (code), not just the language in places like https://pontoon.mozilla.org/teams/.