### PR TITLE
Touch #1416256 String tiers util

### DIFF
--- a/pontoon/tags/utils/__init__.py
+++ b/pontoon/tags/utils/__init__.py
@@ -1,10 +1,21 @@
 
+from .latest_activity import LatestActivity, LatestActivityUser
 from .resources import TagsResourcesTool
 from .stats import TagsStatsTool
+from .tagged import TaggedLocale
+from .tag import TagTool
+from .tags import TagsTool
 from .translations import TagsLatestTranslationsTool
 
 
 __all__ = (
+    'LatestActivity',
+    'LatestActivityTranslation',
+    'LatestActivityUser',
+    'TagChart',
+    'TaggedLocale',
+    'TagsLatestTranslationsTool',
     'TagsResourcesTool',
     'TagsStatsTool',
-    'TagsLatestTranslationsTool')
+    'TagsTool',
+    'TagTool')

--- a/pontoon/tags/utils/latest_activity.py
+++ b/pontoon/tags/utils/latest_activity.py
@@ -1,0 +1,59 @@
+
+# The classes here provide similar functionality to
+# ProjectLocale.get_latest_activity in mangling latest activity data,
+# although they use queryset `values` rather than objects
+
+from pontoon.base.models import user_gravatar_url
+
+
+class LatestActivityUser(object):
+
+    def __init__(self, user):
+        self.user = user
+
+    @property
+    def email(self):
+        return self.user.get('user__email')
+
+    @property
+    def first_name(self):
+        return self.user.get('user__first_name')
+
+    @property
+    def name_or_email(self):
+        return self.first_name or self.email
+
+    def gravatar_url(self, *args):
+        if self.email:
+            return user_gravatar_url(self, *args)
+
+
+class LatestActivity(object):
+
+    def __init__(self, activity):
+        self.activity = activity
+
+    @property
+    def approved_date(self):
+        return self.activity.get('approved_date')
+
+    @property
+    def date(self):
+        return self.activity.get('date')
+
+    @property
+    def translation(self):
+        return self.activity.get('string')
+
+    @property
+    def user(self):
+        return (
+            LatestActivityUser(self.activity)
+            if 'user__email' in self.activity
+            else None)
+
+    @property
+    def type(self):
+        if self.approved_date is not None and self.approved_date > self.date:
+            return 'approved'
+        return 'submitted'

--- a/pontoon/tags/utils/stats.py
+++ b/pontoon/tags/utils/stats.py
@@ -1,4 +1,8 @@
 
+# The classes here provide similar functionality to
+# TranslatedResource.stats in mangling stats data,
+# although they use queryset `values` rather than objects
+
 from django.db.models import F, Sum, Value
 from django.db.models.functions import Coalesce
 
@@ -61,7 +65,7 @@ class TagsStatsTool(TagsTRTool):
                     pk__in=(
                         r['locale']
                         for r
-                        in result)).values('pk', 'name', 'code')}
+                        in result)).values('pk', 'name', 'code', 'population')}
             for r in result:
                 # update the stats with locale data
                 r.update(locales[r['locale']])

