### PR TITLE
Bug 1431436: [FTL] Support PLATFORM()

### DIFF
--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -51,16 +51,15 @@ var Pontoon = (function (my) {
     var content = '';
     var simpleElements = [];
 
-    elements.forEach(function (element, i, array) {
+    elements.forEach(function (element, i) {
       // Adjoining simple elements are concatenated and presented as a simple string
       if (Pontoon.fluent.isSimpleElement(element)) {
         simpleElements.push(element);
 
-        if (i === array.length - 1) {
+        if (i === elements.length - 1) {
           content += renderOriginalSimpleElement(simpleElements, title);
         }
       }
-
       // SelectExpression elements are presented as a list of variants
       else if (element.type === 'SelectExpression') {
         content += renderOriginalSimpleElement(simpleElements, title);
@@ -267,7 +266,7 @@ var Pontoon = (function (my) {
               'ExternalArgument',
               'MessageReference',
               'SelectExpression'
-            ].indexOf(item.type) >= 0;
+            ].indexOf(item.type) === 0;
           });
         }
 
@@ -291,7 +290,7 @@ var Pontoon = (function (my) {
           'TextElement',
           'ExternalArgument',
           'MessageReference'
-        ].indexOf(element.type) >= 0;
+        ].indexOf(element.type) === 0;
       },
 
 
@@ -356,8 +355,6 @@ var Pontoon = (function (my) {
        * Is SelectExpression?
        */
       isSelectExpression: function (ast) {
-        var self = this;
-
         if (
           ast &&
           ast.value &&

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -731,11 +731,6 @@ var Pontoon = (function (my) {
             tree = ast.attributes[0];
           }
 
-          // This should never happen! Return fallback.
-          else {
-            return fallback;
-          }
-
           // Simple string: use entire value
           var elements = tree.value.elements;
 

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -354,6 +354,7 @@ var Pontoon = (function (my) {
        * markPlaceables Should placeables be marked up?
        */
       serializePlaceables: function (elements, markPlaceables) {
+        var self = this;
         var translatedValue = '';
         var startMarker = '';
         var endMarker = '';
@@ -381,6 +382,13 @@ var Pontoon = (function (my) {
               endMarker = '</mark>';
             }
             translatedValue += startMarker + '{' + item.id.name + '}' + endMarker;
+          }
+          else if (item.variants) {
+            var variantElements = item.variants.filter(function (item) {
+              return item.default;
+            })[0].value.elements;
+
+            translatedValue += self.serializePlaceables(variantElements);
           }
         });
 
@@ -711,19 +719,7 @@ var Pontoon = (function (my) {
             tree = ast.attributes[0];
           }
 
-          var elements = tree.value.elements;
-
-          // String with variants: use default variant
-          try {
-            elements = elements[0].variants.filter(function (item) {
-              return item.default;
-            })[0].value.elements;
-          }
-
-          // Simple string: use entire value
-          catch (e) {}
-
-          response = this.serializePlaceables(elements);
+          response = this.serializePlaceables(tree.value.elements);
 
           // Update source string markup
           if (object.hasOwnProperty('original')) {

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -34,36 +34,35 @@ var Pontoon = (function (my) {
     '</li>';
   }
 
-  function renderOriginalSimpleElement(simpleElements, title) {
-    if (simpleElements.length) {
-      var response = renderOriginalVariant(title, simpleElements);
-      simpleElements = [];
-      return response;
-    }
-
-    return '';
-  }
-
   /*
    * Render original string elements.
+   *
+   * - Adjoining simple elements are concatenated and presented as a simple string
+   * - SelectExpression elements are presented as a list of variants
    */
   function renderOriginalElements(elements, title) {
     var content = '';
     var simpleElements = [];
 
     elements.forEach(function (element, i) {
-      // Adjoining simple elements are concatenated and presented as a simple string
-      if (Pontoon.fluent.isSimpleElement(element)) {
-        simpleElements.push(element);
+      var isSimpleElement = Pontoon.fluent.isSimpleElement(element);
+      var isLastElement = i === elements.length - 1;
 
-        if (i === elements.length - 1) {
-          content += renderOriginalSimpleElement(simpleElements, title);
+      // Collect simple elements
+      if (isSimpleElement) {
+        simpleElements.push(element);
+      }
+
+      // Render collected simple elements when non-simple or last element is met
+      if (!isSimpleElement || isLastElement) {
+        if (simpleElements.length) {
+          content += renderOriginalVariant(title, simpleElements);
+          simpleElements = [];
         }
       }
-      // SelectExpression elements are presented as a list of variants
-      else if (element.type === 'SelectExpression') {
-        content += renderOriginalSimpleElement(simpleElements, title);
 
+      // Render SelectExpression
+      if (element.type === 'SelectExpression') {
         element.variants.forEach(function (item) {
           content += renderOriginalVariant(item.key.value || item.key.name, item.value.elements);
         });

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -54,11 +54,9 @@ var Pontoon = (function (my) {
       }
 
       // Render collected simple elements when non-simple or last element is met
-      if (!isSimpleElement || isLastElement) {
-        if (simpleElements.length) {
-          content += renderOriginalVariant(title, simpleElements);
-          simpleElements = [];
-        }
+      if ((!isSimpleElement || isLastElement) && simpleElements.length) {
+        content += renderOriginalVariant(title, simpleElements);
+        simpleElements = [];
       }
 
       // Render SelectExpression

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -351,24 +351,6 @@ var Pontoon = (function (my) {
 
 
       /*
-       * Is SelectExpression?
-       */
-      isSelectExpression: function (ast) {
-        if (
-          ast &&
-          ast.value &&
-          ast.value.elements &&
-          ast.value.elements.length &&
-          ast.value.elements[0].type === 'SelectExpression'
-        ) {
-          return true;
-        }
-
-        return false;
-      },
-
-
-      /*
        * Serialize value with placeables into a simple string
        *
        * markPlaceables Should placeables be marked up?
@@ -718,7 +700,7 @@ var Pontoon = (function (my) {
           }
 
           var ast = fluentParser.parseEntry(source);
-          var tree = null;
+          var tree;
 
           // Value: use entire ast
           if (ast.value) {
@@ -733,12 +715,15 @@ var Pontoon = (function (my) {
           // Simple string: use entire value
           var elements = tree.value.elements;
 
-          // SelectExpression: use default variant
-          if (this.isSelectExpression(tree)) {
+          // String with variants: use default variant
+          try {
             elements = elements[0].variants.filter(function (item) {
               return item.default;
             })[0].value.elements;
           }
+
+          // Simple string: use entire value
+          catch (e) {}
 
           response = this.serializePlaceables(elements);
 

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -725,7 +725,7 @@ var Pontoon = (function (my) {
             tree = ast;
           }
 
-          // Attributes: use first attribute
+          // Attributes: use ast of the first attribute
           else if (ast.attributes.length) {
             tree = ast.attributes[0];
           }
@@ -733,9 +733,11 @@ var Pontoon = (function (my) {
           // Simple string: use entire value
           var elements = tree.value.elements;
 
-          // SelectExpression: use first variant
+          // SelectExpression: use default variant
           if (this.isSelectExpression(tree)) {
-            elements = elements[0].variants[0].value.elements;
+            elements = elements[0].variants.filter(function (item) {
+              return item.default;
+            })[0].value.elements;
           }
 
           response = this.serializePlaceables(elements);

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -265,7 +265,7 @@ var Pontoon = (function (my) {
               'ExternalArgument',
               'MessageReference',
               'SelectExpression'
-            ].indexOf(item.type) === 0;
+            ].indexOf(item.type) >= 0;
           });
         }
 
@@ -289,7 +289,7 @@ var Pontoon = (function (my) {
           'TextElement',
           'ExternalArgument',
           'MessageReference'
-        ].indexOf(element.type) === 0;
+        ].indexOf(element.type) >= 0;
       },
 
 

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -702,17 +702,17 @@ var Pontoon = (function (my) {
           var ast = fluentParser.parseEntry(source);
           var tree;
 
-          // Value: use entire ast
+          // Value: use entire AST
           if (ast.value) {
             tree = ast;
           }
 
-          // Attributes: use ast of the first attribute
-          else if (ast.attributes.length) {
+          // Attributes (must be present in valid AST if value isn't):
+          // use AST of the first attribute
+          else {
             tree = ast.attributes[0];
           }
 
-          // Simple string: use entire value
           var elements = tree.value.elements;
 
           // String with variants: use default variant

--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -268,6 +268,13 @@ def _serialize_elements(elements):
             elif type(element.expression) == ast.MessageReference:
                 response += '{ ' + element.expression.id.name + ' }'
 
+            elif hasattr(element, 'expression') and hasattr(element.expression, 'variants'):
+                variant_elements = filter(
+                    lambda x: x.default, element.expression.variants
+                )[0].value.elements
+
+                response += _serialize_elements(variant_elements)
+
     return response
 
 
@@ -289,16 +296,4 @@ def as_simple_translation(source):
     else:
         tree = translation_ast.attributes[0]
 
-    elements = tree.value.elements
-
-    # String with variants: use default variant
-    try:
-        elements = filter(
-            lambda x: x.default, elements[0].expression.variants
-        )[0].value.elements
-
-    # Simple string: use entire value
-    except (AttributeError, IndexError):
-        pass
-
-    return _serialize_elements(elements)
+    return _serialize_elements(tree.value.elements)

--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -296,7 +296,6 @@ def as_simple_translation(source):
 
     # String with variants: use first variant
     try:
-        print elements
         elements = elements[0].expression.variants[0].value.elements
 
     # Simple string: use entire value

--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -290,9 +290,11 @@ def as_simple_translation(source):
 
     elements = tree.value.elements
 
-    # String with variants: use first variant
+    # String with variants: use default variant
     try:
-        elements = elements[0].expression.variants[0].value.elements
+        elements = filter(
+            lambda x: x.default, elements[0].expression.variants
+        )[0].value.elements
 
     # Simple string: use entire value
     except (AttributeError, IndexError):

--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -280,23 +280,27 @@ def as_simple_translation(source):
     if type(translation_ast) == ast.Junk:
         return source
 
+    # Value: use entire ast
     if translation_ast.value:
-        # Strings with variants: display first variant
-        try:
-            elements = translation_ast.value.elements
-            variants = elements[0].expression.variants
-            return _serialize_elements(variants[0].value.elements)
+        tree = translation_ast
 
-        # Simple strings
-        except (AttributeError, IndexError):
-            return _serialize_elements(translation_ast.value.elements)
+    # Attributes: use first attribute
+    elif translation_ast.attributes:
+        tree = translation_ast.attributes[0]
 
+    # This should never happen! Return fallback.
     else:
-        # Strings with attributes: display first attribute
-        try:
-            attributes = translation_ast.attributes
-            return _serialize_elements(attributes[0].value.elements)
+        return source
 
-        # All other strings: display unchanged
-        except (AttributeError, IndexError):
-            return source
+    elements = tree.value.elements
+
+    # String with variants: use first variant
+    try:
+        print elements
+        elements = elements[0].expression.variants[0].value.elements
+
+    # Simple string: use entire value
+    except (AttributeError, IndexError):
+        pass
+
+    return _serialize_elements(elements)

--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -288,10 +288,6 @@ def as_simple_translation(source):
     elif translation_ast.attributes:
         tree = translation_ast.attributes[0]
 
-    # This should never happen! Return fallback.
-    else:
-        return source
-
     elements = tree.value.elements
 
     # String with variants: use first variant

--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -280,12 +280,13 @@ def as_simple_translation(source):
     if type(translation_ast) == ast.Junk:
         return source
 
-    # Value: use entire ast
+    # Value: use entire AST
     if translation_ast.value:
         tree = translation_ast
 
-    # Attributes: use first attribute
-    elif translation_ast.attributes:
+    # Attributes (must be present in valid AST if value isn't):
+    # use AST of the first attribute
+    else:
         tree = translation_ast.attributes[0]
 
     elements = tree.value.elements

--- a/pontoon/base/tests/test_helpers.py
+++ b/pontoon/base/tests/test_helpers.py
@@ -103,6 +103,14 @@ class AsSimpleTranslationTests(TestCase):
     .other = Other Simple String'''
         assert_equal(as_simple_translation(source), 'Simple String')
 
+    def test_attribute_select_expression(self):
+        source = '''key
+    .placeholder = { PLATFORM() ->
+        [win] Simple String
+       *[other] Other Simple String
+    }'''
+        assert_equal(as_simple_translation(source), 'Simple String')
+
     def test_other_ftl(self):
         source = 'warning-upgrade = { LINK("Link text", title: "Link title") }Simple String'
         assert_equal(as_simple_translation(source), 'Simple String')

--- a/pontoon/base/tests/test_helpers.py
+++ b/pontoon/base/tests/test_helpers.py
@@ -90,7 +90,7 @@ class AsSimpleTranslationTests(TestCase):
         [1] Simple String
        *[other] Other Simple String
     }'''
-        assert_equal(as_simple_translation(source), 'Simple String')
+        assert_equal(as_simple_translation(source), 'Other Simple String')
 
     def test_attribute(self):
         source = '''key
@@ -109,7 +109,7 @@ class AsSimpleTranslationTests(TestCase):
         [win] Simple String
        *[other] Other Simple String
     }'''
-        assert_equal(as_simple_translation(source), 'Simple String')
+        assert_equal(as_simple_translation(source), 'Other Simple String')
 
     def test_other_ftl(self):
         source = 'warning-upgrade = { LINK("Link text", title: "Link title") }Simple String'

--- a/pontoon/base/tests/test_helpers.py
+++ b/pontoon/base/tests/test_helpers.py
@@ -92,6 +92,15 @@ class AsSimpleTranslationTests(TestCase):
     }'''
         assert_equal(as_simple_translation(source), 'Other Simple String')
 
+    def test_wrapped_select_expression(self):
+        source = '''key =
+    Anne liked your comment on { $photo_count ->
+        [male] his
+        [female] her
+       *[other] their
+    } post.'''
+        assert_equal(as_simple_translation(source), 'Anne liked your comment on their post.')
+
     def test_attribute(self):
         source = '''key
     .placeholder = Simple String'''


### PR DESCRIPTION
To make review easier, I've split the patch for bug [1431436](https://bugzilla.mozilla.org/show_bug.cgi?id=1431436) into two pieces, which can also be landed separately. This is the first piece that contains:

1. Simple preview updates, which all Pontoon to display virtually any valid FTL Message in the string list, latest activity column and other places where simplified preview is used.

2. Original string presentation updates to support any FTL Message that contains any combination of elements of type `TextElement`, `ExternalArgument`, `MessageReference` and `SelectExpression` in their value or attribute. That includes strings with plurals, PLATFORM() and strings that contain both - value and attribute.

The second piece will bring the editor support.

A [pontoon-ftl](https://github.com/mozilla-l10n/pontoon-ftl/blob/master/en-US/demo.ftl) repository is available for testing and set up on stage:
https://mozilla-pontoon-staging.herokuapp.com/fr/test-fluent/demo.ftl/

**NOTE: Stage is not up to date with this branch ATM.**