### PR TITLE
Fix bug 1389820: Break resources into new lines if needed

### DIFF
--- a/pontoon/base/static/css/heading_info.css
+++ b/pontoon/base/static/css/heading_info.css
@@ -71,6 +71,10 @@ ul {
   white-space: nowrap;
 }
 
+#heading .details .resources .value.overflow {
+  white-space: normal;
+}
+
 #heading .progress {
   float: left;
   margin: -10px 65px 0;

--- a/pontoon/base/templates/widgets/heading_info.html
+++ b/pontoon/base/templates/widgets/heading_info.html
@@ -47,7 +47,7 @@
 
 {% macro details_item_resources(resources, locale_code=None) %}
   {% if resources|length %}
-  <li class="resources">
+  <li class="resources clearfix">
     <span class="title">Resources</span>
     <span class="value overflow">
       {% for resource in resources %}


### PR DESCRIPTION
This fixes the bug as shown in the screenshot:

![screen shot 2018-03-13 at 16 05 17](https://user-images.githubusercontent.com/626716/37353483-b8b8157a-26df-11e8-9c1e-20c8953829b3.png)
