### PR TITLE
Bug 1442745 upgrade bleach to 2.1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -120,9 +120,9 @@ https://github.com/mathjazz/silme/archive/v0.9.3.zip#egg=silme==0.9.3 \
 # Requirements with sub-dependencies.
 # ==================================================================================
 
-bleach==2.1.1 \
-    --hash=sha256:7a316eac1eef1e98b9813636ebe05878aab1a658d2708047fb00fe2bcbc49f84 \
-    --hash=sha256:760a9368002180fb8a0f4ea48dc6275378e6f311c39d0236d7b904fca1f5ea0d
+bleach==2.1.3 \
+    --hash=sha256:eb7386f632349d10d9ce9d4a838b134d4731571851149f9cc2c05a9a837a9a44 \
+    --hash=sha256:b8fa79e91f96c2c2cd9fd1f9eda906efb1b88b483048978ba62fef680e962b34
 
 # Required by bleach
 html5lib==0.999999999 \


### PR DESCRIPTION
Updated bleach to fix a security issue affecting versions from 2.1
to 2.1.2. In pontoon this is mitigated by CSP.