### PR TITLE
Bug 1417530 - Install test requirements in docker.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,8 +9,10 @@ RUN DEBIAN_FRONTEND=noninteractive /app/set_up_ubuntu.sh
 # Install Pontoon Python requirements
 COPY requirements.txt /app/requirements.txt
 COPY requirements-dev.txt /app/requirements-dev.txt
+COPY requirements-test.txt /app/requirements-test.txt
 RUN pip install -U 'pip>=8'
 RUN pip install --no-cache-dir --require-hashes -r requirements-dev.txt
+RUN pip install --no-cache-dir --require-hashes -r requirements-test.txt
 
 COPY . /app/
 COPY ./docker/config/webapp.env /app/.env

--- a/docker/run_tests_in_docker.sh
+++ b/docker/run_tests_in_docker.sh
@@ -63,5 +63,16 @@ else
            local/pontoon \
            python manage.py test $@
 
+    docker run \
+           --rm \
+           --volumes-from pontoon-tests \
+           --workdir /app \
+           --network pontoon_default \
+           --link "${DC} ps -q postgresql" \
+           --env-file ./docker/config/webapp.env \
+           -e LOCAL_USER_ID=$UID \
+           local/pontoon \
+           py.test
+
     echo "Done!"
 fi


### PR DESCRIPTION
I did not succeed in running tests with pytest in `make dockertest` for the moment, for a reason I don't understand. For now, this allows to manually run them with `make dockershell`, which is all I need. 