### PR TITLE
Bug 1379149: Optimize Contributors query

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -158,7 +158,11 @@ class UserTranslationsManager(UserManager):
             contributor.translations_needs_work_count = user['fuzzy']
             contributor.user_role = contributor.role(managers, translators)
 
-        return sorted(contributors, key=lambda x: -x.translations_count)[:100]
+        contributors_list = sorted(contributors, key=lambda x: -x.translations_count)
+        if limit:
+            contributors_list = contributors_list[:limit]
+
+        return contributors_list
 
 
 class UserCustomManager(UserManager):

--- a/pontoon/teams/views.py
+++ b/pontoon/teams/views.py
@@ -122,13 +122,11 @@ def ajax_permissions(request, locale):
     translators = l.translators_group.user_set.exclude(pk__in=managers).all()
     all_users = User.objects.exclude(pk__in=managers).exclude(pk__in=translators).exclude(email='')
 
-    contributors = (
-        User.translators
-        .filter(translation__locale=l)
-        .values_list('email', flat=True)
-        .distinct()
-    )
+    contributors_qs = User.translators.with_translation_counts(None, Q(locale=l))
+    contributors = set([contributor.email for contributor in contributors_qs])
+
     locale_projects = l.projects_permissions
+
     return render(request, 'teams/includes/permissions.html', {
         'locale': l,
         'all_users': all_users,

--- a/pontoon/teams/views.py
+++ b/pontoon/teams/views.py
@@ -123,7 +123,7 @@ def ajax_permissions(request, locale):
     all_users = User.objects.exclude(pk__in=managers).exclude(pk__in=translators).exclude(email='')
 
     contributors_qs = User.translators.with_translation_counts(None, Q(locale=l))
-    contributors = set([contributor.email for contributor in contributors_qs])
+    contributors = set(contributor.email for contributor in contributors_qs)
 
     locale_projects = l.projects_permissions
 

--- a/pontoon/teams/views.py
+++ b/pontoon/teams/views.py
@@ -122,7 +122,7 @@ def ajax_permissions(request, locale):
     translators = l.translators_group.user_set.exclude(pk__in=managers).all()
     all_users = User.objects.exclude(pk__in=managers).exclude(pk__in=translators).exclude(email='')
 
-    contributors_qs = User.translators.with_translation_counts(None, Q(locale=l))
+    contributors_qs = User.translators.with_translation_counts(None, Q(locale=l), None)
     contributors = set(contributor.email for contributor in contributors_qs)
 
     locale_projects = l.projects_permissions


### PR DESCRIPTION
@jotes r?

As mentioned in the [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1379149#c2), this is a simple optimization of the contributors query inspired by [bug 1357361](https://bugzilla.mozilla.org/show_bug.cgi?id=1357361).

I tested on stage and the entire /permissions page request gets around 60% shorter.