### PR TITLE
[WIP] Touch Bug 1243129: React generic widgets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,13 @@ cache:
   bundler: true
   directories:
     - node_modules
+    - $HOME/virtualenv/python2.7.14/bin
+    - $HOME/virtualenv/python2.7.14/lib
+    - $HOME/virtualenv/python2.7/bin
 before_install:
   - git submodule update --init --recursive
+  # workaround for travis/aufs to prevent cache upload if no change
+  - cp -a $HOME/virtualenv/python2.7.14/lib/python2.7/site-packages/ $HOME/py-workaround/
 install:
   - pip install -U --force pip
   - pip install --require-hashes -r requirements.txt
@@ -35,6 +40,13 @@ addons:
   apt:
     packages:
       - language-pack-tr
+
+before_cache:
+  # workaround for travis/aufs to prevent cache upload if no change
+  - pip uninstall py pytest -y
+  - pip install py==1.4.34 pytest==3.2.3
+  - pyclean $HOME/virtualenv/python2.7.14/lib/python2.7/site-packages/
+  - cp -a $HOME/py-workaround/* $HOME/virtualenv/python2.7.14/lib/python2.7/site-packages/
 
 env:
   global:

--- a/package-lock.json
+++ b/package-lock.json
@@ -4331,6 +4331,12 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
+    "humanize-plus": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/humanize-plus/-/humanize-plus-1.8.2.tgz",
+      "integrity": "sha1-pls0RZrWNnrbs3B6gqPJ+RYWcDA=",
+      "dev": true
+    },
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2921,6 +2921,18 @@
         "is-extglob": "1.0.0"
       }
     },
+    "extract-text-webpack-plugin": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-3.0.2.tgz",
+      "integrity": "sha512-bt/LZ4m5Rqt/Crl2HiKuAl/oqg0psx1tsTLkvWbJen1CtD+fftkZhMaQ9HOtY2gWsl2Wq+sABmMVi9z3DhKWQQ==",
+      "dev": true,
+      "requires": {
+        "async": "2.6.0",
+        "loader-utils": "1.1.0",
+        "schema-utils": "0.3.0",
+        "webpack-sources": "1.1.0"
+      }
+    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "enzyme-adapter-react-16": "^1.1.1",
     "eslint": "^4.15.0",
     "eslint-plugin-react": "^7.5.1",
+    "extract-text-webpack-plugin": "^3.0.2",
     "humanize-plus": "^1.8.2",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^22.1.2",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "enzyme-adapter-react-16": "^1.1.1",
     "eslint": "^4.15.0",
     "eslint-plugin-react": "^7.5.1",
+    "humanize-plus": "^1.8.2",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^22.1.2",
     "jsdom": "^11.6.0",

--- a/pontoon/static/js/utils/ajax.js
+++ b/pontoon/static/js/utils/ajax.js
@@ -1,5 +1,6 @@
 
 import {strip} from './strip';
+import {PontoonCSRF} from './csrf';
 
 
 export class DjangoAjax {
@@ -180,7 +181,7 @@ export class PontoonDjangoAjax extends DjangoAjax {
 
     get csrf () {
         // this is a bit sketchy but the only afaict way due to session_csrf
-        return document.querySelector('input[name=csrfmiddlewaretoken]').value;
+        return new PontoonCSRF().value;
     }
 }
 

--- a/pontoon/static/js/utils/components.js
+++ b/pontoon/static/js/utils/components.js
@@ -1,0 +1,18 @@
+
+import React from 'react';
+
+
+export function componentManager(WrappedComponent, Components) {
+
+    return class Wrapper extends React.PureComponent {
+
+        render() {
+            let {components} = this.props;
+            return (
+                <WrappedComponent
+                   {...this.props}
+                   components={Object.assign({}, (components || {}), (Components || {}))}
+                   />);
+            }
+    }
+}

--- a/pontoon/static/js/utils/csrf.js
+++ b/pontoon/static/js/utils/csrf.js
@@ -1,0 +1,8 @@
+
+
+export class PontoonCSRF {
+
+    get value () {
+        return document.querySelector('input[name=csrfmiddlewaretoken]').value;
+    }
+}

--- a/pontoon/static/js/utils/data.js
+++ b/pontoon/static/js/utils/data.js
@@ -1,0 +1,90 @@
+
+import React from 'react';
+
+import {ajax} from 'utils/ajax';
+
+
+export class DataManager {
+
+    constructor (component, data) {
+        this.component = component;
+        this.handleResponse = this.handleResponse.bind(this);
+        this.handleSubmit = this.handleSubmit.bind(this);
+        this.refreshData = this.refreshData.bind(this);
+        this.initialData = data;
+    }
+
+    get data () {
+        const {data} = this.component.state;
+        return data;
+    }
+
+    get errors () {
+        const {errors} = this.component.state;
+        return errors;
+    }
+
+    get api () {
+        return this.component.props.api;
+    }
+
+    get requestMethod () {
+        return this.component.props.requestMethod || 'get';
+    }
+
+    get submitMethod () {
+        return this.component.props.submitMethod || this.requestMethod;
+    }
+
+    async refreshData (params) {
+        if (this.initialData) {
+            this.component.setState({data: this.initialData, errors: []});
+            this.initialData = undefined;
+            return
+        }
+        return this.handleResponse(
+            await ajax[this.requestMethod](this.api, params));
+    }
+
+    async handleResponse (response) {
+        const {status} = response;
+        const json = await response.json();
+        if (status === 200) {
+            const {data} = json;
+            this.component.setState({data, errors: {}});
+            return;
+        }
+        const {errors} = json;
+        this.component.setState({errors});
+    }
+
+    async handleSubmit (params) {
+        return this.handleResponse(
+            await ajax[this.submitMethod](this.api, params));
+    }
+}
+
+
+export function dataManager(WrappedComponent, Manager, data) {
+
+    return class Wrapper extends React.Component {
+
+        constructor(props) {
+            super(props);
+            Manager = Manager || DataManager;
+            this.manager = new Manager(this, data);
+            this.state = {errors: {}, data: []};
+        }
+
+        render() {
+            return (
+                <WrappedComponent
+                   manager={this.manager}
+                   errors={this.manager.errors}
+                   data={this.manager.data}
+                   handleSubmit={this.manager.handleSubmit}
+                   refreshData={this.manager.refreshData}
+                   {...this.props} />);
+        }
+    };
+}

--- a/pontoon/static/js/utils/stats.js
+++ b/pontoon/static/js/utils/stats.js
@@ -1,0 +1,106 @@
+
+
+export class Stats {
+
+    /* Takes basic stats values as provided by Django
+     * and turns them into stats as required to build
+     * a stats progress chart or other stats summary
+     *
+     */
+
+    constructor (data) {
+        this.data = data;
+    }
+
+    get approvedPercent() {
+        if (this.translatedStrings === 0 || this.totalStrings === 0) {
+            return 0;
+        }
+        return parseInt(
+            Math.floor(
+                this.translatedStrings
+                    / parseFloat(this.totalStrings) * 100));
+    }
+
+    get fuzzyShare () {
+        return this._share(this.fuzzyStrings);
+    }
+
+    get fuzzyStrings () {
+        return this.data ? this.data.fuzzy_strings || 0 : 0;
+    }
+
+    get missingShare () {
+        if (this.totalStrings === 0) {
+            return 0;
+        }
+        return this._share(this.missingStrings);
+    }
+
+    get missingStrings () {
+        return (
+            this.totalStrings
+                - this.translatedStrings
+                - this.fuzzyStrings
+                - this.suggestedStrings);
+    }
+
+    get suggestedShare () {
+        return this._share(this.suggestedStrings);
+    }
+
+    get suggestedStrings () {
+        return this.data && this.data.translated_strings || 0 ? this.data.translated_strings : 0;
+    }
+
+    get totalStrings () {
+        return this.data && this.data.total_strings || 0 ? this.data.total_strings : 0;
+    }
+
+    get translatedShare () {
+        return this._share(this.translatedStrings);
+    }
+
+    get translatedStrings () {
+        return this.data && this.data.approved_strings ? this.data.approved_strings : 0;
+    }
+
+    _share (item) {
+        if (item === 0 || this.totalStrings === 0) {
+            return 0;
+        }
+        return Math.round(item / parseFloat(this.totalStrings) * 100);
+    }
+}
+
+
+export class AggregateStats extends Stats {
+
+    get translatedStrings () {
+        if (!this._translated) {
+            this._translated = this.data.map(x => x.approved_strings).reduce((_s, x) => _s + x);
+        }
+        return this._translated;
+    }
+
+    get fuzzyStrings () {
+        if (!this._fuzzy) {
+            this._fuzzy =  this.data.map(x => x.fuzzy_strings).reduce((_s, x) => _s + x);
+        }
+        return this._fuzzy;
+    }
+
+    get suggestedStrings () {
+        if (!this._suggested) {
+            this._suggested = this.data.map(x => x.translated_strings).reduce((_s, x) => _s + x);
+        }
+        return this._suggested;
+    }
+
+    get totalStrings () {
+        if (!this._total) {
+            this._total = this.data.map(x => x.total_strings).reduce((_s, x) => _s + x);
+        }
+        return this._total;
+    }
+}

--- a/pontoon/static/js/widgets/charts/index.js
+++ b/pontoon/static/js/widgets/charts/index.js
@@ -1,0 +1,2 @@
+
+export {default as WheelChart} from './wheel'

--- a/pontoon/static/js/widgets/charts/index.js
+++ b/pontoon/static/js/widgets/charts/index.js
@@ -1,2 +1,3 @@
 
+export {ProgressChart} from './progress'
 export {default as WheelChart} from './wheel'

--- a/pontoon/static/js/widgets/charts/progress/chart.js
+++ b/pontoon/static/js/widgets/charts/progress/chart.js
@@ -1,0 +1,30 @@
+
+import React from 'react';
+
+import ProgressChartData from './data';
+import ProgressChartLegend from './legend';
+
+import './progress.css';
+
+
+export default class ProgressChart extends React.PureComponent {
+
+    get components () {
+        const components = {data: ProgressChartData, legend: ProgressChartLegend};
+        return Object.assign({}, components, (this.props.components || {}));
+    }
+
+    render () {
+        const {data: Data, legend: Legend} = this.components;
+        const {stats, percentages} = this.props;
+        return (
+            <div className="progress-inline">
+              <Data
+                 data={percentages}
+                 />
+              <Legend
+                 items={stats}
+                 />
+            </div>);
+    }
+}

--- a/pontoon/static/js/widgets/charts/progress/data-item.js
+++ b/pontoon/static/js/widgets/charts/progress/data-item.js
@@ -1,0 +1,13 @@
+
+import React from 'react';
+
+
+export default class ProgressChartDataItem extends React.PureComponent {
+
+    render () {
+        return (
+            <span
+               className={this.props.className}
+               style={{width: this.props.data + '%'}} />);
+    }
+}

--- a/pontoon/static/js/widgets/charts/progress/data.js
+++ b/pontoon/static/js/widgets/charts/progress/data.js
@@ -1,0 +1,47 @@
+
+import React from 'react';
+
+import ProgressChartDataItem from './data-item';
+
+
+export default class ProgressChartData extends React.PureComponent {
+
+    get className () {
+        return this.props.className || "chart";
+    }
+
+    get components () {
+        const components = {item: ProgressChartDataItem};
+        return Object.assign({}, components, (this.props.components || {}));
+    }
+
+    render () {
+        return (
+            <div className="chart-wrapper">
+              {this.renderTotal()}
+              {this.renderChart()}
+            </div>);
+    }
+
+    renderTotal () {
+        return (
+            <span className="percent">
+              {this.props.data.total}%
+            </span>);
+    }
+
+    renderChart () {
+        const {item: Item} = this.components;
+        const {total, ...items} = this.props.data;
+        return (
+            <span className={this.className}>
+                {Object.entries(items).map(([name, data], key) => {
+                    return (
+                        <Item
+                           className={name}
+                           data={data}
+                           key={key} />);
+                })}
+            </span>);
+    }
+}

--- a/pontoon/static/js/widgets/charts/progress/index.js
+++ b/pontoon/static/js/widgets/charts/progress/index.js
@@ -1,0 +1,6 @@
+
+export {default as ProgressChart} from './chart';
+export {default as ProgressChartData} from './data';
+export {default as ProgressChartLegend} from './legend';
+export {default as ProgressChartLegendItem} from './legend-item';
+export {default as ProgressChartDataItem} from './data-item';

