### PR TITLE
Fix bug 1421495: Define favicon type

### DIFF
--- a/pontoon/base/templates/base.html
+++ b/pontoon/base/templates/base.html
@@ -10,7 +10,8 @@
     <meta name="description" content="Live web localization tool">
     <meta name="author" content="Mozilla">
 
-    <link rel="icon" href="{{ static('img/logo.svg') }}">
+    <!-- Defining a type is a workaround for bug 1422289. -->
+    <link rel="icon" href="{{ static('img/logo.svg') }}" type="image/svg+xml">
     <link rel="icon" href="{{ static('img/favicon.ico') }}">
 
     {% block site_css %}


### PR DESCRIPTION
Without the type defined, Firefox uses the last defined favicon. See bug 1422289 for more details.