### PR TITLE
Fix bug 1410569: Translation author not set to user if there are no changes

### DIFF
--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -545,9 +545,6 @@ def update_translation(request):
                     fuzzy=False,
                 )
 
-                if t.user is None:
-                    t.user = user
-
                 t.approved = True
                 t.approved_date = timezone.now()
                 t.fuzzy = False
@@ -573,9 +570,6 @@ def update_translation(request):
                     warnings = utils.quality_check(original, string, l, ignore)
                     if warnings:
                         return warnings
-
-                    if t.user is None:
-                        t.user = user
 
                     t.approved = False
                     t.approved_user = None

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -524,8 +524,7 @@ def update_translation(request):
             if can_translate:
 
                 # Unless there's nothing to be changed
-                if t.user is not None and t.approved and t.approved_user \
-                        and t.approved_date and not t.fuzzy:
+                if t.approved and not t.fuzzy:
                     return JsonResponse({
                         'same': True,
                         'message': 'Same translation already exists.',
@@ -546,7 +545,6 @@ def update_translation(request):
                 )
 
                 t.approved = True
-                t.approved_date = timezone.now()
                 t.fuzzy = False
                 t.rejected = False
                 t.rejected_user = None


### PR DESCRIPTION
Earlier the user who hits the save button for a translation without making any changes is set as author for the translation if author is not set. I have removed the condition which sets the author for non changing translations 