### PR TITLE
Fix Bug 1437365: React ajax get fix

### DIFF
--- a/pontoon/static/js/utils/ajax.js
+++ b/pontoon/static/js/utils/ajax.js
@@ -34,7 +34,7 @@ export class DjangoAjax {
 
     appendParams (container, data)  {
         /**
-         * For a given data container - either FormData/URLSearchParameters
+         * For a given data container - either FormData/URLSearchParams
          * appends data from an object
          *
          * If any of the object values are arrayish, it will append k=v[n]
@@ -52,9 +52,9 @@ export class DjangoAjax {
 
     asGetParams (data) {
         /**
-         * Mangle a data object to URLSearchParameters
+         * Mangle a data object to URLSearchParams
          */
-        return this.appendParams(new URLSearchParameters(), data);
+        return this.appendParams(new URLSearchParams(), data);
     }
 
     asMultipartForm (data) {

--- a/tests/js/utils.js
+++ b/tests/js/utils.js
@@ -39,7 +39,7 @@ test('PontoonDjangoAjax headers', () => {
 test('PontoonDjangoAjax asGetParams', () => {
     const _ajax = new PontoonDjangoAjax();
     const parameters = {append: jest.fn()}
-    window.URLSearchParameters = jest.fn(() => parameters)
+    window.URLSearchParams = jest.fn(() => parameters)
     expect(_ajax.asGetParams({foo: 7, bar: 23, baz: 43})).toBe(parameters)
     expect(parameters.append.mock.calls).toEqual(
         [["foo", 7], ["bar", 23], ["baz", 43]])


### PR DESCRIPTION
current code uses `URLSearchParameters` but it should be `URLSearchParams`