### PR TITLE
Add jinja env setup

### DIFF
--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -177,6 +177,7 @@ TEMPLATES = [
         'NAME': 'jinja2',
         'APP_DIRS': True,
         'OPTIONS': {
+            'environment': 'pontoon.settings.jinja2_setup.environment',
             'match_extension': '',
             'match_regex': r'^(?!(admin|registration|account|socialaccount)/).*\.(html|jinja|js)$',
             'context_processors': CONTEXT_PROCESSORS,

--- a/pontoon/settings/jinja2_setup.py
+++ b/pontoon/settings/jinja2_setup.py
@@ -1,0 +1,14 @@
+
+from django.contrib.staticfiles.storage import staticfiles_storage
+from django.urls import reverse
+
+from jinja2 import Environment
+
+
+def environment(**options):
+    env = Environment(**options)
+    env.globals.update({
+        'static': staticfiles_storage.url,
+        'url': reverse,
+    })
+    return env


### PR DESCRIPTION
Allows you to use the `url` template tag, to get reversed urls (as you would with django templates)