### PR TITLE
Touch bug #1416256: Doctest support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [tool:pytest]
 python_files=*.py
-addopts=--tb=short tests
+addopts=--tb=short tests --doctest-glob='*.tst'
 norecursedirs=.git _build tmp* requirements commands/*
 DJANGO_SETTINGS_MODULE=pontoon.settings
 
@@ -10,3 +10,4 @@ omit =
     *migrations*
 include =
     *pontoon*
+    *tests*

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,16 @@ def _load_fixtures(*modules):
 
 
 @pytest.fixture(scope='session')
-def tests_use_db(request):
+def doctests_use_db(request):
+    # mark all doctests as using db as they
+    # are unable to do it themselves
+    for item in request.node.items:
+        if item.name.endswith('.tst'):
+            item.add_marker('django_db')
+
+
+@pytest.fixture(scope='session')
+def tests_use_db(request, doctests_use_db):
     """Check if any of the tests in this run require db setup"""
     return any(
         item for item

--- a/tests/fixtures/doctest.py
+++ b/tests/fixtures/doctest.py
@@ -1,0 +1,11 @@
+
+import pytest
+
+from pontoon.base.models import Locale, Project
+
+
+@pytest.fixture
+def db_doctest(db):
+    # clear all Locales and Projects to make doctest clearer
+    Locale.objects.all().delete()
+    Project.objects.all().delete()


### PR DESCRIPTION
The tag api is a little complex, so a doctest is useful to work through it, explain it, and as a form of integration test. This just adds doctest support in the env