### PR TITLE
Fix bug 1421495: Add SVG favicon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_script:
   - psql -c 'create database pontoon;' -U postgres
 script:
   - pylama pontoon
+  - python manage.py collectstatic --noinput
   - python manage.py test --with-coverage
   - py.test --cov-append --cov-report=term --cov=. -v
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
   - pip install -U --force pip
   - pip install --require-hashes -r requirements.txt
   - pip install --require-hashes -r requirements-test.txt
+  - npm install
 before_script:
   - psql -c 'create database pontoon;' -U postgres
 script:

--- a/pontoon/base/templates/base.html
+++ b/pontoon/base/templates/base.html
@@ -11,6 +11,7 @@
     <meta name="author" content="Mozilla">
 
     <link rel="icon" href="{{ static('img/logo.svg') }}">
+    <link rel="icon" href="{{ static('img/favicon.ico') }}">
 
     {% block site_css %}
       {% stylesheet 'base' %}

--- a/pontoon/base/templates/base.html
+++ b/pontoon/base/templates/base.html
@@ -10,6 +10,8 @@
     <meta name="description" content="Live web localization tool">
     <meta name="author" content="Mozilla">
 
+    <link rel="icon" href="{{ static('img/logo.svg') }}">
+
     {% block site_css %}
       {% stylesheet 'base' %}
 


### PR DESCRIPTION
Adding the HiRes SVG favicon for nicer display in the Firefox's new tab.

For more details, see https://bugzilla.mozilla.org/show_bug.cgi?id=1421495.

We still need to use the old `.ico` favicon:
https://caniuse.com/#feat=link-icon-svg