### PR TITLE
Fix bug 1398852: Add all strings column in the project request view

### DIFF
--- a/pontoon/base/static/css/table.css
+++ b/pontoon/base/static/css/table.css
@@ -29,8 +29,7 @@ table.table {
 }
 
 .table th.population,
-.table th.deadline,
-.table th.all-strings {
+.table th.deadline {
   width: 90px;
 }
 
@@ -39,7 +38,8 @@ table.table {
   width: 70px;
 }
 
-.table th.latest-activity {
+.table th.latest-activity,
+.table th.all-strings {
   width: 140px;
 }
 

--- a/pontoon/base/static/css/table.css
+++ b/pontoon/base/static/css/table.css
@@ -29,7 +29,8 @@ table.table {
 }
 
 .table th.population,
-.table th.deadline {
+.table th.deadline,
+.table th.all-strings {
   width: 90px;
 }
 

--- a/pontoon/projects/templates/projects/widgets/project_list.html
+++ b/pontoon/projects/templates/projects/widgets/project_list.html
@@ -11,7 +11,7 @@
         <th class="latest-activity">Latest Activity<i class="fa"></i></th>
         <th class="progress">Progress<i class="fa"></i></th>
         {% if request %}
-          <th class="all-strings">All Strings<i class="fa"></i></th>
+          <th class="all-strings">Number of Strings<i class="fa"></i></th>
           <th class="check">Request<i class="fa"></i></th>
         {% endif %}
       </tr>

--- a/pontoon/projects/templates/projects/widgets/project_list.html
+++ b/pontoon/projects/templates/projects/widgets/project_list.html
@@ -11,6 +11,7 @@
         <th class="latest-activity">Latest Activity<i class="fa"></i></th>
         <th class="progress">Progress<i class="fa"></i></th>
         {% if request %}
+          <th class="all-strings">All Strings<i class="fa"></i></th>
           <th class="check">Request<i class="fa"></i></th>
         {% endif %}
       </tr>
@@ -44,6 +45,13 @@
       {% endif %}
     </td>
     {% if request %}
+      <td class="all-strings">
+        {% if project.total_strings %}
+          <span>{{ project.total_strings|intcomma }}</span>
+        {% else %}
+          <span class="not">Not synced yet</span>
+        {% endif %}
+      </td>
       <td class="check fa fa-fw"></td>
     {% endif %}
   </tr>

--- a/pontoon/teams/static/css/team.css
+++ b/pontoon/teams/static/css/team.css
@@ -26,12 +26,17 @@
   display: block;
 }
 
+.projects.request .project-list .all-strings {
+  display: table-cell;
+}
+
 .projects.request .project-list th.check {
   text-align: right;
   width: auto;
 }
 
-.project-list .check {
+.project-list .check,
+.project-list .all-strings {
   display: none;
 }
 


### PR DESCRIPTION
Show total number of strings in the project request view of the team page,
so one can see how big the project is.

Here is the screenshot:
![image](https://user-images.githubusercontent.com/24241258/35476791-0824ac3a-03dc-11e8-9589-ff706b555d32.png)
