### PR TITLE
Fix bug 1411225 - Accept white spaces in search for entities.

### DIFF
--- a/pontoon/base/forms.py
+++ b/pontoon/base/forms.py
@@ -216,13 +216,22 @@ class GetEntitiesForm(forms.Form):
     entity = forms.IntegerField(required=False)
 
     def clean_paths(self):
-        return self.data.getlist('paths[]')
+        try:
+            return self.data.getlist('paths[]')
+        except AttributeError:
+            # If the data source is not a QueryDict, it won't have a `getlist` method.
+            return self.data.get('paths[]') or []
 
     def clean_limit(self):
         try:
             return int(self.cleaned_data['limit'])
         except (TypeError, ValueError):
             return 50
+
+    def clean_search(self):
+        # Return the search input as is, without any cleaning. This is in order to allow
+        # users to search for strings with leading or trailing whitespaces.
+        return self.data.get('search')
 
     def clean_exclude_entities(self):
         return utils.split_ints(self.cleaned_data['exclude_entities'])

--- a/pontoon/base/tests/test_forms.py
+++ b/pontoon/base/tests/test_forms.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from django_nose.tools import (
+    assert_equal,
+    assert_true,
+)
+
+from pontoon.base.tests import TestCase
+from pontoon.base.forms import GetEntitiesForm
+
+
+class TestGetEntitiesForm(TestCase):
+    def test_search_with_whitespace(self):
+        input_data = {
+            'project': 'firefox',
+            'locale': 'kl',
+            'search': ' z',
+        }
+        form = GetEntitiesForm(input_data)
+
+        assert_true(form.is_valid())
+        assert_equal(form.cleaned_data['search'], ' z')


### PR DESCRIPTION
I'm not confident this covers all the use cases from before, but logically it should (as it is now effectively doing the same thing than before my change to using a Form). 