### PR TITLE
Bug 1357361: Speed up contributors list

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -43,96 +43,100 @@ from pontoon.sync import KEY_SEPARATOR
 log = logging.getLogger(__name__)
 
 
-# User class extensions
 class UserTranslationsManager(UserManager):
-    """
-    Provides various method to interact with larger sets of translations and their stats for user.
-    """
-
-    def _changed_translations_count(self, *args):
-        """
-        Helper method, returns expression object which allows us to annotate querysets
-        with counts of translations.
-        """
-        translation_query = Q(translation__user__isnull=False)
-        for arg in args:
-            translation_query &= arg
-
-        # For each translation that matches the filter, return 1. Aggregate
-        # the sum of all those results to count the number of matching
-        # translations.
-        return Sum(
-            Case(
-                When(translation_query, then=1), output_field=models.IntegerField(), default=0))
-
     def with_translation_counts(self, start_date=None, query_filters=None, limit=100):
         """
-        Returns contributors list, sorted by count of their translations.
-        Every user instance has added following properties:
+        Returns contributors list, sorted by count of their translations. Every user instance has
+        the following properties:
         * translations_count
         * translations_approved_count
         * translations_unapproved_count
         * translations_needs_work_count
-        Method has been created mainly to improve performance and to optimize
-        count of sql queries during generation of metrics.
+        * user_role
+
         All counts will be returned from start_date to now().
         :param date start_date: start date for translations.
         :param django.db.models.Q query_filters: filters contributors by given query_filters.
         :param int limit: limit results to this number.
         """
-        def translations_count(query=None):
-            """Short helper to avoid duplication of passing dates."""
-            query = query or Q()
-            if start_date:
-                query &= Q(translation__date__gte=start_date)
 
-            if query_filters:
-                query &= query_filters
+        # Collect data for faster user stats calculation.
+        user_stats = {}
+        translations = Translation.objects.exclude(user=None)
 
-            return self._changed_translations_count(query)
+        if start_date:
+            translations = translations.filter(date__gte=start_date)
+        if query_filters:
+            translations = translations.filter(query_filters)
 