--- a/pontoon/static/js/widgets/charts/progress/legend-item.js
+++ b/pontoon/static/js/widgets/charts/progress/legend-item.js
@@ -1,0 +1,26 @@
+
+import React from 'react';
+
+import Humanize from 'humanize-plus';
+
+import {ListItem} from 'widgets/lists/generic';
+
+
+export default class ProgressChartLegendItem extends React.PureComponent {
+
+    render () {
+        const title = this.props[0];
+        const value = this.props[1];
+        const link = '?status=' + title;
+        return (
+            <ListItem className={title}>
+              <a href={link}>
+                <div className="title">{title}</div>
+                <div className="value" data-value={value}>
+                  {Humanize.intComma(value)}
+                </div>
+              </a>
+            </ListItem>
+        );
+    }
+}

--- a/pontoon/static/js/widgets/charts/progress/legend.js
+++ b/pontoon/static/js/widgets/charts/progress/legend.js
@@ -1,0 +1,23 @@
+
+import React from 'react';
+
+import {List} from 'widgets/lists/generic';
+
+import ProgressChartLegendItem from './legend-item';
+
+
+export default class ProgressChartLegend extends React.PureComponent {
+
+    get components () {
+        const components = {item: ProgressChartLegendItem};
+        return Object.assign({}, components, (this.props.components || {}));
+    }
+
+    render () {
+        return (
+            <List
+               className="legend"
+               items={Object.entries(this.props.items)}
+               components={this.components} />);
+    }
+}

--- a/pontoon/static/js/widgets/charts/progress/progress.css
+++ b/pontoon/static/js/widgets/charts/progress/progress.css
@@ -1,0 +1,102 @@
+
+
+.progress-inline .chart-wrapper {
+  position: relative;
+}
+
+.progress-inline .chart-wrapper .chart {
+  display: table;
+  font-size: 0;
+  height: 3px;
+  margin-top: 2px;
+  table-layout: fixed;
+  width: 320px;
+}
+
+
+.progress-inline.full-width .chart-wrapper .chart {
+  width: 920px;
+}
+
+
+.progress-inline .chart-wrapper .chart span {
+  display: table-cell;
+  height: 100%;
+}
+
+.progress-inline .chart-wrapper .percent {
+  position: absolute;
+  right: 0;
+  top: -7px;
+}
+
+.progress-inline .chart-wrapper .translated {
+  background: #7BC876;
+}
+
+.progress-inline .chart-wrapper .suggested {
+  background: #4FC4F6;
+}
+
+.progress-inline .chart-wrapper .fuzzy {
+  background: #FED271;
+}
+
+.progress-inline .chart-wrapper .missing {
+  background: #637283;
+}
+
+.progress-inline .legend {
+  display: none;
+  margin-bottom: -9px;
+}
+
+.progress-inline .legend ul {
+  font-size: 0;
+  margin-top: -1px;
+}
+
+.progress-inline .legend li {
+  display: inline-block;
+  padding: 0;
+  text-align: center;
+  width: 72px;
+}
+
+.progress-inline .legend li a {
+  color: #AAAAAA;
+  display: block;
+  margin-top: -5px;
+}
+
+.progress-inline .legend li .title {
+  font-size: 10px;
+  font-weight: 400;
+  line-height: 10px;
+  text-transform: uppercase;
+}
+
+.progress-inline .legend li.translated .title {
+  color: #7BC876;
+}
+
+.progress-inline .legend li.suggested .title {
+  color: #4FC4F6;
+}
+
+.progress-inline .legend li.fuzzy .title {
+  color: #FED271;
+}
+
+.progress-inline .legend li.missing .title {
+  color: #7C8B9C;
+}
+
+.progress-inline .legend li.all .title {
+  color: #AAAAAA;
+}
+
+.progress-inline .legend li .value {
+  font-size: 18px;
+  line-height: 22px;
+}

--- a/pontoon/static/js/widgets/charts/wheel.css
+++ b/pontoon/static/js/widgets/charts/wheel.css
@@ -1,0 +1,31 @@
+
+.wheel-chart {
+    float: inherit;
+    margin: -10px auto 0 auto;
+    position: relative;
+    text-align: center;
+}
+
+.wheel-chart .number {
+  display: none;
+  font-size: 50px;
+  font-weight: bold;
+  left: 0;
+  right: 0;
+  top: 25px;
+  margin: 0;
+  position: absolute;
+}
+
+.wheel-chart .number:after {
+  content: "%";
+  color: #888888;
+  display: block;
+  font-size: 20px;
+  font-weight: 100;
+  line-height: 10px;
+}
+
+.wheel-chart .react-number {
+    display: inherit;
+}

--- a/pontoon/static/js/widgets/charts/wheel.js
+++ b/pontoon/static/js/widgets/charts/wheel.js
@@ -1,0 +1,112 @@
+
+import React from 'react';
+
+import './wheel.css';
+
+
+export default class WheelChart extends React.PureComponent {
+
+    constructor (props) {
+        super(props);
+        this.canvas;
+    }
+
+    componentDidMount () {
+        this.drawChart();
+    }
+
+    componentDidUpdate () {
+        this.drawChart();
+    }
+
+    get canvasClassName () {
+        return this.props.canvasClassName || "drawing";
+    }
+
+    get className () {
+        return this.props.className || "wheel-chart";
+    }
+
+    get drawing () {
+        return this.canvas.getContext('2d');
+    }
+
+    get height () {
+        return this.props.height || '130px';
+    }
+
+    get percentageClassName () {
+        return this.props.percentageClassName || 'number react-number noselect';
+    }
+
+    get radius () {
+        return (this.canvas.width - this.drawing.lineWidth) / 2;
+    }
+
+    get width () {
+        return this.props.width || '130px';
+    }
+
+    get x () {
+        return this.canvas.width / 2;
+    }
+
+    get y () {
+        return this.canvas.height / 2;
+    }
+
+    drawChart () {
+        // Clear old canvas content to avoid aliasing
+        this.drawing.clearRect(0, 0, this.canvas.width, this.canvas.height);
+        this.drawing.lineWidth = 3;
+        let start = -.5;
+        let end, length;
+        Object.entries(this.props.data).forEach(([, v]) => {
+            if (!v.value) {
+                return;
+            }
+            length = v.value / this.props.total * 2;
+            end = start + length;
+            this.fillChart(start, end, v.color);
+            start = end;
+        });
+    }
+
+    fillChart (start, end, color) {
+        this.drawing.beginPath();
+        this.drawing.arc(
+            this.x,
+            this.y,
+            this.radius,
+            start * Math.PI,
+            end * Math.PI);
+        this.drawing.strokeStyle = color;
+        this.drawing.stroke();
+    }
+
+    render () {
+        return (
+            <div className={this.className}>
+                {this.renderCanvas()}
+                {this.renderPercentage()}
+            </div>
+        );
+    }
+
+    renderCanvas () {
+        return (
+            <canvas
+               ref={(el) => this.canvas = el}
+              className={this.canvasClassName}
+              height={this.height}
+              width={this.width}>
+            </canvas>);
+    }
+
+    renderPercentage () {
+        return (
+            <span className={this.percentageClassName}>
+              {this.props.percentage}
+            </span>);
+    }
+}

--- a/pontoon/static/js/widgets/columns.js
+++ b/pontoon/static/js/widgets/columns.js
@@ -2,14 +2,14 @@
 import React from 'react';
 
 
