### PR TITLE
Fix bug 1393523: Search and replace text values only

### DIFF
--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -778,6 +778,9 @@ var Pontoon = (function (my) {
       var self = this;
 
       self.checkUnsavedChanges(function() {
+        // We must hide batch editor first in order to display FTL editor properly
+        self.clearSelection();
+
         var oldEntity = self.getEditorEntity();
 
         if (newEntity.body || (oldEntity && oldEntity.body)) {
@@ -786,8 +789,6 @@ var Pontoon = (function (my) {
         if (!newEntity.body) {
           self.openEditor(newEntity);
         }
-
-        self.clearSelection();
       });
     },
 

--- a/pontoon/batch/utils.py
+++ b/pontoon/batch/utils.py
@@ -97,14 +97,16 @@ def find_and_replace(translations, find, replace, user):
         # Cache the old value to identify changed translations
         string = translation.string
 
-        # Create new translation
-        translation.pk = None
-
         if translation.entity.resource.format == 'ftl':
             translation.string = ftl_find_and_replace(string, find, replace)
         else:
             translation.string = string.replace(find, replace)
 
+        # Quit early if no changes are made
+        if translation.string == string:
+            return
+
+        translation.pk = None  # Create new translation
         translation.user = translation.approved_user = user
         translation.date = translation.approved_date = now
         translation.approved = True
@@ -112,9 +114,7 @@ def find_and_replace(translations, find, replace, user):
         translation.rejected_date = None
         translation.rejected_user = None
         translation.fuzzy = False
-
-        if translation.string != string:
-            translations_to_create.append(translation)
+        translations_to_create.append(translation)
 
     # Create new translations
     changed_translations = Translation.objects.bulk_create(translations_to_create)

--- a/pontoon/batch/utils.py
+++ b/pontoon/batch/utils.py
@@ -52,7 +52,7 @@ def ftl_find_and_replace(string, find, replace):
     """
 
     def replace_text_elements(node):
-        """Recursively traverse the AST and perform find and replace on text values only"""
+        """Perform find and replace on text values only"""
         if type(node) == ast.TextElement:
             node.value = node.value.replace(find, replace)
         return node
@@ -117,6 +117,8 @@ def find_and_replace(translations, find, replace, user):
         translations_to_create.append(translation)
 
     # Create new translations
-    changed_translations = Translation.objects.bulk_create(translations_to_create)
+    changed_translations = Translation.objects.bulk_create(
+        translations_to_create
+    )
 
     return translations, changed_translations


### PR DESCRIPTION
To make search and replace work for FTL strings, we can't just use
Translation.string.replace(keyword, replacement) like for other file
formats, becuse we store the entire source code of the FTL Message in
Translation.string.

Instead, we need to:

  1. Parse each string and get AST
  2. Recursively traverse AST and run find & replace on text values only
  3. Serialize updated AST.