--- a/pontoon/tags/utils/tag.py
+++ b/pontoon/tags/utils/tag.py
@@ -1,0 +1,93 @@
+
+from django.utils.functional import cached_property
+
+from .tagged import Tagged, TaggedLocale
+
+
+class TagTool(Tagged):
+    """This wraps ``Tag`` model kwargs providing an API for
+    efficient retrieval of related information, eg tagged ``Resources``,
+    ``Locales`` and ``Projects``, and methods for managing linked
+    ``Resources``.
+    """
+
+    def __init__(self, tags_tool, **kwargs):
+        self.tags_tool = tags_tool
+        self.name = kwargs.pop("name")
+        self.pk = kwargs.pop("pk")
+        self.priority = kwargs.pop("priority")
+        self.slug = kwargs.pop("slug")
+        self.project = kwargs.pop("project")
+        super(TagTool, self).__init__(**kwargs)
+
+    @property
+    def linkable_resources(self):
+        """``Resources`` that could be linked to this ``Tag``"""
+        return self.resource_tool.get_linkable_resources(
+            self.slug).order_by('path')
+
+    @property
+    def linked_resources(self):
+        """``Resources`` that are linked to this ``Tag``"""
+        return self.resource_tool.get_linked_resources(
+            self.slug).order_by('path')
+
+    @property
+    def locale_stats(self):
+        return self.tags_tool.stat_tool(
+            slug=self.slug,
+            groupby='locale').data
+
+    @cached_property
+    def locale_latest(self):
+        """A cached property containing latest locale changes
+        """
+        return self.tags_tool.translation_tool(
+            slug=self.slug,
+            groupby='locale').data
+
+    @cached_property
+    def object(self):
+        """Returns the ``Tag`` model object for this tag.
+        This is useful for introspection, but should be avoided in
+        actual code
+        """
+        return self.tags_tool.tag_manager.select_related(
+            'project').get(pk=self.pk)
+
+    @cached_property
+    def resource_tool(self):
+        """This is a cached version of a TagsResourcesTool, and is used
+        for retrieving un/linked information about resources.
+
+        If the the tag's project is not set, then it uses the resource_tool
+        provided by tags_tool, otherwise it clones tags_tool, setting projects
+        to [self.project] to ensure we only retrieve the correct information.
+        """
+        return (
+            self.tags_tool.resource_tool(projects=[self.project])
+            if self.project
+            else self.tags_tool.resource_tool)
+
+    def iter_locales(self, project=None):
+        """Iterate ``Locales`` that are associated with this tag
+        (given any filtering in ``self.tags_tool``)
+
+        yields a ``TaggedLocale`` that can be used to get eg chart data
+        """
+        for locale in self.locale_stats:
+            yield TaggedLocale(
+                project=project,
+                latest_translation=self.locale_latest.get(locale["locale"]),
+                **locale)
+
+    def link_resources(self, resources):
+        """Link Resources to this tag, raises an Error if the tag's
+        Project is set, and the requested resource is not in  that Project
+        """
+        return self.resource_tool.link(self.slug, resources=resources)
+
+    def unlink_resources(self, resources):
+        """Unlink Resources from this tag
+        """
+        return self.resource_tool.unlink(self.slug, resources=resources)

--- a/pontoon/tags/utils/tagged.py
+++ b/pontoon/tags/utils/tagged.py
@@ -1,0 +1,70 @@
+
+from .latest_activity import LatestActivity
+
+
+class Tagged(object):
+    """Base class for wrapping `values` dictionaries of related
+    tag information
+    """
+
+    def __init__(self, **kwargs):
+        self._latest_translation = kwargs.pop(
+            "latest_translation", None)
+        self.approved_strings = kwargs.get('approved_strings')
+        self.fuzzy_strings = kwargs.get('fuzzy_strings')
+        self.total_strings = kwargs.get('total_strings')
+        self.translated_strings = kwargs.get('translated_strings')
+        self.kwargs = kwargs
+
+    @property
+    def chart(self):
+        """Generate a dict of chart information
+        """
+        return (
+            {k: v
+             for k, v
+             in self.kwargs.items()
+             if k in ['approved_strings',
+                      'fuzzy_strings',
+                      'total_strings',
+                      'translated_strings']}
+            if self.kwargs.get('total_strings')
+            else None)
+
+    @property
+    def latest_translation(self):
+        return self._latest_translation
+
+    @property
+    def latest_activity(self):
+        """Returns wrapped LatestActivity data if available
+        """
+        return (
+            LatestActivity(self.latest_translation)
+            if self.latest_translation
+            else None)
+
+    @property
+    def tag(self):
+        return self.kwargs.get('slug')
+
+
+class TaggedLocale(Tagged):
+    """Wraps a Locale to provide stats and latest information
+    """
+
+    @property
+    def code(self):
+        return self.kwargs.get('code')
+
+    @property
+    def name(self):
+        return self.kwargs.get('name')
+
+    @property
+    def population(self):
+        return self.kwargs.get('population')
+
+    @property
+    def project(self):
+        return self.kwargs.get('project')

