### PR TITLE
Fix bug 1442209: Replace total_string with avg_string_count in requestproject template.

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -1287,6 +1287,10 @@ class Project(AggregatedStats):
         except Subpage.DoesNotExist:
             return paths
 
+    @property
+    def avg_string_count(self):
+        return int(self.total_strings / self.enabled_locales)
+
 
 @python_2_unicode_compatible
 class ExternalResource(models.Model):

--- a/pontoon/projects/templates/projects/widgets/project_list.html
+++ b/pontoon/projects/templates/projects/widgets/project_list.html
@@ -47,7 +47,7 @@
     {% if request %}
       <td class="all-strings">
         {% if project.total_strings %}
-          <span>{{ project.total_strings|intcomma }}</span>
+          <span>{{ project.avg_string_count|intcomma }}</span>
         {% else %}
           <span class="not">Not synced yet</span>
         {% endif %}

--- a/pontoon/teams/views.py
+++ b/pontoon/teams/views.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.mail import EmailMessage
 from django.db import transaction
-from django.db.models import Q
+from django.db.models import Q, Count
 from django.http import Http404, HttpResponse, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404, render
 from django.views.decorators.http import require_POST
@@ -53,6 +53,7 @@ def ajax_projects(request, locale):
         .filter(Q(locales=locale) | Q(can_be_requested=True))
         .prefetch_project_locale(locale)
         .order_by('name')
+        .annotate(enabled_locales=Count('project_locale', distinct=True))
     )
 
     if not projects:


### PR DESCRIPTION
I have replaced the earlier used `project.total_strings` with `chart.total_strings` which gives the correct number of strings in the project. This also addresses the discrepancy mentioned here : 
https://github.com/mozilla/pontoon/pull/827#issuecomment-372854230