### PR TITLE
Fix status icon for partially translated strings

### DIFF
--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -293,7 +293,10 @@ body > header .locale.select {
 #filter .missing:not(.hover) .status:before,
 #entitylist .wrapper .selected.missing .status:before,
 #entitylist .wrapper .hovered.missing .status:before,
-#entitylist .wrapper li:hover.missing .status:before {
+#entitylist .wrapper li:hover.missing .status:before,
+#entitylist .wrapper .selected.partial .status:before,
+#entitylist .wrapper .hovered.partial .status:before,
+#entitylist .wrapper li:hover.partial .status:before {
   color: #3F4752;
 }
 


### PR DESCRIPTION
Partially translated strings use a different CSS class than missing
strings, depite the fact that the status icon looks the same. That is
because we have translations to show for the partially translated
strings, so the source strings column can only occupy half the width.

Missing strings on the other hand don't have translations (d'oh), so
the original string can occupy the entire string list width.