### PR TITLE
Fix bug 1423460: Do not hardcode plural selector

### DIFF
--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -316,7 +316,8 @@ var Pontoon = (function (my) {
             }
 
             if (value) {
-              value = '{ $num ->' + value + '\n  }';
+              var entity_ast = fluentParser.parseEntry(entity.original);
+              value = '{ ' + entity_ast.value.elements[0].expression.id.name + ' ->' + value + '\n  }';
             }
           }
 


### PR DESCRIPTION
@flodolo Thanks for noticing and filing the bug! Could you confirm that we also need to re-export all strings that are broken because of this bug?