--- a/pontoon/tags/utils/tags.py
+++ b/pontoon/tags/utils/tags.py
@@ -1,0 +1,94 @@
+
+from django.utils.functional import cached_property
+
+from pontoon.base.utils import glob_to_regex
+from pontoon.tags.models import Tag
+
+from .base import Clonable
+from .resources import TagsResourcesTool
+from .stats import TagsStatsTool
+from .tag import TagTool
+from .translations import TagsLatestTranslationsTool
+
+
+class TagsTool(Clonable):
+    """This provides an API for retrieving related ``Tags`` for given filters,
+    providing breakdowns of statistical information about the ``Tags``, and
+    managing ``Tags`` used in the site.
+    """
+
+    tag_class = TagTool
+    resources_class = TagsResourcesTool
+    translations_class = TagsLatestTranslationsTool
+    stats_class = TagsStatsTool
+    clone_kwargs = (
+        'locales',
+        'projects',
+        'priority',
+        'path',
+        'slug')
+
+    def __getitem__(self, k):
+        return self(slug=k)
+
+    def __iter__(self):
+        return self.iter_tags(self.stat_tool.data)
+
+    def __len__(self):
+        return len(self.stat_tool.data)
+
+    @property
+    def tag_manager(self):
+        return Tag.objects
+
+    @cached_property
+    def resource_tool(self):
+        return self.resources_class(
+            projects=self.projects,
+            locales=self.locales,
+            slug=self.slug,
+            path=self.path)
+
+    @cached_property
+    def stat_tool(self):
+        return self.stats_class(
+            slug=self.slug,
+            locales=self.locales,
+            projects=self.projects,
+            priority=self.priority,
+            path=self.path)
+
+    @cached_property
+    def translation_tool(self):
+        return self.translations_class(
+            slug=self.slug,
+            locales=self.locales,
+            projects=self.projects)
+
+    def get(self, slug=None):
+        """Get the first tag by iterating self, or by slug if set
+        """
+        if slug is None:
+            return list(self)[0]
+        return self.tag_class(self, **self.get_tags(slug=slug)[0])
+
+    def get_tags(self, slug=None):
+        """Get `values` of associated tags, filtering by slug if given
+        """
+        tags = self.tag_manager.values(
+            "pk", "name", "slug", "priority", "project")
+        if slug:
+            return tags.filter(slug__regex=glob_to_regex(slug))
+        return tags
+
+    def iter_tags(self, tags):
+        """Iterate associated tags, and create TagTool objects for
+        each, adding latest translation data
+        """
+        for tag in tags:
+            latest_translation = self.translation_tool.data.get(
+                tag["resource__tag"])
+            yield self.tag_class(
+                self,
+                latest_translation=latest_translation,
+                **tag)

