### PR TITLE
Fix bug 1447103: Exclude placeables from access key candidates

### DIFF
--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -921,8 +921,9 @@ $(function () {
       selector = '.attributes [data-id="label"]';
     }
     $('#ftl-area ' + selector + ' textarea').each(function() {
-      // Remove whitespace
-      content += $(this).val().replace(/\s/g,'');
+      content += $(this).val()
+        .replace(/{.*?}/g, '') // Remove placeables: bug 1447103
+        .replace(/\s/g, '');   // Remove whitespace
     });
 
     // Extract unique candidates in a list


### PR DESCRIPTION
Fluent uses curly brackets to denote Placeables, which must not be used to generate access key candidates, because in in Pontoon UI they don't contain translateable text (but references to external arguments or other entities).

Bug on prod:
https://pontoon.mozilla.org/sl/firefox/browser/browser/preferences/preferences.ftl/?string=176239

Fixed on stage:
https://mozilla-pontoon-staging.herokuapp.com/sl/test-fluent/preferences.ftl/?string=176235