### PR TITLE
Touch Bug 1436149: Entities perf hacks 2 - qs.distinct()

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -2232,7 +2232,7 @@ class Entity(DirtyFieldsMixin, models.Model):
         if exclude_entities:
             entities = entities.exclude(pk__in=exclude_entities)
 
-        return entities.distinct().order_by('resource__path', 'order')
+        return entities.order_by('resource__path', 'order')
 
     @classmethod
     def map_entities(cls, locale, entities, visible_entities=None):

--- a/tests/fixtures/entities.py
+++ b/tests/fixtures/entities.py
@@ -36,6 +36,8 @@ def entity_factory(factory):
     def instance_attrs(instance, i):
         if not instance.string:
             instance.string = "Entity %s" % i
+        if not instance.order:
+            instance.order = i
 
     return functools.partial(
         factory, Model=Entity, instance_attrs=instance_attrs)


### PR DESCRIPTION
afaict the qs.distinct is not required here, removing it speeds up  (EDIT: db timings in...) the entities view 3-4x in my testing