### PR TITLE
Fix bug 1418540: Fix overlay image cutoff in all-resources.

### DIFF
--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -21,6 +21,7 @@ body {
   left: 0;
   right: 0;
   margin: 0 auto;
+  max-width: 90%;
 }
 
 mark.placeable {

--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -16,11 +16,12 @@ body {
 
 #overlay img {
   position: absolute;
-  height: 90%;
-  top: 5%;
+  max-height: 90%;
+  top: 0;
   left: 0;
   right: 0;
-  margin: 0 auto;
+  bottom: 0;
+  margin: auto;
   max-width: 90%;
 }
 


### PR DESCRIPTION
I couldn't test it locally but this css addition tends to fix it using developer tools
Reference link : https://pontoon.mozilla.org/fr/fundraising/all-resources/?string=174187
Screenshots : 
Before:
![image](https://user-images.githubusercontent.com/24241258/35642851-714b110c-06ea-11e8-949d-beec50a37269.png)

After
![image](https://user-images.githubusercontent.com/24241258/35669402-fd16daca-075a-11e8-9c7f-f934140bcb95.png)






