### PR TITLE
Fix bug 1399166: Use X-channel repo as source

### DIFF
--- a/bin/mozilla-en-US.py
+++ b/bin/mozilla-en-US.py
@@ -113,7 +113,7 @@ dname = os.path.dirname(abspath)
 os.chdir(dname)
 
 # Clone or update source repository
-url = 'ssh://hg.mozilla.org/users/axel_mozilla.com/gecko-strings/'
+url = 'https://hg.mozilla.org/users/axel_mozilla.com/gecko-strings/'
 target = 'source'
 pull(url, target)
 
@@ -126,11 +126,9 @@ for repo in TARGET_REPOS.keys():
     pull(url, target)
 
     # Prune all subdirectories in target repository in case they get removed from source
-    for root, subdirs, files in os.walk(target, True):
-        for subdir in subdirs:
-            if not subdir.startswith('.'):
-                shutil.rmtree(os.path.join(root, subdir))
-        break
+    for subdir in os.listdir(target):
+        if not subdir.startswith('.'):
+            shutil.rmtree(os.path.join(target, subdir))
 
     # Copy folders from source to target
     for folder in TARGET_REPOS[repo]:

--- a/bin/mozilla-en-US.py
+++ b/bin/mozilla-en-US.py
@@ -19,11 +19,30 @@ import shutil
 import subprocess
 
 TARGET_REPOS = {
-    'firefox': ['browser', 'devtools', 'dom', 'netwerk', 'security', 'services', 'toolkit'],
-    'firefox-for-android': ['mobile'],
-    'thunderbird': ['chat', 'editor', 'mail', 'other-licenses'],
-    'lightning': ['calendar'],
-    'seamonkey': ['suite'],
+    'firefox': [
+        'browser',
+        'devtools',
+        'dom',
+        'netwerk',
+        'security',
+        'services',
+        'toolkit',
+    ],
+    'firefox-for-android': [
+        'mobile',
+    ],
+    'thunderbird': [
+        'chat',
+        'editor',
+        'mail',
+        'other-licenses',
+    ],
+    'lightning': [
+        'calendar',
+    ],
+    'seamonkey': [
+        'suite',
+    ],
 }
 
 

--- a/bin/mozilla-en-US.py
+++ b/bin/mozilla-en-US.py
@@ -125,13 +125,17 @@ for repo in TARGET_REPOS.keys():
     # Clone or update target repository
     pull(url, target)
 
+    # Prune all subdirectories in target repository in case they get removed from source
+    for root, subdirs, files in os.walk(target, True):
+        for subdir in subdirs:
+            if not subdir.startswith('.'):
+                shutil.rmtree(os.path.join(root, subdir))
+        break
+
     # Copy folders from source to target
     for folder in TARGET_REPOS[repo]:
         origin = os.path.join('source', folder)
         destination = os.path.join('target', ending, folder)
-
-        if os.path.exists(destination):
-            shutil.rmtree(destination)
 
         if os.path.exists(origin):
             shutil.copytree(origin, destination)

--- a/bin/mozilla-en-US.py
+++ b/bin/mozilla-en-US.py
@@ -80,6 +80,10 @@ def pull(url, target):
         write(text_type(error))
         write('Clone instead.')
 
+        # Clean up target directory on a failed pull, so that it's empty for a clone
+        command = ["rm", "-rf", target]
+        code, output, error = execute(command)
+
         code, output, error = execute(['hg', 'clone', url, target])
         if code == 0:
             write('Repository at ' + url + ' cloned.')


### PR DESCRIPTION
Cross-channel repository is already limited to localizable files only, and it also includes files from the comm-* repositories.