### PR TITLE
Fix bug 1424845: Language-agnostic links to searches

### DIFF
--- a/pontoon/base/urls.py
+++ b/pontoon/base/urls.py
@@ -38,6 +38,11 @@ urlpatterns = [
         views.authors_and_time_range,
         name='pontoon.authors.and.time.range'),
 
+    # Locale-agnostic links
+    url(r'^projects/(?P<slug>[\w-]+)/(?P<part>.+)/$',
+        views.translate_locale_agnostic,
+        name='pontoon.translate.locale.agnostic'),
+
     # Translate project
     url(r'^(?P<locale>[A-Za-z0-9\-\@\.]+)/(?P<slug>[\w-]+)/(?P<part>.+)/$',
         views.translate,

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -101,6 +101,25 @@ def translate(request, locale, slug, part):
     })
 
 
+def translate_locale_agnostic(request, slug, part):
+    """Locale Agnostic Translate view."""
+    user = request.user
+    project = get_object_or_404(Project.objects.available(), slug=slug)
+
+    if user.is_authenticated():
+        locale = user.profile.custom_homepage
+
+        if locale and project.locales.filter(code=locale).exists():
+            return redirect('pontoon.translate', slug=slug, locale=locale, part=part)
+
+    locale = utils.get_project_locale_from_request(request, project.locales)
+
+    if locale:
+        return redirect('pontoon.translate', slug=slug, locale=locale, part=part)
+    else:
+        return redirect('pontoon.projects.project', slug=slug)
+
+
 @utils.require_AJAX
 def locale_projects(request, locale):
     """Get active projects for locale."""

--- a/tests/base/views/locale_agnostic.py
+++ b/tests/base/views/locale_agnostic.py
@@ -4,7 +4,7 @@ from mock import MagicMock, PropertyMock, patch
 
 from django.http import HttpResponse
 from django.urls import reverse
-from django.contrib.auth.models import User 
+from django.contrib.auth.models import User
 
 
 @patch('pontoon.base.views.get_object_or_404')
@@ -12,7 +12,7 @@ from django.contrib.auth.models import User
 @patch('pontoon.base.views.Project.objects.available')
 @patch('pontoon.base.views.redirect')
 @pytest.mark.django_db