-        def with_roles(self):
-            """Add user roles."""
-            managers = defaultdict(set)
-            translators = defaultdict(set)
-
-            locales = Locale.objects.prefetch_related(
-                Prefetch(
-                    'managers_group__user_set',
-                    to_attr='fetched_managers'
-                ),
-                Prefetch(
-                    'translators_group__user_set',
-                    to_attr='fetched_translators'
-                )
-            )
-
-            for locale in locales:
-                for user in locale.managers_group.fetched_managers:
-                    managers[user].add(locale.code)
-                for user in locale.translators_group.fetched_translators:
-                    translators[user].add(locale.code)
-
-            for contributor in self:
-                contributor.user_role = contributor.role(managers, translators)
-
-            return self
-
-        return with_roles(
-            self
-            .annotate(translations_count=translations_count(),
-                      translations_approved_count=translations_count(Q(translation__approved=True)),
-                      translations_unapproved_count=translations_count(Q(translation__approved=False, translation__fuzzy=False)),
-                      translations_needs_work_count=translations_count(Q(translation__fuzzy=True)))
-            .exclude(translations_count=0)
-            .distinct().order_by('-translations_count')[:limit]
+        translations = (
+            translations
+            .values('user', 'approved', 'fuzzy')
+            .annotate(count=Count('user'))
         )
+
+        for translation in translations:
+            count = translation['count']
+            user = translation['user']
+
+            if translation['approved']:
+                status = 'approved'
+            elif translation['fuzzy']:
+                status = 'fuzzy'
+            else:
+                status = 'suggested'
+
+            if user not in user_stats:
+                user_stats[user] = {
+                    'total': 0,
+                    'approved': 0,
+                    'suggested': 0,
+                    'fuzzy': 0,
+                }
+
+            user_stats[user]['total'] += count
+            user_stats[user][status] += count
+
+        # Collect data for faster user role detection.
+        managers = defaultdict(set)
+        translators = defaultdict(set)
+
+        locales = Locale.objects.prefetch_related(
+            Prefetch(
+                'managers_group__user_set',
+                to_attr='fetched_managers'
+            ),
+            Prefetch(
+                'translators_group__user_set',
+                to_attr='fetched_translators'
+            )
+        )
+
+        for locale in locales:
+            for user in locale.managers_group.fetched_managers:
+                managers[user].add(locale.code)
+            for user in locale.translators_group.fetched_translators:
+                translators[user].add(locale.code)
+
+        # Assign properties to user objects.
+        contributors = self.filter(pk__in=user_stats.keys())
+
+        for contributor in contributors:
+            user = user_stats[contributor.pk]
+            contributor.translations_count = user['total']
+            contributor.translations_approved_count = user['approved']
+            contributor.translations_unapproved_count = user['suggested']
+            contributor.translations_needs_work_count = user['fuzzy']
+            contributor.user_role = contributor.role(managers, translators)
+
+        return sorted(contributors, key=lambda x: -x.translations_count)[:100]
 
 
 class UserCustomManager(UserManager):
     """
-    Django migrations is able to migrate managers, and throws an error if we directly call UserManager.from_queryset():
-        Please note that you need to inherit from managers you dynamically generated with 'from_queryset()'.
+    Django migrations is able to migrate managers, and throws an error if we directly call
+    UserManager.from_queryset(): Please note that you need to inherit from managers you dynamically
+    generated with 'from_queryset()'.
     """
     use_in_migrations = False
 

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -54,11 +54,7 @@ class UserTranslationsManager(UserManager):
         Helper method, returns expression object which allows us to annotate querysets
         with counts of translations.
         """
-        translation_query = (
-            ~Q(translation__string=F('translation__entity__string')) &
-            ~Q(translation__string=F('translation__entity__string_plural')) &  # noqa
-            Q(translation__user__isnull=False)
-        )
+        translation_query = Q(translation__user__isnull=False)
         for arg in args:
             translation_query &= arg
 
@@ -298,12 +294,7 @@ def user_locale_role(self, locale):
 @property
 def contributed_translations(self):
     """Filtered contributions provided by user."""
-    translations = (
-        Translation.objects.filter(user=self)
-        .exclude(string=F('entity__string'))
-        .exclude(string=F('entity__string_plural'))
-    )
-    return translations
+    return Translation.objects.filter(user=self)
 
 
 @property

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -124,7 +124,6 @@ class UserTranslationsManager(UserManager):
 
         return with_roles(
             self
-            .exclude(email__in=settings.EXCLUDE)
             .annotate(translations_count=translations_count(),
                       translations_approved_count=translations_count(Q(translation__approved=True)),
                       translations_unapproved_count=translations_count(Q(translation__approved=False, translation__fuzzy=False)),

--- a/pontoon/base/tests/test_models.py
+++ b/pontoon/base/tests/test_models.py
@@ -488,7 +488,7 @@ class UserTranslationManagerTests(TestCase):
 
         top_contributors = User.translators.with_translation_counts()
 
-        assert_equal(top_contributors.count(), 100)
+        assert_equal(len(top_contributors), 100)
 
     def create_contributor_with_translation_counts(self, approved=0, unapproved=0, needs_work=0, **kwargs):
         """
@@ -511,7 +511,7 @@ class UserTranslationManagerTests(TestCase):
         third_contributor = self.create_contributor_with_translation_counts(approved=1, unapproved=2, needs_work=5)
 
         top_contributors = User.translators.with_translation_counts()
-        assert_equal(top_contributors.count(), 3)
+        assert_equal(len(top_contributors), 3)
 
         assert_equal(top_contributors[0], second_contributor)
         assert_equal(top_contributors[1], first_contributor)
@@ -544,14 +544,14 @@ class UserTranslationManagerTests(TestCase):
 
         top_contributors = User.translators.with_translation_counts(aware_datetime(2015, 6, 10))
 
-        assert_equal(top_contributors.count(), 1)
+        assert_equal(len(top_contributors), 1)
         assert_attributes_equal(top_contributors[0], translations_count=5,
             translations_approved_count=5, translations_unapproved_count=0,
             translations_needs_work_count=0)
 
         top_contributors = User.translators.with_translation_counts(aware_datetime(2015, 5, 10))
 
-        assert_equal(top_contributors.count(), 2)
+        assert_equal(len(top_contributors), 2)
         assert_attributes_equal(top_contributors[0], translations_count=15,
             translations_approved_count=2, translations_unapproved_count=11,
             translations_needs_work_count=2)
@@ -561,7 +561,7 @@ class UserTranslationManagerTests(TestCase):
 
         top_contributors = User.translators.with_translation_counts(aware_datetime(2015, 1, 10))
 
-        assert_equal(top_contributors.count(), 2)
+        assert_equal(len(top_contributors), 2)
         assert_attributes_equal(top_contributors[0], translations_count=20,
             translations_approved_count=17, translations_unapproved_count=1,
             translations_needs_work_count=2)
@@ -583,8 +583,8 @@ class UserTranslationManagerTests(TestCase):
             approved=10, unapproved=12, needs_work=2, locale=locale_first)
 
         # Testing filtering for the first locale
