### PR TITLE
Upgrade to Django 1.11

### DIFF
--- a/pontoon/db/__init__.py
+++ b/pontoon/db/__init__.py
@@ -30,6 +30,9 @@ class IContainsCollate(IContains):
         lhs, params = super(IContainsCollate, self).process_lhs(qn, connection)
         if self.collation:
             lhs = lhs.replace('::text', '::text COLLATE "{}"'.format(self.collation))
+            if '::text' not in lhs:
+                lhs = lhs.replace(
+                    '."string"', '."string"::text COLLATE "{}"'.format(self.collation))
         return lhs, params
 
     def get_rhs_op(self, connection, rhs):

--- a/pontoon/db/__init__.py
+++ b/pontoon/db/__init__.py
@@ -32,7 +32,8 @@ class IContainsCollate(IContains):
             lhs = lhs.replace('::text', '::text COLLATE "{}"'.format(self.collation))
             if '::text' not in lhs:
                 lhs = lhs.replace(
-                    '."string"', '."string"::text COLLATE "{}"'.format(self.collation))
+                    '."{}"'.format(self.lhs.target.column), '."{}"::text COLLATE "{}"'.format(
+                        self.lhs.target.column, self.collation))
         return lhs, params
 
     def get_rhs_op(self, connection, rhs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,9 +41,8 @@ backports.csv==1.0.5 \
 dj-database-url==0.3.0 \
     --hash=sha256:f2e273ed34acbb560962d5cf12917936d8df02297df09bd3089b8546d4584138 \
     --hash=sha256:ca01768fdecde134301f3170743226f60edff5c3935f12437378ebd911506353
-django==1.10.8 \
-    --hash=sha256:ffdc7e938391ae3c2ee8ff82e0b4444e4e6bb15c99d00770285233d42aaf33d6 \
-    --hash=sha256:d4ef83bd326573c00972cb9429beb396d210341a636e4b816fc9b3f505c498bb
+django==1.11 \
+    --hash=sha256:0120b3b60760fb0617848b58aaa9702c0bf963320ed472f0879c5c55ab75b64a
 django-bulk-update==1.1.10 \
     --hash=sha256:ee0b940bfaaafbdc7050887dca0eb923ac217cbb4a03bf2a426e3c8dea165ffe
 django-cors-headers==1.1.0 \

--- a/tests/base/managers/entity.py
+++ b/tests/base/managers/entity.py
@@ -639,6 +639,10 @@ def test_lookup_collation(resource0, locale0, entity_factory, translation_factor
         == set([translations[n] for n in [0, 1, 4]]))
     assert (
         set(Translation.objects.filter(
+            string__icontains_collate=(u'strİng', 'tr_tr')))
+        == set([translations[n] for n in [0, 1, 4]]))
+    assert (
+        set(Translation.objects.filter(
             string__icontains_collate=(u'strıng', 'tr_tr')))
         == set([translations[n] for n in [2, 3]]))
     # Check if differentiation fails without any collation(C)


### PR DESCRIPTION
This, for now, solves the broken collation search in Django-1.11 However its hardcoded for the events objects are filtered based on their string property.

To Do:
- [x]  Check if all the tests passes using Django-1.11.
- [x] Go through all the views to check if any of these breaks.
- [x] Check if sync works fine.