### PR TITLE
Fix bug 1434535: Mark XML tags as placeables

### DIFF
--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -446,9 +446,8 @@ var Pontoon = (function (my) {
 
         elements.forEach(function (item) {
           if (item.type === 'TextElement') {
-            // TODO: We shouldn't rely on markPlaceables in determining when to not render HTML.
             if (markPlaceables) {
-              translatedValue += Pontoon.doNotRender(item.value);
+              translatedValue += Pontoon.markXMLTags(item.value);
             }
             else {
               translatedValue += item.value;

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -148,6 +148,45 @@ var Pontoon = (function (my) {
     },
 
     /*
+     * Markup XML Tags
+     *
+     * Find any XML Tags in a string and mark them up, while making sure
+     * the rest of the text in a string is displayed not rendered.
+     */
+    markXMLTags: function (string) {
+      var self = this;
+
+      var markedString = '';
+      var startMarker = '<mark class="placeable" title="XML Tag">';
+      var endMarker = '</mark>';
+
+      var re = /(<[^(><.)]+>)/gi;
+      var results;
+      var previousIndex = 0;
+
+      function doNotRenderSubstring(start, end) {
+        return self.doNotRender(string.substring(start, end));
+      }
+
+      // Find successive matches
+      while ((results = re.exec(string)) !== null) {
+        markedString += (
+          // Substring between the previous and the current tag: do not render
+          doNotRenderSubstring(previousIndex, results.index) +
+
+          // Tag: do not render and wrap in markup
+          startMarker + doNotRenderSubstring(results.index, re.lastIndex) + endMarker
+        );
+        previousIndex = re.lastIndex;
+      }
+
+      // Substring between the last tag and the end of the string: do not render
+      markedString += doNotRenderSubstring(previousIndex, string.length);
+
+      return markedString;
+    },
+
+    /*
      * Markup placeables
      */
     markPlaceables: function (string) {


### PR DESCRIPTION
This is a next iteration of [bug 1382348](https://bugzilla.mozilla.org/show_bug.cgi?id=1382348).

Among other things, it will mark up DOM Overlays and make them easier to insert into the editor (using a mouse click).