### PR TITLE
Fix Bug 1442281: Cache python dirs in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,26 @@ python:
   - '2.7'
 cache:
   bundler: true
+  # cache the python dirs - this provides a very big speedup
   directories:
     - node_modules
+    - $HOME/virtualenv/python2.7.14/bin
+    - $HOME/virtualenv/python2.7.14/lib
+    - $HOME/virtualenv/python2.7/bin
 before_install:
   - git submodule update --init --recursive
+
+  # make a copy of the python libs before running tests. These are then used to restore
+  # specifically the "py" and "pytest" packages (including any pyc etc) at the end of the
+  # test run. This is necessary to prevent cache uploads with no change.
+
+  # see here for discussion - https://github.com/travis-ci/travis-ci/issues/4873
+
+  # bugzilla bug here: https://bugzilla.mozilla.org/show_bug.cgi?id=1442281
+
+  # caches may need to be cleared from time to time https://docs.travis-ci.com/user/caching#Clearing-Caches
+
+  - cp -a $HOME/virtualenv/python2.7.14/lib/python2.7/site-packages/ $HOME/py-workaround/
 install:
   - pip install -U --force pip
   - pip install --require-hashes -r requirements.txt
@@ -35,6 +51,15 @@ addons:
   apt:
     packages:
       - language-pack-tr
+
+before_cache:
+  # workaround for travis/aufs to prevent cache upload if no change
+  # if real change happens, the cache will still be updated
+
+  - pip uninstall py pytest -y
+  - pip install py==1.4.34 pytest==3.2.3
+  - pyclean $HOME/virtualenv/python2.7.14/lib/python2.7/site-packages/
+  - cp -a $HOME/py-workaround/* $HOME/virtualenv/python2.7.14/lib/python2.7/site-packages/
 
 env:
   global:


### PR DESCRIPTION
This is a massive optimization for (cached) travis runs. Its pretty much as fast as we will get it without removing the old test suite, or speeding up tests themselves

- cache python dirs
- a workaround for travis' use of aufs which otherwise causes it to upload cache without change. 
