### PR TITLE
Touch Bug 1243129: React data manager

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,7 @@ module.exports = {
         es6: true,
         browser: true,
     },
+    parser: "babel-eslint",
     parserOptions: {
         ecmaVersion: 2017,
         ecmaFeatures: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,192 @@
         }
       }
     },
+    "@babel/generator": {
+      "version": "7.0.0-beta.40",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.40.tgz",
+      "integrity": "sha512-c91BQcXyTq/5aFV4afgOionxZS1dxWt8OghEx5Q52SKssdGRFSiMKnk9tGkev1pYULPJBqjSDZU2Pcuc58ffZw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.40",
+        "jsesc": "2.5.1",
+        "lodash": "4.17.4",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.0.0-beta.40",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.40.tgz",
+      "integrity": "sha512-cK9BVLtOfisSISTTHXKGvBc2OBh65tjEk4PgXhsSnnH0i8RP2v+5RCxoSlh2y/i+l2fxQqKqv++Qo5RMiwmRCA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "7.0.0-beta.40",
+        "@babel/template": "7.0.0-beta.40",
+        "@babel/types": "7.0.0-beta.40"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0-beta.40",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.40.tgz",
+      "integrity": "sha512-MwquaPznI4cUoZEgHC/XGkddOXtqKqD4DvZDOyJK2LR9Qi6TbMbAhc6IaFoRX7CRTFCmtGeu8gdXW2dBotBBTA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.40"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0-beta.40",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.40.tgz",
+      "integrity": "sha512-mOhhTrzieV6VO7odgzFGFapiwRK0ei8RZRhfzHhb6cpX3QM8XXuCLXWjN8qBB7JReDdUR80V3LFfFrGUYevhNg==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.2",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
+    "@babel/template": {
+      "version": "7.0.0-beta.40",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.40.tgz",
+      "integrity": "sha512-RlQiVB7eL7fxsKN6JvnCCwEwEL28CBYalXSgWWULuFlEHjtMoXBqQanSie3bNyhrANJx67sb+Sd/vuGivoMwLQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.40",
+        "@babel/types": "7.0.0-beta.40",
+        "babylon": "7.0.0-beta.40",
+        "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0-beta.40",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.40.tgz",
+          "integrity": "sha512-eVXQSbu/RimU6OKcK2/gDJVTFcxXJI4sHbIqw2mhwMZeQ2as/8AhS9DGkEDoHMBBNJZ5B0US63lF56x+KDcxiA==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "7.0.0-beta.40"
+          }
+        },
+        "babylon": {
+          "version": "7.0.0-beta.40",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
+          "integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.0.0-beta.40",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.40.tgz",
+      "integrity": "sha512-h96SQorjvdSuxQ6hHFIuAa3oxnad1TA5bU1Zz88+XqzwmM5QM0/k2D+heXGGy/76gT5ajl7xYLKGiPA/KTyVhQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.40",
+        "@babel/generator": "7.0.0-beta.40",
+        "@babel/helper-function-name": "7.0.0-beta.40",
+        "@babel/types": "7.0.0-beta.40",
+        "babylon": "7.0.0-beta.40",
+        "debug": "3.1.0",
+        "globals": "11.3.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0-beta.40",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.40.tgz",
+          "integrity": "sha512-eVXQSbu/RimU6OKcK2/gDJVTFcxXJI4sHbIqw2mhwMZeQ2as/8AhS9DGkEDoHMBBNJZ5B0US63lF56x+KDcxiA==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "7.0.0-beta.40"
+          }
+        },
+        "babylon": {
+          "version": "7.0.0-beta.40",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
+          "integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg==",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "11.3.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
+          "integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.0.0-beta.40",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.40.tgz",
+      "integrity": "sha512-uXCGCzTgMZxcSUzutCPtZmXbVC+cvENgS2e0tRuhn+Y1hZnMb8IHP0Trq7Q2MB/eFmG5pKrAeTIUfQIe5kA4Tg==",
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "lodash": "4.17.4",
+        "to-fast-properties": "2.0.0"
+      },
+      "dependencies": {
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        }
+      }
+    },
     "@types/node": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-9.3.0.tgz",
@@ -432,6 +618,37 @@
         "private": "0.1.8",
         "slash": "1.0.0",
         "source-map": "0.5.7"
