### PR TITLE
[WIP] Add react loaders

### DIFF
--- a/pontoon/static/js/loaders/click.js
+++ b/pontoon/static/js/loaders/click.js
@@ -1,0 +1,46 @@
+
+import Loader from './loader'
+
+
+export default class ClickLoader extends Loader {
+    // instead of loading components at the nodes identified by
+    // `this.selector`, this Loader listens for clicks (or other events)
+    // on them and loads the components when they happen
+
+    // When this loader first loads it will check if any of the selected
+    // nodes are "active" and simulate the trigger event if it is.
+
+    constructor () {
+        super();
+        this.handle = this.handle.bind(this);
+    }
+
+    get event () {
+        return "click";
+    }
+
+    isActive () {
+        return false;
+    }
+
+    handle (evt) {
+        if (this.nodes.indexOf(evt.target) !== -1) {
+            evt.preventDefault();
+            this.mountComponent(evt.target);
+        }
+    }
+
+    load () {
+        document.addEventListener(this.event, this.handle);
+        this.nodes.forEach(node => {
+            if (this.isActive(node)) {
+                this.loadActive(node);
+            }
+        })
+    }
+
+    loadActive (node) {
+        // give it a click on first load if its active
+        node.click()
+    }
+}

--- a/pontoon/static/js/loaders/index.js
+++ b/pontoon/static/js/loaders/index.js
@@ -1,0 +1,3 @@
+
+export {default as ClickLoader} from './click'
+export {default as Loader} from './loader'

--- a/pontoon/static/js/loaders/loader.js
+++ b/pontoon/static/js/loaders/loader.js
@@ -1,0 +1,57 @@
+
+import ReactDOM from 'react-dom';
+import React from 'react';
+
+import {NotImplementedError} from 'errors';
+
+
+export default class Loader {
+    // finds nodes in the dom for `this.selector`, creates
+    // components of type `this.component`, and then renders
+    // the components into `this.getRenderNode(node)` for each
+    // found node
+
+    constructor () {
+        this.load = this.load.bind(this);
+        this.mountComponent = this.mountComponent.bind(this);
+    }
+
+    get nodes () {
+        return [...document.querySelectorAll(this.selector)];
+    }
+
+    get component () {
+        throw new NotImplementedError();
+    }
+
+    get selector () {
+        throw new NotImplementedError();
+    }
+
+    getProps () {
+        return {};
+    }
+
+    getRenderNode (node) {
+        return node;
+    }
+
+    load () {
+        this.nodes.forEach(this.mountComponent);
+    }
+
+    mountComponent (node) {
+        const Component = this.component;
+        const target = this.getRenderNode(node);
+        // remove existing component gracefully
+        this.unmountComponent(node);
+        target.innerHTML = '';
+        ReactDOM.render(
+            <Component {...this.getProps(node)} />,
+            target);
+    }
+
+    unmountComponent (node) {
+        ReactDOM.unmountComponentAtNode(this.getRenderNode(node));
+    }
+}

--- a/tests/js/loaders/click.js
+++ b/tests/js/loaders/click.js
@@ -1,0 +1,98 @@
+
+import {Loader, ClickLoader} from 'loaders';
+
+
+test('ClickLoader constructor', () => {
+    const loader = new ClickLoader();
+    expect(loader instanceof Loader).toBe(true);
+    expect(loader.event).toBe('click');
+})
+
+
+test('ClickLoader isActive', () => {
+    // Tests that clickloader always returns false for isActive as this
+    // method should be added in descendant classes if required.
+
+    const loader = new ClickLoader();
+    expect(loader.isActive()).toBe(false);
+    expect(loader.isActive('FOO')).toBe(false);
+})
+
+
+test('ClickLoader handle', () => {
+    // Tests that handle mounts the correct components in response to events
+    // on the correct nodes
+
+    class MockLoader extends ClickLoader {
+
+        get nodes () {
+            return [7, 13, 23];
+        }
+    }
+
+    const loader = new MockLoader();
+    loader.mountComponent = jest.fn()
+
+    // fire an event, but with a "node" that is not in this.nodes
+    const evt = {preventDefault: jest.fn(), target: 'x'}
+    loader.handle(evt);
+
+    // nothing called
+    expect(loader.mountComponent.mock.calls).toEqual([])
+    expect(evt.preventDefault.mock.calls).toEqual([])
+
+    // this time, fire an event with a "node" in this.nodes
+    evt.target = 13
+    loader.handle(evt);
+
+    // evt.preventDefault and this.mountComponent were called
+    expect(evt.preventDefault.mock.calls).toEqual([[]])
+    expect(loader.mountComponent.mock.calls).toEqual([[13]])
+})
+
+
+test('ClickLoader loadActive', () => {
+    // Tests that loadActive - which is called after first load,
+    // if any of the nodes are deemed to be "active", clicks the node
+
+    const loader = new ClickLoader();
+    const node = {click: jest.fn()}
+    loader.loadActive(node);
+    expect(node.click.mock.calls).toEqual([[]]);
+})
+
+
+test('ClickLoader load', () => {
+    // Tests that load adds the correct event listeners and that mountComponent
+    // is not called. Also checks that if any "node" is active this.loadActive
+    // is called with it
+
+    class MockLoader extends ClickLoader {
+
+        get nodes () {
+            return [7, 13, 23];
+        }
+    }
+
+    const loader = new MockLoader();
+
+    document.addEventListener = jest.fn()
+    loader.mountComponent = jest.fn()
+    loader.isActive = jest.fn((node) => node === 23)
+    loader.loadActive = jest.fn()
+    loader.load()
+
+    // event was added
+    expect(document.addEventListener.mock.calls).toEqual(
+        [['click', loader.handle]])
+
+    // mountComponent was not called
+    expect(loader.mountComponent.mock.calls).toEqual([])
+
+    // isActive was called with each node
+    expect(loader.isActive.mock.calls).toEqual(
+        [[7], [13], [23]])
+
+    // loadActive was called with the active node
+    expect(loader.loadActive.mock.calls).toEqual([[23]])
+})

