### PR TITLE
Fix bug 1439650 - Track performance of all Ajax requests in Google Analytics

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,7 +41,8 @@ module.exports = {
         editor: false,
         DIFF_INSERT: false,
         DIFF_EQUAL: false,
-        DIFF_DELETE: false
+        DIFF_DELETE: false,
+        ga: false
     },
     plugins: [
         'react',

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -621,6 +621,24 @@ var Pontoon = (function (my) {
 
 /* Main code */
 $(function() {
+  /*
+   * If Google Analytics is enabled, frontend will send additional about Ajax calls.
+   *
+   * To send an event to GA, We pass following informations:
+   * event category - hardcoded 'ajax' string.
+   * event action - hardcoded 'request' string.
+   * event label - contains url that was called by $.ajax() call.
+   *
+   * GA Analytics enriches every event with additional information like e.g. browser, resolution, country etc.
+   */
+  $(document).ajaxComplete(function(event, jqXHR, settings) {
+      if (typeof(ga) !== 'function') {
+        return;
+      }
+
+      ga('send', 'event', 'ajax', 'request', settings.url);
+  });
+
   Pontoon.NProgressBind();
 
   // Display any notifications


### PR DESCRIPTION
Changelog:
* Add start time to every ajax request.e
* Send event to Google Analytics with the overall time of request and requested url.
---

Hey @mathjazz and @Pike,
As we discussed during The Munich workweek, I prepared a small js-snippet that should track the overall time of all Ajax requests sent  from the Front-end to the Back-end.

I'm aware that We probably can't merge this until all non-technical concerns are resolved.
However, I would like to hear your opinions if this kind of metrics is useful and if e.g. We should add/remove some informations from events passed to GA.

To make it easier, I've ran my local instance and generated some events to in my personal GA account (Axel should still have access).

These  screen-shots should give you more context how this can look like in GA panel:
Screenshot #1: Overall events recorded by code provided in this PR
![screen1](https://imgur.com/download/WbiXAsD)

Screenshot #2: Average Value for the response time (in milliseconds)
![screen2](https://imgur.com/download/WlDCEpJ)

**Possible concerns**
Unfortunately, `Analytics.js` (Google Analytics library) currently doesn't allow to send events in batches.
That means: for every request sent from The Front-end to Back-end there will be an additional request to Google Analytics.

I tried to verify if that's an issue by using proxies like e.g. crapify, fiddler to slow down requests etc. but I haven't notice any visible impact in The Translate View on my local machine.

So, I would be glad if you could look at this and express your opinions (and decide if it's ready to pass to Arian/Ryan to do technical review).
Thank you in advance!