+      }
+    },
+    "babel-eslint": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.2.tgz",
+      "integrity": "sha512-Qt2lz2egBxNYWqN9JIO2z4NOOf8i4b5JS6CFoYrOZZTDssueiV1jH/jsefyg+86SeNY3rB361/mi3kE1WK2WYQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.40",
+        "@babel/traverse": "7.0.0-beta.40",
+        "@babel/types": "7.0.0-beta.40",
+        "babylon": "7.0.0-beta.40",
+        "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "1.0.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0-beta.40",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.40.tgz",
+          "integrity": "sha512-eVXQSbu/RimU6OKcK2/gDJVTFcxXJI4sHbIqw2mhwMZeQ2as/8AhS9DGkEDoHMBBNJZ5B0US63lF56x+KDcxiA==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "7.0.0-beta.40"
+          }
+        },
+        "babylon": {
+          "version": "7.0.0-beta.40",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.40.tgz",
+          "integrity": "sha512-AVxF2EcxvGD5hhOuLTOLAXBb0VhwWpEX0HyHdAI2zU+AAP4qEwtQj8voz1JR3uclGai0rfcE+dCTHnNMOnimFg==",
+          "dev": true
+        }
       }
     },
     "babel-generator": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
+    "babel-eslint": "^8.2.2",
     "babel-loader": "^7.1.2",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-plugin-transform-class-properties": "^6.24.1",

--- a/pontoon/static/js/utils/ajax.js
+++ b/pontoon/static/js/utils/ajax.js
@@ -1,5 +1,6 @@
 
 import {strip} from './strip';