--- a/tests/tags/utils/tag.py
+++ b/tests/tags/utils/tag.py
@@ -1,0 +1,272 @@
+
+import types
+
+import pytest
+
+from mock import patch, MagicMock, PropertyMock
+
+from pontoon.tags.utils import TagsTool, TagTool
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [dict(tags_tool=None,
+          name=None,
+          pk=None,
+          priority=None,
+          project=None,
+          slug=None),
+     dict(tags_tool=1,
+          name=2,
+          pk=3,
+          priority=4,
+          project=5,
+          slug=6,
+          latest_translation=7,
+          total_strings=8,
+          approved_strings=9)])
+def test_util_tag_tool_init(kwargs):
+    # Test the TagTool can be instantiated with/out args
+    tags_tool = TagTool(**kwargs)
+    for k, v in kwargs.items():
+        assert getattr(tags_tool, k) == v
+
+
+@patch('pontoon.tags.utils.tags.TagsTool.stat_tool',
+       new_callable=PropertyMock())
+def test_util_tag_tool_locale_stats(stats_mock):
+    stats_mock.configure_mock(
+        **{'return_value.data': 23})
+    tag_tool = TagTool(
+        TagsTool(),
+        name=None,
+        pk=None,
+        priority=None,
+        project=None,
+        slug=7)
+
+    # locale_stats returns self.tags_tool.stats_tool().data
+    assert tag_tool.locale_stats == 23
+
+    # stats_tool was called with slug and groupby
+    assert (
+        list(stats_mock.call_args)
+        == [(), {'groupby': 'locale', 'slug': 7}])
+
+
+@patch('pontoon.tags.utils.tag.TagTool.locale_stats',
+       new_callable=PropertyMock)
+@patch('pontoon.tags.utils.tag.TagTool.locale_latest',
+       new_callable=PropertyMock)
+@patch('pontoon.tags.utils.tag.TaggedLocale')
+def test_util_tag_tool_iter_locales(locale_mock, latest_mock, stats_mock):
+    tag_tool = TagTool(
+        TagsTool(),
+        name=None,
+        pk=None,
+        priority=None,
+        project=None,
+        slug=None)
+
+    # Set mocks
+    locale_mock.return_value = "X"
+    latest_mock.configure_mock(
+        **{'return_value.get.return_value': 23})
+    stats_mock.return_value = [
+        dict(foo=1, locale=1),
+        dict(foo=2, locale=2),
+        dict(foo=3, locale=3)]
+
+    # iter_locales - should generate 3 of 'X'
+    locales = tag_tool.iter_locales()
+    assert isinstance(locales, types.GeneratorType)
+    assert list(locales) == ['X'] * 3
+    assert len(locale_mock.call_args_list) == 3
+    assert stats_mock.called
+
+    # locale_latest is called with each of the locales
+    assert (
+        list(list(a) for a in latest_mock.return_value.get.call_args_list)
+        == [[(1,), {}], [(2,), {}], [(3,), {}]])
+
+    # TaggedLocale is called with locale data
+    for i, args in enumerate(locale_mock.call_args_list):
+        assert args[1]['foo'] == i + 1
+        assert args[1]['latest_translation'] == 23
+
+
+@patch('pontoon.tags.utils.TagTool.resource_tool',
+       new_callable=PropertyMock)
+def test_util_tag_tool_linked_resources(resources_mock):
+    tag_tool = TagTool(
+        TagsTool(),
+        name=None,
+        pk=None,
+        priority=None,
+        project=None,
+        slug=7)
+    resources_mock.configure_mock(
+        **{'return_value.get_linked_resources'
+           '.return_value.order_by.return_value': 23})
+
+    # linked_resources returns
+    # resources.get_linked_resources().order_by()
+    assert tag_tool.linked_resources == 23
+
+    # get_linked_resources was called with slug
+    linked_resources_mock = resources_mock.return_value.get_linked_resources
+    assert (
+        list(linked_resources_mock.call_args)
+        == [(7,), {}])
+
+    # order_by is called with 'path'
+    order_by_mock = linked_resources_mock.return_value.order_by
+    assert (
+        list(order_by_mock.call_args)
+        == [('path',), {}])
+
+
+@patch('pontoon.tags.utils.TagTool.resource_tool',
+       new_callable=PropertyMock)
+def test_util_tag_tool_linkable_resources(resources_mock):
+    tag_tool = TagTool(
+        TagsTool(),
+        name=None,
+        pk=None,
+        priority=None,
+        project=None,
+        slug=7)
+    resources_mock.configure_mock(
+        **{'return_value.get_linkable_resources'
+           '.return_value.order_by.return_value': 23})
+
+    # linkable_resources returns
+    # resources.get_linkable_resources().order_by()
+    assert tag_tool.linkable_resources == 23
+
+    # get_linkable_resources was called with slug
+    linkable_resources_mock = (
+        resources_mock.return_value.get_linkable_resources)
+    assert (
+        list(linkable_resources_mock.call_args)
+        == [(7,), {}])
+
+    # order_by is called with 'path'
+    order_by_mock = linkable_resources_mock.return_value.order_by
+    assert (
+        list(order_by_mock.call_args)
+        == [('path',), {}])
+
+
+@patch('pontoon.tags.utils.TagTool.resource_tool',
+       new_callable=PropertyMock)
+def test_util_tag_tool_link_resources(resources_mock):
+    tag_tool = TagTool(
+        TagsTool(),
+        name=None,
+        pk=None,
+        priority=None,
+        project=None,
+        slug=7)
+    resources_mock.configure_mock(
+        **{'return_value.link.return_value': 23})
+
+    # link_resources returns resources.link()
+    assert tag_tool.link_resources(13) == 23
+
+    # resources.link() is called with correct args
+    assert (
+        list(resources_mock.return_value.link.call_args)
+        == [(7,), {'resources': 13}])
+
+
+@patch('pontoon.tags.utils.TagTool.resource_tool',
+       new_callable=PropertyMock)
+def test_util_tag_tool_unlink_resources(resources_mock):
+    tag_tool = TagTool(
+        TagsTool(),
+        name=None,
+        pk=None,
+        priority=None,
+        project=None,
+        slug=7)
+    resources_mock.configure_mock(
+        **{'return_value.unlink.return_value': 23})
+
+    # unlink_resources returns resources.unlink()
+    assert tag_tool.unlink_resources(13) == 23
+
+    # resources.unlink() is called with correct args
+    assert (
+        list(resources_mock.return_value.unlink.call_args)
+        == [(7,), {'resources': 13}])
+
+
+@patch('pontoon.tags.utils.TagsTool.tag_manager',
+       new_callable=PropertyMock)
+def test_util_tag_tool_object(tag_mock):
+    tag_mock.configure_mock(
+        **{'return_value.select_related'
+           '.return_value.get.return_value': 23})
+    tag_tool = TagTool(
+        TagsTool(),
+        name=None,
+        pk=13,
+        priority=None,
+        project=None,
+        slug=7)
+
+    # object returns tag_manager.select_related().get()
+    assert tag_tool.object is 23
+
+    # tag_manager.select_related().get() is called with the tag pk
+    assert (
+        list(tag_mock.return_value.select_related.return_value.get.call_args)
+        == [(), {'pk': 13}])
+
+
+@patch('pontoon.tags.utils.TagsTool.resource_tool',
+       new_callable=PropertyMock)
+def test_util_tag_tool_resource_tool(resources_mock):
+    tool_mock = MagicMock(return_value=23)
+    resources_mock.return_value = tool_mock
+    tag_tool = TagTool(
+        TagsTool(),
+        name=None,
+        pk=None,
+        priority=None,
+        project=None,
+        slug=None)
+
+    # no project set - returns the tags.resources_tool, but doesnt call it
+    assert tag_tool.resource_tool is tool_mock
+    assert not tool_mock.called
+
+    # project set
+    tag_tool = TagTool(
+        TagsTool(),
+        name=None,
+        pk=None,
+        priority=None,
+        project=43,
+        slug=None)
+    # tool was called with project as args
+    assert tag_tool.resource_tool == 23
+    assert list(tool_mock.call_args) == [(), {'projects': [43]}]
+
+
+@patch('pontoon.tags.utils.TagsTool.translation_tool')
+def test_util_tag_tool_locale_latest(trans_mock):
+    trans_mock.configure_mock(
+        **{'return_value.data': 23})
+    tag_tool = TagTool(
+        TagsTool(),
+        name=None,
+        pk=None,
+        priority=None,
+        project=None,
+        slug=17)
+    assert tag_tool.locale_latest == 23
+    assert (
+        list(trans_mock.call_args)
+        == [(), {'groupby': 'locale', 'slug': 17}])

