### PR TITLE
Fix bug 1447103 more reliably

### DIFF
--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -920,10 +920,20 @@ $(function () {
     if (isLabel) {
       selector = '.attributes [data-id="label"]';
     }
+
+    // Build artificial FTL Message from textarea contents to only take
+    // TextElements into account when generating access key candidates.
+    // See bug 1447103 for more detals.
     $('#ftl-area ' + selector + ' textarea').each(function() {
-      content += $(this).val()
-        .replace(/{.*?}/g, '') // Remove placeables: bug 1447103
-        .replace(/\s/g, '');   // Remove whitespace
+      var message = 'key = ' + $(this).val();
+      var ast = fluentParser.parseEntry(message);
+
+      ast.value.elements.forEach(function (element) {
+        if (element.type === 'TextElement') {
+          content += element.value
+            .replace(/\s/g, ''); // Remove whitespace
+        }
+      });
     });
 
     // Extract unique candidates in a list

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -926,21 +926,20 @@ $(function () {
     // See bug 1447103 for more detals.
     $('#ftl-area ' + selector + ' textarea').each(function() {
       var value = $(this).val();
-      var message = 'key = ' + $(this).val();
+      var message = 'key = ' + value;
       var ast = fluentParser.parseEntry(message);
 
-      if (ast.type === 'Junk') {
-        content += value
-          .replace(/\s/g, ''); // Remove whitespace
-        return true; // continue
+      if (ast.type !== 'Junk') {
+        value = '';
+        ast.value.elements.forEach(function (element) {
+          if (element.type === 'TextElement') {
+            value += element.value;
+          }
+        });
       }
 
-      ast.value.elements.forEach(function (element) {
-        if (element.type === 'TextElement') {
-          content += element.value
-            .replace(/\s/g, ''); // Remove whitespace
-        }
-      });
+      content += value
+        .replace(/\s/g, ''); // Remove whitespace
     });
 
     // Extract unique candidates in a list

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -925,8 +925,15 @@ $(function () {
     // TextElements into account when generating access key candidates.
     // See bug 1447103 for more detals.
     $('#ftl-area ' + selector + ' textarea').each(function() {
+      var value = $(this).val();
       var message = 'key = ' + $(this).val();
       var ast = fluentParser.parseEntry(message);
+
+      if (ast.type === 'Junk') {
+        content += value
+          .replace(/\s/g, ''); // Remove whitespace
+        return true; // continue
+      }
 
       ast.value.elements.forEach(function (element) {
         if (element.type === 'TextElement') {


### PR DESCRIPTION
Exclude Placeables from generating access key candidates by building a
fake FTL Message from textarea contents, parsing it and only taking
TextElements into account.

Previous implementation used regex to try to do the same, which would
fail when curly brackets are escaped, e.g.:

```
key = Hello \{ and then { -brand-short-name} World
```