### PR TITLE
Prevent Fluent UI from breaking into new line

### DIFF
--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -1457,12 +1457,12 @@ body > header aside p {
 }
 
 .ftl-area section .id {
-  font-weight: 300;
   border: 1px solid #5E6475;
   background: transparent;
   color: #AAAAAA;
   display: inline-block;
   font-weight: normal;
+  float: left;
   margin: 2px 5px 2px 0;
   padding: 0 4px;
   position: relative;


### PR DESCRIPTION
Finally I was able to see in person how fluent UI breaks for some people:

![index](https://user-images.githubusercontent.com/626716/36535792-1d035234-17cb-11e8-8e8b-16ae2eddea77.jpg)

The bug is only reproducible on certain OSes and/or screen resolutions and/or screen densities.

Thanks to @flodolo, this patch should provide a fix (and also remove a duplicated CSS property).