-def test_view_lang_agnostic_authed(redirect_mock, projects_mock, 
+def test_view_lang_agnostic_authed(redirect_mock, projects_mock,
                                    util_mock, get_mock, client):
     ''' User is authenticated and Userprofile.custom_homepage defined,
     redirect to Userprofile.custom_homepage '''
@@ -22,43 +22,43 @@ def test_view_lang_agnostic_authed(redirect_mock, projects_mock,
         'pontoon.translate.locale.agnostic',
         kwargs=dict(slug='FOO', part='BAR'))
 
-    # mock return value for Project.objects.available                                                                                                                                                                                                        
+    # mock return value for Project.objects.available
     projects_mock.return_value = 'AVAILABLEPROJECTS'
 
     # create a mock Project with .locales
     project_mock = MagicMock()
     type(project_mock).locales = PropertyMock(return_value='LOCALES')
 
-    # mock return value for get_object_or_404 for Project                                                                                                                                                                                                    
+    # mock return value for get_object_or_404 for Project
     get_mock.return_value = project_mock
 
-    # mock return value for redirect                                                                                                                                                                                                                         
+    # mock return value for redirect
     mock_response = HttpResponse()
     redirect_mock.return_value = mock_response
 
-    # mock return_value for get_project_locale_from_request                                                                                                                                                                                                  
+    # mock return_value for get_project_locale_from_request
     util_mock.return_value = 23
 
     profile_mock = MagicMock()
     type(profile_mock).custom_homepage = PropertyMock(return_value=None)
 
-    # mock return_value for user.is_authenticated and custom homepage    
+    # mock return_value for user.is_authenticated and custom homepage
     user_mock = MagicMock()
     type(user_mock).is_authenticated = PropertyMock(return_value=True)
     type(user_mock).profile = PropertyMock(return_value=profile_mock)
 
     response = client.get(view)
 
-    # Project.objects.available was called with no args     
+    # Project.objects.available was called with no args
     assert list(projects_mock.call_args) == [(), {}]
 
-    # get_object_or_404 was called with Project.objects.available and                                                                                                                                                                                        
-    # the requested slug                                                                                                                                                                                                                                     
+    # get_object_or_404 was called with Project.objects.available and
+    # the requested slug
     assert (
         list(get_mock.call_args)
         == [('AVAILABLEPROJECTS',), {'slug': u'FOO'}])
 
-    # redirect was called with args...                                                                                                                                                                                                                       
+    # redirect was called with args...
     assert (
         list(redirect_mock.call_args) ==
         [('pontoon.translate',),
@@ -72,49 +72,48 @@ def test_view_lang_agnostic_authed(redirect_mock, projects_mock,
 @patch('pontoon.base.views.utils.get_project_locale_from_request')
 @patch('pontoon.base.views.Project.objects.available')
 @patch('pontoon.base.views.redirect')
-def test_view_lang_agnostic_anon_available_accept_language(redirect_mock, projects_mock, 
+def test_view_lang_agnostic_anon_available_accept_language(redirect_mock, projects_mock,
                                                            util_mock, get_mock, client):
     '''User is not authenticated, redirect to first
-+        available accept-language locale'''
-    
+        available accept-language locale'''
     view = reverse(
         'pontoon.translate.locale.agnostic',
         kwargs=dict(slug='FOO', part='BAR'))
 
-    # mock return value for Project.objects.available                                                                                                                                                                                                        
+    # mock return value for Project.objects.available
     projects_mock.return_value = 'AVAILABLEPROJECTS'
 
-    # create a mock Project with .locales                                                                                                                                                                                                                    
+    # create a mock Project with .locales
     project_mock = MagicMock()
     type(project_mock).locales = PropertyMock(return_value='LOCALES')
 
-    # mock return value for get_object_or_404 for Project                                                                                                                                                                                                    
+    # mock return value for get_object_or_404 for Project
     get_mock.return_value = project_mock
 
-    # mock return value for redirect                                                                                                                                                                                                                         
+    # mock return value for redirect
     mock_response = HttpResponse()
     redirect_mock.return_value = mock_response
 
-    # mock return_value for get_project_locale_from_request                                                                                                                                                                                                  
+    # mock return_value for get_project_locale_from_request
     util_mock.return_value = 23
 
     response = client.get(view)
 
-    # Project.objects.available was called with no args                                                                                                                                                                                                  
+    # Project.objects.available was called with no args
     assert list(projects_mock.call_args) == [(), {}]
 
-    # get_object_or_404 was called with Project.objects.available and                                                                                                                                                                                        
-    # the requested slug                                                                                                                                                                                                                                     
+    # get_object_or_404 was called with Project.objects.available and
+    # the requested slug
     assert (
         list(get_mock.call_args)
         == [('AVAILABLEPROJECTS',), {'slug': u'FOO'}])
 
-    # get_project_locale_from_request                                                                                                                                                                                                                        
+    # get_project_locale_from_request
     assert (
         list(util_mock.call_args)
         == [(response.wsgi_request, 'LOCALES'), {}])
 
-    # redirect was called with args...                                                                                                                                                                                                                       
+    # redirect was called with args...
     assert (
         list(redirect_mock.call_args) ==
         [('pontoon.translate',),
@@ -128,7 +127,7 @@ def test_view_lang_agnostic_anon_available_accept_language(redirect_mock, projec
 @patch('pontoon.base.views.utils.get_project_locale_from_request')
 @patch('pontoon.base.views.Project.objects.available')
 @patch('pontoon.base.views.redirect')
-def test_view_lang_agnostic_anon_unavailable_accept_language(redirect_mock, projects_mock, 
+def test_view_lang_agnostic_anon_unavailable_accept_language(redirect_mock, projects_mock,
                                                              util_mock, get_mock, client):
     ''' User is not authenticated and Userprofile.custom_homepage not defined,
     redirect to project dashboard '''
@@ -137,43 +136,42 @@ def test_view_lang_agnostic_anon_unavailable_accept_language(redirect_mock, proj
         'pontoon.translate.locale.agnostic',
         kwargs=dict(slug='FOO', part='BAR'))
 
-    # mock return value for Project.objects.available                                                                                                                                                                                                        
+    # mock return value for Project.objects.available
     projects_mock.return_value = 'AVAILABLEPROJECTS'
 
     # create a mock Project with .locales
     project_mock = MagicMock()
     type(project_mock).locales = PropertyMock(return_value='LOCALES')
 
-    # mock return value for get_object_or_404 for Project                                                                                                                                                                                                    
-    get_mock.return_value = project_mock        
+    # mock return value for get_object_or_404 for Project
+    get_mock.return_value = project_mock
 
-    # mock return value for redirect                                                                                                                                                                                                                         
+    # mock return value for redirect
     mock_response = HttpResponse()
     redirect_mock.return_value = mock_response
 
-    # mock return_value for get_project_locale_from_request                                                                                                                                                                                                  
+    # mock return_value for get_project_locale_from_request
     util_mock.return_value = None
 
     response = client.get(view)
 
-    # Project.objects.available was called with no args                                                                                                                                                                                                      
+    # Project.objects.available was called with no args
     assert list(projects_mock.call_args) == [(), {}]
 
-    # get_object_or_404 was called with Project.objects.available and                                                                                                                                                                                        
-    # the requested slug                                                                                                                                                                                                                                     
+    # get_object_or_404 was called with Project.objects.available and
+    # the requested slug
     assert (
         list(get_mock.call_args)
         == [('AVAILABLEPROJECTS',), {'slug': u'FOO'}])
 
-    # get_project_locale_from_request                                                                                                                                                                                                                        
+    # get_project_locale_from_request
     assert (
         list(util_mock.call_args)
         == [(response.wsgi_request, 'LOCALES'), {}])
 
-    # redirect was called with args...                                                                                                                                                                                                                       
+    # redirect was called with args...
     assert (
         list(redirect_mock.call_args) ==
         [('pontoon.projects.project',),
          {'slug': u'FOO'}])
     assert response is mock_response
-    

--- a/tests/base/views/locale_agnostic.py
+++ b/tests/base/views/locale_agnostic.py
@@ -176,3 +176,4 @@ def test_view_lang_agnostic_anon_unavailable_accept_language(redirect_mock, proj
         [('pontoon.projects.project',),
          {'slug': u'FOO'}])
     assert response is mock_response
+    

--- a/tests/base/views/locale_agnostic.py
+++ b/tests/base/views/locale_agnostic.py
@@ -1,0 +1,178 @@
+import pytest
+
+from mock import MagicMock, PropertyMock, patch
+
+from django.http import HttpResponse
+from django.urls import reverse
+from django.contrib.auth.models import User 
+
+
+@patch('pontoon.base.views.get_object_or_404')
+@patch('pontoon.base.views.utils.get_project_locale_from_request')
+@patch('pontoon.base.views.Project.objects.available')
+@patch('pontoon.base.views.redirect')
+@pytest.mark.django_db
+def test_view_lang_agnostic_authed(redirect_mock, projects_mock, 
+                                   util_mock, get_mock, client):
+    ''' User is authenticated and Userprofile.custom_homepage defined,
+    redirect to Userprofile.custom_homepage '''
+    client.force_login(User.objects.get_or_create(username='testuser')[0])
+
+    view = reverse(
+        'pontoon.translate.locale.agnostic',
+        kwargs=dict(slug='FOO', part='BAR'))
+
+    # mock return value for Project.objects.available                                                                                                                                                                                                        
+    projects_mock.return_value = 'AVAILABLEPROJECTS'
+
+    # create a mock Project with .locales
+    project_mock = MagicMock()
+    type(project_mock).locales = PropertyMock(return_value='LOCALES')
+
+    # mock return value for get_object_or_404 for Project                                                                                                                                                                                                    
+    get_mock.return_value = project_mock
+
+    # mock return value for redirect                                                                                                                                                                                                                         
+    mock_response = HttpResponse()
+    redirect_mock.return_value = mock_response
+
+    # mock return_value for get_project_locale_from_request                                                                                                                                                                                                  
+    util_mock.return_value = 23
+
+    profile_mock = MagicMock()
+    type(profile_mock).custom_homepage = PropertyMock(return_value=None)
+
+    # mock return_value for user.is_authenticated and custom homepage    
+    user_mock = MagicMock()
+    type(user_mock).is_authenticated = PropertyMock(return_value=True)
+    type(user_mock).profile = PropertyMock(return_value=profile_mock)
+
+    response = client.get(view)
+
+    # Project.objects.available was called with no args     
+    assert list(projects_mock.call_args) == [(), {}]
+
+    # get_object_or_404 was called with Project.objects.available and                                                                                                                                                                                        
+    # the requested slug                                                                                                                                                                                                                                     
+    assert (
+        list(get_mock.call_args)
+        == [('AVAILABLEPROJECTS',), {'slug': u'FOO'}])
+
+    # redirect was called with args...                                                                                                                                                                                                                       
+    assert (
+        list(redirect_mock.call_args) ==
+        [('pontoon.translate',),
+         {'locale': 23,
+          'part': u'BAR',
+          'slug': u'FOO'}])
+    assert response is mock_response
+
+
+@patch('pontoon.base.views.get_object_or_404')
+@patch('pontoon.base.views.utils.get_project_locale_from_request')
+@patch('pontoon.base.views.Project.objects.available')
+@patch('pontoon.base.views.redirect')
+def test_view_lang_agnostic_anon_available_accept_language(redirect_mock, projects_mock, 
+                                                           util_mock, get_mock, client):
+    '''User is not authenticated, redirect to first
++        available accept-language locale'''
+    
+    view = reverse(
+        'pontoon.translate.locale.agnostic',
+        kwargs=dict(slug='FOO', part='BAR'))
+
+    # mock return value for Project.objects.available                                                                                                                                                                                                        
+    projects_mock.return_value = 'AVAILABLEPROJECTS'
+
+    # create a mock Project with .locales                                                                                                                                                                                                                    
+    project_mock = MagicMock()
+    type(project_mock).locales = PropertyMock(return_value='LOCALES')
+
+    # mock return value for get_object_or_404 for Project                                                                                                                                                                                                    
+    get_mock.return_value = project_mock
+
+    # mock return value for redirect                                                                                                                                                                                                                         
+    mock_response = HttpResponse()
+    redirect_mock.return_value = mock_response
+
+    # mock return_value for get_project_locale_from_request                                                                                                                                                                                                  
+    util_mock.return_value = 23
+
+    response = client.get(view)
+
+    # Project.objects.available was called with no args                                                                                                                                                                                                  
+    assert list(projects_mock.call_args) == [(), {}]
+
+    # get_object_or_404 was called with Project.objects.available and                                                                                                                                                                                        
+    # the requested slug                                                                                                                                                                                                                                     
+    assert (
+        list(get_mock.call_args)
+        == [('AVAILABLEPROJECTS',), {'slug': u'FOO'}])
+
+    # get_project_locale_from_request                                                                                                                                                                                                                        
+    assert (
+        list(util_mock.call_args)
+        == [(response.wsgi_request, 'LOCALES'), {}])
+
+    # redirect was called with args...                                                                                                                                                                                                                       
+    assert (
+        list(redirect_mock.call_args) ==
+        [('pontoon.translate',),
+         {'locale': 23,
+          'part': u'BAR',
+          'slug': u'FOO'}])
+    assert response is mock_response
+
+
+@patch('pontoon.base.views.get_object_or_404')
+@patch('pontoon.base.views.utils.get_project_locale_from_request')
+@patch('pontoon.base.views.Project.objects.available')
+@patch('pontoon.base.views.redirect')
+def test_view_lang_agnostic_anon_unavailable_accept_language(redirect_mock, projects_mock, 
+                                                             util_mock, get_mock, client):
+    ''' User is not authenticated and Userprofile.custom_homepage not defined,
+    redirect to project dashboard '''
+
+    view = reverse(
+        'pontoon.translate.locale.agnostic',
+        kwargs=dict(slug='FOO', part='BAR'))
+
+    # mock return value for Project.objects.available                                                                                                                                                                                                        
+    projects_mock.return_value = 'AVAILABLEPROJECTS'
+
+    # create a mock Project with .locales
+    project_mock = MagicMock()
+    type(project_mock).locales = PropertyMock(return_value='LOCALES')
+
+    # mock return value for get_object_or_404 for Project                                                                                                                                                                                                    
+    get_mock.return_value = project_mock        
+
+    # mock return value for redirect                                                                                                                                                                                                                         
+    mock_response = HttpResponse()
+    redirect_mock.return_value = mock_response
+
+    # mock return_value for get_project_locale_from_request                                                                                                                                                                                                  
+    util_mock.return_value = None
+
+    response = client.get(view)
+
+    # Project.objects.available was called with no args                                                                                                                                                                                                      
+    assert list(projects_mock.call_args) == [(), {}]
+
+    # get_object_or_404 was called with Project.objects.available and                                                                                                                                                                                        
+    # the requested slug                                                                                                                                                                                                                                     
+    assert (
+        list(get_mock.call_args)
+        == [('AVAILABLEPROJECTS',), {'slug': u'FOO'}])
+
+    # get_project_locale_from_request                                                                                                                                                                                                                        
+    assert (
+        list(util_mock.call_args)
+        == [(response.wsgi_request, 'LOCALES'), {}])
+
+    # redirect was called with args...                                                                                                                                                                                                                       
+    assert (
+        list(redirect_mock.call_args) ==
+        [('pontoon.projects.project',),
+         {'slug': u'FOO'}])
+    assert response is mock_response


### PR DESCRIPTION
This PR is for bug 1424845 on Bugzilla. I modified my code according to @jotes 's gist. Thanks a lot!
Per comment 9 (https://bugzilla.mozilla.org/show_bug.cgi?id=1424845#c9):

I'm not sure about hard-coding 'en-GB', but should we have something in case there is no accept-language locales?

Can I remove 'en-GB' from line 118 in views.py? I think it might be redundant since we are setting it as the locale in line 121.

Let me know if I need to change anything.