### PR TITLE
Bug 1311053: Always assign plural examples

### DIFF
--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -498,14 +498,11 @@ var Pontoon = (function (my) {
      */
     generateLocalePluralExamples: function () {
       var self = this;
-      var examples = self.locale.examples = {};
+      var examples = self.locale.examples = {0: 1, 1: 2};
       var nplurals = self.locale.nplurals;
       var n = 0;
 
-      if (nplurals === 2) {
-        examples = {0: 1, 1: 2};
-
-      } else {
+      if (nplurals !== 2) {
         while (Object.keys(examples).length < nplurals) {
           var rule = eval(self.locale.plural_rule);
           if (!examples[rule]) {


### PR DESCRIPTION
For each plural form of a locale, we calculate example number to use as a hint in the UI. Examples were not assigned to locales with 2 plural forms prior to this fix.

Compare plural tab content for [Slovenian](https://pontoon.mozilla.org/sl/amo-frontend/all-resources/?search=count&string=162963) (4 plural forms) and [German](https://pontoon.mozilla.org/de/amo-frontend/all-resources/?search=count&string=162963) (2 plural forms).

Note: This is the first step (codenamed "make it work as advertised") in moving this code to locale admin.