-        top_contributors = User.translators.with_translation_counts(aware_datetime(2015, 1, 1), Q(translation__locale=locale_first))
-        assert_equal(top_contributors.count(), 2)
+        top_contributors = User.translators.with_translation_counts(aware_datetime(2015, 1, 1), Q(locale=locale_first))
+        assert_equal(len(top_contributors), 2)
         assert_equal(top_contributors[0], third_contributor)
         assert_attributes_equal(top_contributors[0], translations_count=24,
             translations_approved_count=10, translations_unapproved_count=12,
@@ -596,9 +596,9 @@ class UserTranslationManagerTests(TestCase):
             translations_needs_work_count=2)
 
         # Testing filtering for the second locale
-        top_contributors = User.translators.with_translation_counts(aware_datetime(2015, 1, 1), Q(translation__locale=locale_second))
+        top_contributors = User.translators.with_translation_counts(aware_datetime(2015, 1, 1), Q(locale=locale_second))
 
-        assert_equal(top_contributors.count(), 1)
+        assert_equal(len(top_contributors), 1)
         assert_equal(top_contributors[0], second_contributor)
         assert_attributes_equal(top_contributors[0], translations_count=14,
             translations_approved_count=11, translations_unapproved_count=1,

--- a/pontoon/base/tests/test_models.py
+++ b/pontoon/base/tests/test_models.py
@@ -23,7 +23,6 @@ from pontoon.base.tests import (
     assert_attributes_equal,
     ChangedEntityLocaleFactory,
     EntityFactory,
-    IdenticalTranslationFactory,
     LocaleFactory,
     PluralEntityFactory,
     ProjectFactory,
@@ -461,18 +460,6 @@ class UserTranslationManagerTests(TestCase):
         top_contributors = User.translators.with_translation_counts()
         assert_true(active_contributor in top_contributors)
         assert_true(inactive_contributor not in top_contributors)
-
-    def test_unique_translations(self):
-        """
-        Checks if contributors with identical translations are returned.
-        """
-
-        unique_translator = TranslationFactory.create().user
-        identical_translator = IdenticalTranslationFactory.create().user
-        top_contributors = User.translators.with_translation_counts()
-
-        assert_true(unique_translator in top_contributors)
-        assert_true(identical_translator not in top_contributors)
 
     def test_contributors_order(self):
         """

--- a/pontoon/base/tests/test_models.py
+++ b/pontoon/base/tests/test_models.py
@@ -10,7 +10,6 @@ from django_nose.tools import (
     assert_true,
 )
 from django.db.models import Q
-from django.test.utils import override_settings
 
 from mock import call, Mock, patch
 
@@ -452,19 +451,6 @@ class RepositoryTests(TestCase):
 
 
 class UserTranslationManagerTests(TestCase):
-    @override_settings(EXCLUDE=('excluded@example.com',))
-    def test_excluded_contributors(self):
-        """
-        Checks if contributors with mails in settings.EXCLUDE are excluded
-        from top contributors list.
-        """
-        included_contributor = TranslationFactory.create(user__email='included@example.com').user
-        excluded_contributor = TranslationFactory.create(user__email='excluded@example.com').user
-
-        top_contributors = User.translators.with_translation_counts()
-        assert_true(included_contributor in top_contributors)
-        assert_true(excluded_contributor not in top_contributors)
-
     def test_users_without_translations(self):
         """
         Checks if user contributors without translations aren't returned.

--- a/pontoon/contributors/static/css/contributors.css
+++ b/pontoon/contributors/static/css/contributors.css
@@ -87,7 +87,3 @@ th:last-child sup {
   font-size: 20px;
   padding: 3px 0 0;
 }
-
-#fn-translations {
-  font-size: inherit;
-}

--- a/pontoon/contributors/templates/contributors/contributors.html
+++ b/pontoon/contributors/templates/contributors/contributors.html
@@ -34,7 +34,7 @@
           {{ HeadingInfo.details_item(
             title='Role',
             class='role',
-            value=top_contributor.role())
+            value=top_contributor.user_role)
           }}
           {{ HeadingInfo.details_item(
             title='Active since',

--- a/pontoon/contributors/templates/contributors/widgets/contributor_list.html
+++ b/pontoon/contributors/templates/contributors/widgets/contributor_list.html
@@ -18,7 +18,7 @@
       <tr>
         <th class="rank">Rank</th>
         <th>Contributor</th>
-        <th>Translations<sup><a href="#fn-translations" id="ref-translations">*</a></sup></th>
+        <th>Translations</th>
       </tr>
     </thead>
     <tbody>
@@ -52,11 +52,6 @@
       </tr>
     {% endfor %}
     </tbody>
-    <tfoot>
-      <tr>
-        <td colspan="3"><sup id="fn-translations">*Translation counts do not include unchanged translations.<a href="#ref-translations" title="Jump back to top.">↩</a></sup></td>
-      </tr>
-    </tfoot>
   </table>
 {% endmacro %}
 

--- a/pontoon/localizations/views.py
+++ b/pontoon/localizations/views.py
@@ -126,6 +126,6 @@ class LocalizationContributorsView(ContributorsMixin, DetailView):
 
     def contributors_filter(self, **kwargs):
         return Q(
-            translation__entity__resource__project=self.object.project,
-            translation__locale=self.object.locale
+            entity__resource__project=self.object.project,
+            locale=self.object.locale
         )

--- a/pontoon/projects/views.py
+++ b/pontoon/projects/views.py
@@ -155,4 +155,4 @@ class ProjectContributorsView(ContributorsMixin, DetailView):
         return 'project'
 
     def contributors_filter(self, **kwargs):
-        return Q(translation__entity__resource__project=self.object)
+        return Q(entity__resource__project=self.object)

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -717,9 +717,6 @@ ALLOWED_ATTRIBUTES = {
     'acronym': ['title'],
 }
 
-# Contributors to exclude from Top Contributors list
-EXCLUDE = os.environ.get('EXCLUDE', '').split(',')
-
 SYNC_TASK_TIMEOUT = 60 * 60 * 1  # 1 hour
 
 SYNC_LOG_RETENTION = 90  # days

--- a/pontoon/teams/views.py
+++ b/pontoon/teams/views.py
@@ -198,4 +198,4 @@ class LocaleContributorsView(ContributorsMixin, DetailView):
         return 'locale'
 
     def contributors_filter(self, **kwargs):
-        return Q(translation__locale=self.object)
+        return Q(locale=self.object)


### PR DESCRIPTION
This brings around 80% speed up to the /contributors view, and up to 90% on more specific contributors pages (/sl/contributors, /projects/firefox/contributors, /sl/firefox/contributors).

On production the load time of these pages averages around 6 seconds, so this should bring us to around 1.5 seconds. I'm not sure we can achieve much more without changing the data model.

Please review each commit separately. I tried to be as verbose as possible in commit messsages. To further clarify the last commit (https://github.com/mozilla/pontoon/pull/706/commits/0f9ce46cc7a9d29d950a22c7e257017b74077023), I'm adding the before and after SQL query:

Before:
```sql
SELECT DISTINCT "auth_user"."id",
                "auth_user"."password",
                "auth_user"."last_login",
                "auth_user"."is_superuser",
                "auth_user"."username",
                "auth_user"."first_name",
                "auth_user"."last_name",
                "auth_user"."email",
                "auth_user"."is_staff",
                "auth_user"."is_active",
                "auth_user"."date_joined",
                Sum(CASE
                      WHEN ( "base_translation"."user_id" IS NOT NULL
                             AND "base_translation"."approved" = true ) THEN 1
                      ELSE 0
                    end) AS "translations_approved_count",
                Sum(CASE
                      WHEN ( "base_translation"."user_id" IS NOT NULL
                             AND "base_translation"."fuzzy" = false
                             AND "base_translation"."approved" = false ) THEN 1
                      ELSE 0
                    end) AS "translations_unapproved_count",
                Sum(CASE
                      WHEN "base_translation"."user_id" IS NOT NULL THEN 1
                      ELSE 0
                    end) AS "translations_count",
                Sum(CASE
                      WHEN ( "base_translation"."user_id" IS NOT NULL
                             AND "base_translation"."fuzzy" = true ) THEN 1
                      ELSE 0
                    end) AS "translations_needs_work_count"
FROM   "auth_user"
       LEFT OUTER JOIN "base_translation"
                    ON ( "auth_user"."id" = "base_translation"."user_id" )
GROUP  BY "auth_user"."id"
HAVING NOT ( Sum(CASE
                   WHEN "base_translation"."user_id" IS NOT NULL THEN 1
                   ELSE 0
                 end) = 0 )
ORDER  BY "translations_count" DESC
LIMIT  100  
```

After:
```sql
SELECT "base_translation"."user_id",
       "base_translation"."approved",
       "base_translation"."fuzzy",
       Count("base_translation"."user_id") AS "count"
FROM   "base_translation"
WHERE  NOT ( "base_translation"."user_id" IS NULL )
GROUP  BY "base_translation"."user_id",
          "base_translation"."approved",
          "base_translation"."fuzzy"  
```
