### PR TITLE
Bug 1447095: FTL access key UI fixes

### DIFF
--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -1526,7 +1526,6 @@ body > header aside p {
   padding: 0 4px;
   resize: none;
   text-align: center;
-  text-transform: uppercase;
   width: 24px;
 }
 

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -293,7 +293,7 @@ var Pontoon = (function (my) {
           $('#ftl-area .attributes ul:first').append(attributes);
 
           // Update access keys presentation
-          $('#ftl-area textarea:visible').keyup();
+          $('#ftl-area textarea.value').keyup();
         }
 
         // Ignore editing for anonymous users

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -293,7 +293,7 @@ var Pontoon = (function (my) {
           $('#ftl-area .attributes ul:first').append(attributes);
 
           // Update access keys presentation
-          $('#ftl-area .attributes textarea').keyup();
+          $('#ftl-area textarea:visible').keyup();
         }
 
         // Ignore editing for anonymous users

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -959,7 +959,7 @@ $(function () {
 
   // Select access key using text input
   $('#ftl-area .attributes').on('keyup', '#ftl-id-accesskey', function () {
-    var accesskey = $(this).val().toUpperCase();
+    var accesskey = $(this).val();
 
     if (accesskey) {
       $('.accesskeys div').removeClass('active');


### PR DESCRIPTION
This patch brings two fixes for the access key UI:
1. The list of candidates is now initialized properly - by extending the selector.
2. The access key textarea element no longer transforms text to uppercase.

@phlax Since you reviewed #899, which is related, I'd like to ask you to look at this one as well.

I deployed the patch to stage.

The bug on prod:
https://pontoon.mozilla.org/sl/firefox/browser/browser/preferences/preferences.ftl/?search=accessk&string=176239

The fix on stage:
https://mozilla-pontoon-staging.herokuapp.com/sl/test-fluent/preferences.ftl/?search=accessk&string=176235