### PR TITLE
Bug 1439650 - Migrate to analytics.js

### DIFF
--- a/pontoon/base/templates/base.html
+++ b/pontoon/base/templates/base.html
@@ -21,22 +21,7 @@
       {% endblock %}
     {% endblock %}
 
-    {% if settings.GOOGLE_ANALYTICS_KEY %}
-    <!-- Google Analytics -->
-    <script type="text/javascript">
-
-      var _gaq = _gaq || [];
-      _gaq.push(['_setAccount', '{{ settings.GOOGLE_ANALYTICS_KEY }}']);
-      _gaq.push(['_trackPageview']);
-
-      (function() {
-        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-      })();
-
-    </script>
-    {% endif %}
+    {% include "tracker.html" %}
   </head>
 
   <body class="{% block class %}{% endblock %}">

--- a/pontoon/base/templates/django/base.html
+++ b/pontoon/base/templates/django/base.html
@@ -15,22 +15,9 @@
     <link rel="stylesheet" href="{% static 'css/font-awesome.css' %}" title="" type="text/css" />
     <link rel="stylesheet" href="{% static 'css/nprogress.css' %}" title="" type="text/css" />
     <link rel="stylesheet" href="{% static 'css/style.css' %}" title="" type="text/css" />
-    {% if settings.GOOGLE_ANALYTICS_KEY %}
-    <!-- Google Analytics -->
-    <script type="text/javascript">
 
-      var _gaq = _gaq || [];
-      _gaq.push(['_setAccount', '{{ settings.GOOGLE_ANALYTICS_KEY }}']);
-      _gaq.push(['_trackPageview']);
+    {% include "tracker.html" %}
 
-      (function() {
-        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-      })();
-
-    </script>
-    {% endif %}
     {% block extend_css %}
     {% endblock %}
     {% block extend_js %}

--- a/pontoon/base/templates/tracker.html
+++ b/pontoon/base/templates/tracker.html
@@ -1,0 +1,14 @@
+{% if settings.GOOGLE_ANALYTICS_KEY %}
+  <!-- Google Analytics -->
+  <script type="text/javascript">
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+    ga('create', '{{ settings.GOOGLE_ANALYTICS_KEY }}', 'auto');
+    ga('send', 'pageview');
+  </script>
+  <!-- End Google Analytics -->
+{% endif %}
+

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -642,15 +642,17 @@ CSP_IMG_SRC = (
     "'self'",
     "https:",
     "https://*.wp.com/pontoon.mozilla.org/",
-    "https://ssl.google-analytics.com",
+    "https://www.google-analytics.com",
     "https://www.gravatar.com/avatar/",
 )
 CSP_SCRIPT_SRC = (
     "'self'",
     "'unsafe-eval'",
-    "'sha256-x3niK4UU+vG6EGT2NK2rwi2j/etQodJd840oRpEnqd4='",
     "'sha256-fDsgbzHC0sNuBdM4W91nXVccgFLwIDkl197QEca/Cl4='",
-    "https://ssl.google-analytics.com/ga.js",
+
+    # Rules related to Google Analytics
+    "'sha256-G5/M3dBlZdlvno5Cibw42fbeLr2PTEGd1M909Z7vPZE='",
+    "https://www.google-analytics.com/analytics.js",
 )
 CSP_STYLE_SRC = ("'self'", "'unsafe-inline'",)
 


### PR DESCRIPTION
* Create a template for Google Analytics snippet and point to it in base templates
* Update the inline js snippet
* Update related CSP hashes and update CSP Rules

@mathjazz / @phlax Could you review and then push it to the staging to check if migrations works?

I tested it locally and analytics.js sends data to `https://www.google-analytics.com/collect?v=1&...` (it uses pixel tracking).