--- a/tests/tags/utils/tagged.py
+++ b/tests/tags/utils/tagged.py
@@ -1,0 +1,145 @@
+
+from mock import patch
+
+from pontoon.tags.utils import (
+    LatestActivity, LatestActivityUser, TaggedLocale)
+from pontoon.tags.utils.tagged import Tagged
+
+
+def test_util_tag_tagged():
+    # Tests the base Tagged class
+
+    # called with no args - defaults
+    tagged = Tagged()
+    assert tagged.latest_activity is None
+    assert tagged.chart is None
+    assert tagged.kwargs == {}
+
+    # called with random arg - added to kwargs
+    tagged = Tagged(foo='bar')
+    assert tagged.latest_activity is None
+    assert tagged.chart is None
+    assert tagged.kwargs == dict(foo='bar')
+
+    # called with total_strings - chart added
+    tagged = Tagged(total_strings=23)
+    assert tagged.latest_activity is None
+    assert tagged.chart == dict(total_strings=23)
+
+    # called with latest_translation - latest activity added
+    tagged = Tagged(latest_translation=23)
+    with patch('pontoon.tags.utils.tagged.LatestActivity') as m:
+        m.return_value = "y"
+        assert tagged.latest_activity == "y"
+
+    assert tagged.chart is None
+    assert tagged.kwargs == {}
+
+
+def test_util_tag_tagged_locale():
+    # Tests instantiation of TaggedLocale wrapper
+
+    # defaults
+    tagged = TaggedLocale()
+    assert tagged.code is None
+    assert tagged.name is None
+    assert tagged.total_strings is None
+    assert tagged.latest_activity is None
+    assert tagged.tag is None
+    assert tagged.project is None
+    assert tagged.population is None
+    assert tagged.kwargs == {}
+
+    # call with locale data
+    tagged = TaggedLocale(
+        slug='bar',
+        pk=23,
+        code="foo",
+        name="A foo",
+        project=43,
+        population=113)
+    assert tagged.tag == 'bar'
+    assert tagged.code == "foo"
+    assert tagged.name == "A foo"
+    assert tagged.total_strings is None
+    assert tagged.latest_activity is None
+    assert (
+        tagged.kwargs
+        == dict(
+            slug='bar',
+            pk=23,
+            code="foo",
+            name="A foo",
+            project=43,
+            population=113))
+
+    # call with latest_translation and stat data
+    tagged = TaggedLocale(latest_translation=7, total_strings=23)
+    with patch('pontoon.tags.utils.tagged.LatestActivity') as m:
+        m.return_value = "y"
+        assert tagged.latest_activity == "y"
+        assert tagged.chart == dict(total_strings=23)
+
+
+def test_util_latest_activity():
+    # Tests instantiating the latest_activity wrapper
+
+    # call with random activity - defaults
+    activity = LatestActivity(dict(foo='bar'))
+    assert activity.activity == dict(foo='bar')
+    assert activity.type == 'submitted'
+    assert activity.translation is None
+    assert activity.user is None
+
+    # check approved_date
+    activity = LatestActivity(dict(approved_date=7))
+    assert activity.approved_date == 7
+
+    # check data
+    activity = LatestActivity(dict(date=23))
+    assert activity.date == 23
+
+    # check type is approved
+    activity = LatestActivity(
+        dict(date=23, approved_date=113))
+    assert activity.type == 'approved'
+
+    # check user is created if present
+    activity = LatestActivity(dict(user__email=43))
+    assert isinstance(activity.user, LatestActivityUser)
+    assert activity.user.user == {'user__email': 43}
+
+
+@patch('pontoon.tags.utils.latest_activity.user_gravatar_url')
+def test_util_latest_activity_user(avatar_mock):
+    # Tests instantiating a latest activity user wrapper
+
+    avatar_mock.return_value = 113
+
+    # call with random user data - defaults
+    user = LatestActivityUser(dict(foo='bar'))
+    assert user.email is None
+    assert user.first_name is None
+    assert user.name_or_email is None
+    assert user.gravatar_url(23) is None
+
+    # call with email - user data added
+    user = LatestActivityUser(
+        dict(user__email='bar@ba.z'))
+    assert user.email == 'bar@ba.z'
+    assert user.first_name is None
+    assert user.name_or_email == 'bar@ba.z'
+    assert user.gravatar_url(23) == 113
+    assert list(avatar_mock.call_args) == [(user, 23), {}]
+
+    avatar_mock.reset_mock()
+
+    # call with email and name - correct name
+    user = LatestActivityUser(
+        dict(user__email='bar@ba.z',
+             user__name='FOOBAR'))
+    assert user.email == 'bar@ba.z'
+    assert user.first_name is None
+    assert user.name_or_email == 'bar@ba.z'
+    assert user.gravatar_url(23) == 113
+    assert list(avatar_mock.call_args) == [(user, 23), {}]

