### PR TITLE
Fix preferred locales and homepage selector interferance

### DIFF
--- a/pontoon/teams/static/js/team_selector.js
+++ b/pontoon/teams/static/js/team_selector.js
@@ -1,5 +1,5 @@
 $(function() {
-  $('.locale .menu li:not(".no-match")').click(function () {
+  $('.locale-selector .locale .menu li:not(".no-match")').click(function () {
     $('.locale .selector').html($(this).html());
   });
 });


### PR DESCRIPTION
If the locale is selected on the preffered locales multi locale
selector, that same locale also gets selected as the homepage.
This patch fixes that.

@jotes r?