### PR TITLE
Touch Bug 1440940: Docker postgres collations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,13 +30,10 @@ services:
     volumes:
       - .:/app
 
-  # -----------------------------
-  # External services
-  # -----------------------------
-
-  # https://hub.docker.com/_/postgres/
   postgresql:
-    image: postgres:9.4
+    build:
+      context: ./docker/postgres
+      dockerfile: ./Dockerfile
     environment:
       # Create the superuser account
       - POSTGRES_USER=pontoon

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,0 +1,6 @@
+FROM postgres:9.4
+
+RUN echo "tr_TR.UTF-8 UTF-8\nen_US.UTF-8 UTF-8" >> /etc/locale.gen \
+    && locale-gen
+
+ADD ./docker-entrypoint-initdb.d /docker-entrypoint-initdb.d

--- a/docker/postgres/docker-entrypoint-initdb.d/collations.sql
+++ b/docker/postgres/docker-entrypoint-initdb.d/collations.sql
@@ -1,0 +1,2 @@
+
+CREATE COLLATION tr_tr (LOCALE = 'tr_TR.utf8');


### PR DESCRIPTION
Collations were fixed for turkish at least in previous bugs/PRS:

https://bugzilla.mozilla.org/show_bug.cgi?id=1346180

https://github.com/mozilla/pontoon/pull/554

This fix requires the collation set to be added/setup in the db env.

This PR adds that setup, which at least allows us to test against that bug in dev. It doesnt however fix it for any other locales, so we may wish to add (lots?) more locales, or see if we can do this without having to add a separate collation for each lang.
