### PR TITLE
Touch bug #1416256: Glob to regex util

### DIFF
--- a/pontoon/base/utils.py
+++ b/pontoon/base/utils.py
@@ -1,4 +1,5 @@
 import codecs
+import fnmatch
 import functools
 import json
 import os
@@ -657,3 +658,18 @@ def build_translation_memory_file(creation_date, locale_code, entries):
         u'\n\t</body>'
         u'\n</tmx>'
     )
+
+
+def glob_to_regex(glob):
+    """This util uses python's fnmatch to convert a glob to a regex in a way
+    that can then be used with django's `__regex` queryset selector.
+
+    It prefixes the regex with `^`, and replaces the more complex match ending
+    provided by fnmatch, with the simpler `$`
+
+    """
+    regex = "^%s" % fnmatch.translate(glob)
+    return (
+        "%s$" % regex[:-7]
+        if regex[-7:] == "\Z(?ms)"
+        else regex)

--- a/tests/base/utils.py
+++ b/tests/base/utils.py
@@ -1,0 +1,32 @@
+
+import pytest
+
+from pontoon.base.models import Resource
+from pontoon.base.utils import glob_to_regex
+
+
+def test_util_glob_to_regex():
+    assert glob_to_regex('*') == '^.*$'
+    assert glob_to_regex('/foo*') == '^\\/foo.*$'
+    assert glob_to_regex('*foo') == '^.*foo$'
+    assert glob_to_regex('*foo*') == '^.*foo.*$'
+
+
+@pytest.mark.django_db
+def test_util_glob_to_regex_db(resource0, resource1):
+    assert resource0 in Resource.objects.filter(path__regex=glob_to_regex('*'))
+    assert resource1 in Resource.objects.filter(path__regex=glob_to_regex('*'))
+    assert (
+        list(Resource.objects.filter(path__regex=glob_to_regex('*')))
+        == list(Resource.objects.all()))
+    assert (
+        resource0
+        in Resource.objects.filter(
+            path__regex=glob_to_regex('*0*')))
+    assert (
+        resource1
+        not in Resource.objects.filter(
+            path__regex=glob_to_regex('*0*')))
+    assert (
+        list(Resource.objects.filter(path__regex=glob_to_regex('*0*')))
+        == list(Resource.objects.filter(path__contains='0')))


### PR DESCRIPTION
Adds a util that uses python's fnmatch to convert a glob to a regex in a way that can then be used with django's `__regex` queryset selector.