### PR TITLE
Fix bug 1366259: beautify FTL strings in latest activity

### DIFF
--- a/pontoon/base/templates/widgets/latest_activity.html
+++ b/pontoon/base/templates/widgets/latest_activity.html
@@ -10,7 +10,7 @@
       {% set user = '' %}
       {% set avatar = '' %}
     {% endif %}
-    <time datetime="{{ latest_activity.date.isoformat() }}" data-translation="{{ latest_activity.translation.string }}" data-action="{{ action }}" data-user-name="{{ user }}" data-user-avatar="{{ avatar }}">{{ latest_activity.date|naturaltime }}</time>
+    <time datetime="{{ latest_activity.date.isoformat() }}" data-translation="{{ latest_activity.translation.string|as_simple_translation() }}" data-action="{{ action }}" data-user-name="{{ user }}" data-user-avatar="{{ avatar }}">{{ latest_activity.date|naturaltime }}</time>
   {% else %}
     <span class="not">―</span>
   {% endif %}

--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -274,11 +274,6 @@ def _serialize_elements(elements):
 @library.filter
 def as_simple_translation(source):
     """Transfrom complex FTL-based strings into single-value strings."""
-
-    # Empty string
-    if not source:
-        return source
-
     translation_ast = parser.parse_entry(source)
 
     # Non-FTL string or string with an error

--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -292,7 +292,7 @@ def as_simple_translation(source):
             return _serialize_elements(variants[0].value.elements)
 
         # Simple strings
-        except (AttributeError, IndexError) as e:
+        except (AttributeError, IndexError):
             return _serialize_elements(translation_ast.value.elements)
 
     else:
@@ -302,5 +302,5 @@ def as_simple_translation(source):
             return _serialize_elements(attributes[0].value.elements)
 
         # All other strings: display unchanged
-        except (AttributeError, IndexError) as e:
+        except (AttributeError, IndexError):
             return source

--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -263,10 +263,10 @@ def _serialize_elements(elements):
 
         elif type(element) == ast.Placeable:
             if type(element.expression) == ast.ExternalArgument:
-                response += '{$' + element.expression.id.name + '}'
+                response += '{ $' + element.expression.id.name + ' }'
 
             elif type(element.expression) == ast.MessageReference:
-                response += '{' + element.expression.id.name + '}'
+                response += '{ ' + element.expression.id.name + ' }'
 
     return response
 

--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -2,6 +2,11 @@ import cgi
 import datetime
 import json
 
+import jinja2
+from allauth.socialaccount import providers
+from allauth.utils import get_request_param
+from django_jinja import library
+from fluent.syntax import FluentParser, ast
 from six import text_type
 from six.moves.urllib import parse as six_parse
 
@@ -14,13 +19,9 @@ from django.utils.encoding import smart_str
 from django.utils.encoding import force_text
 from django.utils.functional import Promise
 
-import jinja2
-from django_jinja import library
-from allauth.socialaccount import providers
-from allauth.utils import get_request_param
-
 
 register = template.Library()
+parser = FluentParser()
 
 
 class LazyObjectsJsonEncoder(json.JSONEncoder):
@@ -250,3 +251,56 @@ def dict_html_attrs(dict_obj):
     return jinja2.Markup(' '.join(
         [u'data-{}="{}"'.format(k, v) for k, v in dict_obj.items()]
     ))
