### PR TITLE
Fix bug 1389969 - Fix display of trailing/leading spaces and newlines…

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,7 +38,10 @@ module.exports = {
         NProgress: false,
         diff_match_patch: false,
         Highcharts: false,
-        editor: false
+        editor: false,
+        DIFF_INSERT: false,
+        DIFF_EQUAL: false,
+        DIFF_DELETE: false
     },
     plugins: [
         'react',


### PR DESCRIPTION
… in the diff view.

Major changes:
* markPlaceables() is applied only once in diff(), that allows to mark
  leading/trailing spaces correctly
* fixed issue with missing trailing/leading spaces for multiline strings
* translation diff displays newlines correctly instead of flat string

Minor changes:
* use a switch statement instead of three if blocks
* use constants provided by Diff.js instead of magic numbers

@mathjazz could you look at this? I'm trying to finish things assigned to me ;-)