### PR TITLE
Parametrize docker test runner.

### DIFF
--- a/docker/run_tests_in_docker.sh
+++ b/docker/run_tests_in_docker.sh
@@ -61,7 +61,7 @@ else
            --env-file ./docker/config/webapp.env \
            -e LOCAL_USER_ID=$UID \
            local/pontoon \
-           python manage.py test
+           python manage.py test $@
 
     echo "Done!"
 fi


### PR DESCRIPTION
Hey @mathjazz & @adngdb 
Sometimes I need to run tests with different verbosity or with `--no-input` to reset the database [when database already exists] between tests runs.
This patch should pass all arguments from the makefile to django test runner.
Could you review?
Thanks in advance!