### PR TITLE
Reset screenshot on string navigation

### DIFF
--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -530,8 +530,9 @@ var Pontoon = (function (my) {
 
       // Metadata: comment
       $('#metadata').empty();
-      if (entity.comment) {
+      $('#source-pane').removeClass().find('#screenshots').empty();
 
+      if (entity.comment) {
         // Translation length limit
         var split = entity.comment.split('\n'),
             splitComment = entity.comment;
@@ -549,7 +550,6 @@ var Pontoon = (function (my) {
         self.appendMetaData('Comment', comment);
 
         // Screenshot
-        $('#source-pane').removeClass().find('#screenshots').empty();
         $('#metadata').find('a').each(function() {
           var url = $(this).html();
           if (/(https?:\/\/.*\.(?:png|jpg))/im.test(url)) {


### PR DESCRIPTION
If a string contains a link to a JPG or PNG file in its comment, we
render the linked image as a thumbnail in the source panel. If the
subsequently openned string does not have a comment, we keep the
screenshot visible instead of removing it. This patch fixes that.