### PR TITLE
Fix bug 1416528: Modified color of links in dashboard header

### DIFF
--- a/pontoon/base/static/css/heading_info.css
+++ b/pontoon/base/static/css/heading_info.css
@@ -45,6 +45,7 @@ ul {
 }
 
 #heading .details .value {
+  color: #AAA;
   float: right;
 }
 
@@ -131,7 +132,7 @@ ul {
 }
 
 #heading .legend li span.value {
-  color: #EBEBEB;
+  color: #AAA;
   float: right;
 }
 

--- a/pontoon/base/static/css/heading_info.css
+++ b/pontoon/base/static/css/heading_info.css
@@ -57,10 +57,6 @@ ul {
   color: #7BC876;
 }
 
-#heading .details li:hover .value a {
-  color: #7BC876;
-}
-
 #heading .details .priority .value {
   margin-top: 6px;
 }

--- a/pontoon/base/static/css/heading_info.css
+++ b/pontoon/base/static/css/heading_info.css
@@ -49,10 +49,15 @@ ul {
 }
 
 #heading .details .value a {
-  color: #EBEBEB;
+  color: #FFFFFF;
 }
 
 #heading .details .value a:hover {
+  color: #7BC876;
+}
+
+#heading .details li:hover .value a {
+  text-decoration: underline;
   color: #7BC876;
 }
 
@@ -107,6 +112,15 @@ ul {
   position: relative;
   text-align: left;
   text-transform: uppercase;
+}
+
+#heading .legend li a {
+  color: #FFFFFF;
+}
+
+#heading .legend li:hover a {
+  text-decoration: underline;
+  color: #7BC876;
 }
 
 #heading .legend li.banner {

--- a/pontoon/base/static/css/heading_info.css
+++ b/pontoon/base/static/css/heading_info.css
@@ -57,7 +57,6 @@ ul {
 }
 
 #heading .details li:hover .value a {
-  text-decoration: underline;
   color: #7BC876;
 }
 
@@ -119,7 +118,6 @@ ul {
 }
 
 #heading .legend li:hover a {
-  text-decoration: underline;
   color: #7BC876;
 }
 

--- a/pontoon/base/static/css/heading_info.css
+++ b/pontoon/base/static/css/heading_info.css
@@ -136,6 +136,14 @@ ul {
   float: right;
 }
 
+#heading .legend li a span.value {
+  color: #FFFFFF;
+}
+
+#heading .legend li:hover a span.value {
+  color: #7BC876;
+}
+
 #heading .banner .title {
   color: #7BC876;
 }


### PR DESCRIPTION
I have changed the color to brightest possible shade of white i.e. #FFFFFF also the links gets underlined when someone hovers on the whole list(ref: https://pontoon.mozilla.org/projects/ ). Also added the same with right ones in one of the pages (ref: https://pontoon.mozilla.org/ach/activity-stream-new-tab/ )

Here is the screenshot and hovering effect as well 
![image](https://user-images.githubusercontent.com/24241258/35668145-4844776e-0756-11e8-8eab-e07a84fb2149.png)

![image](https://user-images.githubusercontent.com/24241258/35668162-612380cc-0756-11e8-9286-d0ae8a03c4e7.png)

![peek 2018-02-01 13-47](https://user-images.githubusercontent.com/24241258/35668184-86755fc6-0756-11e8-8cbd-4e3380988181.gif)

