### PR TITLE
Fix bug 1437857: Add support for Functions

### DIFF
--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -318,7 +318,8 @@ var Pontoon = (function (my) {
        * Message is supported if all value elements
        * and all attribute elements are of type:
        * - TextElement
-       * - Placeable with expression type ExternalArgument, MessageReference or SelectExpression
+       * - Placeable with expression type CallExpression, ExternalArgument,
+       *   MessageReference or SelectExpression
        */
       isSupportedMessage: function (ast) {
         var self = this;
@@ -349,7 +350,8 @@ var Pontoon = (function (my) {
       /*
        * Is element of type that can be presented as a simple string:
        * - TextElement
-       * - Placeable with expression type ExternalArgument or MessageReference
+       * - Placeable with expression type CallExpression, ExternalArgument
+       *   or MessageReference
        */
       isSimpleElement: function (element) {
         if (element.type === 'TextElement') {
@@ -360,6 +362,7 @@ var Pontoon = (function (my) {
         if (
           element.expression &&
           [
+            'CallExpression',
             'ExternalArgument',
             'MessageReference'
           ].indexOf(element.expression.type) >= 0
@@ -464,6 +467,13 @@ var Pontoon = (function (my) {
                 endMarker = '</mark>';
               }
               translatedValue += startMarker + '{' + element.expression.id.name + '}' + endMarker;
+            }
+            else if (element.expression.type === 'CallExpression') {
+              if (markPlaceables) {
+                startMarker = '<mark class="placeable" title="Call Expression">';
+                endMarker = '</mark>';
+              }
+              translatedValue += startMarker + '{' + fluentSerializer.serializeExpression(element.expression) + '}' + endMarker;
             }
             else if (self.isSelectExpressionElement(element)) {
               var variantElements = element.expression.variants.filter(function (variant) {

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -473,7 +473,8 @@ var Pontoon = (function (my) {
                 startMarker = '<mark class="placeable" title="Call Expression">';
                 endMarker = '</mark>';
               }
-              translatedValue += startMarker + '{' + fluentSerializer.serializeExpression(element.expression) + '}' + endMarker;
+              var expression = fluentSerializer.serializeExpression(element.expression);
+              translatedValue += startMarker + '{' + expression + '}' + endMarker;
             }
             else if (self.isSelectExpressionElement(element)) {
               var variantElements = element.expression.variants.filter(function (variant) {

--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -6,7 +6,7 @@ import jinja2
 from allauth.socialaccount import providers
 from allauth.utils import get_request_param
 from django_jinja import library
-from fluent.syntax import FluentParser, ast
+from fluent.syntax import FluentParser, FluentSerializer, ast
 from six import text_type
 from six.moves.urllib import parse as six_parse
 
@@ -22,6 +22,7 @@ from django.utils.functional import Promise
 
 register = template.Library()
 parser = FluentParser()
+serializer = FluentSerializer()
 
 
 class LazyObjectsJsonEncoder(json.JSONEncoder):
@@ -254,7 +255,7 @@ def dict_html_attrs(dict_obj):
 
 
 def _serialize_elements(elements):
-    """Serialize text elements and references into a simple string."""
+    """Serialize text elements and placeables into a simple string."""
     response = ''
 
     for element in elements:
@@ -267,6 +268,9 @@ def _serialize_elements(elements):
 
             elif isinstance(element.expression, ast.MessageReference):
                 response += '{ ' + element.expression.id.name + ' }'
+
+            elif isinstance(element.expression, ast.CallExpression):
+                response += '{ ' + serializer.serialize_expression(element.expression) + ' }'
 
             elif hasattr(element.expression, 'variants'):
                 variant_elements = filter(

--- a/tests/base/helpers.py
+++ b/tests/base/helpers.py
@@ -13,9 +13,9 @@ from pontoon.base.utils import aware_datetime
 
 
 MULTILINE_SOURCE = '''key =
- Simple String
- In Multiple
- Lines'''
+    Simple String
+    In Multiple
+    Lines'''
 PLURAL_SOURCE = '''key =
     { $number ->
         [1] Simple String
@@ -34,8 +34,8 @@ ATTRIBUTES_SOURCE = '''key
     .other = Other Simple String'''
 ATTRIBUTE_SELECT_SOURCE = '''key
     .placeholder = { PLATFORM() ->
-    [win] Simple String
-    *[other] Other Simple String
+        [win] Simple String
+        *[other] Other Simple String
     }'''
 
 SIMPLE_TRANSLATION_TESTS = OrderedDict((
@@ -53,9 +53,7 @@ SIMPLE_TRANSLATION_TESTS = OrderedDict((
       '{ LINK("Link text", title: "Link title") }Simple String'))))
 
 
-@pytest.mark.parametrize(
-    "k",
-    SIMPLE_TRANSLATION_TESTS)
+@pytest.mark.parametrize("k", SIMPLE_TRANSLATION_TESTS)
 def test_helper_as_simple_translation(k):
     string, expected = SIMPLE_TRANSLATION_TESTS[k]
     assert as_simple_translation(string) == expected

--- a/tests/base/helpers.py
+++ b/tests/base/helpers.py
@@ -50,7 +50,7 @@ SIMPLE_TRANSLATION_TESTS = OrderedDict((
     ('attributes-select-expression', (ATTRIBUTE_SELECT_SOURCE, 'Other Simple String')),
     ('other-ftl',
      ('warning-upgrade = { LINK("Link text", title: "Link title") }Simple String',
-      'Simple String'))))
+      '{ LINK("Link text", title: "Link title") }Simple String'))))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
We already have strings in the wild that use [Functions](projectfluent.org/fluent/guide/functions.html). Pontoon doesn't support Functions in the Rich FTL UI, so such strings are [displayed as source](https://pontoon.mozilla.org/cs/common-voice/messages.ftl/?search=DATE&string=175940).

This patch fixes that and treats Functions (AKA `CallExpressions`) as placeables (in the Pontoon definition of the word), meaning they are highlighted and be inserted into the editor with a click.

![screen shot 2018-03-21 at 16 16 41](https://user-images.githubusercontent.com/626716/37718572-4ab16f8c-2d23-11e8-9bac-aa6c0e336248.png)

@adngdb Let me know if you can review this or do you want me to [refactor](https://bugzilla.mozilla.org/show_bug.cgi?id=1433499) first.