### PR TITLE
Faster notifications page

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -348,7 +348,7 @@ def menu_notifications(self):
     if unread_count > count:
         count = unread_count
 
-    return self.notifications.all()[:count]
+    return self.notifications.prefetch_related('actor', 'target')[:count]
 
 
 User.add_to_class('profile_url', user_profile_url)

--- a/pontoon/contributors/views.py
+++ b/pontoon/contributors/views.py
@@ -179,7 +179,7 @@ def settings(request):
 @login_required(redirect_field_name='', login_url='/403')
 def notifications(request):
     """View and edit user notifications."""
-    notifications = request.user.notifications.order_by('-pk')
+    notifications = request.user.notifications.prefetch_related('actor', 'target').order_by('-pk')
     projects = {}
 
     for notification in notifications:


### PR DESCRIPTION
Another quick fix, with the same background as #703.

The average call to the /notifications page triggers 178 base_project select DB queries, which makes the page slow. With this fix, the number goes down to 2 and the page load is around 75% faster.

Note that the page is the 3rd most popular view (after translate view and team view) - possibly due to the [Pontoon Tools](https://addons.mozilla.org/sl/firefox/addon/pontoon-tools/?src=search) extension.

We use the same trick on the notifications menu. The impact is less obvious, because we usually only load the latest 7 notifications.

```
/notifications speedup: 60%
```