### PR TITLE
Fix bug 1392255: Enable source view for FTL messages

### DIFF
--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -1207,6 +1207,7 @@ body > header aside p {
 
 #editor p#original,
 #editor p.original,
+#ftl-original .main-value li,
 #editor p.translation {
   text-align: start;
   white-space: pre-wrap;
@@ -1378,9 +1379,7 @@ body > header aside p {
   color: #222222;
   display: block;
   font-size: 13px;
-  height: 20%;
   line-height: 22px;
-  min-height: 100px;
   overflow: auto;
   padding: 10px;
   width: 100%;
@@ -1391,6 +1390,22 @@ body > header aside p {
 
 #editor textarea[data-script="Arabic"] {
   font-size: 15px;
+}
+
+#editor #translation {
+  height: 20%;
+  min-height: 100px;
+}
+
+#ftl-area {
+  position: relative;
+}
+
+#ftl-area #only-value {
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
 }
 
 .ftl-area {
@@ -1626,7 +1641,6 @@ body > header aside p {
 }
 
 #editor #single #ftl {
-  display: none; /* TODO: Remove once source view support is implemented */
   color: #AAAAAA;
   float: left;
   font-size: 18px;

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -151,6 +151,7 @@ var Pontoon = (function (my) {
           }
 
           $('#translation').val(value);
+          Pontoon.updateCachedTranslation();
           Pontoon.fluent.toggleEditor(false);
           return;
         }
@@ -582,6 +583,7 @@ $(function () {
       }
 
       $('#translation').val(translation);
+      Pontoon.updateCachedTranslation();
     }
 
     Pontoon.fluent.toggleEditor($(this).is('.active'));

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -374,8 +374,8 @@ var Pontoon = (function (my) {
        * Return translation in the editor as FTL source
        */
       getTranslationSource: function () {
-        var entity = Pontoon.getEditorEntity(),
-            fallback = $('#translation').val();
+        var entity = Pontoon.getEditorEntity();
+        var fallback = $('#translation').val();
 
         // For non-FTL entities, return unchanged translations
         if (entity.format !== 'ftl') {

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -167,6 +167,11 @@ var Pontoon = (function (my) {
 
         Pontoon.fluent.focusFirstField();
         Pontoon.fluent.toggleEditorToolbar();
+
+        Pontoon.moveCursorToBeginning();
+        Pontoon.updateCurrentTranslationLength();
+        Pontoon.updateInPlaceTranslation();
+
         return true;
       },
 
@@ -275,6 +280,11 @@ var Pontoon = (function (my) {
         var show = entity.format !== 'ftl' || !Pontoon.fluent.isComplexFTL();
 
         $('#translation-length, #copy').toggle(show);
+
+        if ($('#translation-length').is(':visible')) {
+          var original = this.getSimplePreview(entity, entity.original, entity);
+          $('#translation-length').find('.original-length').html(original.length);
+        }
       },
 
 

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -144,7 +144,7 @@ var Pontoon = (function (my) {
         // Show source if rich FTL editor does not support the translation or
         // if translation is not available and source string is displayed as source
         else if ($('#ftl-original .main-value ul li.source').length) {
-          var value = entity.key + ' = ';
+          var value = entity.key + ' = \n';
 
           if (isTranslated) {
             value = translation.string;
@@ -371,6 +371,37 @@ var Pontoon = (function (my) {
 
 
       /*
+       * Return translation in the editor as FTL source
+       */
+      getTranslationSource: function () {
+        var entity = Pontoon.getEditorEntity(),
+            fallback = $('#translation').val();
+
+        // For non-FTL entities, return unchanged translations
+        if (entity.format !== 'ftl') {
+          return fallback;
+        }
+
+        var translation = this.serializeTranslation(entity, fallback);
+
+        // Special case: empty translations in rich FTL editor don't serialize properly
+        if (this.isFTLEditorEnabled()) {
+          var richTranslation = $.map(
+            $('#ftl-area input.value:visible, #ftl-area textarea:visible'), function(i) {
+              return $(i).val();
+            }
+          ).join('');
+
+          if (!richTranslation.length) {
+            translation = '';
+          }
+        }
+
+        return translation;
+      },
+
+
+      /*
        * Get AST and any errors for the entity's translation
        */
       serializeTranslation: function (entity, translation) {
@@ -579,7 +610,7 @@ $(function () {
 
       // If translation broken, incomplete or empty
       if (translation.error) {
-        translation = entity.key + ' = ';
+        translation = entity.key + ' = \n';
       }
 
       $('#translation').val(translation);

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -1,62 +1,81 @@
+/* global FluentSyntax */
+
 /* Public functions used across different files */
 var Pontoon = (function (my) {
-  const fluentParser = new FluentSyntax.FluentParser({ withSpans: false });
-  const fluentSerializer = new FluentSyntax.FluentSerializer();
+  var fluentParser = new FluentSyntax.FluentParser({ withSpans: false });
+  var fluentSerializer = new FluentSyntax.FluentSerializer();
 
   return $.extend(true, my, {
     fluent: {
 
       /*
-       * Populate FTL translation area with existing data
+       * Render form-based FTL editor. Different widgets are displayed depending on the source
+       * string and the translation.
        */
       renderEditor: function (translation) {
         $('#ftl-area > .main-value').show().find('input').val('');
         $('#ftl-area .attributes ul:first').empty();
         $('#ftl-area > .main-value ul li:not(":first")').remove();
 
-        var self = this,
-            entity = Pontoon.getEditorEntity(),
-            isFTLplural = entity.isFTLplural,
-            translation = translation || entity.translation[0],
-            isTranslated = translation.pk,
-            entity_ast = fluentParser.parseEntry(entity.original),
-            entityAttributes = [],
-            id, value;
+        var self = this;
+        var entity = Pontoon.getEditorEntity();
 
-        var attributes = entity_ast.attributes;
+        translation = translation || entity.translation[0];
+
+        var isTranslated = translation.pk;
+        var entityAST = fluentParser.parseEntry(entity.original);
+        var entityAttributes = [];
+        var attributes = entityAST.attributes;
+
+        var translationAST;
         if (isTranslated) {
-          var translation_ast = fluentParser.parseEntry(translation.string);
-          attributes = translation_ast.attributes;
+          translationAST = fluentParser.parseEntry(translation.string);
+          attributes = translationAST.attributes;
         }
 
-        if (entity_ast.attributes) {
-          entityAttributes = $.map(entity_ast.attributes, function(item) {
+        if (entityAST.attributes) {
+          entityAttributes = entityAST.attributes.map(function (item) {
             return item.id.name;
           });
         }
 
-        // Plurals
-        if (isFTLplural) {
-          var pluralForms = $(Pontoon.locale.cldr_plurals).map(
-            function() {
-              return Pontoon.CLDR_PLURALS[this];
-            }
-          ).get();
+        // Simple string: only value
+        if (
+          self.isSimpleString(translationAST) ||
+          self.isSimpleString(entityAST)
+        ) {
+          var value = '';
 
-          if (translation_ast) {
-            var variants = translation_ast.value.elements[0].variants;
+          if (translationAST) {
+            value = self.serializePlaceables(translationAST.value.elements);
+          }
+
+          $('#only-value')
+            .val(value)
+            .parents('li')
+            .show();
+        }
+        // Plurals
+        else if (entity.isFTLplural) {
+          var pluralForms = Pontoon.locale.cldr_plurals.map(function (item) {
+            return Pontoon.CLDR_PLURALS[item];
+          });
+
+          var variants;
+          if (translationAST) {
+            variants = translationAST.value.elements[0].variants;
           }
 
           if (!Pontoon.locale.examples) {
             Pontoon.generateLocalePluralExamples();
           }
 
-          $.each(pluralForms, function(pluralForm) {
+          pluralForms.forEach(function (pluralStr, pluralInt) {
             var value = '';
 
-            if (translation_ast) {
+            if (translationAST) {
               for (var i = 0; i < variants.length; i++) {
-                if (variants[i].key.name === this.toString()) {
+                if (variants[i].key.name === pluralStr) {
                   value = self.serializePlaceables(variants[i].value.elements);
                   break;
                 }
@@ -66,64 +85,78 @@ var Pontoon = (function (my) {
             $('#ftl-area .main-value ul')
               .append(
                 '<li class="clearfix">' +
-                  '<label class="id built-in" for="ftl-id-' + this + '">' +
-                    '<span>' + this + ' (e.g. </span><span class="stress">' + Pontoon.locale.examples[pluralForm] + '</span>)<sub class="fa fa-remove remove" title="Remove"></sub>' +
+                  '<label class="id built-in" for="ftl-id-' + pluralStr + '">' +
+                    '<span>' + pluralStr + ' (e.g. </span>' +
+                    '<span class="stress">' + Pontoon.locale.examples[pluralInt] + '</span>)' +
+                    '<sub class="fa fa-remove remove" title="Remove"></sub>' +
                   '</label>' +
-                  self.inputValueElement(this, value) +
-                '</li>');
+                  self.inputValueElement(pluralStr, value) +
+                '</li>'
+              );
           });
 
-          $('#entity-value').parents('li').hide();
-
-
-        // Main Value
-        } else if (translation_ast && translation_ast.value) {
-          $('#ftl-area > .main-value #entity-value').val(self.serializePlaceables(translation_ast.value.elements));
+          $('#only-value').parents('li').hide();
         }
-
         // Attributes
-        if (!(attributes && attributes.length)) {
+        else if (attributes && attributes.length) {
+          attributes.forEach(function (attr) {
+            var id = attr.id.name;
+            var value = isTranslated ? self.serializePlaceables(attr.value.elements) : '';
+
+            var maxlength = '';
+            var label = '';
+            var input = '';
+            var cls = '';
+
+            if (id === 'accesskey') {
+              maxlength = '1';
+              input = '<div class="accesskeys"></div>';
+            }
+            input += self.inputValueElement(id, value, maxlength);
+
+            if ($.inArray(id, [entityAttributes])) {
+              label = '<label class="id" for="ftl-id-' + id + '">' +
+                '<span>' + id + '</span>' +
+              '</label>';
+
+            }
+            else {
+              cls = ' class="custom-attribute clearfix"';
+              label = '<div class="wrapper">' +
+                '<input type="text" class="id" placeholder="enter-attribute-id" value="' + id + '">' +
+                '<sub class="fa fa-remove remove" title="Remove"></sub>' +
+              '</div>';
+            }
+
+            $('#ftl-area .attributes ul:first')
+              .append(
+                '<li' + cls + '>' +
+                  label +
+                  input +
+                '</li>'
+              );
+          });
+
+          // Update access keys presentation
+          $('#ftl-area .attributes input').keyup();
+
+        }
+        // Show source if rich FTL editor does not support the translation or
+        // if translation is not available and source string is displayed as source
+        else if ($('#ftl-original .main-value ul li.source').length) {
+          var value = entity.key + ' = ';
+
+          if (isTranslated) {
+            value = translation.string;
+          }
+
+          $('#translation').val(value);
+          Pontoon.fluent.toggleEditor(false);
           return;
         }
 
-        $.each(attributes, function() {
-          id = this.id.name;
-          value = isTranslated ? self.serializePlaceables(this.value.elements) : '';
-
-          var maxlength = label = input = cls = '';
-
-          if (id === 'accesskey') {
-            maxlength = '1';
-            input = '<div class="accesskeys"></div>';
-          }
-          input += self.inputValueElement(id, value, maxlength);
-
-          if ($.inArray(id, [entityAttributes])) {
-            label = '<label class="id" for="ftl-id-' + id + '">' +
-              '<span>' + id + '</span>' +
-            '</label>';
-
-          } else {
-            cls = ' class="custom-attribute clearfix"';
-            label = '<div class="wrapper">' +
-              '<input type="text" class="id" placeholder="enter-attribute-id" value="' + id + '">' +
-              '<sub class="fa fa-remove remove" title="Remove"></sub>' +
-            '</div>';
-          }
-
-          $('#ftl-area .attributes ul:first')
-            .append(
-              '<li' + cls + '>' +
-                label +
-                input +
-              '</li>');
-        });
-
-        // Update access keys presentaion
-        $('#ftl-area .attributes input').keyup();
-
         // If no value in source string, no value in translation
-        if (!entity_ast.value) {
+        if (!entityAST.value) {
           $('#ftl-area > .main-value').hide();
         }
 
@@ -131,31 +164,45 @@ var Pontoon = (function (my) {
         if (!Pontoon.user.id) {
           $('#ftl-area input').prop('readonly', true);
         }
-      },
 
-
-      /*
-       * Render editor with given translation
-       */
-      renderEditorWithTranslation: function (translation) {
-        Pontoon.fluent.renderEditor(translation);
         Pontoon.fluent.focusFirstField();
+        Pontoon.fluent.toggleEditorToolbar();
+        return true;
       },
 
 
       /*
-       * Serialize value with placeables into a simple strings
+       * Is ast of a simple string?
+       */
+      isSimpleString: function (ast) {
+        if (
+          ast &&
+          ast.value &&
+          ast.value.elements.length === 1 &&
+          ast.value.elements[0].type === 'TextElement'
+        ) {
+          return true;
+        }
+
+        return false;
+      },
+
+
+      /*
+       * Serialize value with placeables into a simple string
        */
       serializePlaceables: function (elements) {
         var translatedValue = '';
 
-        $.each(elements, function(i) {
-          if (this.type === 'TextElement') {
-            translatedValue += this.value;
-          } else if (this.type === 'ExternalArgument') {
-            translatedValue += ('{$' + this.id.name + '}');
-          } else if (this.type === 'MessageReference') {
-            translatedValue += ('{' + this.id.name + '}');
+        elements.forEach(function (item) {
+          if (item.type === 'TextElement') {
+            translatedValue += item.value;
+          }
+          else if (item.type === 'ExternalArgument') {
+            translatedValue += '{$' + item.id.name + '}';
+          }
+          else if (item.type === 'MessageReference') {
+            translatedValue += '{' + item.id.name + '}';
           }
         });
 
@@ -164,22 +211,24 @@ var Pontoon = (function (my) {
 
 
       /*
-       * Generate Input value element
+       * Generate input element with the given properties
        */
-      inputValueElement: function (id, value, maxLength) {
+      inputValueElement: function (id, value, maxlength) {
         var base = '<input class="value" id="ftl-id-' + id + '" type="text" value="' + value + '"';
 
-        if (typeof maxlength !== "undefined"){
+        if (typeof maxlength !== 'undefined' && maxlength !== null) {
           base += ' maxlength="' + maxlength + '"';
         }
 
-        base += ' dir="' + Pontoon.locale.direction + '" data-script="' + Pontoon.locale.script + '" lang="' + Pontoon.locale.code + '">';
+        base += ' dir="' + Pontoon.locale.direction +
+          '" data-script="' + Pontoon.locale.script +
+          '" lang="' + Pontoon.locale.code + '">';
         return base;
       },
 
 
       /*
-       * Toggle FTL button
+       * Toggle FTL button visibility
        */
       toggleButton: function () {
         var entity = Pontoon.getEditorEntity();
@@ -188,41 +237,70 @@ var Pontoon = (function (my) {
 
 
       /*
-       * Toggle between standard and FTL translation editor
+       * Toggle between source and FTL translation editor
        */
-      toggleEditor: function (activate) {
-        if (activate) {
-          $('#ftl-area').show();
-          // TODO: Uncomment once attributes are fully supported (defaults, removing, validation)
-          // $('#add-attribute').show();
-          $('#translation-length, #copy').hide();
-
-          $('#editor textarea').hide();
-          $('#ftl').addClass('active');
-
-          this.renderEditor();
-          this.focusFirstField();
-
-        } else {
-          $('#ftl-area').hide();
-          // TODO: Uncomment once attributes are fully supported (defaults, removing, validation)
-          // $('#add-attribute').hide();
-          $('#translation-length, #copy').show();
-
-          $('#editor textarea').show().focus();
-          $('#ftl').removeClass('active');
+      toggleEditor: function (showFTL) {
+        var entity = Pontoon.getEditorEntity();
+        if (typeof showFTL === 'undefined' || showFTL === null) {
+          showFTL = entity.format === 'ftl';
         }
 
+        if (showFTL) {
+          $('#ftl-area').show();
+          $('#translation').hide();
+          $('#ftl').removeClass('active');
+
+          // TODO: Uncomment once attributes are fully supported (defaults, removing, validation)
+          // $('#add-attribute').show();
+        }
+        else {
+          $('#ftl-area').hide();
+          $('#translation').show().focus();
+          $('#ftl').addClass('active');
+
+          // TODO: Uncomment once attributes are fully supported (defaults, removing, validation)
+          // $('#add-attribute').hide();
+        }
+
+        Pontoon.fluent.toggleEditorToolbar();
         Pontoon.moveCursorToBeginning();
       },
 
 
       /*
-       * Toggle between standard and FTL original string
+       * Toggle translation length and Copy button in editor toolbar
+       */
+      toggleEditorToolbar: function () {
+        var entity = Pontoon.getEditorEntity();
+        var show = entity.format !== 'ftl' || !Pontoon.fluent.isComplexFTL();
+
+        $('#translation-length, #copy').toggle(show);
+      },
+
+
+      /*
+       * Is FTL editor enabled?
+       */
+      isFTLEditorEnabled: function () {
+        return $('#ftl-area').is(':visible');
+      },
+
+
+      /*
+       * Is string in FTL editor complex?
+       * As opposed to simple which only contains a string value.
+       */
+      isComplexFTL: function () {
+        return !$('#only-value').is(':visible');
+      },
+
+
+      /*
+       * Toggle between source and FTL display of the original string
        */
       toggleOriginal: function () {
-        var self = this,
-            entity = Pontoon.getEditorEntity();
+        var self = this;
+        var entity = Pontoon.getEditorEntity();
 
         $('#original').show();
         $('#ftl-original').hide();
@@ -231,89 +309,106 @@ var Pontoon = (function (my) {
           return;
         }
 
-        var ast = fluentParser.parseEntry(entity.original),
-            original = '';
-
-        function renderOriginal(obj) {
-          if (entity.isFTLplural) {
-            var variants = ast.value.elements[0].variants;
-            $.each(variants, function() {
-              original += '<li><span class="id">' + (this.key.value || this.key.name) + '</span><span class="value">';
-              original += self.serializePlaceables(this.value.elements);
-              original += '</span></li>';
-            });
-
-          } else if (obj.value) {
-            original += '<li><span class="id">Value</span><span class="value">';
-            original += obj.value.elements[0].value;
-            original += '</span></li>';
-          }
-
-          if (obj.attributes) {
-            var id, value;
-            $.each(obj.attributes, function() {
-              id = this.id.name;
-              value = this.value.elements[0].value;
-
-              $('#ftl-original .attributes ul')
-                .append(
-                  '<li>' +
-                    '<span class="id">' + id + '</span>' +
-                    '<span class="value">' + value + '</span>' +
-                  '</li>');
-            });
-          }
-        }
+        var ast = fluentParser.parseEntry(entity.original);
+        var original = '';
 
         $('#ftl-original section ul').empty();
+        $('#original').hide();
+        $('#ftl-original').show();
 
-        if (entity.isComplexFTL) {
-          $('#original').hide();
-          $('#ftl-original').show();
+        // Plurals
+        if (entity.isFTLplural) {
+          var variants = ast.value.elements[0].variants;
+          variants.forEach(function (item) {
+            original += '<li>' +
+              '<span class="id">' + (item.key.value || item.key.name) + '</span>' +
+              '<span class="value">' + self.serializePlaceables(item.value.elements) +
+              '</span>' +
+            '</li>';
+          });
 
-          renderOriginal(ast);
-          $('#ftl-original .main-value ul').append(original);
         }
+        else if (
+          ast.value &&
+          ast.value.elements.length === 1 &&
+          ast.value.elements[0].type === 'TextElement'
+        ) {
+          original += '<li><p>' + self.serializePlaceables(ast.value.elements) + '</p></li>';
+        }
+
+        // Attributes
+        if (ast.attributes && ast.attributes.length) {
+          ast.attributes.forEach(function (attr) {
+            $('#ftl-original .attributes ul')
+              .append(
+                '<li>' +
+                  '<span class="id">' + attr.id.name + '</span>' +
+                  '<span class="value">' + attr.value.elements[0].value + '</span>' +
+                '</li>'
+              );
+          });
+        }
+        // Rich FTL string display does not support the translation: show source
+        else if (original === '') {
+          // Remove comment
+          ast.comment = null;
+          original = '<li class="source">' + fluentSerializer.serializeEntry(ast) + '</li>';
+        }
+
+        $('#ftl-original .main-value ul').append(original);
       },
 
 
       /*
        * Get AST and any errors for the entity's translation
        */
-      serializeTranslation: function(entity, translation) {
+      serializeTranslation: function (entity, translation) {
         if (entity.format !== 'ftl') {
           return translation;
         }
 
-        if ($('#ftl').is('.active')) {
+        if (!this.isComplexFTL()) {
+          translation = $('#only-value').val();
+
+          // Multiline strings: mark with indent
+          if (translation.indexOf('\n') !== -1) {
+            translation = ' = \n  ' + translation.replace(/\n/g, '\n  ');
+          }
+          // Simple strings
+          else {
+            translation = ' = ' + translation;
+          }
+        }
+        else if (this.isFTLEditorEnabled()) {
           // Main value
-          var value = $('#ftl-area > .main-value input').val(),
-              attributes = '';
+          var value = $('#ftl-area > .main-value input').val();
+          var attributes = '';
 
           // Plurals
           if (entity.isFTLplural) {
             value = '';
-            var variants = $('#ftl-area .main-value li:visible'),
-                nonEmptyVariants = [],
-                def = '';
+            var variants = $('#ftl-area .main-value li:visible');
+            var nonEmptyVariants = [];
+            var def = '';
 
-            variants.each(function(i) {
-              var id = $(this).find('.id span:first').html().split(' ')[0],
-                  val = $(this).find('.value').val();
+            variants.each(function () {
+              var id = $(this).find('.id span:first').html().split(' ')[0];
+              var val = $(this).find('.value').val();
 
               if (id && val) {
                 nonEmptyVariants.push('[' + id + '] ' + val);
               }
             });
 
-            for (var i = 0; i < nonEmptyVariants.length; i++) {
+            nonEmptyVariants.forEach(function (variant, i) {
+            // for (var i = 0; i < nonEmptyVariants.length; i++) {
               // Mark the last variant as default
               // TODO: Should be removed by bug 1237667
               if (i === nonEmptyVariants.length - 1) {
                 def = '*';
               }
-              value += '\n  ' + def + nonEmptyVariants[i];
-            }
+              value += '\n  ' + def + variant;
+            });
 
             if (value) {
               value = '{ $num ->' + value + '\n  }';
@@ -321,9 +416,9 @@ var Pontoon = (function (my) {
           }
 
           // Attributes
-          $('#ftl-area .attributes ul:first li').each(function() {
-            var id = $(this).find('.id span').html() || $(this).find('.id').val(),
-                val = $(this).find('.value').val();
+          $('#ftl-area .attributes ul:first li').each(function () {
+            var id = $(this).find('.id span').html() || $(this).find('.id').val();
+            var val = $(this).find('.value').val();
 
             if (id && val) {
               attributes += '\n  .' + id + ' = ' + val;
@@ -331,37 +426,39 @@ var Pontoon = (function (my) {
           });
 
           translation = (value ? ' = ' + value : '') + (attributes || '');
-
-        // Mark multiline strings with indent
-        } else if (translation.indexOf('\n') !== -1) {
-          translation = ' = \n  ' + translation.replace(/\n/g, '\n  ');
-
-        // Simple strings
-        } else {
-          translation = ' = ' + translation;
         }
 
-        var content = entity.key + translation,
-            ast = fluentParser.parseEntry(content),
-            entityAst = fluentParser.parseEntry(entity.original),
-            error = null;
+        var content = entity.key + translation;
+        // Source view
+        if (!this.isFTLEditorEnabled()) {
+          content = translation;
+        }
+
+        var ast = fluentParser.parseEntry(content);
+        var entityAst = fluentParser.parseEntry(entity.original);
+        var error = null;
 
         // Parse error
         if (ast.type === 'Junk') {
           error = ast.annotations[0].message;
-
+        }
         // TODO: Should be removed by bug 1237667
         // Detect missing values
-        } else if (entityAst && ast && entityAst.value && !ast.value) {
-          error = "Please make sure to fill in the value";
+        else if (entityAst && ast && entityAst.value && !ast.value) {
+          error = 'Please make sure to fill in the value';
+        }
         // Detect missing attributes
-        } else if (entityAst.attributes && ast.attributes && entityAst.attributes.length !== ast.attributes.length) {
-          error = "Please make sure to fill in all the attributes";
+        else if (
+          entityAst.attributes &&
+          ast.attributes &&
+          entityAst.attributes.length !== ast.attributes.length
+        ) {
+          error = 'Please make sure to fill in all the attributes';
         }
 
         if (error) {
           return {
-            error: error
+            error: error,
           };
         }
 
@@ -370,9 +467,10 @@ var Pontoon = (function (my) {
 
 
       /*
-       * Get simplified preview of the FTL object
+       * Get simplified preview of the FTL message, used when full presentation not possible
+       * due to lack of real estate (e.g. string list).
        */
-      getSimplePreview: function(object, fallback, entity) {
+      getSimplePreview: function (object, fallback, entity) {
         var response = fallback;
 
         if (entity.format === 'ftl') {
@@ -383,13 +481,13 @@ var Pontoon = (function (my) {
             return response;
           }
 
-          ast = fluentParser.parseEntry(source);
+          var ast = fluentParser.parseEntry(source);
 
           if (ast.value) {
             response = this.serializePlaceables(ast.value.elements);
-
+          }
           // Attributes
-          } else {
+          else {
             var attributes = ast.attributes;
             if (attributes && attributes.length) {
               response = this.serializePlaceables(attributes[0].value.elements);
@@ -397,33 +495,25 @@ var Pontoon = (function (my) {
           }
 
           // Plurals
-          if (ast.value && ast.value.elements && ast.value.elements.length && ast.value.elements[0].expression && ast.value.elements[0].variants) {
-            var variants = ast.value.elements[0].variants,
-                isFTLplural = variants.every(function(element) {
-                  var key = element.key.name,
-                      isPlural = Pontoon.CLDR_PLURALS.indexOf(key) !== -1,
-                      isInteger = element.key.type === 'NumberExpression';
+          if (
+            ast.value &&
+            ast.value.elements &&
+            ast.value.elements.length &&
+            ast.value.elements[0].expression &&
+            ast.value.elements[0].variants
+          ) {
+            var variants = ast.value.elements[0].variants;
+            var isFTLplural = variants.every(function (element) {
+              var key = element.key.name;
+              var isPlural = Pontoon.CLDR_PLURALS.indexOf(key) !== -1;
+              var isInteger = element.key.type === 'NumberExpression';
 
-                  return isPlural || isInteger;
-                });
+              return isPlural || isInteger;
+            });
 
             if (isFTLplural) {
               response = this.serializePlaceables(variants[0].value.elements);
               entity.isFTLplural = true;
-            }
-          }
-
-          // Mark complex strings
-          if (ast.attributes && ast.attributes.length || (ast.value && ast.value.elements && ast.value.elements.length && ast.value.elements[0].expression && ast.value.elements[0].variants.length > 1)) {
-            object.isComplexFTL = true;
-
-          // Update entity and translation objects
-          } else {
-            if (object.hasOwnProperty('original')) {
-              object.original = response;
-              response = object.marked = Pontoon.doNotRender(response);
-            } else if (object.hasOwnProperty('string')) {
-              object.string = response;
             }
           }
         }
@@ -435,25 +525,56 @@ var Pontoon = (function (my) {
       /*
        * Focus first field of the FTL editor
        */
-      focusFirstField: function(object, fallback, entity) {
-        $('#ftl-area input.value:visible:first').focus();
-      }
+      focusFirstField: function () {
+        $('#ftl-area input.value:visible, #ftl-area textarea:visible').first().focus();
+      },
 
-    }
+    },
   });
 }(Pontoon || {}));
 
-$(function() {
+$(function () {
 
   // Ignore editing for anonymous users
   if (!Pontoon.user.id) {
     return;
   }
 
-  // Toggle FTL mode
+  // Toggle FTL and source editors
   $('#ftl').click(function (e) {
     e.preventDefault();
-    Pontoon.fluent.toggleEditor(!$(this).is('.active'));
+
+    var entity = Pontoon.getEditorEntity();
+    var translation = null;
+
+    // Update FTL editor
+    if ($(this).is('.active')) {
+      translation = $('#translation').val();
+
+      var translated = (translation !== entity.key + ' = ');
+      var isRichEditorSupported = Pontoon.fluent.renderEditor({
+        pk: translated, // An indicator that the string is translated
+        string: translation,
+      });
+
+      // Rich FTL editor does not support the translation
+      if (!isRichEditorSupported) {
+        return;
+      }
+    }
+    // Update source editor
+    else {
+      translation = Pontoon.fluent.serializeTranslation(entity, translation);
+
+      // If translation broken, incomplete or empty
+      if (translation.error) {
+        translation = entity.key + ' = ';
+      }
+
+      $('#translation').val(translation);
+    }
+
+    Pontoon.fluent.toggleEditor($(this).is('.active'));
   });
 
   // Add attribute
@@ -469,21 +590,26 @@ $(function() {
   });
 
   // Generate access key list
-  $('#ftl-area .attributes').on('keyup', 'input:first', function() {
-    var active = $('.accesskeys').find('.active').html(),
-        unique = $(this).val().toUpperCase().split('').filter(function(item, i, ar) {
-          return ar.indexOf(item) === i;
-        });
+  $('#ftl-area .attributes').on('keyup', 'input:first', function () {
+    var active = $('.accesskeys').find('.active').html();
+    var unique = $(this).val()
+      .toUpperCase()
+      .split('')
+      .filter(function (item, i, ar) {
+        return ar.indexOf(item) === i;
+      });
 
     $('.accesskeys').empty();
 
-    $.each(unique, function(i, v) {
-      $('.accesskeys').append('<div' + ((v === active) ? ' class="active"' : '') + '>' + v + '</div>');
+    $.each(unique, function (i, v) {
+      $('.accesskeys').append(
+        '<div' + ((v === active) ? ' class="active"' : '') + '>' + v + '</div>'
+      );
     });
   });
 
   // Select access key via click
-  $('#ftl-area .attributes').on('click', '.accesskeys div', function() {
+  $('#ftl-area .attributes').on('click', '.accesskeys div', function () {
     var selected = $(this).is('.active');
     $('.accesskeys div').removeClass('active');
 
@@ -495,7 +621,7 @@ $(function() {
   });
 
   // Select access key via input
-  $('#ftl-area .attributes').on('keyup', '#ftl-id-accesskey', function() {
+  $('#ftl-area .attributes').on('keyup', '#ftl-id-accesskey', function () {
     var accesskey = $(this).val().toUpperCase();
 
     if (accesskey) {

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -1903,7 +1903,7 @@ var Pontoon = (function (my) {
 
         var entity = self.getEditorEntity(),
             original = entity['original' + self.isPluralized()],
-            source = original;
+            source = self.fluent.getSimplePreview(entity, original, entity);
 
         self.updateAndFocusTranslationEditor(source);
         self.moveCursorToBeginning();

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -706,11 +706,11 @@ var Pontoon = (function (my) {
       }
 
       var before = this.cachedTranslation,
-          after = $('#translation').val();
+          after = this.fluent.serializeTranslation(entity, $('#translation').val());
 
       if ((before !== null) && (before !== after)) {
         $('#unsaved').show();
-        $('#translation').focus();
+        $('#editor textarea:visible:first').focus();
         this.checkUnsavedChangesCallback = callback;
 
       } else {

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -618,7 +618,7 @@ var Pontoon = (function (my) {
       $('.warning-overlay:visible .cancel').click();
 
       // Length
-      var original = entity['original' + this.isPluralized()].length;
+      var original = entity['original' + this.isPluralized()];
 
       // Toggle translation length display
       $('#translation-length')
@@ -626,7 +626,7 @@ var Pontoon = (function (my) {
         .find('.countdown').toggle(!!self.translationLengthLimit);
 
       // Need to show if sidebar opened by default
-      $('#translation-length').show().find('.original-length').html(original);
+      $('#translation-length').show().find('.original-length').html(original.length);
       self.moveCursorToBeginning();
       self.updateCurrentTranslationLength();
       self.updateCachedTranslation();

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -418,17 +418,8 @@ var Pontoon = (function (my) {
      * Move cursor to the beginning of translation textarea
      */
     moveCursorToBeginning: function () {
-      var standard = $('#translation'),
-          ftl = $('#ftl-area input.value:visible:first'),
-          element = null;
-
-      if (standard.is(':visible')) {
-        element = standard;
-      } else if (ftl.is(':visible')) {
-        element = ftl;
-      }
-
-      if (element) {
+      var element = $('#editor textarea:visible:first');
+      if (element.length) {
         element[0].setSelectionRange(0, 0);
       }
     },
@@ -439,7 +430,7 @@ var Pontoon = (function (my) {
      */
     updateCurrentTranslationLength: function () {
       var limit = this.translationLengthLimit,
-          translation = $('#translation').val();
+          translation = $('#editor textarea:visible:first').val() || '';
 
       if (limit) {
         var length = this.stripHTML(translation).length,
@@ -468,7 +459,7 @@ var Pontoon = (function (my) {
      * Update the standard translation editor and focus it
      */
     updateAndFocusTranslationEditor: function (translation) {
-      $('#translation').val(translation).focus();
+      $('#editor textarea:visible:first').val(translation).focus();
     },
 
 
@@ -1680,7 +1671,7 @@ var Pontoon = (function (my) {
     updateInPlaceTranslation: function (translation) {
       var entity = this.getEditorEntity(),
           pluralForm = this.getPluralForm(true),
-          translation = translation || $('#translation').val();
+          translation = translation || $('#editor textarea:visible:first').val();
 
       if (entity.body && pluralForm === 0 && (this.user.canTranslate() || !entity.translation[pluralForm].approved)) {
         this.postMessage("SAVE", {
@@ -1980,7 +1971,7 @@ var Pontoon = (function (my) {
         }
 
         // FTL Editor
-        if (self.fluent.isFTLEditorEnabled()) {
+        if (self.fluent.isFTLEditorEnabled() && $('#helpers .history').is(':visible')) {
           self.fluent.renderEditor({
             pk: $(this).data('id'),
             string: this.string

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -706,7 +706,7 @@ var Pontoon = (function (my) {
       }
 
       var before = this.cachedTranslation,
-          after = this.fluent.serializeTranslation(entity, $('#translation').val());
+          after = this.fluent.getTranslationSource();
 
       if ((before !== null) && (before !== after)) {
         $('#unsaved').show();

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -285,10 +285,7 @@
         <section class="main-value">
           <ul>
             <li>
-              <label class="id" for="entity-value">
-                <span>Value</span>
-              </label>
-              <input type="text" id="entity-value" class="value" placeholder="Enter translation"></li>
+              <textarea {% if not user.is_authenticated() %} readonly {% endif %} id="only-value" placeholder="Type translation and press Enter to save"></textarea>
             </li>
           </ul>
         </section>


### PR DESCRIPTION
Restore FTL button and enable switching between source and FTL editor:
- Fallback to source view for translations not supported in FTL editor.
- Same for source strings.
- Switching reflects changes in either editor.
- Prevent switching to rich editor if message not supported.
- Show translation length and Copy from source only for simple FTL strings and only in FTL editor.
- For untranslated strings not supported in rich editor, show source view if source string displayed as source.

Always use #translation textarea for source editor and #ftl-area for FTL editor (even for simple strings). Similarly, even simple source strings are displayed in #ftl-original. To make that possible, we keep entity and translation objects unchanged for non-complex FTL strings.

Other improvements:
- Bugfix: Update editor when FTL message unrejected.
- Join renderEditorWithTranslation() and renderEditor() functions.
- Focus first element, regardless if <input> or <textarea>.

To test and review, use the test project containing a good balance of FTL messages:
https://github.com/mathjazz/pontoon-ftl/