--- a/tests/js/loaders/loader.js
+++ b/tests/js/loaders/loader.js
@@ -1,0 +1,119 @@
+
+import ReactDOM from 'react-dom';
+import React from 'react';
+
+import {Loader} from 'loaders';
+import {NotImplementedError} from 'errors';
+
+
+test('Loader constructor', () => {
+    const loader = new Loader();
+
+    // component and selector *must* be set on descendant classes
+    expect(() => {
+        loader.component
+    }).toThrow(NotImplementedError);
+    expect(() => {
+        loader.selector
+    }).toThrow(NotImplementedError);
+    expect(() => {
+        loader.nodes
+    }).toThrow(NotImplementedError);
+
+    // getting props and the node to render to can be overridden
+    // but return {} and the trigger node respectively by default
+    expect(loader.getProps('FOO')).toEqual({});
+    expect(loader.getRenderNode('BAR')).toBe('BAR');
+})
+
+
+test('Loader nodes', () => {
+    // tests that nodes are found by querying the dom with this.selector
+
+    class MockLoader extends Loader {
+
+        get selector () {
+            return 7;
+        }
+    }
+
+    const loader = new MockLoader();
+    document.querySelectorAll = jest.fn(() => [1, 2, 3])
+    expect(loader.nodes).toEqual([1, 2, 3]);
+    expect(document.querySelectorAll.mock.calls).toEqual([[7]]);
+})
+
+
+test('Loader load', () => {
+    // Tests that when load is called mountComponent is called with each
+    // of the found nodes.
+
+    class MockLoader extends Loader {
+
+        get nodes () {
+            return ['a', 'b', 'c']
+        }
+    }
+
+    const loader = new MockLoader();
+    loader.mountComponent = jest.fn()
+    loader.load()
+    expect(loader.mountComponent.mock.calls.map(x => x[0])).toEqual(['a', 'b', 'c']);
+})
+
+
+test('Loader mountComponent', () => {
+    // Tests that ReactDOM.render is called with the correct component and target node.
+    // Also ensures that the node is unmounted and emptied before loading
+
+    class MockComponent extends React.PureComponent {
+        render () {
+            return (<div>MOCK</div>);
+        }
+    }
+
+    class MockLoader extends Loader {
+
+        get component () {
+            return MockComponent
+        }
+    }
+
+    const loader = new MockLoader();
+    loader.getRenderNode = jest.fn(() => ({innerHTML: 'REMOVEME'}))
+    loader.getProps = jest.fn(() => ({FOO: 2, BAR: 3}))
+    loader.unmountComponent = jest.fn()
+    ReactDOM.render = jest.fn()
+
+    loader.mountComponent('X');
+
+    // any existing components should be unmounted
+    expect(loader.unmountComponent.mock.calls).toEqual([['X']])
+
+    // getRenderNode is called to get correct target node
+    expect(loader.getRenderNode.mock.calls).toEqual([['X']]);
+
+    // getProps was called with the node
+    expect(loader.getProps.mock.calls).toEqual([['X']]);
+
+    // ReactDOM.render was called with the component and the target node
+    // emptied of HTML
+    expect(ReactDOM.render.mock.calls).toEqual(
+        [[<MockComponent FOO={2} BAR={3} />, {"innerHTML": ""}]])
+})
+
+
+test('Loader unmountComponent', () => {
+    // Tests that ReactDOM.unmountComponentAtNode is called with the correct target
+    // node.
+
+    const loader = new Loader();
+    loader.getRenderNode = jest.fn(() => 23);
+    ReactDOM.unmountComponentAtNode = jest.fn();
+
+    loader.unmountComponent(7);
+
+    // getRenderNode was called
+    expect(loader.getRenderNode.mock.calls).toEqual([[7]])
+    expect(ReactDOM.unmountComponentAtNode.mock.calls).toEqual([[23]])
+})


### PR DESCRIPTION
This adds 2 loaders for rendering react components into the DOM

## `Loader`

This will load the component specified in `this.component` to all nodes found by `this.selector`. Each node will get the props that are created by calling `this.getProps` with the `node`

By default the component will be rendered into the found node, but this can be changed by overriding `this.getRenderNode` which is called with the `node`


## `ToggleLoader`

This will listen for (by default click) events on the nodes found by `this.selector`.

When the event happens the component is loaded or unloaded, and a toggle indicator if found is toggled.

Like the generic loader you must specify `this.component`, and can specify `this.getProps` and `this.getRenderNode`

@adngdb , @Pike i know this is not the way that you guys suggested, but i already needed a variant of the loader, so i have separated out the code for further discussion.

for reference here are the 2 uses of the loaders:

https://github.com/phlax/pontoon/blob/bd8ac8bd083a2756dcc23f92dee0777399620e47/pontoon/static/js/tags/locales/index.js


https://github.com/phlax/pontoon/blob/4a629a8522d86d8e431146f0e0a6a0d532236441/pontoon/static/js/tags/admin/index.js


One of the benefits of using these is that we can write some tests for these loaders, and any other loaders just need to be tested for their specific properties