--- a/tests/tags/utils/tags.py
+++ b/tests/tags/utils/tags.py
@@ -1,0 +1,224 @@
+
+import pytest
+
+from mock import MagicMock, patch, PropertyMock
+
+from pontoon.tags.models import Tag
+from pontoon.tags.utils import (
+    TagsLatestTranslationsTool, TagsResourcesTool,
+    TagsStatsTool, TagsTool, TagTool)
+from pontoon.tags.utils.base import Clonable
+
+
+def test_util_tags_tool():
+    # test tags tool instantiation
+    tags_tool = TagsTool()
+    assert tags_tool.tag_class is TagTool
+    assert tags_tool.resources_class is TagsResourcesTool
+    assert tags_tool.translations_class is TagsLatestTranslationsTool
+    assert tags_tool.stats_class is TagsStatsTool
+    assert tags_tool.locales is None
+    assert tags_tool.projects is None
+    assert tags_tool.priority is None
+    assert tags_tool.slug is None
+    assert tags_tool.path is None
+    assert tags_tool.tag_manager == Tag.objects
+
+
+@patch('pontoon.tags.utils.TagsTool.stats_class')
+def test_util_tags_tool_stats(stats_mock, tag_init_kwargs):
+    # tests instantiation of tag.stats_tool with different args
+    tags_tool = TagsTool(**tag_init_kwargs)
+    stats_mock.return_value = 23
+    assert tags_tool.stat_tool == 23
+    assert stats_mock.call_args[1] == tag_init_kwargs
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [dict(
+        slug=None,
+        locales=None,
+        projects=None,
+        path=None),
+     dict(
+         slug=1,
+         locales=2,
+         projects=3,
+         path=4)])
+@patch('pontoon.tags.utils.TagsTool.resources_class')
+def test_util_tags_tool_resources(resources_mock, kwargs):
+    # tests instantiation of tag.resources_tool with different args
+    tags_tool = TagsTool(**kwargs)
+    resources_mock.return_value = 23
+    assert tags_tool.resource_tool == 23
+    assert resources_mock.call_args[1] == kwargs
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [dict(
+        slug=None,
+        locales=None,
+        projects=None),
+     dict(
+         slug=1,
+         locales=2,
+         projects=3)])
+@patch('pontoon.tags.utils.TagsTool.translations_class')
+def test_util_tags_tool_translations(trans_mock, kwargs):
+    # tests instantiation of tag.translations_tool with different args
+    tags_tool = TagsTool(**kwargs)
+    trans_mock.return_value = 23
+    assert tags_tool.translation_tool == 23
+    assert trans_mock.call_args[1] == kwargs
+
+
+@patch('pontoon.tags.utils.TagsTool.tag_class')
+@patch('pontoon.tags.utils.TagsTool.get_tags')
+@patch('pontoon.tags.utils.TagsTool.__len__')
+@patch('pontoon.tags.utils.TagsTool.__iter__')
+def test_util_tags_tool_get(iter_mock, len_mock, tags_mock, class_mock):
+    # tests getting a TagTool from TagsTool
+    tags_tool = TagsTool()
+    class_mock.return_value = 23
+    len_mock.return_value = 7
+    iter_mock.return_value = iter([3, 17, 73])
+
+    # with no slug returns first result from iter(self)
+    assert tags_tool.get() == 3
+    assert not class_mock.called
+    assert not tags_mock.called
+    assert len_mock.called
+    assert iter_mock.called
+    len_mock.reset_mock()
+    iter_mock.reset_mock()
+
+    # calling with slug creates a TagTool instance
+    # and doesnt call iter(self) at all
+    assert tags_tool.get(113) == 23
+    assert not len_mock.called
+    assert not iter_mock.called
+    assert (
+        list(class_mock.call_args)
+        == [(tags_tool, ), {}])
+    assert (
+        list(tags_mock.call_args)
+        == [(), {'slug': 113}])
+
+
+def test_util_tags_tool_call_and_clone():
+    # tests cloning a TagsTool
+    tags_tool = TagsTool()
+    cloned = tags_tool()
+    assert cloned is not tags_tool
+    assert isinstance(tags_tool, Clonable)
+    assert isinstance(cloned, Clonable)
+
+
+@patch('pontoon.tags.utils.TagsTool.__call__')
+def test_util_tags_tool_getitem(call_mock):
+    # test that calling __getitem__ calls __call__ with slug
+    tags_tool = TagsTool()
+    slugs = ["foo", "bar"]
+    for slug in slugs:
+        tags_tool[slug]
+    assert call_mock.call_args_list[0][1] == dict(slug=slugs[0])
+    assert call_mock.call_args_list[1][1] == dict(slug=slugs[1])
+
+
+@patch('pontoon.tags.utils.TagsTool.iter_tags')
+@patch('pontoon.tags.utils.TagsTool.stat_tool',
+       new_callable=PropertyMock)
+def test_util_tags_tool_iter(stats_mock, iter_mock):
+    # tests that when you iter it calls iter_tags with
+    # stats data
+    tags_tool = TagsTool()
+    stats_mock.configure_mock(
+        **{'return_value.data': [7, 23]})
+    iter_mock.return_value = iter([])
+    assert list(tags_tool) == []
+    assert stats_mock.called
+    assert (
+        list(iter_mock.call_args)
+        == [([7, 23],), {}])
+
+
+@patch('pontoon.tags.utils.TagsTool.stat_tool',
+       new_callable=PropertyMock)
+def test_util_tags_tool_len(stats_mock):
+    # tests that when you len() you get the len
+    # of the stats data
+    m_len = MagicMock()
+    m_len.__len__.return_value = 23
+    stats_mock.configure_mock(
+        **{'return_value.data': m_len})
+    tags_tool = TagsTool()
+    assert len(tags_tool) == 23
+    assert m_len.__len__.called
+
+
+@patch('pontoon.tags.utils.TagsTool.translation_tool',
+       new_callable=PropertyMock)
+@patch('pontoon.tags.utils.TagsTool.tag_class')
+def test_util_tags_tool_iter_tags(tag_mock, trans_mock):
+    # tests that iter_tags calls instantiates a TagTool with
+    # stat data and latest_translation data
+
+    trans_mock.configure_mock(
+        **{'return_value.data.get.return_value': 23})
+    tags_tool = TagsTool()
+    list(
+        tags_tool.iter_tags(
+            [dict(resource__tag=1, foo="bar"),
+             dict(resource__tag=2, foo="bar"),
+             dict(resource__tag=3, foo="bar")]))
+
+    # translation_tool.data.get() was called 3 times with tag pks
+    assert (
+        [x[0][0] for x in trans_mock.return_value.data.get.call_args_list]
+        == [1, 2, 3])
+
+    # TagTool was called 3 times with the tags tool as arg
+    assert (
+        [x[0][0] for x in tag_mock.call_args_list]
+        == [tags_tool] * 3)
+
+    # and stat + translation data as kwargs
+    assert (
+        [x[1] for x in tag_mock.call_args_list]
+        == [{'resource__tag': 1, 'latest_translation': 23, 'foo': 'bar'},
+            {'resource__tag': 2, 'latest_translation': 23, 'foo': 'bar'},
+            {'resource__tag': 3, 'latest_translation': 23, 'foo': 'bar'}])
+
+
+@patch('pontoon.tags.utils.TagsTool.tag_manager',
+       new_callable=PropertyMock)
+@patch('pontoon.tags.utils.tags.glob_to_regex')
+def test_util_tags_tool_get_tags(glob_mock, tag_mock):
+    glob_mock.return_value = 17
+    filter_mock = MagicMock(
+        **{'filter.return_value': 23})
+    tag_mock.configure_mock(
+        **{'return_value.values.return_value': filter_mock})
+    tags_tool = TagsTool()
+
+    # no slug provided, returns `values`
+    assert tags_tool.get_tags() is filter_mock
+    assert not filter_mock.called
+    assert not glob_mock.called
+    assert (
+        list(tag_mock.return_value.values.call_args)
+        == [('pk', 'name', 'slug', 'priority', 'project'), {}])
+
+    tag_mock.reset_mock()
+
+    # slug provided, `values` is filtered
+    assert tags_tool.get_tags('FOO') == 23
+    assert (
+        list(filter_mock.filter.call_args)
+        == [(), {'slug__regex': 17}])
+    assert list(glob_mock.call_args) == [('FOO',), {}]
+    assert (
+        list(tag_mock.return_value.values.call_args)
+        == [('pk', 'name', 'slug', 'priority', 'project'), {}])


