### PR TITLE
Bug 1431436: [FTL] Support PLATFORM() - 2nd half (editor & serializer)

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -748,7 +748,7 @@ class Locale(AggregatedStats):
             'name': self.name,
             'nplurals': self.nplurals,
             'plural_rule': self.plural_rule,
-            'cldr_plurals': self.cldr_id_list(),
+            'cldr_plurals': self.cldr_plurals_list(),
             'direction': self.direction,
             'script': self.script,
             'ms_translator_code': self.ms_translator_code,

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -686,7 +686,7 @@ var Pontoon = (function (my) {
             value = '\n  ' + value.replace(/\n/g, '\n  ');
           }
 
-          content = entity.key + ' = ' + value;
+          content += value;
         }
 
         // Unsupported string
@@ -699,7 +699,7 @@ var Pontoon = (function (my) {
           value = serializeElements(valueElements);
 
           if (value) {
-            content = entity.key + ' = ' + value;
+            content += value;
           }
         }
 

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -236,9 +236,7 @@ var Pontoon = (function (my) {
         var translationAST = null;
         if (translation.pk) {
           translationAST = fluentParser.parseEntry(translation.string);
-          if (translationAST.attributes.length) {
-            attributesTree = translationAST.attributes;
-          }
+          attributesTree = translationAST.attributes;
         }
 
         // Reset default editor values

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -246,8 +246,8 @@ var Pontoon = (function (my) {
 
         // Simple string: only value
         if (
-          self.isSimpleString(translationAST) ||
-          self.isSimpleString(entityAST)
+          (translationAST && self.isSimpleString(translationAST)) ||
+          (!translationAST && self.isSimpleString(entityAST))
         ) {
           value = '';
 

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -186,6 +186,7 @@ var Pontoon = (function (my) {
       else {
         var elementValue = expression + ' ->';
         var variants = $(element).find('ul li');
+        var hasTranslatedVariants = false;
         var def = '';
 
         variants.each(function(index) {
@@ -199,10 +200,11 @@ var Pontoon = (function (my) {
 
           if (id && val) {
             elementValue += '\n  ' + def + '[' + id + '] ' + val;
+            hasTranslatedVariants = true;
           }
         });
 
-        if (elementValue) {
+        if (hasTranslatedVariants) {
           value += '{ ' + elementValue + '\n  }';
         }
       }

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -244,25 +244,8 @@ var Pontoon = (function (my) {
         $('#ftl-area .attributes ul:first').empty();
         $('#only-value').parents('li').hide();
 
-        // Simple string: only value
-        if (
-          (translationAST && self.isSimpleString(translationAST)) ||
-          (!translationAST && self.isSimpleString(entityAST))
-        ) {
-          value = '';
-
-          if (translationAST) {
-            value = self.serializePlaceables(translationAST.value.elements);
-          }
-
-          $('#only-value')
-            .val(value)
-            .parents('li')
-            .show();
-        }
-
         // Unsupported translation or unsuppported original: show source view
-        else if (
+        if (
           (translationAST && !self.isSupportedMessage(translationAST)) ||
           (!translationAST && !self.isSupportedMessage(entityAST))
         ) {
@@ -278,6 +261,24 @@ var Pontoon = (function (my) {
           Pontoon.updateCachedTranslation();
 
           return;
+        }
+
+
+        // Simple string: only value
+        else if (
+          (translationAST && self.isSimpleString(translationAST)) ||
+          (!translationAST && self.isSimpleString(entityAST))
+        ) {
+          value = '';
+
+          if (translationAST) {
+            value = self.serializePlaceables(translationAST.value.elements);
+          }
+
+          $('#only-value')
+            .val(value)
+            .parents('li')
+            .show();
         }
 
         // Value
@@ -596,21 +597,21 @@ var Pontoon = (function (my) {
         var value = '';
         var attributes = '';
 
-        // Simple string: only value
-        if (self.isSimpleString(ast)) {
-          value = '<li><p>' +
-            self.serializePlaceables(ast.value.elements, true) +
-          '</p></li>';
-        }
-
         // Unsupported string: render as source
-        else if (!self.isSupportedMessage(ast)) {
+        if (!self.isSupportedMessage(ast)) {
           ast.comment = null; // Remove comment
           value = '<li class="source">' +
             fluentSerializer.serializeEntry(ast) +
           '</li>';
 
           unsupported = true;
+        }
+
+        // Simple string: only value
+        else if (self.isSimpleString(ast)) {
+          value = '<li><p>' +
+            self.serializePlaceables(ast.value.elements, true) +
+          '</p></li>';
         }
 
         // Value
@@ -676,8 +677,13 @@ var Pontoon = (function (my) {
         var value = '';
         var attributes = '';
 
+        // Unsupported string
+        if (!this.isFTLEditorEnabled()) {
+          content = translation;
+        }
+
         // Simple string
-        if (!this.isComplexFTL()) {
+        else if (!this.isComplexFTL()) {
           value = $('#only-value').val();
 
           // Multiline strings: mark with indent
@@ -686,11 +692,6 @@ var Pontoon = (function (my) {
           }
 
           content += value;
-        }
-
-        // Unsupported string
-        else if (!this.isFTLEditorEnabled()) {
-          content = translation;
         }
 
         // Value

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -335,7 +335,7 @@ var Pontoon = (function (my) {
 
 
       /*
-       * Is ast of a supported message?
+       * Is ast of a message, supported in rich FTL editor?
        *
        * Message is supported if all value elements
        * and all attribute elements are of type:
@@ -354,6 +354,11 @@ var Pontoon = (function (my) {
               'SelectExpression'
             ].indexOf(item.type) >= 0;
           });
+        }
+
+        // Parse error
+        if (ast.type === 'Junk') {
+          return false;
         }
 
         var valueSupported = !ast.value || elementsSupported(ast.value.elements);

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -19,9 +19,8 @@ var Pontoon = (function (my) {
       case 'NamedArgument':
         return expression.name.name + ': ' + serializeExpression(expression.val);
       case 'CallExpression':
-        var args = [];
-        expression.args.forEach(function (arg) {
-          args.push(serializeExpression(arg));
+        var args = expression.args.map(function (arg) {
+          return serializeExpression(arg);
         });
         return expression.callee.name + '(' + args.join(', ') + ')';
     }

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -181,34 +181,29 @@ var Pontoon = (function (my) {
           '</li>';
         }
 
-        function renderEditorSimpleElement(simpleElements, title) {
-          if (simpleElements.length) {
-            var response = renderEditorVariant(title, simpleElements);
-            simpleElements = [];
-            return response;
-          }
-
-          return '';
-        }
-
         function renderEditorElements(elements, title) {
           var content = '';
           var simpleElements = [];
 
-          elements.forEach(function (element, i, array) {
-            // Adjoining simple elements are concatenated and presented as a simple string
-            if (Pontoon.fluent.isSimpleElement(element)) {
-              simpleElements.push(element);
+          elements.forEach(function (element, i) {
+            var isSimpleElement = Pontoon.fluent.isSimpleElement(element);
+            var isLastElement = i === elements.length - 1;
 
-              if (i === array.length - 1) {
-                content += renderEditorSimpleElement(simpleElements, title);
+            // Collect simple elements
+            if (isSimpleElement) {
+              simpleElements.push(element);
+            }
+
+            // Render collected simple elements when non-simple or last element is met
+            if (!isSimpleElement || isLastElement) {
+              if (simpleElements.length) {
+                content += renderEditorVariant(title, simpleElements);
+                simpleElements = [];
               }
             }
 
-            // SelectExpression elements are presented as a list of variants
-            else if (element.type === 'SelectExpression') {
-              content += renderEditorSimpleElement(simpleElements, title);
-
+            // Render SelectExpression
+            if (element.type === 'SelectExpression') {
               var expression = serializeExpression(element.expression);
               content = '<li data-expression="' + expression + '"><ul>' + content;
 

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -671,7 +671,7 @@ var Pontoon = (function (my) {
         }
 
         var entityAST = fluentParser.parseEntry(entity.original);
-        var content;
+        var content = entity.key + ' = '; // Initialize untranslated string
         var valueElements = $('#ftl-area .main-value ul:first > li:visible');
         var attributeElements = $('#ftl-area .attributes ul:first > li:visible');
         var value = '';

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -186,7 +186,7 @@ var Pontoon = (function (my) {
         var elementValue = expression + ' ->';
         var variants = $(element).find('ul li');
         var hasTranslatedVariants = false;
-        var def = '';
+        var defaultMarker = '';
 
         variants.each(function(index) {
           var id = $(this).find('.id span:first').html();
@@ -194,11 +194,11 @@ var Pontoon = (function (my) {
 
           // TODO: UI should allow for explicitly selecting a default variant
           if (index === variants.length - 1) {
-            def = '*';
+            defaultMarker = '*';
           }
 
           if (id && val) {
-            elementValue += '\n  ' + def + '[' + id + '] ' + val;
+            elementValue += '\n  ' + defaultMarker + '[' + id + '] ' + val;
             hasTranslatedVariants = true;
           }
         });


### PR DESCRIPTION
This is the continuation of #814, which brings support for editing (6ba9882) and saving (7d68a94) translations that contain selectors in values and attributes. If selectors are surrounded (with other selectors or simple strings), that's supported too.

A [pontoon-ftl](https://github.com/mozilla-l10n/pontoon-ftl/blob/master/en-US/demo.ftl) repository is available for testing and set up on stage. Feel free to deploy this patch to stage if needed.