### PR TITLE
Touch Bug 1243129: Add Dockerwebpack makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,10 @@ dockerloaddb:
 
 dockerrun:
 	${DC} run --rm --service-ports webapp
+
+dockerwebpack:
+	./docker/run_tests_in_docker.sh --shell -c " \
+	  export NVM_DIR=\"/home/app/.nvm\" \
+	    && . \"/home/app/.nvm/nvm.sh\" \
+	    && nvm use node \
+	    && ./node_modules/.bin/webpack -w"

--- a/docker/run_tests_in_docker.sh
+++ b/docker/run_tests_in_docker.sh
@@ -33,7 +33,7 @@ if [ "$1" == "--shell" ]; then
            -e LOCAL_USER_ID=$UID \
            --tty \
            --interactive \
-           local/pontoon /bin/bash
+           local/pontoon /bin/bash "${@:2}"
 
 else
     # Create a data container to hold the repo directory contents and copy the


### PR DESCRIPTION
Adds a `dockerwebpack` command to the makefile to run webpack in the foreground