### PR TITLE
Bug 1305281: Translate all locale projects

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -2410,9 +2410,6 @@ class Translation(DirtyFieldsMixin, models.Model):
             locale=locale
         )
 
-        if project.slug != 'all-projects':
-            translations = translations.filter(entity__resource__project=project)
-
         if paths:
             paths = project.parts_to_paths(paths)
             translations = translations.filter(entity__resource__path__in=paths)

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -2274,6 +2274,7 @@ class Entity(DirtyFieldsMixin, models.Model):
                 'marked_plural': entity.marked_plural,
                 'key': entity.cleaned_key,
                 'path': entity.resource.path,
+                'project': entity.resource.project.serialize(),
                 'format': entity.resource.format,
                 'comment': entity.comment,
                 'order': entity.order,

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -986,12 +986,10 @@ class Locale(AggregatedStats):
         else:
             stats = self
 
-        all_paths = translatedresources.values_list("resource__path", flat=True)
-
         details_list = list(details) + list(unbound_details)
         details_list.append({
             'title': 'all-resources',
-            'resource__path': list(all_paths),
+            'resource__path': [],
             'resource__total_strings': stats.total_strings,
             'fuzzy_strings': stats.fuzzy_strings,
             'translated_strings': stats.translated_strings,
@@ -2623,14 +2621,18 @@ class TranslatedResourceQuerySet(models.QuerySet):
         """
         translated_resources = self.filter(
             locale=locale,
-            resource__project__disabled=False
+            resource__project__disabled=False,
         )
 
         if project.slug != 'all-projects':
             translated_resources = translated_resources.filter(
                 resource__project=project,
-                resource__path__in=paths
             )
+
+            if paths:
+                translated_resources = translated_resources.filter(
+                    resource__path__in=paths,
+                )
 
         return translated_resources.aggregated_stats()
 

--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -262,7 +262,14 @@ body > header .locale.select {
   padding: 2px 4px;
 }
 
+.menu .static-links .internal {
+  border-bottom: 1px solid #5E6475;
+  margin-bottom: 5px;
+  padding-bottom: 5px;
+}
+
 .menu ul li.current,
+.menu .static-links .all-projects.current,
 .menu .static-links .all-resources.current {
   color: #7BC876;
 }

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -2428,7 +2428,7 @@ var Pontoon = (function (my) {
       // Update parts menu
       if (entity && total) {
         var paths = [],
-            parts = $('.project .menu li .name[data-slug=' + self.project.slug + ']')
+            parts = $('.project .menu .name[data-slug=' + self.project.slug + ']')
                       .data('parts')[self.locale.code];
 
         $(parts).each(function() {
@@ -2762,6 +2762,14 @@ var Pontoon = (function (my) {
       // Make sure part menu is always updated
       $('.project .menu [data-slug="' + slug + '"]').parent().click();
 
+      // Update All Projects menu entry parts
+      var parts = {};
+      parts[this.getSelectedLocale()] = [{
+        title: 'all-resources',
+        resource__path: []
+      }];
+      $('.project .menu .all-projects .name').data('parts', parts);
+
       this.updateGoButton();
     },
 
@@ -2868,7 +2876,7 @@ var Pontoon = (function (my) {
       });
 
       // Project menu handler
-      $('.project .menu li:not(".no-match")').click(function () {
+      $('.project .menu li:not(".no-match"), .static-links .all-projects').click(function () {
         var project = $(this).find('.name'),
             name = project.html(),
             slug = project.data('slug'),
@@ -3060,6 +3068,8 @@ var Pontoon = (function (my) {
 
       $('#profile .admin-current-project a').attr('href', '/admin/projects/' + slug + '/');
       $('#profile .upload').toggle(this.state.paths && this.user.canTranslate() && this.part !== 'all-resources');
+      $('#profile .download, #profile .upload + .horizontal-separator').toggle(this.project.slug !== 'all-projects');
+
       $('#profile .langpack')
         .toggle(this.project.langpack_url !== '')
         .find('a').attr('href', this.project.langpack_url.replace('{locale_code}', this.locale.code));
@@ -3077,13 +3087,18 @@ var Pontoon = (function (my) {
 
 
     /*
-     * Mark current project & locale and set links
+     * Mark current values and set links
      */
     updateMainMenu: function () {
+      // Mark currect values
+      $('header .menu li').removeClass('current');
       $('.project .menu li .name[data-slug=' + this.project.slug + '], ' +
         '.locale .menu li .language[data-code=' + this.locale.code + ']')
-        .parent().addClass('current').siblings().removeClass('current');
+        .parent().addClass('current');
+      $('.static-links .all-projects')
+        .toggleClass('current', this.project.slug === 'all-projects');
 
+      // Set current links
       $('.static-links .current-team').parent()
         .attr('href', '/' + this.locale.code);
       $('.static-links .current-project').parent()
@@ -3527,10 +3542,10 @@ var Pontoon = (function (my) {
         url: "",
         title: "",
         slug: self.getProjectData('slug'),
-        info: self.getProjectData('info'),
+        info: self.getProjectData('info') || '',
         width: self.getProjectWidth(),
         links: self.getProjectData('links') === 'True' ? true : false,
-        langpack_url: self.getProjectData('langpack_url'),
+        langpack_url: self.getProjectData('langpack_url') || '',
         hasSubPages: self.getProjectData('parts')[this.locale.code].some(function(item) {
           return !!item['url'];
         })
@@ -3962,7 +3977,7 @@ var Pontoon = (function (my) {
      */
     getProjectData: function(attribute) {
       var slug = this.getSelectedProject();
-      return $('.project .menu li .name[data-slug=' + slug + ']').data(attribute);
+      return $('.project .menu .name[data-slug=' + slug + ']').data(attribute);
     },
 
 
@@ -4134,7 +4149,7 @@ var Pontoon = (function (my) {
 window.onpopstate = function(e) {
   if (e.state) {
     // Update main menu
-    $('.project .menu li [data-slug="' + e.state.project + '"]').parent().click();
+    $('.project .menu .name[data-slug="' + e.state.project + '"]').parent().click();
     $('.locale .menu li .language[data-code="' + e.state.locale + '"]').parent().click();
 
     if (e.state.paths) {

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -581,18 +581,24 @@ var Pontoon = (function (my) {
             linkClass = null;
 
         // Resources can be mapped into multiple subpages.
-        if (!self.project.hasSubPages) {
+        if (!entity.project.url) {
           link = self.getResourceLink(
             self.locale.code,
-            self.project.slug,
+            entity.project.slug,
             entity.path
           );
 
-          linkClass = 'resource-path';
+          if (self.project.slug !== 'all-projects') {
+            linkClass = 'resource-path';
+          }
         }
 
-        self.appendMetaData('Resource path', entity.path, link, linkClass);
+        self.appendMetaData('Resource', entity.path, link, linkClass);
       }
+
+      // Metadata: project
+      var projectLink = '/' + self.locale.code + '/' +  entity.project.slug + '/';
+      self.appendMetaData('Project', entity.project.name, projectLink);
 
       // Original string and plurals
       $('#original').html(entity.marked);
@@ -3552,10 +3558,7 @@ var Pontoon = (function (my) {
         info: self.getProjectData('info') || '',
         width: self.getProjectWidth(),
         links: self.getProjectData('links') === 'True' ? true : false,
-        langpack_url: self.getProjectData('langpack_url') || '',
-        hasSubPages: self.getProjectData('parts')[this.locale.code].some(function(item) {
-          return !!item['url'];
-        })
+        langpack_url: self.getProjectData('langpack_url') || ''
       };
 
       /* Copy of User.can_translate(), used on client to improve performance */

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -2792,6 +2792,7 @@ var Pontoon = (function (my) {
      */
     updatePartMenu: function () {
       var locale = this.getSelectedLocale(),
+          project = this.getSelectedProject(),
           parts = this.getProjectData('parts')[locale],
           currentPart = this.getSelectedPart(),
           part = $.grep(parts, function (e) { return e.title === currentPart; });
@@ -2800,6 +2801,9 @@ var Pontoon = (function (my) {
       if (!part.length) {
         this.updatePartSelector(parts[0].title);
       }
+
+      // Hide part menu for All Projects
+      $('.part.select').toggleClass('hidden', project === 'all-projects');
 
       this.updateGoButton();
     },

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -2907,8 +2907,15 @@ var Pontoon = (function (my) {
             self.updatePartMenu();
 
           } else {
+            var url;
+            if (slug !== 'all-projects') {
+              url = '/' + locale + '/' + slug + '/parts/';
+            } else {
+              url = '/teams/' + locale + '/stats/';
+            }
+
             $.ajax({
-              url: '/' + locale + '/' + slug + '/parts/',
+              url: url,
               success: function(parts) {
                 if (projectParts) {
                   projectParts[locale] = parts;

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -3090,7 +3090,9 @@ var Pontoon = (function (my) {
       var code = this.locale.code,
           slug = this.project.slug;
 
-      $('#profile .admin-current-project a').attr('href', '/admin/projects/' + slug + '/');
+      $('#profile .admin-current-project a')
+        .attr('href', '/admin/projects/' + slug + '/')
+        .toggle(this.project.slug !== 'all-projects');
       $('#profile .upload').toggle(this.state.paths && this.user.canTranslate() && this.part !== 'all-resources');
       $('#profile .download, #profile .upload + .horizontal-separator').toggle(this.project.slug !== 'all-projects');
 
@@ -3123,12 +3125,13 @@ var Pontoon = (function (my) {
         .toggleClass('current', this.project.slug === 'all-projects');
 
       // Set current links
-      $('.static-links .current-team').parent()
-        .attr('href', '/' + this.locale.code);
-      $('.static-links .current-project').parent()
-        .attr('href', '/projects/' + this.project.slug);
-      $('.static-links .current-localization').parent()
-        .attr('href', '/' + this.locale.code + '/' + this.project.slug);
+      $('.static-links .current-team')
+        .parent().attr('href', '/' + this.locale.code);
+      $('.static-links .current-project')
+        .toggle(this.project.slug !== 'all-projects')
+        .parent().attr('href', '/projects/' + this.project.slug);
+      $('.static-links .current-localization')
+        .parent().attr('href', '/' + this.locale.code + '/' + this.project.slug);
 
       this.updateGoButton();
     },

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -1450,6 +1450,13 @@ var Pontoon = (function (my) {
           return;
         }
 
+        // Disable for All Projects for performance reasons
+        if (self.project.slug === 'all-projects') {
+          self.updateRangePicker([]);
+          self.updateAuthors([]);
+          return;
+        }
+
         self.NProgressUnbind();
 
         $.ajax({

--- a/pontoon/base/urls.py
+++ b/pontoon/base/urls.py
@@ -28,6 +28,11 @@ urlpatterns = [
         views.locale_projects,
         name='pontoon.locale.projects'),
 
+    # AJAX: Get locale stats used in All Resources part
+    url(r'^teams/(?P<locale>[A-Za-z0-9\-\@\.]+)/stats/$',
+        views.locale_stats,
+        name='pontoon.locale.stats'),
+
     # AJAX: Get locale-project pages/paths with stats
     url(r'^(?P<locale>[A-Za-z0-9\-\@\.]+)/(?P<slug>[\w-]+)/parts/$',
         views.locale_project_parts,

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -78,16 +78,20 @@ def home(request):
 def translate(request, locale, slug, part):
     """Translate view."""
     locale = get_object_or_404(Locale, code=locale)
-    project = get_object_or_404(Project.objects.available(), slug=slug)
-
-    if locale not in project.locales.all():
-        raise Http404
 
     projects = (
         Project.objects.available()
         .prefetch_related('subpage_set')
         .order_by('name')
     )
+
+    if slug.lower() == 'all-projects':
+        project = Project(name='All Projects', slug=slug.lower())
+
+    else:
+        project = get_object_or_404(Project.objects.available(), slug=slug)
+        if locale not in project.locales.all():
+            raise Http404
 
     return render(request, 'translate.html', {
         'download_form': forms.DownloadFileForm(),
@@ -113,7 +117,11 @@ def locale_projects(request, locale):
 def locale_project_parts(request, locale, slug):
     """Get locale-project pages/paths with stats."""
     locale = get_object_or_404(Locale, code=locale)
-    project = get_object_or_404(Project, slug=slug)
+
+    if slug == 'all-projects':
+        project = Project(slug=slug)
+    else:
+        project = get_object_or_404(Project, slug=slug)
 
     try:
         return JsonResponse(locale.parts_stats(project), safe=False)
@@ -226,8 +234,13 @@ def entities(request):
     if not form.is_valid():
         return HttpResponseBadRequest(form.errors.as_json())
 
-    project = get_object_or_404(Project, slug=form.cleaned_data['project'])
     locale = get_object_or_404(Locale, code=form.cleaned_data['locale'])
+
+    project_slug = form.cleaned_data['project']
+    if project_slug == 'all-projects':
+        project = Project(slug=project_slug)
+    else:
+        project = get_object_or_404(Project, slug=project_slug)
 
     # Only return entities with provided IDs (batch editing)
     if form.cleaned_data['entity_ids']:

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -114,14 +114,17 @@ def locale_projects(request, locale):
 
 
 @utils.require_AJAX
+def locale_stats(request, locale):
+    """Get locale stats used in All Resources part."""
+    locale = get_object_or_404(Locale, code=locale)
+    return JsonResponse(locale.stats(), safe=False)
+
+
+@utils.require_AJAX
 def locale_project_parts(request, locale, slug):
     """Get locale-project pages/paths with stats."""
     locale = get_object_or_404(Locale, code=locale)
-
-    if slug == 'all-projects':
-        project = Project(slug=slug)
-    else:
-        project = get_object_or_404(Project, slug=slug)
+    project = get_object_or_404(Project, slug=slug)
 
     try:
         return JsonResponse(locale.parts_stats(project), safe=False)

--- a/pontoon/localizations/templates/localizations/widgets/resource_selector.html
+++ b/pontoon/localizations/templates/localizations/widgets/resource_selector.html
@@ -15,13 +15,15 @@
     </ul>
 
     <div class="static-links">
-      <div class="all-resources">
-        <span class="title">All Resources</span>
-        <span class="percent"></span>
-      </div>
+      <section class="internal">
+        <div class="all-resources">
+          <span class="title">All Resources</span>
+          <span class="percent"></span>
+        </div>
+      </section>
       <a href="{{ url('pontoon.localizations.localization', locale.code, project.slug) }}">
         <div class="current-localization">
-          <span class="title">Current Localization</span>
+          <span class="title">Current Localization Dashboard</span>
           <span class="percent"></span>
         </div>
       </a>

--- a/pontoon/localizations/templates/localizations/widgets/resource_selector.html
+++ b/pontoon/localizations/templates/localizations/widgets/resource_selector.html
@@ -1,5 +1,5 @@
 <!-- Resource selector -->
-<div class="part select">
+<div class="part select {% if project.slug == 'all-projects' %}hidden{% endif %}">
   <div class="button breadcrumbs selector" title="{{ part }}">
     <span class="title noselect">{% if part == 'all-resources' %}{{ 'All Resources' }}{% else %}{{ part.rsplit('/')[-1] }}{% endif %}</span>
   </div>

--- a/pontoon/projects/templates/projects/widgets/project_selector.html
+++ b/pontoon/projects/templates/projects/widgets/project_selector.html
@@ -31,7 +31,7 @@
     <div class="static-links">
       <section class="internal">
         <div class="all-projects">
-          <span class="name title" data-name="All Projects" data-slug="all-projects" {% if project.slug == 'all-projects' %}data-parts="{{ {locale.code: locale.parts_stats(project)}|to_json }}"{% endif %}>All Projects</span>
+          <span class="name title" data-name="All Projects" data-slug="all-projects" {% if project.slug == 'all-projects' %}data-parts="{{ {locale.code: locale.stats()}|to_json }}"{% endif %}>All Projects</span>
         </div>
       </section>
       <a href="{{ url('pontoon.projects') }}">

--- a/pontoon/projects/templates/projects/widgets/project_selector.html
+++ b/pontoon/projects/templates/projects/widgets/project_selector.html
@@ -29,14 +29,19 @@
     </ul>
 
     <div class="static-links">
-      <a href="{{ url('pontoon.projects') }}">
+      <section class="internal">
         <div class="all-projects">
-          <span class="title">All Projects</span>
+          <span class="name title" data-name="All Projects" data-slug="all-projects" {% if project.slug == 'all-projects' %}data-parts="{{ {locale.code: locale.parts_stats(project)}|to_json }}"{% endif %}>All Projects</span>
+        </div>
+      </section>
+      <a href="{{ url('pontoon.projects') }}">
+        <div>
+          <span class="title">Projects Dashboard</span>
         </div>
       </a>
       <a href="{{ url('pontoon.projects.project', project.slug) }}">
         <div class="current-project">
-          <span class="title">Current Project</span>
+          <span class="title">Current Project Dashboard</span>
         </div>
       </a>
     </div>

--- a/pontoon/teams/templates/teams/team.html
+++ b/pontoon/teams/templates/teams/team.html
@@ -63,7 +63,8 @@
     </ul>
 
     {{ HeadingInfo.progress_chart() }}
-    {{ HeadingInfo.progress_chart_legend(locale) }}
+    {{ HeadingInfo.progress_chart_legend(locale, url('pontoon.translate', locale.code, 'all-projects', 'all-resources')) }}
+
   </div>
 </section>
 {% endblock %}

--- a/pontoon/teams/templates/teams/teams.html
+++ b/pontoon/teams/templates/teams/teams.html
@@ -68,11 +68,11 @@
 
     {% for locale in locales %}
       {% set main_link = url('pontoon.teams.team', locale.code) %}
-      {% set chart_link = url('pontoon.teams.team', locale.code) %}
+      {% set chart_link = url('pontoon.translate', locale.code, 'all-projects', 'all-resources') %}
       {% set latest_activity = locale.get_latest_activity() %}
       {% set chart = locale.get_chart() %}
 
-      {{ TeamList.item(locale, main_link, chart_link, latest_activity, chart) }}
+      {{ TeamList.item(locale, main_link, chart_link, latest_activity, chart, link_parameter=True) }}
     {% endfor %}
 
     {{ TeamList.footer() }}

--- a/pontoon/teams/templates/teams/widgets/team_selector.html
+++ b/pontoon/teams/templates/teams/widgets/team_selector.html
@@ -34,13 +34,13 @@
       {% if part and locale %}
       <div class="static-links">
         <a href="{{ url('pontoon.teams') }}">
-          <div class="all-teams">
-            <span class="title">All Teams</span>
+          <div>
+            <span class="title">Teams Dashboard</span>
           </div>
         </a>
         <a href="{{ url('pontoon.teams.team', locale.code) }}">
           <div class="current-team">
-            <span class="title">Current Team</span>
+            <span class="title">Current Team Dashboard</span>
           </div>
         </a>
       </div>

--- a/tests/base/models/entity.py
+++ b/tests/base/models/entity.py
@@ -52,6 +52,7 @@ def test_entity_project_locale_no_paths(entity_test_models, localeX, project1):
         'marked': unicode(entity0.string),
         'key': '',
         'path': unicode(resource0.path),
+        'project': project0.serialize(),
         'translation': [
             {'pk': tr0.pk,
              'fuzzy': False,


### PR DESCRIPTION
This patch adds the ability to load all strings across all projects for a selected locale in a translate view. That means localizers can also search and filter such strings, which simplifies tasks like:
* work on all untranslated strings for my locale
* review all suggestions for my locale or
* ensure consistency of a term translation across all projects in my locale

Translation of all locale projects can be requested from dashboards or by selecting "All Projects" in the project menu in the translate view. The part menu is hidden, because it contains too many items to be useful (for most locales). Time and author filters are disabled for performance reasons. A project name is now also listed in string metadata (under comment).

I tried to separate logic into multiple commits as I developed the feature. More context is available in commit messages. It might be a good idea to review commit by commit.

@jotes Since you reviewed the original patch, I wonder if you'd be willing to do it again?