### PR TITLE
[WIP] NOBUG - Request for comments - Move markPlaceables outside main.js

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,13 +1,19 @@
 {
   "presets": [
-     "env",
+     ["env", {
+      "modules": false,
+      "targets": {
+        "yuglify": true,
+      }
+     }],
      "stage-2",
      "react"
   ],
   "plugins": [
-     "transform-runtime"
+     "transform-runtime",
+     "transform-es2015-modules-commonjs"
   ],
   "ignore": [
-     "node_modules",
+     "node_modules"
   ]
 }

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -190,15 +190,7 @@ var Pontoon = (function (my) {
      * Markup placeables
      */
     markPlaceables: function (string) {
-      function getReplacement(title, replacement) {
-        return '<mark class="placeable" title="' + title + '">' + replacement + '</mark>';
-      }
-
-      function markup(string, regex, title, replacement) {
-        replacement = replacement || '$&';
-        return string.replace(regex, getReplacement(title, replacement));
-      }
-
+      return string;
       string = this.doNotRender(string);
 
       /* Special spaces */
@@ -249,17 +241,17 @@ var Pontoon = (function (my) {
 
         // Inserted
         if (type === 1) {
-          output += '<ins>' + self.markPlaceables(slice) + '</ins>';
+          output += '<ins>' + placeables.markAll(slice) + '</ins>';
         }
 
         // Deleted
         if (type === -1) {
-          output += '<del>' + self.markPlaceables(slice) + '</del>';
+          output += '<del>' + placeables.markAll(slice) + '</del>';
         }
 
         // Equal
         if (type === 0) {
-          output += self.markPlaceables(slice);
+          output += placeables.markAll(slice);
         }
       });
 

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -366,6 +366,7 @@ PIPELINE_JS = {
             'js/lib/jquery.timeago.js',
             'js/lib/jquery.color-2.1.2.js',
             'js/lib/nprogress.js',
+            'webpack_bundles/placeables.js',
             'js/main.js',
         ),
         'output_filename': 'js/base.min.js',

--- a/pontoon/static/js/legacy/placeables.js
+++ b/pontoon/static/js/legacy/placeables.js
@@ -1,0 +1,20 @@
+function getReplacement(title, replacement) {
+    return '<mark class="placeable" title="' + title + '">' + replacement + '</mark>';
+}
+
+function replaceMarkup(string, regex, title, replacement) {
+    replacement = replacement || '$&';
+    return string.replace(regex, getReplacement(title, replacement));
+}
+
+function safeRenderString(string) {
+    return $('<div/>').text(string).html();
+}
+
+export function markAll(string) {
+    string = safeRenderString(string);
+
+    // Test of values
+    string = replaceMarkup(string, / /gi, 'Any space');
+    return string;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,15 +3,43 @@ const webpack = require('webpack');
 var BundleTracker = require('webpack-bundle-tracker');
 
 
-module.exports = {
+module.exports = [{
+    entry: {
+        placeables: 'legacy/placeables',
+    },
+    output: {
+        // This copies each source entry into the extension dist folder named
+        // after its entry config key.
+        path: path.resolve(__dirname, 'assets/webpack_bundles/'),
+        filename: '[name].js',
+        library: '[name]',
+        libraryTarget: "window",
+    },
+
+    module: {
+        // This transpiles all code (except for third party modules) using Babel.
+        loaders: [{
+            exclude: /node_modules/,
+            test: /placeables\.js$/,
+            loaders: ['babel-loader'],
+        }]
+    },
+
+    resolve: {
+        // This allows you to import modules just like you would in a NodeJS app.
+        extensions: ['.js', '.jsx'],
+        modules: [path.resolve(__dirname, 'pontoon/static/js/'), "node_modules"]
+    },
+    devtool: "sourcemap"
+}, {
   entry: {
-      'placeholder': 'placeholder/placeholder'
+      'placeholder': 'placeholder/placeholder',
   },
   output: {
     // This copies each source entry into the extension dist folder named
     // after its entry config key.
       path: path.resolve(__dirname, 'assets/webpack_bundles/'),
-      filename: '[name].js'
+      filename: '[name].js',
   },
   module: {
     // This transpiles all code (except for third party modules) using Babel.
@@ -44,4 +72,4 @@ module.exports = {
   // This will expose source map files so that errors will point to your
   // original source files instead of the transpiled files.
   devtool: 'sourcemap',
-};
+}];


### PR DESCRIPTION
@mathjazz
Hey, so after my declaration at our irc channel I experimented with code related to markPlaceables (I feel kinda forced by struggles introduced during work on #836).
Important disclaimer: So, this PR isn't like ready to merge thing. I haven't add tests yet, but I feel it can be (easily) done later. `placeables.js` is built by webpack. Placeables are later visible as `placeables.markAll()` in `main.js`

The question is if we want to pursue such way of working with the legacy Pontoon js -> move some parts of `main.js` code to separate modules and expose them globally (via `window`).

From my perspective that approach has following benefits:
* you can use sort-of name-spaces instead of one god-like objects
* unit-testing

I feel that those things still can be valuable during the transition phase to Translate.next and to add some anti-regression tests.
Aaaand there's a huge chance that there are better approaches to handle such legacy code in Javascript -> I'm open to learn something new.
If We want to pursue that, I'll create a proper PR to add support for legacy modules and later add PR for refactoring which will move placeables, fixes issue with leading/trailing spaces (1-2 days of afterhours :D).

Feel free to ping Adrian/Ryan -> I'm not sure who's less busy right now :(