### PR TITLE
Fix bug 1435258: Keep dir-based alignement in diff view

### DIFF
--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -1210,7 +1210,8 @@ body > header aside p {
 #editor p#original,
 #editor p.original,
 #ftl-original .main-value li,
-#editor p.translation {
+#editor p.translation,
+#editor p.translation-diff {
   text-align: start;
   white-space: pre-wrap;
 }


### PR DESCRIPTION
@jotes Could you r, given that you're working on a related PR #836?

This also fixes the "newlines issue" in the diff view:
https://bugzilla.mozilla.org/show_bug.cgi?id=1389969#c1