### PR TITLE
No bug - Enable Sync button in admin for local development.

### DIFF
--- a/docker/config/webapp.env.template
+++ b/docker/config/webapp.env.template
@@ -2,6 +2,7 @@ SECRET_KEY=insert_random_key
 DJANGO_DEV=True
 DJANGO_DEBUG=True
 DATABASE_URL=postgres://pontoon:asdf@postgresql/pontoon
+MANUAL_SYNC=True
 SESSION_COOKIE_SECURE=False
 SITE_URL=#SITE_URL#
 FXA_CLIENT_ID=2651b9211a44b7b2


### PR DESCRIPTION
Running sync locally can be difficult, so allowing to do so from the admin interface is quite convenient for local development. This commit makes that the default behavior.