### PR TITLE
Fix bug 1411284: Disable amaGama

### DIFF
--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -480,35 +480,6 @@ var Pontoon = (function (my) {
         }).error(error).complete(complete);
       }
 
-      // amaGama
-      requests++;
-
-      if (self.XHRamagama) {
-        self.XHRamagama.abort();
-      }
-
-      self.XHRamagama = $.ajax({
-        url: '/amagama/',
-        data: {
-          text: original,
-          locale: self.locale.code
-        }
-
-      }).success(function(data) {
-        if (data) {
-          $.each(data, function() {
-            append({
-              original: this.source,
-              quality: Math.round(this.quality) + '%',
-              url: 'http://amagama.translatehouse.org/',
-              title: 'Visit amaGama',
-              source: 'Open Source',
-              translation: this.target
-            });
-          });
-        }
-      }).error(error).complete(complete);
-
       // Transvision
       if (self.locale.transvision) {
         requests++;

--- a/pontoon/machinery/urls.py
+++ b/pontoon/machinery/urls.py
@@ -22,8 +22,6 @@ urlpatterns = [
         name='pontoon.machine_translation'),
     url(r'^microsoft-terminology/$', views.microsoft_terminology,
         name='pontoon.microsoft_terminology'),
-    url(r'^amagama/$', views.amagama,
-        name='pontoon.amagama'),
     url(r'^transvision/$', views.transvision,
         name='pontoon.transvision'),
 ]

--- a/pontoon/machinery/views.py
+++ b/pontoon/machinery/views.py
@@ -164,39 +164,6 @@ def microsoft_terminology(request):
         return HttpResponseBadRequest('Bad Request: {error}'.format(error=e))
 
 
-def amagama(request):
-    """Get open source translations from amaGama service."""
-    try:
-        text = request.GET['text']
-        locale = request.GET['locale']
-    except MultiValueDictKeyError as e:
-        return HttpResponseBadRequest('Bad Request: {error}'.format(error=e))
-
-    try:
-        text = quote(text.encode('utf-8'))
-    except KeyError as e:
-        return HttpResponseBadRequest('Bad Request: {error}'.format(error=e))
-
-    # No trailing slash at the end or slash becomes part of the source text
-    url = (
-        u'https://amagama-live.translatehouse.org/api/v1/en/{locale}/unit/'
-        .format(locale=locale)
-    )
-
-    payload = {
-        'source': text,
-        'max_candidates': 5,
-        'min_similarity': 70,
-    }
-
-    try:
-        r = requests.get(url, params=payload)
-        return JsonResponse(r.json(), safe=False)
-
-    except Exception as e:
-        return HttpResponseBadRequest('Bad Request: {error}'.format(error=e))
-
-
 def transvision(request):
     """Get Mozilla translations from Transvision service."""
     try:


### PR DESCRIPTION
Amagama is down due to an expired web server certificate. We don't have
a mechanism to simply turn it off. So we're removing it completely.

That is because:
* The content hasn't seen an update for years.
* New Relic shows it's the most time consuming transaction in Pontoon.
* We don't know when the server will be back up.
* The changeset is rather small so we should be able to revert it if needed.