### PR TITLE
Remove filter/distinct from Locale aggregate method 

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -893,9 +893,8 @@ class Locale(AggregatedStats):
     def aggregate_stats(self):
         TranslatedResource.objects.filter(
             resource__project__disabled=False,
-            resource__entities__obsolete=False,
             locale=self
-        ).distinct().aggregate_stats(self)
+        ).aggregate_stats(self)
 
     def parts_stats(self, project):
         """Get locale-project pages/paths with stats."""


### PR DESCRIPTION
this might be required - im not sure - but in testijng the sql i always got the same results - and it took about 90% off of the query time. This method is used quite a lot i think