### PR TITLE
Bug 1403861 - Hide Suggested and Fuzzy statistics in the API

### DIFF
--- a/pontoon/api/schema.py
+++ b/pontoon/api/schema.py
@@ -20,8 +20,7 @@ class ProjectLocale(DjangoObjectType, Stats):
     class Meta:
         model = ProjectLocaleModel
         only_fields = (
-            'total_strings', 'approved_strings', 'translated_strings',
-            'fuzzy_strings', 'project', 'locale'
+            'project', 'locale', 'total_strings', 'approved_strings', 'fuzzy_strings'
         )
 
 
@@ -29,9 +28,8 @@ class Project(DjangoObjectType, Stats):
     class Meta:
         model = ProjectModel
         only_fields = (
-            'name', 'slug', 'disabled', 'info', 'deadline', 'priority',
-            'contact', 'total_strings', 'approved_strings',
-            'translated_strings', 'fuzzy_strings'
+            'name', 'slug', 'disabled', 'info', 'deadline', 'priority', 'contact', 'total_strings',
+            'approved_strings', 'fuzzy_strings'
         )
 
     localizations = graphene.List(ProjectLocale)
@@ -45,9 +43,8 @@ class Locale(DjangoObjectType, Stats):
     class Meta:
         model = LocaleModel
         only_fields = (
-            'name', 'code', 'direction', 'script', 'population',
-            'total_strings', 'approved_strings', 'translated_strings',
-            'fuzzy_strings'
+            'name', 'code', 'direction', 'script', 'population', 'total_strings',
+            'approved_strings', 'fuzzy_strings'
         )
 
     localizations = graphene.List(ProjectLocale, include_disabled=graphene.Boolean(False))

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -479,7 +479,7 @@ class AggregatedStats(models.Model):
 
     @property
     def complete(self):
-        return self.missing_strings == 0
+        return self.total_strings == self.approved_strings
 
 
 def validate_cldr(value):


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1403861

The Suggested status is pending a refactor in bug 1377969 and until it's
fixed, it's confusing to use `translatedStrings` for Suggested.

The Fuzzy status might get folded into Unreviewed Strings as part of bug
1377969 too. Let's remove it for now and re-add if it stays around.

The Complete flag will now only be true if all strings are Approved.
Suggested and Fuzzy strings don't count towards this flag anymore.