+
+
+def _serialize_elements(elements):
+    """Serialize text elements and references into a simple string."""
+    response = ''
+
+    for element in elements:
+        if type(element) == ast.TextElement:
+            response += element.value
+
+        elif type(element) == ast.ExternalArgument:
+            response += '{$' + element.id.name + '}'
+
+        elif type(element) == ast.MessageReference:
+            response += '{' + element.id.name + '}'
+
+    return response
+
+
+@library.filter
+def as_simple_translation(source):
+    """Transfrom complex FTL-based strings into single-value strings."""
+
+    # Empty string
+    if not source:
+        return source
+
+    translation_ast = parser.parse_entry(source)
+
+    # Non-FTL string or string with an error
+    if type(translation_ast) == ast.Junk:
+        return source
+
+    if translation_ast.value:
+        # Strings with variants: display first variant
+        try:
+            elements = translation_ast.value.elements
+            variants = elements[0].expression.variants
+            return _serialize_elements(variants[0].value.elements)
+
+        # Simple strings
+        except (AttributeError, IndexError) as e:
+            return _serialize_elements(translation_ast.value.elements)
+
+    else:
+        # Strings with attributes: display first attribute
+        try:
+            attributes = translation_ast.attributes
+            return _serialize_elements(attributes[0].value.elements)
+
+        # All other strings: display unchanged
+        except (AttributeError, IndexError) as e:
+            return source

--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -261,11 +261,12 @@ def _serialize_elements(elements):
         if type(element) == ast.TextElement:
             response += element.value
 
-        elif type(element) == ast.ExternalArgument:
-            response += '{$' + element.id.name + '}'
+        elif type(element) == ast.Placeable:
+            if type(element.expression) == ast.ExternalArgument:
+                response += '{$' + element.expression.id.name + '}'
 
-        elif type(element) == ast.MessageReference:
-            response += '{' + element.id.name + '}'
+            elif type(element.expression) == ast.MessageReference:
+                response += '{' + element.expression.id.name + '}'
 
     return response
 

--- a/pontoon/base/tests/test_helpers.py
+++ b/pontoon/base/tests/test_helpers.py
@@ -4,7 +4,13 @@ from six import text_type
 
 from django_nose.tools import assert_equal
 
-from pontoon.base.templatetags.helpers import format_datetime, format_timedelta, nospam
+from pontoon.base.templatetags.helpers import (
+    as_simple_translation,
+    format_datetime,
+    format_timedelta,
+    nospam,
+)
+
 from pontoon.base.tests import TestCase
 from pontoon.base.utils import aware_datetime
 
@@ -54,3 +60,49 @@ class NoSpamTests(TestCase):
 
     def test_escape(self):
         assert_equal(str(nospam('<>\'"@&')), '&lt;&gt;&quot;&quot;&#64;&amp;')
+
+
+class AsSimpleTranslationTests(TestCase):
+    """Tests related to the as_simple_translation template filter."""
+
+    def test_empty_string(self):
+        source = ''
+        assert_equal(as_simple_translation(source), '')
+
+    def test_non_ftl(self):
+        source = 'Simple String'
+        assert_equal(as_simple_translation(source), 'Simple String')
+
+    def test_simple(self):
+        source = 'key = Simple String'
+        assert_equal(as_simple_translation(source), 'Simple String')
+
+    def test_multiline(self):
+        source = '''key =
+    Simple String
+    In Multiple
+    Lines'''
+        assert_equal(as_simple_translation(source), 'Simple String\nIn Multiple\nLines')
+
+    def test_plural(self):
+        source = '''key =
+    { $number ->
+        [1] Simple String
+       *[other] Other Simple String
+    }'''
+        assert_equal(as_simple_translation(source), 'Simple String')
+
+    def test_attribute(self):
+        source = '''key
+    .placeholder = Simple String'''
+        assert_equal(as_simple_translation(source), 'Simple String')
+
+    def test_attributes(self):
+        source = '''key
+    .attribute = Simple String
+    .other = Other Simple String'''
+        assert_equal(as_simple_translation(source), 'Simple String')
+
+    def test_other_ftl(self):
+        source = 'warning-upgrade = { LINK("Link text", title: "Link title") }Simple String'
+        assert_equal(as_simple_translation(source), 'Simple String')


### PR DESCRIPTION
Same as #618, but server side. The idea is to show FTL translations as simple strings instead of source in the latest activity column tooltip on dashboards.

Not pretty, but still better IMHO.

Let me know if this makes sense and I can add some tests.