### PR TITLE
Faster translate view

### DIFF
--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -126,6 +126,7 @@ def translate(request, locale, slug, part):
         'download_form': forms.DownloadFileForm(),
         'upload_form': forms.UploadFileForm(),
         'locale': locale,
+        'locale_projects': locale.available_projects_list(),
         'locales': Locale.objects.available(),
         'part': part,
         'project': project,

--- a/pontoon/projects/templates/projects/widgets/project_selector.html
+++ b/pontoon/projects/templates/projects/widgets/project_selector.html
@@ -12,12 +12,12 @@
 
     <ul>
       {% for p in projects %}
-        <li class="clearfix{% if locale and p.slug in locale.available_projects_list() %} limited{% endif %}">
+        <li class="clearfix{% if p.slug in locale_projects %} limited{% endif %}">
           <span class="name"
             {% for key, value in p.serialize().iteritems() %}
               data-{{ key }}="{{ value }}"
             {% endfor %}
-            {% if project and locale and project == p %}
+            {% if project == p %}
               data-parts="{{ {locale.code: locale.parts_stats(p)}|to_json }}"
             {% endif %}
           >


### PR DESCRIPTION
While looking at performance data of the search speedup, New Relic pointed me to a simple fix for improving page load time of the translate view.

It's a simple trick to cache a DB query in a variable insted of querying the DB with the same request in a loop.

Note that the translate view is also used as the homepage for users that are not authenticated or don't have any contributions, which makes it the most popular view.

```
translate view speedup: 40%
```