### PR TITLE
Fix bug 1405256: Fix migration

### DIFF
--- a/pontoon/base/migrations/0117_bug_1405256_ftl_delete_duplicates.py
+++ b/pontoon/base/migrations/0117_bug_1405256_ftl_delete_duplicates.py
@@ -43,8 +43,10 @@ def delete_ftl_duplicates(apps, schema):
         translations = Translation.objects.filter(pk__in=duplicates)
         tms = TranslationMemoryEntry.objects.filter(translation__pk__in=duplicates)
 
-        translations.delete()
+        # Delete TranslationMemoryEntry instances first, because the tms QuerySet
+        # gets empty after the Translation instances are deleted.
         tms.delete()
+        translations.delete()
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
Delete TranslationMemoryEntry instances first, because the tms QuerySet gets empty after the Translation instances are deleted.