### PR TITLE
Touch Bug 1243129: Heroku webpack support

### DIFF
--- a/bin/post_compile
+++ b/bin/post_compile
@@ -2,8 +2,10 @@
 
 # Compile static assets
 export PATH=/app/.heroku/node/bin:$PATH
+npm install .
 ./manage.py migrate --noinput
 ./manage.py collectstatic --noinput
+./node_modules/.bin/webpack
 
 # Create a file with the current git HEAD revision.
 # We use that file to expose the git revision in our web app, allowing

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "dependencies": {},
   "engines": {
-    "node": "6.9.5"
+    "node": "9.4.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR

- increases the version of node used
- adds a webpack command to heroku deployment

The webpacked resources are not actually used yet, this is more to test/ensure that we can build resources properly on heroku