-export class Columns extends React.Component {
+export class Columns extends React.PureComponent {
 
     render() {
         return (
             <Container
-               columns={this.columns.length}
-               ratios={this.columns.map(([, v]) => v)}>
-              {this.columns.map(([column,], key) => {
+               columns={this.props.columns.length}
+               ratios={this.props.columns.map(([, v]) => v)}>
+              {this.props.columns.map(([column,], key) => {
                   return (
                       <Column key={key}>
                         {column}
@@ -25,7 +25,6 @@ export class Container extends React.Component {
     createColumnStyle(width) {
         return {
             float: "left",
-            overflow: "hidden",
             boxSizing: "border-box",
             width: width.toString() + "%"};
     }

--- a/pontoon/static/js/widgets/deadline.js
+++ b/pontoon/static/js/widgets/deadline.js
@@ -1,0 +1,25 @@
+
+import React from 'react';
+
+import Datetime from 'utils/datetime';
+
+
+export class Deadline extends React.PureComponent {
+
+    render () {
+        if (!this.props.deadline) {
+            return <span>No deadline set</span>;
+        }
+        const deadline = new Date(this.props.deadline);
+        const now = new Date();
+        let className = '';
+        if (now > deadline) {
+            className = 'overdue';
+        }
+        return (
+            <time className={className} dateTime={this.props.deadline}>
+              {new Datetime(this.props.deadline).date}
+            </time>
+        );
+    }
+}

--- a/pontoon/static/js/widgets/forms.js
+++ b/pontoon/static/js/widgets/forms.js
@@ -1,0 +1,74 @@
+
+import React from 'react';
+
+import {PontoonCSRF} from 'utils/csrf';
+
+
+export class CSRFToken extends React.PureComponent {
+
+    get csrf () {
+        return new PontoonCSRF().value;
+    }
+
+    render () {
+        return (
+            <input
+               value={this.csrf}
+               name="csrfmiddlewaretoken"
+               type="hidden" />);
+    }
+}
+
+
+export class Form extends React.PureComponent {
+
+    constructor (props) {
+        super(props);
+        this.handleFormLoad = this.handleFormLoad.bind(this);
+    }
+
+    handleFormLoad (form) {
+        if (this.props.handleFormLoad) {
+            this.props.handleFormLoad(form);
+        }
+    }
+
+    render () {
+        const {action, children, method, ...props} = this.props;
+        return (
+            <form
+               method={method || "POST"}
+               ref={this.handleFormLoad}
+               action={this.props.action || ''}
+               {...props}>
+              {this.renderCSRF()}
+              {children}
+            </form>);
+    }
+
+    renderCSRF () {
+        return <CSRFToken />;
+    }
+}
+
+
+export class SignoutForm extends React.PureComponent {
+
+    get action () {
+        return "/accounts/logout/?next=" + this.redirectURL;
+    }
+
+    get redirectURL() {
+        return window.location.pathname + window.location.search;
+    }
+
+    render () {
+        return (
+            <Form
+               style={{display: "none"}}
+               action={this.action}
+               className="csrf"
+               {...this.props}
+               />);
+    }
+}

--- a/pontoon/static/js/widgets/icons.js
+++ b/pontoon/static/js/widgets/icons.js
@@ -1,0 +1,34 @@
+
+import React from 'react';
+
+
+export class Icon extends React.PureComponent {
+
+    get className () {
+        let className = this.props.className ? ' ' + this.props.className : '';
+        return "icon fa fa-" + this.props.name + " fa-fw" + className;
+    }
+
+    render () {
+        if (!this.props.name) {
+            return '';
+        }
+        return <i className={this.className}></i>;
+    }
+}
+
+
+export class IconLink extends React.PureComponent {
+
+    render () {
+        const {children, icon, href, ...props} = this.props;
+        if (!icon) {
+            return '';
+        }
+        return (
+            <a href={href} {...props}>
+              <Icon name={icon} />
+              {children}
+            </a>);
+    }
+}

--- a/pontoon/static/js/widgets/images.js
+++ b/pontoon/static/js/widgets/images.js
@@ -1,0 +1,128 @@
+
+import React from 'react';
+
+
+export class Image extends React.PureComponent {
+
+    render () {
+        if (!this.props.src) {
+            return '';
+        }
+        return (
+            <img src={this.props.src}
+                 className={this.props.className}
+                 width={this.props.width}
+                 height={this.props.height} />);
+    }
+}
+
+
+export class ImageLink extends React.PureComponent {
+
+    get components () {
+        const components = {image: Image};
+        return Object.assign({}, components, (this.props.components || {}));
+    }
+
+    render () {
+        if (!this.props.src) {
+            return '';
+        }
+        const {image: Image} = this.components;
+        return (
+            <a className={this.props.className}
+               href={this.props.href}>
+              <Image
+                 src={this.props.src}
+                 width={this.props.width}
+                 height={this.props.height}
+                 {...this.props.imageProps} />
+              {this.props.children}
+            </a>);
+    }
+}
+
+
+export class Logo extends React.PureComponent {
+
+    get height () {
+        return this.props.height || 32;
+    }
+
+    get width () {
+        return this.props.width || 32;
+    }
+
+    get className () {
+        return this.props.className || "logo";
+    }
+
+    render () {
+        return (
+            <ImageLink
+               className={this.className}
+               href={this.props.href}
+               src={this.props.src}
+               height={this.height}
+               width={this.width}
+               />);
+    }
+}
+
+
+export class Avatar extends React.PureComponent {
+
+    get avatar () {
+        return this.props.src + this.size.toString();
+    }
+
+    get className () {
+        return this.props.className || '';
+    }
+
+    get size () {
+        return this.props.size || 88;
+    }
+
+    render () {
+        if (!this.props.src) {
+            return '';
+        }
+        return (
+            <Image
+               {...this.props}
+               className={this.className}
+               src={this.avatar} />);
+    }
+}
+
+
+export class AvatarLink extends React.PureComponent {
+
+    get components () {
+        const components = {image: Avatar}
+        return Object.assign({}, components, (this.props.components || {}))
+    }
+
+    get imageProps () {
+        const imageProps = {
+            className: 'rounded',
+            width: this.props.width,
+            height: this.props.height};
+        return Object.assign({}, imageProps, (this.props.imageProps || {}));
+    }
+
+    render () {
+        if (!this.props.src) {
+            return '';
+        }
+        return (
+            <ImageLink
+               className="avatar"
+               src={this.props.src}
+               imageProps={this.imageProps}
+               components={this.components}>
+              {this.props.children}
+            </ImageLink>);
+    }
+}

--- a/pontoon/static/js/widgets/lists/generic.js
+++ b/pontoon/static/js/widgets/lists/generic.js
@@ -1,0 +1,45 @@
+
+import React from 'react';
+
+
+export class ListItem extends React.PureComponent {
+
+    render () {
+        return (
+            <li className={this.props.className}>
+              {this.props.children}
+            </li>);
+    }
+}
+
+
+export class List extends React.PureComponent {
+
+    get components () {
+        const components = {item: ListItem};
+        return Object.assign({}, components, (this.props.components || {}));
+    }
+
+    render () {
+        const {className, items, ...props} = this.props;
+        if (!items) {
+            return '';
+        }
+        const {item, ...components} = this.components;
+        const Item = item;
+        return (
+            <ul className={className}>
+              {items.map((v, key) => {
+                  const {label, value, ...itemProps} = v;
+                  return (
+                      <Item
+                         {...props}
+                         {...itemProps}
+                         components={components}
+                         key={key}>
+                        {value || label}
+                      </Item>);
+              })}
+            </ul>);
+    }
+}

--- a/pontoon/static/js/widgets/lists/info-list.css
+++ b/pontoon/static/js/widgets/lists/info-list.css
@@ -1,0 +1,49 @@
+
+
+.details {
+    margin: 0;
+}
+
+#heading .details,
+#heading .legend {
+  font-weight: 300;
+  width: 360px;
+}
+
+#heading .details li,
+#heading .legend li {
+  line-height: 24px;
+}
+
+#heading .details .title {
+  color: #AAAAAA;
+  padding-right: 5px;
+  text-transform: uppercase;
+}
+
+#heading .details .value {
+  color: #AAA;
+  float: right;
+}
+
+#heading .details .value a {
+  color: #FFFFFF;
+}
+
+#heading .details .value a:hover {
+  color: #7BC876;
+}
+
+#heading .details .priority .value {
+  margin-top: 6px;
+}
+
+#heading .details .value.overflow {
+  max-width: 275px;
+  overflow: hidden;
+  padding-left: 1px; /* Needed to avoid cutting off overlay due to overflow: hidden; */
+  padding-right: 1px; /* Needed to avoid cutting off overlay due to overflow: hidden; */
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/pontoon/static/js/widgets/lists/info.js
+++ b/pontoon/static/js/widgets/lists/info.js
@@ -1,0 +1,44 @@
+
+import React from 'react';
+
+import './info-list.css';
+
+import {List, ListItem} from 'widgets/lists/generic';
+
+
+export class InfoList extends React.PureComponent {
+
+    get components () {
+        const components = {item: InfoListItem};
+        return Object.assign({}, components, (this.props.components || {}));
+    }
+
+    render () {
+        if (!this.props.items) {
+            return '';
+        }
+        return (
+            <List
+               className={this.props.className || "details"}
+               items={Object.entries(this.props.items)}
+               components={this.components} />);
+    }
+}
+
+
+export class InfoListItem extends React.PureComponent {
+
+    get className () {
+        return this.props.className || this.props[0].toLowerCase().replace(' ', '-');
+    }
+
+    render () {
+        const k = this.props[0];
+        const v = this.props[1];
+        return (
+            <ListItem className={this.className}>
+              <span className="title">{k}</span>
+              <span className="value overflow">{v}</span>
+            </ListItem>);
+    }
+}

--- a/pontoon/static/js/widgets/lists/links.css
+++ b/pontoon/static/js/widgets/lists/links.css
@@ -1,6 +1,10 @@
 
-.links li {
+.links .link {
     list-style: none;
     display: inline-block;
     margin-left: 20px;
+}
+
+.links .link a:link, .links .link a:visited {
+    color: #EBEBEB;
 }

--- a/pontoon/static/js/widgets/lists/links.css
+++ b/pontoon/static/js/widgets/lists/links.css
@@ -1,0 +1,6 @@
+
+.links li {
+    list-style: none;
+    display: inline-block;
+    margin-left: 20px;
+}

--- a/pontoon/static/js/widgets/lists/links.js
+++ b/pontoon/static/js/widgets/lists/links.js
@@ -1,0 +1,44 @@
+
+import React from 'react';
+
+import {List, ListItem} from './generic';
+
+import './links.css';
+
+
+export class LinkListItem extends React.PureComponent {
+
+    get className () {
+        return this.props.className || 'link';
+    }
+
+    render () {
+        return (
+            <ListItem className={this.className}>
+              <a href={this.props.href}>
+                {this.props.children}
+              </a>
+            </ListItem>);
+    }
+}
+
+
+export class LinkList extends React.PureComponent {
+
+    get components () {
+        const components = {item: LinkListItem};
+        return Object.assign({}, components, (this.props.components || {}));
+    }
+
+    get className () {
+        return this.props.className || 'links';
+    }
+
+    render () {
+        return (
+            <List
+               components={this.components}
+               className={this.className}
+               items={this.props.links} />);
+    }
+}

--- a/pontoon/static/js/widgets/lists/tabs.css
+++ b/pontoon/static/js/widgets/lists/tabs.css
@@ -1,0 +1,47 @@
+
+.tabs {
+    margin: 0;
+    padding: 0;
+    margin-bottom: -1px;
+}
+
+.tabs .tab {
+    margin: 0;
+    padding: 0;
+    border-style: solid solid none;
+    border-width: 1px 1px 0;
+    border-color: transparent;
+}
+
+
+.tabs .tab .count {
+    background: #3F4752;
+    border-radius: 3px;
+    color: #CCCCCC;
+    margin-left: 5px;
+    padding: 0 5px;
+}
+
+.tabs .tab.active {
+  border-color: #5E6475;
+  background: #272A2F;
+}
+
+.tabs .tab a {
+  padding: 12px 30px;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+.tabs .tab a:link,
+.tabs .tab a:visited {
+  color: #AAAAAA;
+  display: inline-block;
+  text-transform: uppercase;
+}
+
+.tabs li.active a,
+.tabs a:hover,
+.tabs a:active {
+  color: #7BC876;
+}

--- a/pontoon/static/js/widgets/lists/tabs.js
+++ b/pontoon/static/js/widgets/lists/tabs.js
@@ -1,0 +1,56 @@
+
+import React from 'react';
+
+import {LinkList, LinkListItem} from './links';
+
+import './tabs.css';
+
+
+export class TabList extends React.PureComponent {
+
+    get components () {
+        const {item, count} = (this.props.components || {});
+        return {
+            item: item || Tab,
+            count: count || TabCount};
+    }
+
+    render () {
+        if (!this.props.tabs) {
+            return '';
+        }
+        return (
+            <LinkList
+               links={this.props.tabs || []}
+               className="tabs links"
+               components={this.components}
+               />);
+    }
+}
+
+
+export class Tab extends React.PureComponent {
+
+    render () {
+        const TabCount = this.props.components.count;
+        const className = this.props.active ? 'active tab link' : 'tab link';
+        return (
+            <LinkListItem
+               className={className}
+               href={this.props.href}>
+              {this.props.children}
+              <TabCount count={this.props.count} />
+            </LinkListItem>);
+    }
+}
+
+
+export class TabCount extends React.PureComponent {
+
+    render () {
+        if (this.props.count) {
+            return <span className="count">{this.props.count}</span>;
+        }
+        return '';
+    }
+}

--- a/pontoon/static/js/widgets/menus/dropdown/button.js
+++ b/pontoon/static/js/widgets/menus/dropdown/button.js
@@ -1,0 +1,60 @@
+
+import React from 'react';
+
+
+export default class DropdownMenuButton extends React.Component {
+
+    constructor (props) {
+        super(props);
+        this.handleClick = this.handleClick.bind(this);
+        this.handleClose = this.handleClose.bind(this);
+        this.refNode = this.refNode.bind(this);
+        this.state = {open: false};
+    }
+
+    handleClick () {
+        this.setState((prevState) => ({open: !prevState.open}));
+    }
+
+    handleClose (evt) {
+        if (this.buttonNode && this.buttonNode.contains(evt.target)) {
+            return;
+        }
+        this.setState({open: false});
+    }
+
+    refNode (node) {
+        this.buttonNode = node;
+    }
+
+    render () {
+        const {id, className} = this.props;
+        return (
+            <div id={id} className={className}>
+              {this.renderButton()}
+              {this.renderMenu()}
+            </div>);
+    }
+
+    renderButton () {
+        const {buttonProps, components, menuProps, ...props} = this.props;
+        const {button: Button} = components;
+        return (
+            <div
+               className="button selector"
+               onClick={this.handleClick}
+               ref={this.refNode}>
+              <Button {...props} {...buttonProps} />
+            </div>);
+    }
+
+    renderMenu () {
+        const {open} = this.state;
+        if (!open) {
+            return '';
+        }
+        const {buttonProps, components, menuProps, ...props} = this.props;
+        const {menu: Menu} = components;
+        return <Menu handleClose={this.handleClose} {...props} {...menuProps} />;
+    }
+}

--- a/pontoon/static/js/widgets/menus/dropdown/index.js
+++ b/pontoon/static/js/widgets/menus/dropdown/index.js
@@ -1,0 +1,4 @@
+
+export {default as DropdownMenu} from './menu'
+export {default as DropdownMenuItem} from './item'
+export {default as DropdownMenuButton} from './button'

--- a/pontoon/static/js/widgets/menus/dropdown/item.js
+++ b/pontoon/static/js/widgets/menus/dropdown/item.js
@@ -1,0 +1,15 @@
+
+import React from 'react';
+
+import {ListItem} from 'widgets/lists/generic';
+
+
+export default class DropdownMenuItem extends React.PureComponent {
+
+    render () {
+        if (!this.props.children) {
+            return <ListItem className="menu-item horizontal-separator" />;
+        }
+        return <ListItem className="menu-item">{this.props.children}</ListItem>;
+    }
+}

--- a/pontoon/static/js/widgets/menus/dropdown/menu.css
+++ b/pontoon/static/js/widgets/menus/dropdown/menu.css
@@ -1,0 +1,48 @@
+
+
+
+.menu .menu-item {
+    padding: 2px 4px;
+    font-weight: 300;
+}
+
+
+.menu.dropdown .menu-item .avatar {
+    text-align: center;
+    padding: 10px 4px;
+}
+
+.menu.dropdown .menu-item:hover {
+    background: #3f4752;
+}
+
+.menu.dropdown .menu-item:hover a {
+    color: white;
+}
+
+.menu.dropdown .menu-item.horizontal-separator {
+    border-top: 1px solid #525A65;
+    height: 0;
+    margin: 5px 0;
+    padding: 0;
+}
+
+.menu.dropdown {
+    border: 1px solid #333941;
+    border-top: none;
+    line-height: 18px;
+    padding-top: 0;
+    width: 250px;
+    position: absolute;
+    bottom: auto;
+    right: 0;
+    top: 60px;
+    background: #272A2F;
+    z-index: 1000;
+    padding: 12px;
+}
+
+.menu.dropdown .menu-item {
+  padding-bottom: 0;
+  padding-top: 0;
+}

--- a/pontoon/static/js/widgets/menus/dropdown/menu.js
+++ b/pontoon/static/js/widgets/menus/dropdown/menu.js
@@ -1,0 +1,52 @@
+
+import React from 'react';
+
+import {List} from 'widgets/lists/generic';
+
+import MenuItem from './item'
+
+import './menu.css';
+
+
+export default class DropdownMenu extends React.PureComponent {
+
+    constructor(props) {
+        super(props);
+        this.handleClickOutside = this.handleClickOutside.bind(this);
+    }
+
+    get components () {
+        const components = {item: MenuItem};
+        return Object.assign({}, components, (this.props.components || {}));
+    }
+
+    get items () {
+        return this.props.items.map(item => {
+            return {value: item};
+        });
+    }
+
+    componentDidMount() {
+        document.addEventListener('mousedown', this.handleClickOutside);
+    }
+
+    componentWillUnmount() {
+        document.removeEventListener('mousedown', this.handleClickOutside);
+    }
+
+    handleClickOutside (evt) {
+        if (this.node && !this.node.contains(evt.target) && this.props.handleClose) {
+            this.props.handleClose(evt);
+        }
+    }
+
+    render () {
+        return (
+            <div ref={n => this.node = n}>
+              <List
+                 items={this.items}
+                 components={this.components}
+                 className="menu dropdown" />
+            </div>);
+    }
+}

--- a/pontoon/static/js/widgets/menus/generic.js
+++ b/pontoon/static/js/widgets/menus/generic.js
@@ -1,0 +1,46 @@
+
+import React from 'react';
+
+import {List, ListItem} from 'widgets/lists/generic';
+
+
+export class MenuItem extends React.Component {
+
+    get className () {
+        return this.props.className || 'menu-item';
+    }
+
+    render () {
+        return (
+            <ListItem className={this.className}>
+              {this.props.children}
+            </ListItem>);
+    }
+}
+
+
+export class Menu extends React.PureComponent {
+
+    get className () {
+        return this.props.className || 'menu';
+    }
+
+    get components () {
+        const components = {item: MenuItem};
+        return Object.assign({}, components, (this.props.components || {}));
+    }
+
+    get items () {
+        return this.props.items.map(item => {
+            return {value: item};
+        });
+    }
+
+    render () {
+        return (
+            <List
+               items={this.items}
+               components={this.components}
+               className={this.className} />);
+    }
+}

--- a/pontoon/static/js/widgets/search.css
+++ b/pontoon/static/js/widgets/search.css
@@ -1,0 +1,82 @@
+.controls {
+    margin-bottom: 20px;
+    position: relative;
+}
+
+.controls .search-wrapper {
+    border-bottom: 1px solid #5E6475;
+    margin-bottom: 10px;
+    position: relative;
+}
+
+.controls .search-wrapper .icon {
+    color: #AAAAAA;
+    font-size: 1.2em;
+    position: absolute;
+    left: 3px;
+    top: 5px;
+}
+
+.controls .search-wrapper input[type="search"] {
+    color: #FFFFFF;
+}
+
+.controls .search-wrapper input[type="search"]::-webkit-search-decoration,
+.controls .search-wrapper input[type="search"]::-webkit-search-cancel-button {
+    display: none;
+}
+
+.controls .search-wrapper .menu input[type=search] {
+    background: transparent;
+    color: #FFFFFF;
+    float: none;
+    font-weight: 300;
+    padding-left: 25px;
+    padding-right: 0;
+    width: 200px;
+}
+
+.controls .search-wrapper .menu input[type=search]:focus {
+    background-color: transparent;
+}
+
+.controls .search-wrapper.small {
+    width: 240px;
+}
+
+.controls > .search-wrapper {
+  border: none;
+  display: inline-block;
+  height: 28px;
+  margin: 0;
+  vertical-align: top;
+  width: 100%;
+}
+
+.controls > .search-wrapper.small {
+  width: 240px;
+}
+
+.controls > .search-wrapper.big {
+  width: 714px;
+}
+
+.controls > .search-wrapper .icon {
+  left: 6px;
+  top: 6px;
+  z-index: 20;
+  width: auto;
+}
+
+.controls > .search-wrapper input {
+  background: #333941;
+  border: 1px solid #4D5967;
+  border-radius: 3px;
+  font-size: 13px;
+  font-weight: 300;
+  height: 28px;
+  padding-left: 25px;
+  position: absolute;
+  width: 100%;
+  z-index: 10;
+}

--- a/pontoon/static/js/widgets/search.js
+++ b/pontoon/static/js/widgets/search.js
@@ -1,0 +1,38 @@
+
+import React from 'react';
+
+import {Icon} from 'widgets/icons';
+
+import './search.css';
+
+
+export class SearchControls extends React.PureComponent {
+
+    constructor (props) {
+        super(props);
+        this.handleFilterChange = this.handleFilterChange.bind(this);
+    }
+
+    handleFilterChange (evt) {
+        if (this.props.handleFilterChange) {
+            return this.props.handleFilterChange(evt.target.value);
+        }
+    }
+
+    render () {
+        return (
+            <menu className="controls">
+              <div className="search-wrapper small clearfix">
+                <Icon name="search" />
+                <input
+                   onChange={this.handleFilterChange}
+                   className="table-filter"
+                   autoComplete="off"
+                   autoFocus="off"
+                   placeholder={this.props.placeholder}
+                   type="search"
+                   />
+              </div>
+            </menu>);
+    }
+}

--- a/pontoon/static/js/widgets/section.js
+++ b/pontoon/static/js/widgets/section.js
@@ -1,0 +1,19 @@
+
+import React from 'react';
+
+
+export class Section extends React.PureComponent {
+
+    get className () {
+        return this.props.className || 'wrapper';
+    }
+
+    render () {
+        return (
+            <section id={this.props.id}>
+              <div className={this.className}>
+                {this.props.children}
+              </div>
+            </section>);
+    }
+}

--- a/pontoon/static/js/widgets/stars.css
+++ b/pontoon/static/js/widgets/stars.css
@@ -1,0 +1,10 @@
+
+.stars .star {
+  color: #637283;
+  float: left;
+  width: inherit;
+}
+
+.stars .star.active {
+  color: #7BC876;
+}

--- a/pontoon/static/js/widgets/stars.js
+++ b/pontoon/static/js/widgets/stars.js
@@ -1,0 +1,46 @@
+
+import React from 'react';
+
+import './stars.css';
+
+import {Icon} from 'widgets/icons';
+
+
+export class Star extends React.PureComponent {
+
+    get className () {
+        const className = "star";
+        if (!this.props.className) {
+            return className;
+        }
+        return className + " " + this.props.className;
+    }
+
+    render () {
+        return (
+            <Icon
+               name="star"
+               className={this.className} />);
+    }
+}
+
+
+export class Stars extends React.PureComponent {
+
+    render () {
+        let stars = this.props.stars;
+        if (this.props.total && this.props.total > this.props.stars) {
+            stars = this.props.total;
+        }
+	return (
+            <span className="stars">
+              {Array(stars || 0).fill().map((_, k) => {
+                  let className = '';
+                  if (this.props.stars > k) {
+                      className = "active";
+                  }
+                  return <Star key={k} className={className} />;
+              })}
+            </span>);
+    }
+}

--- a/pontoon/static/js/widgets/title.js
+++ b/pontoon/static/js/widgets/title.js
@@ -1,0 +1,35 @@
+
+
+import React from 'react';
+
+
+export class Title extends React.PureComponent {
+
+    render () {
+        if (!this.props.title) {
+            return '';
+        }
+        return (
+            <h1 className={this.props.className}>
+              {this.renderTitle()}
+              {this.renderSubtitle()}
+            </h1>);
+    }
+
+    renderSubtitle () {
+        if (!this.props.subtitle) {
+            return '';
+        }
+        return (
+            <a href={this.props.href || "#"} className="small">
+              {this.props.subtitle}
+            </a>);
+    }
+
+    renderTitle () {
+        return (
+            <a href={this.props.href || "#"}>
+              {this.props.title}
+            </a>);
+    }
+}

--- a/tests/js/utils/components.js
+++ b/tests/js/utils/components.js
@@ -1,0 +1,23 @@
+
+
+import React from 'react';
+
+import {shallow} from 'enzyme';
+
+import {componentManager} from 'utils/components';
+
+
+test('componentManager component', () => {
+
+    class MockComponent extends React.PureComponent {
+
+        render () {
+            return <div>MOCKED</div>
+        }
+    }
+
+    const ManagedComponent = componentManager(MockComponent, {bar: 43, baz: 73});
+    const component = shallow(<ManagedComponent components={{foo: 7, bar: 23}} />);
+
+    expect(component.props().components).toEqual({"bar": 43, "baz": 73, "foo": 7})
+});

--- a/tests/js/utils/data.js
+++ b/tests/js/utils/data.js
@@ -1,0 +1,196 @@
+
+import React from 'react';
+
+import {shallow} from 'enzyme';
+
+import {ajax} from 'utils/ajax';
+
+import {DataManager, dataManager} from 'utils/data';
+
+
+test('DataManager constructor', () => {
+    const component = {state: {data: 'FOO', errors: 'BAR'}, props: {api: 'BAZ'}};
+    const manager = new DataManager(component);
+    expect(manager.component).toBe(component);
+    expect(manager.data).toBe('FOO');
+    expect(manager.errors).toBe('BAR');
+    expect(manager.api).toBe('BAZ');
+    expect(manager.requestMethod).toBe('get');
+    expect(manager.submitMethod).toBe('get');
+});
+
+
+test('DataManager requestMethod', () => {
+    // requestMethod can be overriden in props
+    const component = {props: {requestMethod: 23}};
+    const manager = new DataManager(component);
+    expect(manager.requestMethod).toBe(23);
+    expect(manager.submitMethod).toBe(23);
+});
+
+
+test('DataManager submitMethod', () => {
+    // submitMethod can be overriden in props
+    const component = {props: {submitMethod: 7}};
+    const manager = new DataManager(component);
+    expect(manager.requestMethod).toBe('get');
+    expect(manager.submitMethod).toBe(7);
+});
+
+
+test('DataManager refreshData', async () => {
+    // refreshData calls ajax and gives the child components a shakedown
+    // with the results. Its called in componentDidMount as well as in
+    // response to user actions.
+
+    const manager = new DataManager({props: {api: 43}});
+    manager.handleResponse = jest.fn(async () => 23);
+    ajax.get = jest.fn(async () => 37);
+    let result = await manager.refreshData({foo: 'BAR'});
+
+    // we get back the Promise of a handled Response.
+    expect(result).toBe(23);
+
+    // handleResponse was called with the awaited content from ajax.get
+    expect(manager.handleResponse.mock.calls).toEqual([[37]]);
+
+    // and ajax.get was called with the expected vars
+    expect(ajax.get.mock.calls).toEqual([[43, {"foo": "BAR"}]]);
+});
+
+
+test('DataManager refreshData initialData', async () => {
+    // refreshData calls ajax and gives the child components a shakedown
+    // with the results. Its called in componentDidMount as well as in
+    // response to user actions.
+
+    const setState = jest.fn()
+    const manager = new DataManager({props: {api: 43}, setState: setState}, 23);
+    await manager.refreshData({foo: 'BAR'});
+
+    // state is set to initialData
+    expect(setState.mock.calls).toEqual([[{data: 23, errors: []}]]);
+});
+
+
+
+test('DataManager handleSubmit', async () => {
+    // Tests what happens when user clicks handleSubmit
+
+    const manager = new DataManager({props: {api: 43}});
+    const response = {json: async () => '113'};
+    ajax.get = jest.fn(async () => response);
+
+    manager.handleResponse = jest.fn(async () => 23);
+
+    // ajax gets fired from componentDidMount, so lets clear it
+    ajax.get.mockClear();
+
+    let result = await manager.handleSubmit(7);
+
+    // we expect the async response from handleResponse to be returned
+    expect(result).toBe(23);
+
+    // handleResponse gets called with the Promise of some json from ajax
+    expect(manager.handleResponse.mock.calls).toEqual([[response]]);
+
+    // and ajax got called with all of the expected post data.
+    expect(ajax.get.mock.calls).toEqual([[43, 7]]);
+});
+
+
+test('DataManager handleResponse errors', async () => {
+    // Tests error handling in the ResourceManager widget
+
+    const component = {setState: jest.fn(async () => 23)};
+    const manager = new DataManager(component);
+
+    // trigger handleResponse with bad status
+    const response = {status: 500, json: jest.fn(async () => ({}))};
+    await manager.handleResponse(response);
+
+    // setState was called with our errors, which we didnt specify, but thats ok.
+    expect(manager.component.setState.mock.calls).toEqual([[{"errors": undefined}]]);
+
+    // lets see what happens when we specify errors.
+    response.json = jest.fn(async () => ({errors: {foo: 'bad', bar: 'stuff'}}));
+    await manager.handleResponse(response);
+
+    // but this time setState was called with the errors
+    expect(manager.component.setState.mock.calls[1]).toEqual(
+        [{"errors": {"bar": "stuff", "foo": "bad"}}]);
+});
+
+
+test('DataManager handleResponse', async () => {
+    // Tests what happens when the manager component receives a response
+    // from ajax requests.
+    // This can either be the result of a search operation or as a
+    // consequence of dis/associating resources to a tag.
+
+    const component = {setState: jest.fn(async () => 23)};
+    const manager = new DataManager(component);
+
+    const response = {status: 200, json: jest.fn(async () => ({}))};
+
+    // lets trigger an event with good status
+    await manager.handleResponse(response);
+
+    // we didnt specify any data, but thats OK, and we dont expect any errors
+    expect(manager.component.setState.mock.calls).toEqual(
+        [[{"data": undefined, "errors": {}}]]);
+
+    // lets handle a response with some actual data
+    response.json = jest.fn(async () => ({data: {foo: 'good', bar: 'stuff'}}));
+    await manager.handleResponse(response);
+
+    // and setState was called with some lovely data.
+    expect(manager.component.setState.mock.calls[1]).toEqual(
+        [{"data": {"bar": "stuff", "foo": "good"}, "errors": {}}]);
+});
+
+
+test('dataManager component', () => {
+
+    class MockManager extends DataManager {
+
+        get data () {
+            return 7;
+        }
+
+        get errors () {
+            return 23;
+        }
+
+        refreshData () {
+            return '';
+        }
+
+        handleSubmit () {
+            return '';
+        }
+    }
+
+    class MockComponent extends React.PureComponent {
+
+        render () {
+            return <div>MOCKED</div>
+        }
+    }
+
+    const ManagedComponent = dataManager(MockComponent, MockManager);
+    const component = shallow(<ManagedComponent api={43} foo={43} bar={73} />);
+    const manager = component.instance().manager;
+    expect(manager instanceof MockManager).toBe(true);
+    expect(manager.component).toBe(component.instance());
+
+    const wrapped = component.find(MockComponent);
+    expect(wrapped.length).toBe(1);
+    expect(wrapped.props().manager).toBe(manager);
+    expect(wrapped.props().refreshData).toBe(manager.refreshData);
+    expect(wrapped.props().handleSubmit).toBe(manager.handleSubmit);
+    expect(wrapped.props().data).toBe(7);
+    expect(wrapped.props().errors).toBe(23);
+    expect(wrapped.props().foo).toBe(43);
+    expect(wrapped.props().bar).toBe(73);
+});

--- a/tests/js/utils/stats.js
+++ b/tests/js/utils/stats.js
@@ -1,0 +1,94 @@
+
+import {AggregateStats, Stats} from 'utils/stats';
+
+
+test('Stats constructor', () => {
+    let stats = new Stats(
+        {approved_strings: 7,
+         fuzzy_strings: 11,
+         translated_strings: 13,
+         total_strings: 43});
+    expect(stats.fuzzyStrings).toBe(11);
+    expect(stats.missingStrings).toBe(12);
+    expect(stats.suggestedStrings).toBe(13);
+    expect(stats.totalStrings).toBe(43);
+    expect(stats.translatedStrings).toBe(7);
+
+    expect(stats.approvedPercent).toBe(16);
+    expect(stats.fuzzyShare).toBe(26);
+    expect(stats.missingShare).toBe(28);
+    expect(stats.suggestedShare).toBe(30);
+    expect(stats.translatedShare).toBe(16);
+})
+
+
+test('Stats constructor some zeros', () => {
+    let stats = new Stats(
+        {approved_strings: 0,
+         fuzzy_strings: 0,
+         translated_strings: 13,
+         total_strings: 43});
+    expect(stats.fuzzyStrings).toBe(0);
+    expect(stats.missingStrings).toBe(30);
+    expect(stats.suggestedStrings).toBe(13);
+    expect(stats.totalStrings).toBe(43);
+    expect(stats.translatedStrings).toBe(0);
+
+    expect(stats.approvedPercent).toBe(0);
+    expect(stats.fuzzyShare).toBe(0);
+    expect(stats.missingShare).toBe(70);
+    expect(stats.suggestedShare).toBe(30);
+    expect(stats.translatedShare).toBe(0);
+})
+
+
+test('Stats constructor defaults', () => {
+    let stats = new Stats()
+    expect(stats.fuzzyStrings).toBe(0);
+    expect(stats.missingStrings).toBe(0);
+    expect(stats.totalStrings).toBe(0);
+    expect(stats.suggestedStrings).toBe(0);
+    expect(stats.translatedStrings).toBe(0);
+
+    expect(stats.approvedPercent).toBe(0);
+    expect(stats.fuzzyShare).toBe(0);
+    expect(stats.missingShare).toBe(0);
+    expect(stats.suggestedShare).toBe(0);
+    expect(stats.translatedShare).toBe(0);
+})
+
+
+test('Stats approved', () => {
+    let stats = new Stats(
+        {approved_strings: 1337, fuzzy_strings: 723, total_strings: 5000});
+    expect(stats.approvedPercent).toBe(
+        parseInt(
+            Math.floor(
+                1337 / parseFloat(5000) * 100)))
+});
+
+
+test('Stats shares', () => {
+    let stats = new Stats(
+        {approved_strings: 1337, fuzzy_strings: 723, total_strings: 5000});
+    expect(stats.fuzzyShare).toBe(Math.round(723 / parseFloat(5000) * 100));
+});
+
+
+test('AggregateStats constructor', () => {
+    const data = [
+        {approved_strings: 7,
+         fuzzy_strings: 11,
+         translated_strings: 13,
+         total_strings: 43},
+        {approved_strings: 23,
+         fuzzy_strings: 17,
+         translated_strings: 19,
+         total_strings: 31}]
+    let stats = new AggregateStats(data);
+    expect(stats instanceof Stats).toBe(true);
+    expect(stats.fuzzyStrings).toBe(28);
+    expect(stats.suggestedStrings).toBe(32);
+    expect(stats.totalStrings).toBe(74);
+    expect(stats.translatedStrings).toBe(30);
+});

--- a/tests/js/widgets/charts.js
+++ b/tests/js/widgets/charts.js
@@ -1,0 +1,203 @@
+
+
+import React from 'react';
+
+import {mount, shallow} from 'enzyme';
+
+import {WheelChart} from 'widgets/charts';
+
+
+test('WheelChart render', () => {
+    const drawChart = jest.fn();
+    const drawing = {lineWidth: 17};
+    const canvas = {getContext: jest.fn(() => drawing), width: 23, height: 113};
+
+    class MockWheelChart extends WheelChart {
+
+        drawChart () {
+            drawChart.apply(this, arguments);
+        }
+
+        get canvas () {
+            return canvas;
+        }
+
+        renderCanvas () {
+            return 'CANVAS';
+        }
+
+        renderPercentage () {
+            return 'PERCENTAGE';
+        }
+    }
+
+    let chart = shallow(<MockWheelChart />);
+    expect(chart.text()).toBe('CANVASPERCENTAGE');
+    expect(drawChart.mock.calls).toEqual([[]]);
+    expect(chart.find('div.wheel-chart').length).toBe(1)
+    expect(chart.instance().canvasClassName).toBe('drawing');
+    expect(chart.instance().className).toBe('wheel-chart');
+    expect(chart.instance().height).toBe('130px');
+    expect(chart.instance().width).toBe('130px');
+    expect(chart.instance().percentageClassName).toBe(
+        'number react-number noselect');
+    expect(chart.instance().radius).toBe((canvas.width - drawing.lineWidth) / 2);
+    expect(chart.instance().x).toBe(canvas.width / 2);
+    expect(chart.instance().y).toBe(canvas.height / 2);
+
+    drawChart.mockClear();
+    chart.instance().componentDidUpdate();
+    expect(drawChart.mock.calls).toEqual([[]]);
+});
+
+
+test('WheelChart renderPercentage', () => {
+
+    class MockWheelChart extends WheelChart {
+
+        drawChart () {
+            return;
+        }
+    }
+
+    let chart = shallow(
+        <MockWheelChart
+           percentage={23}
+           percentageClassName="foo"
+           />);
+    let percentage = chart.find('span.foo');
+    expect(percentage.length).toBe(1);
+    expect(percentage.props().children).toBe(23);
+});
+
+
+test('WheelChart renderCanvas', () => {
+
+    class MockWheelChart extends WheelChart {
+
+        drawChart () {
+            return;
+        }
+    }
+
+    let chart = mount(
+        <MockWheelChart
+           height={73}
+           width={113}
+           canvasClassName="bar"
+           />);
+    let canvas = chart.find('canvas.bar');
+    expect(canvas.length).toBe(1);
+    expect(canvas.props().height).toBe(73);
+    expect(canvas.props().width).toBe(113);
+    expect(chart.instance().canvas).toBe(canvas.instance());
+});
+
+
+test('WheelChart props', () => {
+    const drawChart = jest.fn();
+    const drawing = {lineWidth: 17};
+    const canvas = {getContext: jest.fn(() => drawing), width: 23, height: 113};
+
+    class MockWheelChart extends WheelChart {
+
+        drawChart () {
+            drawChart.apply(this, arguments);
+        }
+
+        get canvas () {
+            return canvas;
+        }
+    }
+
+    let chart = shallow(
+        <MockWheelChart
+           canvasClassName={7}
+           className={13}
+           height={17}
+           width={23}
+           />);
+    expect(chart.instance().canvasClassName).toBe(7);
+    expect(chart.instance().className).toBe(13);
+    expect(chart.instance().height).toBe(17);
+    expect(chart.instance().width).toBe(23);
+
+});
+
+
+test('WheelChart fillChart', () => {
+    const drawing = {lineWidth: 11, beginPath: jest.fn(), arc: jest.fn(), stroke: jest.fn()};
+    const drawChart = jest.fn();
+    const canvas = {getContext: jest.fn(() => drawing), width: 23, height: 113};
+
+    class MockWheelChart extends WheelChart {
+
+        drawChart () {
+            drawChart.apply(this, arguments);
+        }
+
+        get canvas () {
+            return canvas;
+        }
+
+        get drawing () {
+            return drawing;
+        }
+    }
+
+    let chart = shallow(<MockWheelChart />);
+    chart.instance().fillChart(23, 113, 'purple');
+
+    expect(drawing.beginPath.mock.calls).toEqual([[]]);
+    expect(drawing.arc.mock.calls).toEqual([
+        [chart.instance().x,
+         chart.instance().y,
+         chart.instance().radius,
+         23 * Math.PI,
+         113 * Math.PI]]);
+    expect(drawing.strokeStyle).toBe('purple');
+    expect(drawing.stroke.mock.calls).toEqual([[]]);
+});
+
+
+test('WheelChart drawChart', () => {
+    const canvas = {width: 17, height: 43};
+    const drawing = {clearRect: jest.fn(), arc: jest.fn(), stroke: jest.fn()};
+    const fillChart = jest.fn();
+
+    class MockWheelChart extends WheelChart {
+
+        get canvas () {
+            return canvas;
+        }
+
+        get drawing () {
+            return drawing;
+        }
+
+        componentDidMount () {
+            return;
+        }
+
+        fillChart (start, end, color) {
+            fillChart(start, end, color);
+        }
+    }
+    const data = [
+        {value: 1, color: 'foo'},
+        {value: undefined},
+        {value: 2, color: 'bar'},
+        {value: 3, color: 'baz'}];
+    let chart = shallow(
+        <MockWheelChart
+           data={data}
+           total={113} />);
+    chart.instance().drawChart();
+
+    expect(drawing.clearRect.mock.calls).toEqual([[0, 0, 17, 43]]);
+    expect(drawing.lineWidth).toBe(3);
+    expect(fillChart.mock.calls).toEqual(
+        [[-0.5, -0.4823008849557522, "foo"],
+         [-0.4823008849557522, -0.4469026548672566, "bar"],
+         [-0.4469026548672566, -0.3938053097345132, "baz"]]);
+});

--- a/tests/js/widgets/columns.js
+++ b/tests/js/widgets/columns.js
@@ -7,15 +7,8 @@ import {Columns, Container, Column} from 'widgets/columns';
 
 
 test('Columns render', () => {
-
-    class MockColumns extends Columns {
-
-        get columns () {
-            return [['a', 2], ['b', 3], ['c', 7]];
-        }
-    }
-
-    const columns = shallow(<MockColumns />);
+    const columndescriptors = [['a', 2], ['b', 3], ['c', 7]];
+    const columns = shallow(<Columns columns={columndescriptors} />);
     const container = columns.find(Container);
     expect(container.length).toBe(1);
     expect(container.props().columns).toBe(3);
@@ -59,9 +52,9 @@ test('Container render', () => {
     expect(container.text()).toBe('');
     div = container.find('div');
     expect(container.instance().columnStyles).toEqual(
-        [{"boxSizing": "border-box", "float": "left", "overflow": "hidden", "width": "33.333333333333336%"},
-         {"boxSizing": "border-box", "float": "left", "overflow": "hidden", "width": "33.333333333333336%"},
-         {"boxSizing": "border-box", "float": "left", "overflow": "hidden", "width": "33.333333333333336%"}]);
+        [{"boxSizing": "border-box", "float": "left", "width": "33.333333333333336%"},
+         {"boxSizing": "border-box", "float": "left", "width": "33.333333333333336%"},
+         {"boxSizing": "border-box", "float": "left", "width": "33.333333333333336%"}]);
     expect(div.props().children).toEqual([]);
     expect(div.props().style).toEqual(
         {"content": "", "display": "table", "width": "100%"});
@@ -69,9 +62,9 @@ test('Container render', () => {
     container = shallow(<Container columns={3} ratios={[2, 3, 7]} />);
     expect(container.text()).toBe('');
     expect(container.instance().columnStyles).toEqual(
-        [{"boxSizing": "border-box", "float": "left", "overflow": "hidden", "width": "16.666666666666664%"},
-         {"boxSizing": "border-box", "float": "left", "overflow": "hidden", "width": "25%"},
-         {"boxSizing": "border-box", "float": "left", "overflow": "hidden", "width": "58.333333333333336%"}]);
+        [{"boxSizing": "border-box", "float": "left", "width": "16.666666666666664%"},
+         {"boxSizing": "border-box", "float": "left", "width": "25%"},
+         {"boxSizing": "border-box", "float": "left", "width": "58.333333333333336%"}]);
 });
 
 

--- a/tests/js/widgets/deadline.js
+++ b/tests/js/widgets/deadline.js
@@ -1,0 +1,37 @@
+
+import React from 'react';
+
+import {shallow} from 'enzyme';
+
+import {Deadline} from 'widgets/deadline';
+import Datetime from 'utils/datetime';
+
+jest.mock('utils/datetime');
+
+
+test('Deadline render', () => {
+
+    let deadline = shallow(<Deadline />);
+    expect(deadline.text()).toBe("No deadline set");
+
+    deadline = shallow(<Deadline deadline={0} />);
+    expect(deadline.text()).toBe("No deadline set");
+
+    Datetime.mockImplementation(() => ({date: 'DATETIME'}))
+
+    deadline = shallow(<Deadline deadline={23} />);
+    expect(deadline.text()).toBe("DATETIME");
+
+    expect(Datetime.mock.calls).toEqual([[23]])
+    let time = deadline.find('time');
+    expect(time.length).toBe(1)
+    expect(time.props().className).toBe('overdue');
+    expect(time.props().dateTime).toBe(23);
+
+    const future = new Date();
+    future.setDate(future.getDate() + 1);
+    deadline = shallow(<Deadline deadline={future} />);
+    time = deadline.find('time');
+    expect(time.props().dateTime).toBe(future);
+    expect(time.props().className).toBe('');
+});

--- a/tests/js/widgets/forms.js
+++ b/tests/js/widgets/forms.js
@@ -1,0 +1,93 @@
+
+
+import React from 'react';
+
+import {mount, shallow} from 'enzyme';
+
+import {PontoonCSRF} from 'utils/csrf';
+import {Form, CSRFToken, SignoutForm} from 'widgets/forms';
+
+jest.mock('utils/csrf');
+
+
+test('Form render', () => {
+    let form = shallow(<Form />);
+    expect(form.props()).toEqual(
+        {action: '',
+         children: [<CSRFToken />, undefined],
+         method: "POST"});
+    form = shallow(
+        <Form
+           action="/somewhere/else"
+           foo={7}
+           bar={23}>
+          BAZ
+        </Form>);
+    expect(form.props()).toEqual(
+        {action: '/somewhere/else',
+         foo: 7,
+         bar: 23,
+         children: [<CSRFToken />, 'BAZ'],
+         method: "POST"});
+});
+
+
+test('Form mount', () => {
+    class MockForm extends Form {
+
+        renderCSRF () {
+            return 'CSRF';
+        }
+    }
+
+    let form = mount(<MockForm />);
+    expect(form.find('form').getElement().ref).toBe(
+        form.instance().handleFormLoad);
+});
+
+
+test('Form handleFormLoad', () => {
+
+    let form = shallow(<Form />);
+    form.instance().handleFormLoad();
+
+    const handleFormLoad = jest.fn();
+    form = shallow(<Form handleFormLoad={handleFormLoad} />);
+
+    form.instance().handleFormLoad(23);
+    expect(handleFormLoad.mock.calls).toEqual([[23]]);
+});
+
+
+test('SignoutForm render', () => {
+    let form = shallow(<SignoutForm />);
+    expect(form.text()).toEqual('<Form />');
+    expect(form.props()).toEqual(
+        {action: "/accounts/logout/?next=/at/all",
+         className: "csrf",
+         style: {"display": "none"}});
+    form = shallow(
+        <SignoutForm
+           foo={7}
+           action="/nowhere"
+           className="other"
+           />);
+    expect(form.props()).toEqual(
+        {action: "/nowhere",
+         className: "other",
+         foo: 7,
+         style: {"display": "none"}});
+});
+
+
+test('CSRFToken render', () => {
+    PontoonCSRF.mockImplementation(() => 23);
+
+    let token = shallow(<CSRFToken />);
+    expect(token.text()).toEqual('');
+    let input = token.find('input');
+    expect(input.props()).toEqual(
+        {name: "csrfmiddlewaretoken",
+         type: "hidden",
+         value: undefined});
+});

--- a/tests/js/widgets/icons.js
+++ b/tests/js/widgets/icons.js
@@ -1,0 +1,44 @@
+
+import React from 'react';
+
+import {shallow} from 'enzyme';
+
+import {Icon, IconLink} from 'widgets/icons';
+
+
+test('Icon render', () => {
+    let icon = shallow(<Icon />);
+    expect(icon.text()).toBe('');
+    let i = icon.find('i');
+    expect(i.length).toBe(0);
+    icon = shallow(<Icon name="foo" />);
+    expect(icon.text()).toBe('');
+    i = icon.find('i');
+    expect(i.length).toBe(1);
+    expect(i.props().className).toBe("icon fa fa-foo fa-fw");
+    icon = shallow(<Icon name="foo" className="something else" />);
+    expect(icon.text()).toBe('');
+    i = icon.find('i');
+    expect(i.length).toBe(1);
+    expect(i.props().className).toBe("icon fa fa-foo fa-fw something else");
+});
+
+
+test('IconLink render', () => {
+    let iconlink = shallow(<IconLink />);
+    expect(iconlink.text()).toBe('');
+    iconlink = shallow(
+        <IconLink
+           icon='bar'
+           href='/nowhere'
+           baz={23}>
+          ICONTEXT
+        </IconLink>);
+    expect(iconlink.text()).toBe('<Icon />ICONTEXT');
+    const anchor = iconlink.find('a');
+    expect(anchor.props()).toEqual(
+        {"baz": 23,
+         "children": [<Icon name="bar" />,
+                      "ICONTEXT"],
+         "href": "/nowhere"});
+});

--- a/tests/js/widgets/images.js
+++ b/tests/js/widgets/images.js
@@ -1,0 +1,166 @@
+
+import React from 'react';
+
+import {shallow} from 'enzyme';
+
+import {Avatar, AvatarLink, Image, ImageLink, Logo} from 'widgets/images';
+
+
+test('Image render', () => {
+    let image = shallow(<Image />);
+    expect(image.text()).toBe('');
+    let img = image.find('img');
+    expect(img.length).toBe(0);
+
+    image = shallow(
+        <Image
+           width={23}
+           height={43}
+           className='foo'
+           src="/some/image.svg" />);
+    expect(image.text()).toBe('');
+    img = image.find('img');
+    expect(img.length).toBe(1);
+    expect(img.props().src).toBe('/some/image.svg');
+    expect(img.props().height).toBe(43);
+    expect(img.props().width).toBe(23);
+    expect(img.props().className).toBe('foo');
+});
+
+
+test('ImageLink render', () => {
+    let imagelink = shallow(<ImageLink />);
+    expect(imagelink.text()).toBe('');
+
+    // no src - nothing is rendered
+    expect(imagelink.find('a').length).toBe(0);
+
+    // set the src
+    imagelink = shallow(<ImageLink src="/some/image.svg" />);
+
+    // anchor tag is there but nothing set
+    let anchor = imagelink.find('a');
+    expect(anchor.length).toBe(1);
+    expect(anchor.props().className).toBe(undefined);
+    expect(anchor.props().href).toBe(undefined);
+
+    let image = anchor.find(Image);
+    expect(image.length).toBe(1);
+    expect(image.props().src).toBe("/some/image.svg");
+
+    imagelink = shallow(
+        <ImageLink
+           src="/some/image.svg"
+           href="/nowhere"
+           className="some-special-image"
+           width={23}
+           height={43}
+           />);
+
+    anchor = imagelink.find('a');
+    expect(anchor.length).toBe(1);
+    expect(anchor.props().className).toBe('some-special-image');
+    expect(anchor.props().href).toBe('/nowhere');
+
+    image = anchor.find(Image);
+    expect(image.length).toBe(1);
+    expect(image.props().src).toBe("/some/image.svg");
+    expect(image.props().width).toBe(23);
+    expect(image.props().height).toBe(43);
+});
+
+
+test('Logo render', () => {
+    let logo = shallow(<Logo />);
+    expect(logo.text()).toBe('<ImageLink />');
+    let image = logo.find(ImageLink);
+    expect(image.props().className).toBe('logo');
+    expect(image.props().src).toBe(undefined);
+    expect(image.props().href).toBe(undefined);
+    expect(image.props().height).toBe(32);
+    expect(image.props().width).toBe(32);
+
+    logo = shallow(
+        <Logo
+           className="special-logo"
+           src="/some/image.svg"
+           href="/nowhere"
+           height={17}
+           width={113}
+           />);
+    image = logo.find(ImageLink);
+    expect(image.props().className).toBe('special-logo');
+    expect(image.props().src).toBe('/some/image.svg');
+    expect(image.props().href).toBe('/nowhere');
+    expect(image.props().height).toBe(17);
+    expect(image.props().width).toBe(113);
+});
+
+
+test('Avatar render', () => {
+    let avatar = shallow(<Avatar />);
+    expect(avatar.text()).toBe('');
+    let image = avatar.find('Image');
+    expect(image.length).toBe(0);
+
+    avatar = shallow(<Avatar src="/some/avatatar.png?s=" />);
+    expect(avatar.text()).toBe('<Image />');
+    image = avatar.find('Image');
+    expect(image.length).toBe(1);
+    expect(image.props().src).toBe("/some/avatatar.png?s=88");
+
+    avatar = shallow(
+        <Avatar
+           foo={23}
+           bar={43}
+           size={13}
+           className="another"
+           src="/another/avatatar.png?s=" />);
+    expect(avatar.text()).toBe('<Image />');
+    image = avatar.find('Image');
+    expect(image.length).toBe(1);
+    expect(image.props().src).toBe("/another/avatatar.png?s=13");
+    expect(image.props().className).toBe("another");
+    expect(image.props().foo).toBe(23);
+    expect(image.props().bar).toBe(43);
+});
+
+
+test('AvatarLink render', () => {
+    let avatarlink = shallow(<AvatarLink />);
+    expect(avatarlink.text()).toBe('');
+
+    avatarlink = shallow(<AvatarLink src="/some/avatar.png" />);
+    expect(avatarlink.text()).toBe('<ImageLink />');
+    let imagelink = avatarlink.find(ImageLink);
+    expect(imagelink.props()).toEqual(
+        {children: undefined,
+         className: "avatar",
+         components: {image: Avatar},
+         imageProps: {
+             className: "rounded",
+             height: undefined,
+             width: undefined},
+         src: "/some/avatar.png"});
+
+
+    avatarlink = shallow(
+        <AvatarLink
+           components={{image: 7, foo: 23}}
+           imageProps={{baz: 17, className: 'other'}}
+           src="/some/avatar.png">
+          AVATARTEXT
+        </AvatarLink>);
+    expect(avatarlink.text()).toBe('<ImageLink />');
+    imagelink = avatarlink.find(ImageLink);
+    expect(imagelink.props()).toEqual(
+        {children: "AVATARTEXT",
+         className: "avatar",
+         components: {image: 7, foo: 23},
+         imageProps: {
+             baz: 17,
+             className: "other",
+             height: undefined,
+             width: undefined},
+         src: "/some/avatar.png"});
+});

--- a/tests/js/widgets/lists.js
+++ b/tests/js/widgets/lists.js
@@ -1,0 +1,223 @@
+
+import React from 'react';
+
+import {shallow} from 'enzyme';
+
+import {InfoList, InfoListItem} from 'widgets/lists/info';
+import {List, ListItem} from 'widgets/lists/generic';
+import {LinkList, LinkListItem} from 'widgets/lists/links';
+import {Tab, TabCount, TabList} from 'widgets/lists/tabs';
+
+
+test('List render', () => {
+    let list = shallow(<List />);
+    expect(list.text()).toBe('');
+
+    // children are taken from either label or value
+    // props are passed from this.props and the items attrs
+    const items = [
+        {value: 1, foo: 13, bar: 23},
+        {label: 2},
+        {label: 3}];
+    list = shallow(
+        <List
+           bar={17}
+           baz={113}
+           items={items} />);
+    expect(list.text()).toBe("<ListItem /><ListItem /><ListItem />");
+    let listitem = list.find(ListItem).first();
+    expect(listitem.props().children).toBe(1);
+    expect(listitem.props().components).toEqual({});
+    expect(listitem.props().foo).toBe(13);
+    expect(listitem.props().bar).toBe(23);
+    expect(listitem.props().baz).toBe(113);
+
+    listitem = list.find(ListItem).last();
+    expect(listitem.props().children).toBe(3);
+    expect(listitem.props().components).toEqual({});
+});
+
+
+test('List render components', () => {
+    let list = shallow(<List />);
+    expect(list.text()).toBe('');
+    const items = [
+        {value: 1, foo: 13, bar: 23},
+        {label: 2},
+        {label: 3}];
+    list = shallow(
+        <List
+           components={{comp1: 23, comp2: 43}}
+           items={items} />);
+    expect(list.text()).toBe("<ListItem /><ListItem /><ListItem />");
+    let listitem = list.find(ListItem).first();
+    expect(listitem.props().components).toEqual({"comp1": 23, "comp2": 43});
+    listitem = list.find(ListItem).last();
+    expect(listitem.props().components).toEqual({"comp1": 23, "comp2": 43});
+});
+
+
+test('ListItem render', () => {
+    let item = shallow(
+        <ListItem>
+          <big>ITEM</big>
+        </ListItem>);
+    expect(item.props().children).toEqual(<big>ITEM</big>);
+    expect(item.text()).toBe('ITEM');
+    let li = item.find('li');
+    expect(li.props().className).toBe(undefined);
+    item = shallow(
+        <ListItem className="FOO">
+          <big>ITEM</big>
+        </ListItem>);
+    li = item.find('li');
+    expect(li.props().className).toBe('FOO');
+});
+
+
+test('LinkListItem render', () => {
+    const item = shallow(
+        <LinkListItem
+           href={23}>
+          ITEM
+        </LinkListItem>);
+    expect(item.text()).toBe('<ListItem />');
+    const listitem = item.find(ListItem);
+    expect(listitem.props().className).toBe('link');
+    expect(listitem.props().children).toEqual(<a href={23}>ITEM</a>);
+});
+
+
+test('LinkList render', () => {
+    const linklist = shallow(
+        <LinkList />);
+    expect(linklist.text()).toBe('<List />');
+    expect(linklist.instance().components.item).toBe(LinkListItem);
+    const list = linklist.find(List);
+    expect(list.props().className).toBe('links');
+});
+
+
+test('LinkList components', () => {
+    const components = {item: 23};
+    const list = shallow(
+        <LinkList components={components} />);
+    expect(list.instance().components.item).toBe(23);
+});
+
+
+test('LinkList items', () => {
+    const links = [{href: 'FOO', label: 7}, {href: 'BAR', label: 23}];
+    const linklist = shallow(<LinkList links={links} />);
+    const list = linklist.find(List);
+    expect(list.props().items).toEqual(links);
+});
+
+
+test('TabList render', () => {
+    let tabs = shallow(<TabList />);
+    expect(tabs.text()).toBe('');
+
+    const tabdescriptors = [
+        {label: 7, href: 'FOO', count: 43},
+        {label: 13, active: true, href: 'BAR', count: 73},
+        {label: 23, href: 'BAZ', count: 113}];
+    tabs = shallow(<TabList tabs={tabdescriptors} />);
+    expect(tabs.text()).toBe("<LinkList />");
+
+    const list = tabs.find(LinkList);
+    expect(list.length).toBe(1);
+    expect(list.props().links).toBe(tabdescriptors);
+    expect(list.props().components.item).toBe(Tab);
+    expect(list.props().components.count).toBe(TabCount);
+});
+
+
+test('Tab render', () => {
+
+    class MockCount extends React.Component {
+
+        render () {
+            return 'COUNT!';
+        }
+    }
+
+    let tab = shallow(
+        <Tab components={{count: MockCount}}
+             href="FOO"
+             count={23}>
+          BAR
+        </Tab>);
+    expect(tab.text()).toBe("<LinkListItem />");
+    let item = tab.find(LinkListItem);
+    expect(item.length).toBe(1);
+    expect(item.props().className).toBe('tab link');
+    expect(item.props().href).toBe('FOO');
+    expect(item.props().children).toEqual(
+        ["BAR", <MockCount count={23} />]);
+
+    tab = shallow(
+        <Tab components={{count: MockCount}}
+             href="FOO"
+             label="BAR"
+             active={true}
+             count={23} />);
+    item = tab.find(LinkListItem);
+    expect(item.props().className).toBe('active tab link');
+});
+
+
+test('TabCount render', () => {
+    let count = shallow(<TabCount />);
+    expect(count.text()).toBe('');
+    count = shallow(
+        <TabCount count={23} />);
+    expect(count.text()).toBe('23');
+    let span = count.find('span');
+    expect(span.length).toBe(1);
+    expect(span.props().className).toBe('count');
+    expect(span.props().children).toBe(23);
+});
+
+
+
+test('InfoList render', () => {
+    let infolist = shallow(<InfoList />);
+    expect(infolist.text()).toBe('');
+
+    infolist = shallow(<InfoList items={{foo: 7, bar: 23}} />);
+    expect(infolist.text()).toBe('<List />');
+
+    let list = infolist.find(List);
+    expect(list.props()).toEqual(
+        {className: 'details',
+         components: {item: InfoListItem},
+         items: [['foo', 7], ['bar', 23]]});
+
+    infolist = shallow(
+        <InfoList
+           className="something-else"
+           components={{item: 13, baz: 17}}
+           items={{foo: 7, bar: 23}} />);
+    list = infolist.find(List);
+    expect(list.props()).toEqual(
+        {className: 'something-else',
+         components: {
+             baz: 17,
+             item: 13},
+         items: [['foo', 7], ['bar', 23]]});
+});
+
+
+test('InfoListItem render', () => {
+    const props = ['foo bAr', 'baz'];
+    let listitem = shallow(<InfoListItem {...props} />);
+    expect(listitem.text()).toBe('<ListItem />');
+    let item = listitem.find(ListItem);
+    const children = [
+            <span className="title">foo bAr</span>,
+            <span className="value overflow">baz</span>];
+    expect(item.props()).toEqual(
+            {children: children,
+             className: "foo-bar"});
+});

--- a/tests/js/widgets/menus.js
+++ b/tests/js/widgets/menus.js
@@ -1,0 +1,240 @@
+
+import React from 'react';
+
+import {mount, shallow} from 'enzyme';
+
+import {List, ListItem} from 'widgets/lists/generic';
+import {Menu, MenuItem} from 'widgets/menus/generic';
+import {DropdownMenu, DropdownMenuButton, DropdownMenuItem} from 'widgets/menus/dropdown';
+
+
+test('Menu render', () => {
+    let menu = shallow(<Menu items={[1, 2, 3]} />);
+    expect(menu.text()).toBe('<List />');
+    expect(menu.props()).toEqual(
+        {className: "menu",
+         components: {item: MenuItem},
+         items: [{value: 1}, {value: 2}, {value: 3}]});
+
+    menu = shallow(
+        <Menu
+           className="bar"
+           components={{foo: 7, item: 23}}
+           items={[4, 5, 6]} />);
+    expect(menu.text()).toBe('<List />');
+    expect(menu.props()).toEqual(
+        {className: "bar",
+         components: {item: 23, foo: 7},
+         items: [{value: 4}, {value: 5}, {value: 6}]});
+});
+
+
+test('MenuItem render', () => {
+    let item = shallow(<MenuItem />);
+    expect(item.text()).toBe('<ListItem />');
+    let listitem = item.find(ListItem);
+    expect(listitem.props()).toEqual(
+        {"children": undefined, "className": "menu-item"});
+
+    item = shallow(<MenuItem className={23}>ITEM</MenuItem>);
+    expect(item.text()).toBe('<ListItem />');
+    listitem = item.find(ListItem);
+    expect(listitem.props()).toEqual(
+        {"children": "ITEM", "className": 23});
+});
+
+
+test('DropdownMenu render', () => {
+    document.addEventListener = jest.fn();
+    let menu = shallow(<DropdownMenu items={[1, 2, 3]} />);
+    expect(menu.text()).toBe('<List />');
+    const list = menu.find(List);
+    expect(list.props().items).toEqual(
+        [{"value": 1}, {"value": 2}, {"value": 3}]);
+    expect(list.props().components).toEqual({"item": DropdownMenuItem});
+    expect(list.props().className).toBe('menu dropdown');
+    expect(document.addEventListener.mock.calls).toEqual(
+        [["mousedown", menu.instance().handleClickOutside]]);
+});
+
+
+test('DropdownMenu componentWillUnmount', () => {
+    document.removeEventListener = jest.fn();
+    let menu = shallow(<DropdownMenu items={[1, 2, 3]} />);
+    menu.instance().componentWillUnmount();
+    expect(document.removeEventListener.mock.calls).toEqual(
+        [["mousedown", menu.instance().handleClickOutside]]);
+});
+
+
+test('DropdownMenu handleClickOutside', () => {
+    const handleClose = jest.fn();
+    let menu = shallow(<DropdownMenu handleClose={handleClose} items={[1, 2, 3]} />);
+    menu.instance().node = {contains: jest.fn(() => true)};
+    menu.instance().handleClickOutside({target: 23});
+    expect(handleClose.mock.calls).toEqual([]);
+
+    menu.instance().node = {contains: jest.fn(() => false)};
+    menu.instance().handleClickOutside({target: 23});
+    expect(handleClose.mock.calls).toEqual([[{"target": 23}]]);
+});
+
+
+test('DropdownMenu components', () => {
+    let menu = shallow(<DropdownMenu components={{item: 7, other: 23}} items={[1, 2, 3]} />);
+    const list = menu.find(List);
+    expect(list.props().components).toEqual({"item": 7, "other": 23});
+});
+
+
+test('DropdownMenu ref', () => {
+    let menu = mount(<DropdownMenu items={[1, 2, 3]} />);
+    const node = menu.find('div').first();
+    expect(menu.instance().node).toBe(node.instance());
+});
+
+
+test('DropdownMenuItem render', () => {
+    let item = shallow(<DropdownMenuItem />);
+    expect(item.text()).toBe('<ListItem />');
+    expect(item.props().className).toBe("menu-item horizontal-separator");
+
+    item = shallow(<DropdownMenuItem>FOO</DropdownMenuItem>);
+    expect(item.text()).toBe('<ListItem />');
+    expect(item.props().className).toBe("menu-item");
+    expect(item.props().children).toBe("FOO");
+});
+
+
+test('DropdownMenuButton render', () => {
+
+    class MockButton extends React.PureComponent {
+        render () {
+            return 'BUTTON';
+        }
+    }
+
+    const components = {button: MockButton}
+    const button = shallow(
+        <DropdownMenuButton
+           foo={7}
+           bar={23}
+           components={components} />);
+    expect(button.text()).toBe('<MockButton />');
+    expect(button.state().open).toBe(false);
+    const wrapper = button.find('div.button.selector');
+    expect(wrapper.length).toBe(1);
+    expect(wrapper.props().onClick).toBe(button.instance().handleClick);
+
+    const buttonContent = wrapper.find(MockButton);
+    expect(buttonContent.length).toBe(1);
+    expect(buttonContent.props().foo).toBe(7);
+    expect(buttonContent.props().bar).toBe(23);
+
+});
+
+
+test('DropdownMenuButton mount', () => {
+
+    class MockButton extends React.PureComponent {
+        render () {
+            return 'BUTTON';
+        }
+    }
+
+    class MockMenu extends React.PureComponent {
+        render () {
+            return 'MENU';
+        }
+    }
+
+    const components = {
+        button: MockButton,
+        menu: MockMenu};
+    const button = mount(
+        <DropdownMenuButton
+           foo={7}
+           bar={23}
+           components={components} />);
+    expect(button.text()).toBe('BUTTON');
+    button.setState({open: true})
+    expect(button.text()).toBe('BUTTONMENU');
+
+    const wrapper = button.find('div.button.selector');
+    expect(button.instance().buttonNode).toBe(wrapper.instance());
+
+    const menuContent = button.find(MockMenu);
+    expect(menuContent.length).toBe(1)
+    expect(menuContent.props().handleClose).toBe(button.instance().handleClose);
+    expect(menuContent.props().foo).toBe(7)
+    expect(menuContent.props().bar).toBe(23)
+});
+
+
+
+test('DropdownMenuButton handleClick', () => {
+
+    class MockButton extends React.PureComponent {
+        render () {
+            return 'BUTTON';
+        }
+    }
+
+    class MockMenu extends React.PureComponent {
+        render () {
+            return 'MENU';
+        }
+    }
+
+    const components = {
+        button: MockButton,
+        menu: MockMenu};
+    const button = shallow(
+        <DropdownMenuButton
+           foo={7}
+           bar={23}
+           components={components} />);
+    expect(button.state().open).toBe(false)
+    button.instance().handleClick()
+    expect(button.state().open).toBe(true)
+    button.instance().handleClick()
+    expect(button.state().open).toBe(false)
+})
+
+
+test('DropdownMenuButton handleClose', () => {
+
+    class MockButton extends React.PureComponent {
+        render () {
+            return 'BUTTON';
+        }
+    }
+
+    class MockMenu extends React.PureComponent {
+        render () {
+            return 'MENU';
+        }
+    }
+
+    const components = {
+        button: MockButton,
+        menu: MockMenu};
+    const button = shallow(
+        <DropdownMenuButton
+           foo={7}
+           bar={23}
+           components={components} />);
+
+    button.instance().handleClick()
+    button.setState({open: true});
+    const buttonNode = {contains: jest.fn(() => true)};
+    button.instance().buttonNode = buttonNode;
+    button.instance().handleClose({target: 7});
+    expect(buttonNode.contains.mock.calls).toEqual([[7]])
+    expect(button.state().open).toBe(true);
+
+    buttonNode.contains = jest.fn(() => false);
+    button.instance().handleClose({target: 23});
+    expect(buttonNode.contains.mock.calls).toEqual([[23]])
+    expect(button.state().open).toBe(false);
+})

--- a/tests/js/widgets/progress.js
+++ b/tests/js/widgets/progress.js
@@ -1,0 +1,125 @@
+
+import React from 'react';
+
+import {shallow} from 'enzyme';
+
+import Humanize from 'humanize-plus';
+
+import {List, ListItem} from 'widgets/lists/generic';
+
+import {ProgressChart} from 'widgets/charts';
+import {
+    ProgressChartData, ProgressChartDataItem,
+    ProgressChartLegend, ProgressChartLegendItem} from 'widgets/charts/progress';
+
+
+test('ProgressChart render', () => {
+    const data = {stats: 7, percentages: 23};
+    const progress = shallow(<ProgressChart {...data} />);
+    expect(progress.text()).toBe(
+        "<ProgressChartData /><ProgressChartLegend />");
+    let chart = progress.find(ProgressChartData);
+    expect(chart.props()).toEqual({data: 23});
+
+    let legend = progress.find(ProgressChartLegend);
+    expect(legend.props()).toEqual({items: 7});
+});
+
+
+test('ProgressChartData render', () => {
+
+    class MockProgressChartData extends ProgressChartData {
+
+        renderTotal () {
+            return 7;
+        }
+
+        renderChart () {
+            return 23;
+        }
+    }
+    const chart = shallow(<MockProgressChartData />);
+    expect(chart.text()).toBe('723');
+});
+
+
+test('ProgressChartData renderTotal', () => {
+    const stats = {total: 23};
+    const chart = shallow(<ProgressChartData data={stats} />);
+    expect(shallow(chart.instance().renderTotal()).text()).toEqual('23%');
+});
+
+
+test('ProgressChartData components', () => {
+    const stats = {translated: 23, fuzzy: 13, suggested: 23, missing: 73, total: 43};
+    const chart = shallow(<ProgressChartData data={stats} />);
+    expect(chart.text()).toBe("43%<ProgressChartDataItem /><ProgressChartDataItem /><ProgressChartDataItem /><ProgressChartDataItem />");
+    const items = chart.find(ProgressChartDataItem);
+    items.forEach((item, i) => {
+        const [k, v] = Object.entries(stats)[i];
+        expect(item.props()).toEqual({className: k, data: v});
+    });
+});
+
+
+test('ProgressChartLegend render', () => {
+    let chart = shallow(<ProgressChartLegend items={[1, 2, 3]} />);
+    expect(chart.text()).toBe('<List />');
+    let list = chart.find(List);
+    expect(list.props()).toEqual(
+        {className: "legend",
+         components: {item: ProgressChartLegendItem},
+         items: [["0", 1], ["1", 2], ["2", 3]]});
+
+    chart = shallow(
+        <ProgressChartLegend
+           components={{foo: 23, item: 7}}
+           items={[1, 2, 3]} />);
+    list = chart.find(List);
+    expect(list.props()).toEqual(
+        {className: "legend",
+         components: {item: 7, foo: 23},
+         items: [["0", 1], ["1", 2], ["2", 3]]});
+});
+
+
+test('ProgressChartDataItem render', () => {
+    let item = shallow(<ProgressChartDataItem />);
+    expect(item.text()).toBe('');
+    let span = item.find('span');
+    expect(span.length).toBe(1);
+    expect(span.props()).toEqual({className: undefined, style: {width: "undefined%"}});
+
+    item = shallow(<ProgressChartDataItem data={23} className="foo" />);
+    expect(item.text()).toBe('');
+    span = item.find('span');
+    expect(span.length).toBe(1);
+    expect(span.props()).toEqual({className: "foo", style: {width: "23%"}});
+
+});
+
+
+test('ProgressChartLegendItem render', () => {
+    let item = shallow(<ProgressChartLegendItem />);
+    expect(item.text()).toBe('<ListItem />');
+    let span = item.find(ListItem);
+    expect(span.props()).toEqual(
+        {children: <a href="?status=undefined"><div className="title" /><div className="value" data-value={undefined}>0</div></a>});
+
+    Humanize.intComma = jest.fn((v) => 2 * v);
+
+    const props = [7, 23];
+    item = shallow(<ProgressChartLegendItem {...props} />);
+    expect(item.text()).toBe('<ListItem />');
+    span = item.find(ListItem);
+
+    const content = shallow(span.props().children);
+    expect(content.text()).toBe('746');
+    expect(content.props().href).toBe("?status=7");
+    const title = content.find('div.title');
+    expect(title.text()).toBe('7');
+
+    const value = content.find('div.value');
+    expect(value.props()['data-value']).toBe(23);
+    expect(value.text()).toBe('46');
+});

--- a/tests/js/widgets/search.js
+++ b/tests/js/widgets/search.js
@@ -1,0 +1,46 @@
+
+import React from 'react';
+
+import {shallow} from 'enzyme';
+
+import {Icon} from 'widgets/icons';
+import {SearchControls} from 'widgets/search';
+
+
+test('SearchControls render', () => {
+    const controls = shallow(
+        <SearchControls
+           placeholder="PLACEHOLDER" />);
+    expect(controls.text()).toBe("<Icon />");
+
+    const menu = controls.find('menu.controls');
+    expect(menu.length).toBe(1);
+
+    const wrapper = menu.find('.search-wrapper.small.clearfix');
+    expect(wrapper.length).toBe(1);
+
+    expect(wrapper.props().children.length).toBe(2);
+    expect(wrapper.props().children[0]).toEqual(<Icon name="search" />);
+    expect(wrapper.props().children[1]).toEqual(
+        <input
+           autoComplete="off"
+           autoFocus="off"
+           className="table-filter"
+           onChange={controls.instance().handleFilterChange}
+           placeholder="PLACEHOLDER"
+           type="search" />);
+});
+
+
+test('SearchControls handleFilterChange', () => {
+
+    let controls = shallow(<SearchControls />);
+    expect(controls.instance().handleFilterChange({target: {value: 23}})).toBe(undefined);
+
+    const handleFilterChange = jest.fn(() => 7);
+
+    controls = shallow(<SearchControls handleFilterChange={handleFilterChange} />);
+    expect(controls.instance().handleFilterChange({target: {value: 23}})).toBe(7);
+
+    expect(handleFilterChange.mock.calls).toEqual([[23]]);
+});

--- a/tests/js/widgets/section.js
+++ b/tests/js/widgets/section.js
@@ -1,0 +1,24 @@
+
+import React from 'react';
+
+import {shallow} from 'enzyme';
+
+import {Section} from 'widgets/section';
+
+
+test('Section render', () => {
+    let section = shallow(<Section />);
+    expect(section.text()).toBe('');
+
+    let node = section.find('section');
+    expect(node.props()).toEqual(
+        {children: <div className="wrapper" />,
+         id: undefined});
+
+    section = shallow(<Section id="foo" className="bar">SECTION</Section>);
+    expect(section.text()).toBe('SECTION');
+    node = section.find('section');
+    expect(node.props()).toEqual(
+        {children: <div className="bar">SECTION</div>,
+         id: "foo"});
+});

--- a/tests/js/widgets/stars.js
+++ b/tests/js/widgets/stars.js
@@ -1,0 +1,29 @@
+
+import React from 'react';
+
+import {shallow} from 'enzyme';
+
+import {Icon} from 'widgets/icons';
+import {Stars, Star} from 'widgets/stars';
+
+
+test('Stars render', () => {
+    let stars = shallow(<Stars />);
+    expect(stars.text()).toBe('');
+    stars = shallow(
+        <Stars stars={3} />);
+    expect(stars.text()).toBe("<Star /><Star /><Star />");
+    stars = shallow(
+        <Stars stars={5} />);
+    expect(stars.text()).toBe("<Star /><Star /><Star /><Star /><Star />");
+});
+
+
+test('Star render', () => {
+    let star = shallow(<Star />);
+    expect(star.text()).toBe("<Icon />");
+    let icon = star.find(Icon);
+    expect(icon.length).toBe(1);
+    expect(icon.props()).toEqual(
+        {className: "star", name: "star"});
+})

--- a/tests/js/widgets/title.js
+++ b/tests/js/widgets/title.js
@@ -1,0 +1,36 @@
+
+import React from 'react';
+
+import {shallow} from 'enzyme';
+
+import {Title} from 'widgets/title';
+
+
+test('Title render', () => {
+    let title = shallow(
+        <Title />);
+    expect(title.text()).toBe('');
+    expect(title.find('h1').length).toBe(0);
+
+    title = shallow(
+        <Title title="FOO" />);
+
+    expect(title.text()).toBe('FOO');
+    let h1 = title.find('h1');
+    expect(h1.length).toBe(1);
+    expect(h1.props().className).toBe(undefined);
+    let anchor = h1.find('a');
+    expect(anchor.props().href).toBe('#');
+    expect(anchor.props().children).toEqual('FOO');
+
+    title = shallow(
+        <Title
+           title="BAR"
+           className="BAZ"
+           href="/nowhere"
+           />);
+    h1 = title.find('h1');
+    expect(h1.props().className).toBe('BAZ');
+    anchor = h1.find('a');
+    expect(anchor.props().href).toBe('/nowhere');
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path');
 const webpack = require('webpack');
+const ExtractTextPlugin = require("extract-text-webpack-plugin");
 var BundleTracker = require('webpack-bundle-tracker');
 
 
@@ -21,7 +22,10 @@ module.exports = {
       loaders: ['babel-loader'],
     },{
         test: /\.css$/,
-        loaders: [ 'style-loader', 'css-loader' ]
+        use: ExtractTextPlugin.extract({
+          fallback: "style-loader",
+          use: "css-loader"
+        })
     },{
 	test: /\.json$/,
 	loader: 'json-loader',
@@ -40,6 +44,7 @@ module.exports = {
       'process.env.NODE_ENV': JSON.stringify('production'),
     }),
     new BundleTracker({filename: './webpack-stats.json'}),
+    new ExtractTextPlugin("[name].css"),
   ],
   // This will expose source map files so that errors will point to your
   // original source files instead of the transpiled files.


### PR DESCRIPTION
Adds generic widgets, used in dashboard components, but mostly of generic utility

- link list
- tab list
- info list
- deadline with class mangling according to relative time
- priority meter with :star2: s
- linked icon
- h1 title
- dropdown menu

also adjusts `Columns` widget for non-inherited usage