### PR DESCRIPTION
Adds a ~~model and~~ util for saving and fetching tags/tiers

#### TagsTool

The `TagsTool` provides the api for retrieving or saving information around tags. It has a number of associated tools that provide more specific apis.

Most simply you can call

```
tool = TagsTool()
```

this will provide you with an iterable object, the items of which will be of type `TagTool` (singular), which can provide further information/stats about a specific `tag`

you can filter the tool by passing kwargs - eg `projects`, `locales` (which should be lists)

you can create a clone of the tool, by calling it - this will carry any kwargs and you can add further - eg

```
filtered_tool = TagsTool(projects=['foo'])
more_filtered_tool = filtered_tool(locales=['en'])
```

You can filter the `tag` or `tags` that it provides information about like so

```
tool = TagsTool()['sometag']
```
the resulting tool will still be an iterable, and you can use glob matching to get info about multiple tags

```
tool = TagsTool()['*tag']
```

which would provide information eg about `sometag` and `othertag`


### TagTool 

This api provides information about an individual `tag`, such as what `projects`, `locales` and `resources` are associated with it and can provide stats breakdowns according to these.

It should not be called directly, but derived by iterating a `TagsTool` instance to ensure efficient calculation of data.

It has `iter_locales`, ~~`iter_projects` and `iter_resources`~~ method that iterates the locales for the tag, yielding a `TaggedLocale` object that can be used for getting stats and generating progress information per locale/project

~~a doctest explaining the api in more detail is available in #811~~