+import {getCSRFToken} from './csrf';
 
 
 export class DjangoAjax {
@@ -180,7 +181,7 @@ export class PontoonDjangoAjax extends DjangoAjax {
 
     get csrf () {
         // this is a bit sketchy but the only afaict way due to session_csrf
-        return document.querySelector('input[name=csrfmiddlewaretoken]').value;
+        return getCSRFToken();
     }
 }
 

--- a/pontoon/static/js/utils/csrf.js
+++ b/pontoon/static/js/utils/csrf.js
@@ -1,0 +1,4 @@
+
+export const getCSRFToken = () => {
+    return document.querySelector('input[name=csrfmiddlewaretoken]').value;
+}

--- a/pontoon/static/js/utils/data.js
+++ b/pontoon/static/js/utils/data.js
@@ -1,0 +1,85 @@
+
+import React from 'react';
+
+import {ajax} from 'utils/ajax';
+
+
+export class DataManager {
+
+    constructor (state) {
+        this.state = state;
+    }
+
+    get data () {
+        return this.state.data;
+    }
+
+    get errors () {
+        return this.state.errors;
+    }
+}
+
+
+export function dataManager(WrappedComponent, Manager, data) {
+
+    return class Wrapper extends React.Component {
+
+        constructor(props) {
+            super(props);
+            this.state = {errors: {}, data: data};
+        }
+
+        get api () {
+            return this.props.api;
+        }
+
+        get requestMethod () {
+            return this.props.requestMethod || 'get';
+        }
+
+        get submitMethod () {
+            return this.props.submitMethod || this.requestMethod;
+        }
+
+        refreshData = async (params) => {
+            return this.handleResponse(
+                await ajax.fetch(
+                    this.api,
+                    params,
+                    {method: this.requestMethod}));
+        }
+
+        handleResponse = async (response) => {
+            const {status} = response;
+            const json = await response.json();
+            if (status === 200) {
+                const {data} = json;
+                this.setState({data, errors: {}});
+                return;
+            }
+            const {errors} = json;
+            this.setState({errors});
+        }
+
+        handleSubmit = async (params) => {
+            return this.handleResponse(
+                await ajax.fetch(
+                    this.api,
+                    params,
+                    {method: this.submitMethod}));
+        }
+
+        render() {
+            Manager = Manager || DataManager;
+            const manager = new Manager(this.state);
+            return (
+                <WrappedComponent
+                   manager={manager}
+                   errors={manager.errors}
+                   data={manager.data}
+                   handleSubmit={this.handleSubmit}
+                   refreshData={this.refreshData}
+                   {...this.props} />);
+        }
+    };
+}

--- a/pontoon/static/js/widgets/columns.js
+++ b/pontoon/static/js/widgets/columns.js
@@ -2,14 +2,14 @@
 import React from 'react';
 
 
-export class Columns extends React.Component {
+export class Columns extends React.PureComponent {
 
     render() {
         return (
             <Container
-               columns={this.columns.length}
-               ratios={this.columns.map(([, v]) => v)}>
-              {this.columns.map(([column,], key) => {
+               columns={this.props.columns.length}
+               ratios={this.props.columns.map(([, v]) => v)}>
+              {this.props.columns.map(([column,], key) => {
                   return (
                       <Column key={key}>
                         {column}
@@ -25,7 +25,6 @@ export class Container extends React.Component {
     createColumnStyle(width) {
         return {
             float: "left",
-            overflow: "hidden",
             boxSizing: "border-box",
             width: width.toString() + "%"};
     }

--- a/tests/js/utils/data.js
+++ b/tests/js/utils/data.js
@@ -1,0 +1,174 @@
+
+import React from 'react';
+
+import {shallow} from 'enzyme';
+
+import {ajax} from 'utils/ajax';
+
+import {DataManager, dataManager} from 'utils/data';
+
+
+class MockComponent extends React.PureComponent {
+
+    render () {
+        return <div />;
+    }
+}
+
+
+test('DataManager constructor', () => {
+    const Manager = dataManager(MockComponent)
+    const manager = shallow(<Manager />);
+    expect(manager.state()).toEqual({data: undefined, errors: {}});
+    expect(manager.instance().requestMethod).toBe('get');
+    expect(manager.instance().submitMethod).toBe('get');
+});
+
+
+test('DataManager requestMethod', () => {
+    // requestMethod can be overriden in props
+    const Manager = dataManager(MockComponent)
+    const manager = shallow(<Manager requestMethod={23} />);
+    expect(manager.instance().requestMethod).toBe(23);
+    expect(manager.instance().submitMethod).toBe(23);
+});
+
+
+test('DataManager submitMethod', () => {
+    // submitMethod can be overriden in props
+    const Manager = dataManager(MockComponent)
+    const manager = shallow(<Manager submitMethod={7} />);
+    expect(manager.instance().requestMethod).toBe('get');
+    expect(manager.instance().submitMethod).toBe(7);
+});
+
+
+test('DataManager refreshData', async () => {
+    // refreshData calls ajax and gives the child components a shakedown
+    // with the results. Its called in componentDidMount as well as in
+    // response to user actions.
+
+    const Manager = dataManager(MockComponent)
+    const manager = shallow(<Manager api={43} />);
+    manager.instance().handleResponse = jest.fn(async () => 23);
+    ajax.get = jest.fn(async () => 37);
+    let result = await manager.instance().refreshData({foo: 'BAR'});
+
+    // we get back the Promise of a handled Response.
+    expect(result).toBe(23);
+
+    // handleResponse was called with the awaited content from ajax.get
+    expect(manager.instance().handleResponse.mock.calls).toEqual([[37]]);
+
+    // and ajax.get was called with the expected vars
+    expect(ajax.get.mock.calls).toEqual([[43, {"foo": "BAR"}, {"method": "get"}]]);
+});
+
+
+test('DataManager handleSubmit', async () => {
+    // Tests what happens when user clicks handleSubmit
+
+    const Manager = dataManager(MockComponent)
+    const manager = shallow(<Manager api={43} submitMethod="post" />);
+
+    const response = {json: async () => '113'};
+    ajax.post = jest.fn(async () => response);
+
+    manager.instance().handleResponse = jest.fn(async () => 23);
+
+    // ajax gets fired from componentDidMount, so lets clear it
+    ajax.post.mockClear();
+
+    let result = await manager.instance().handleSubmit(7);
+
+    // we expect the async response from handleResponse to be returned
+    expect(result).toBe(23);
+
+    // handleResponse gets called with the Promise of some json from ajax
+    expect(manager.instance().handleResponse.mock.calls).toEqual([[response]]);
+
+    // and ajax got called with all of the expected post data.
+    expect(ajax.post.mock.calls).toEqual([[43, 7, {"method": "post"}]]);
+});
+
+
+test('DataManager handleResponse errors', async () => {
+    // Tests error handling in the ResourceManager widget
+
+    const Manager = dataManager(MockComponent)
+    const manager = shallow(<Manager requestMethod={23} />);
+
+    manager.instance().setState = jest.fn(() => 23);
+
+    // trigger handleResponse with bad status
+    const response = {status: 500, json: jest.fn(async () => ({}))};
+    await manager.instance().handleResponse(response);
+
+    // setState was called with our errors, which we didnt specify, but thats ok.
+    expect(manager.instance().setState.mock.calls).toEqual([[{"errors": undefined}]]);
+
+    // lets see what happens when we specify errors.
+    response.json = jest.fn(async () => ({errors: {foo: 'bad', bar: 'stuff'}}));
+    await manager.instance().handleResponse(response);
+
+    // but this time setState was called with the errors
+    expect(manager.instance().setState.mock.calls[1]).toEqual(
+        [{"errors": {"bar": "stuff", "foo": "bad"}}]);
+});
+
+
+test('DataManager handleResponse', async () => {
+    // Tests what happens when the manager component receives a response
+    // from ajax requests.
+    // This can either be the result of a search operation or as a
+    // consequence of dis/associating resources to a tag.
+
+    const Manager = dataManager(MockComponent)
+    const manager = shallow(<Manager requestMethod={23} />);
+
+    manager.instance().setState = jest.fn(() => 23);
+
+    // lets trigger an event with good status
+    const response = {status: 200, json: jest.fn(async () => ({}))};
+    await manager.instance().handleResponse(response);
+
+    // we didnt specify any data, but thats OK, and we dont expect any errors
+    expect(manager.instance().setState.mock.calls).toEqual(
+        [[{"data": undefined, "errors": {}}]]);
+
+    // lets handle a response with some actual data
+    response.json = jest.fn(async () => ({data: {foo: 'good', bar: 'stuff'}}));
+    await manager.instance().handleResponse(response);
+
+    // and setState was called with some lovely data.
+    expect(manager.instance().setState.mock.calls[1]).toEqual(
+        [{"data": {"bar": "stuff", "foo": "good"}, "errors": {}}]);
+});
+
+
+test('dataManager component', () => {
+
+    class MockManager extends DataManager {
+
+        get data () {
+            return 7;
+        }
+
+        get errors () {
+            return 23;
+        }
+
+    }
+
+    const Manager = dataManager(MockComponent, MockManager)
+    const manager = shallow(<Manager api={43} foo={43} bar={73} />);
+    const wrapped = manager.find(MockComponent);
+    expect(wrapped.length).toBe(1);
+    expect(wrapped.props().manager).toEqual(new MockManager(manager.state()));
+    expect(wrapped.props().refreshData).toBe(manager.instance().refreshData);
+    expect(wrapped.props().handleSubmit).toBe(manager.instance().handleSubmit);
+    expect(wrapped.props().data).toBe(7);
+    expect(wrapped.props().errors).toBe(23);
+    expect(wrapped.props().foo).toBe(43);
+    expect(wrapped.props().bar).toBe(73);
+});

--- a/tests/js/widgets/columns.js
+++ b/tests/js/widgets/columns.js
@@ -7,15 +7,8 @@ import {Columns, Container, Column} from 'widgets/columns';
 
 
 test('Columns render', () => {
-
-    class MockColumns extends Columns {
-
-        get columns () {
-            return [['a', 2], ['b', 3], ['c', 7]];
-        }
-    }
-
-    const columns = shallow(<MockColumns />);
+    const columndescriptors = [['a', 2], ['b', 3], ['c', 7]];
+    const columns = shallow(<Columns columns={columndescriptors} />);
     const container = columns.find(Container);
     expect(container.length).toBe(1);
     expect(container.props().columns).toBe(3);
@@ -59,9 +52,9 @@ test('Container render', () => {
     expect(container.text()).toBe('');
     div = container.find('div');
     expect(container.instance().columnStyles).toEqual(
-        [{"boxSizing": "border-box", "float": "left", "overflow": "hidden", "width": "33.333333333333336%"},
-         {"boxSizing": "border-box", "float": "left", "overflow": "hidden", "width": "33.333333333333336%"},
-         {"boxSizing": "border-box", "float": "left", "overflow": "hidden", "width": "33.333333333333336%"}]);
+        [{"boxSizing": "border-box", "float": "left", "width": "33.333333333333336%"},
+         {"boxSizing": "border-box", "float": "left", "width": "33.333333333333336%"},
+         {"boxSizing": "border-box", "float": "left", "width": "33.333333333333336%"}]);
     expect(div.props().children).toEqual([]);
     expect(div.props().style).toEqual(
         {"content": "", "display": "table", "width": "100%"});
@@ -69,9 +62,9 @@ test('Container render', () => {
     container = shallow(<Container columns={3} ratios={[2, 3, 7]} />);
     expect(container.text()).toBe('');
     expect(container.instance().columnStyles).toEqual(
-        [{"boxSizing": "border-box", "float": "left", "overflow": "hidden", "width": "16.666666666666664%"},
-         {"boxSizing": "border-box", "float": "left", "overflow": "hidden", "width": "25%"},
-         {"boxSizing": "border-box", "float": "left", "overflow": "hidden", "width": "58.333333333333336%"}]);
+        [{"boxSizing": "border-box", "float": "left", "width": "16.666666666666664%"},
+         {"boxSizing": "border-box", "float": "left", "width": "25%"},
+         {"boxSizing": "border-box", "float": "left", "width": "58.333333333333336%"}]);
 });
 
 


### PR DESCRIPTION
Adds 

- ~~a data table component that fetches data and builds a reacttable component onMount~~
- ~~a table with checkboxes that can be selected and submitted~~

Adds a higher order component that wraps the wrapper component with a "manager" that retrieves/submits data from/to an api.

The wrapped component is passed `data`  and `errors` , and functions to `refreshData` and `handleSubmit` as props

~~blocked by #854~~

required for strings tiers project and admin views