### PR TITLE
Faster teams and projects pages

### DIFF
--- a/pontoon/projects/templates/projects/projects.html
+++ b/pontoon/projects/templates/projects/projects.html
@@ -20,7 +20,7 @@
       {{ HeadingInfo.details_item(
         title='Number of projects',
         class='projects-count',
-        value=projects.count())
+        value=projects|length)
       }}
       {{ HeadingInfo.details_item(
         title='Most translations',

--- a/pontoon/teams/templates/teams/teams.html
+++ b/pontoon/teams/templates/teams/teams.html
@@ -20,7 +20,7 @@
       {{ HeadingInfo.details_item(
         title='Number of teams',
         class='teams-count',
-        value=locales.count())
+        value=locales|length)
       }}
       {{ HeadingInfo.details_item(
         title='Most translations',


### PR DESCRIPTION
This one was also discovered using the New Relic data.

We now use python to get top instances and aggregated data from projects and locales QuerySets. It's faster than querying the DB with order_by() and aggregate().

The 2nd commit also has a noticable performance impact. We now list all locales that have at least one project enabled, regardless if it's synced or not.

```
/teams speedup: 70%
/projects speedup: 40%
```