### PR TITLE
Bug 1429758 ftl fix copy

### DIFF
--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -1457,7 +1457,7 @@ body > header aside p {
   font-weight: 300;
   border: 1px solid #5E6475;
   background: transparent;
-  color: #FFFFFF;
+  color: #AAAAAA;
   display: inline-block;
   font-weight: normal;
   margin: 2px 5px 2px 0;
@@ -1467,11 +1467,6 @@ body > header aside p {
 
   -moz-box-sizing: border-box;
   box-sizing: border-box;
-}
-
-.ftl-area section .id.built-in,
-.ftl-area .main-value .id {
-  color: #AAAAAA;
 }
 
 .ftl-area section .id .stress {

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -11,7 +11,7 @@ var Pontoon = (function (my) {
     $('#ftl-area .main-value ul')
       .append(
         '<li class="clearfix">' +
-          '<label class="id built-in" for="ftl-id-' + name + '">' +
+          '<label class="id" for="ftl-id-' + name + '">' +
             '<span>' + name + '</span>' +
             (Pontoon.fluent.isCLDRplural(name) && example !== undefined ? '<span> (e.g. ' +
               '<span class="stress">' + example + '</span>' +

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -645,6 +645,19 @@ var Pontoon = (function (my) {
 
 
       /*
+       * Get source string value of a simple FTL message
+       */
+      getSourceStringValue: function (entity, fallback) {
+        if (entity.format !== 'ftl' || this.isComplexFTL()) {
+          return fallback;
+        }
+
+        var ast = fluentParser.parseEntry(entity.original);
+        return this.serializePlaceables(ast.value.elements);
+      },
+
+
+      /*
        * Focus first field of the FTL editor
        */
       focusFirstField: function () {

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -1923,7 +1923,7 @@ var Pontoon = (function (my) {
 
         var entity = self.getEditorEntity(),
             original = entity['original' + self.isPluralized()],
-            source = self.fluent.getSimplePreview(entity, original, entity);
+            source = self.fluent.getSourceStringValue(entity, original);
 
         self.updateAndFocusTranslationEditor(source);
         self.moveCursorToBeginning();


### PR DESCRIPTION
A test case is described in the [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1429758), but it's simply reproducible with any simple FTL string that contains HTML markup, e.g.:
```
key = Value <span>with</span> markup
```

The second commit is unrelated stylistic improvement I noticed along the way.