### PR TITLE
Fix bug 1433499: Refactor fluent_interface.js

### DIFF
--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -82,7 +82,7 @@ var Pontoon = (function (my) {
       }
 
       // Render SelectExpression
-      if (Pontoon.fluent.isSelectExpressionElement(element)) {
+      if (element.expression && element.expression.type === 'SelectExpression') {
         element.expression.variants.forEach(function (item) {
           content += renderOriginalElement(item.key.value || item.key.name, item.value.elements);
         });
@@ -118,7 +118,7 @@ var Pontoon = (function (my) {
       }
 
       // Render SelectExpression
-      if (Pontoon.fluent.isSelectExpressionElement(element)) {
+      if (element.expression && element.expression.type === 'SelectExpression') {
         var expression = fluentSerializer.serializeExpression(element.expression.expression);
         content += '<li data-expression="' + expression + '"><ul>';
 
@@ -328,7 +328,7 @@ var Pontoon = (function (my) {
           return elements.every(function(element) {
             return (
               self.isSimpleElement(element) ||
-              self.isSelectExpressionElement(element)
+              (element.expression && element.expression.type === 'SelectExpression')
             );
           });
         }
@@ -375,25 +375,13 @@ var Pontoon = (function (my) {
 
 
       /*
-       * Is element a SelectExpression?
-       *
-       * We evaluate that by checking if element expression has variants defined.
-       * If yes, the element must be a SelectExpression according to Fluent ASDL:
-       * https://github.com/projectfluent/fluent/blob/master/spec/fluent.asdl
-       */
-      isSelectExpressionElement: function (element) {
-        return element.expression && element.expression.variants;
-      },
-
-
-      /*
        * Is element representing a pluralized string?
        *
        * Keys of all variants of such elements are either
        * CLDR plurals or numbers.
        */
       isPluralElement: function (element) {
-        if (!this.isSelectExpressionElement(element)) {
+        if (!(element.expression && element.expression.type === 'SelectExpression')) {
           return false;
         }
 
@@ -476,7 +464,7 @@ var Pontoon = (function (my) {
               var expression = fluentSerializer.serializeExpression(element.expression);
               translatedValue += startMarker + '{' + expression + '}' + endMarker;
             }
-            else if (self.isSelectExpressionElement(element)) {
+            else if (element.expression.type === 'SelectExpression') {
               var variantElements = element.expression.variants.filter(function (variant) {
                 return variant.default;
               })[0].value.elements;

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -260,12 +260,14 @@ var Pontoon = (function (my) {
 
   /*
    * Serialize values in FTL editor forms into an FTL string
+   *
+   * elementNodes A set of jQuery nodes
    */
-  function serializeElements(elements) {
+  function serializeFTLEditorElements(elementNodes) {
     var value = '';
 
-    elements.each(function (i, element) {
-      var expression = $(element).data('expression');
+    elementNodes.each(function (i, node) {
+      var expression = $(node).data('expression');
 
       // Simple element
       if (!expression) {
@@ -274,8 +276,8 @@ var Pontoon = (function (my) {
 
       // SelectExpression
       else {
-        var elementValue = expression + ' ->';
-        var variants = $(element).find('ul li');
+        var nodeValue = expression + ' ->';
+        var variants = $(node).find('ul li');
         var hasTranslatedVariants = false;
         var defaultMarker = '';
 
@@ -289,13 +291,13 @@ var Pontoon = (function (my) {
           }
 
           if (id && val) {
-            elementValue += '\n  ' + defaultMarker + '[' + id + '] ' + val;
+            nodeValue += '\n  ' + defaultMarker + '[' + id + '] ' + val;
             hasTranslatedVariants = true;
           }
         });
 
         if (hasTranslatedVariants) {
-          value += '{ ' + elementValue + '\n  }';
+          value += '{ ' + nodeValue + '\n  }';
         }
       }
     });
@@ -714,7 +716,7 @@ var Pontoon = (function (my) {
 
         // Value
         else if (valueElements.length) {
-          value = serializeElements(valueElements);
+          value = serializeFTLEditorElements(valueElements);
 
           if (value) {
             content += value;
@@ -725,7 +727,7 @@ var Pontoon = (function (my) {
         if (attributeElements.length) {
           attributeElements.each(function () {
             var id = $(this).data('id');
-            var val = serializeElements($(this).find('ul:first > li'));
+            var val = serializeFTLEditorElements($(this).find('ul:first > li'));
 
             if (id && val) {
               attributes += '\n  .' + id + ' = ' + val;

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -563,17 +563,11 @@ var Pontoon = (function (my) {
           $('#ftl-area').show();
           $('#translation').hide();
           $('#ftl').removeClass('active');
-
-          // TODO: Uncomment once attributes are fully supported (defaults, removing, validation)
-          // $('#add-attribute').show();
         }
         else {
           $('#ftl-area').hide();
           $('#translation').show().focus();
           $('#ftl').addClass('active');
-
-          // TODO: Uncomment once attributes are fully supported (defaults, removing, validation)
-          // $('#add-attribute').hide();
         }
 
         toggleEditorToolbar();
@@ -885,12 +879,6 @@ $(function () {
     }
 
     Pontoon.fluent.toggleEditor($(this).is('.active'));
-  });
-
-  // Add attribute
-  $('#add-attribute').click(function (e) {
-    e.preventDefault();
-    $('#ftl-area .attributes ul:first').append($('#ftl-area .attributes .template li').clone());
   });
 
   // Generate access key candidates

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -523,7 +523,6 @@ var Pontoon = (function (my) {
        * Render original string of FTL and non-FTL messages.
        */
       renderOriginal: function () {
-        var self = this;
         var entity = Pontoon.getEditorEntity();
 
         $('#original').show();
@@ -809,7 +808,7 @@ var Pontoon = (function (my) {
       /*
        * Attach event handlers to FTL editor elements
        */
-      attachFTLEditorHandlers: function (entity, fallback) {
+      attachFTLEditorHandlers: function () {
         var self = this;
 
         // Ignore editing for anonymous users

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -111,11 +111,7 @@ var Pontoon = (function (my) {
    * Render textarea element with the given properties
    */
   function renderTextareaElement(id, value, maxlength) {
-    var element = '<textarea class="value" id="ftl-id-' + id + '"';
-
-    if (typeof maxlength !== 'undefined' && maxlength !== null) {
-      element += ' maxlength="' + maxlength + '"';
-    }
+    var element = '<textarea class="value" id="ftl-id-' + id + '"' + ' maxlength="' + maxlength + '"';
 
     element += ' dir="' + Pontoon.locale.direction +
       '" data-script="' + Pontoon.locale.script +

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -281,7 +281,7 @@ var Pontoon = (function (my) {
 
           $('#translation').val(value);
 
-          Pontoon.fluent.toggleEditor(false);
+          self.toggleEditor(false);
           Pontoon.updateCachedTranslation();
 
           return;

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -221,6 +221,21 @@ var Pontoon = (function (my) {
     }
   }
 
+  /*
+   * Toggle translation length and Copy button in editor toolbar
+   */
+  function toggleEditorToolbar() {
+    var entity = Pontoon.getEditorEntity();
+    var show = entity.format !== 'ftl' || !Pontoon.fluent.isComplexFTL();
+
+    $('#translation-length, #copy').toggle(show);
+
+    if ($('#translation-length').is(':visible')) {
+      var original = Pontoon.fluent.getSimplePreview(entity, entity.original, entity);
+      $('#translation-length').find('.original-length').html(original.length);
+    }
+  }
+
   return $.extend(true, my, {
     fluent: {
 
@@ -334,7 +349,7 @@ var Pontoon = (function (my) {
         // Focus first field of the FTL editor
         $('#ftl-area textarea:not(".id"):visible').first().focus();
 
-        Pontoon.fluent.toggleEditorToolbar();
+        toggleEditorToolbar();
 
         Pontoon.moveCursorToBeginning();
         Pontoon.updateCurrentTranslationLength();
@@ -561,24 +576,8 @@ var Pontoon = (function (my) {
           // $('#add-attribute').hide();
         }
 
-        Pontoon.fluent.toggleEditorToolbar();
+        toggleEditorToolbar();
         Pontoon.moveCursorToBeginning();
-      },
-
-
-      /*
-       * Toggle translation length and Copy button in editor toolbar
-       */
-      toggleEditorToolbar: function () {
-        var entity = Pontoon.getEditorEntity();
-        var show = entity.format !== 'ftl' || !Pontoon.fluent.isComplexFTL();
-
-        $('#translation-length, #copy').toggle(show);
-
-        if ($('#translation-length').is(':visible')) {
-          var original = this.getSimplePreview(entity, entity.original, entity);
-          $('#translation-length').find('.original-length').html(original.length);
-        }
       },
 
 

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -6,7 +6,7 @@ var fluentSerializer = new FluentSyntax.FluentSerializer();
 var Pontoon = (function (my) {
 
   /*
-   * Is element of type that can be presented as a simple string:
+   * Is ast element of type that can be presented as a simple string:
    * - TextElement
    * - Placeable with expression type CallExpression, ExternalArgument
    *   or MessageReference
@@ -32,7 +32,7 @@ var Pontoon = (function (my) {
   }
 
   /*
-   * Is element representing a pluralized string?
+   * Is ast element representing a pluralized string?
    *
    * Keys of all variants of such elements are either
    * CLDR plurals or numbers.
@@ -55,11 +55,10 @@ var Pontoon = (function (my) {
   /*
    * Is ast of a message, supported in rich FTL editor?
    *
-   * Message is supported if all value elements
-   * and all attribute elements are of type:
-   * - TextElement
-   * - Placeable with expression type CallExpression, ExternalArgument,
-   *   MessageReference or SelectExpression
+   * Message is supported if it's valid and all value elements
+   * and all attribute elements are:
+   * - simple elements or
+   * - select expressions
    */
   function isSupportedMessage(ast) {
     function elementsSupported(elements) {
@@ -87,9 +86,8 @@ var Pontoon = (function (my) {
   /*
    * Is ast of a simple message?
    *
-   * A simple message has no attributes or tags,
-   * and the value can only contain text and
-   * references to external arguments or other messages.
+   * A simple message has no attributes and all value
+   * elements are simple.
    */
   function isSimpleMessage(ast) {
     if (
@@ -123,12 +121,12 @@ var Pontoon = (function (my) {
   }
 
   /*
-   * Render original string element: simple string value or a variant.
+   * Render original string element with given title and ast elements
    */
-  function renderOriginalElement(value, elements) {
+  function renderOriginalElement(title, elements) {
     return '<li>' +
       '<span class="id">' +
-        value +
+        title +
       '</span>' +
       '<span class="value">' +
         stringifyElements(elements, true) +
@@ -137,7 +135,7 @@ var Pontoon = (function (my) {
   }
 
   /*
-   * Render editor element: simple string value or a variant.
+   * Render editor element with given title and ast elements
    */
   function renderEditorElement(title, elements, isPlural, isTranslated) {
     // Special case: Access keys
@@ -174,7 +172,7 @@ var Pontoon = (function (my) {
   }
 
   /*
-   * Render original string elements.
+   * Render original string elements
    *
    * - Adjoining simple elements are concatenated and presented as a simple string
    * - SelectExpression elements are presented as a list of variants
@@ -209,7 +207,7 @@ var Pontoon = (function (my) {
   }
 
   /*
-   * Render editor elements.
+   * Render editor elements
    *
    * - Adjoining simple elements are concatenated and presented as a simple string
    * - SelectExpression elements are presented as a list of variants
@@ -261,7 +259,7 @@ var Pontoon = (function (my) {
   }
 
   /*
-   * Serialize values in FTL editor forms into an FTL string.
+   * Serialize values in FTL editor forms into an FTL string
    */
   function serializeElements(elements) {
     var value = '';
@@ -361,7 +359,7 @@ var Pontoon = (function (my) {
   }
 
   /*
-   * Perform error checks for provided translationAST and entityAST.
+   * Perform error checks for provided translationAST and entityAST
    */
   function runChecks(translationAST, entityAST) {
     // Parse error

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -99,9 +99,7 @@ var Pontoon = (function (my) {
       ast &&
       !ast.attributes.length &&
       ast.value &&
-      ast.value.elements.every(function(item) {
-        return isSimpleElement(item);
-      })
+      ast.value.elements.every(isSimpleElement)
     ) {
       return true;
     }

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -301,7 +301,9 @@ var Pontoon = (function (my) {
           $('#ftl-area textarea').prop('readonly', true);
         }
 
-        Pontoon.fluent.focusFirstField();
+        // Focus first field of the FTL editor
+        $('#ftl-area textarea:not(".id"):visible').first().focus();
+
         Pontoon.fluent.toggleEditorToolbar();
 
         Pontoon.moveCursorToBeginning();
@@ -822,14 +824,6 @@ var Pontoon = (function (my) {
 
         var ast = fluentParser.parseEntry(entity.original);
         return this.serializePlaceables(ast.value.elements);
-      },
-
-
-      /*
-       * Focus first field of the FTL editor
-       */
-      focusFirstField: function () {
-        $('#ftl-area textarea:not(".id"):visible').first().focus();
       },
 
     },

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -472,7 +472,7 @@ var Pontoon = (function (my) {
 
       /*
        * Get source string value of a simple FTL message to be used in
-       * tje Copy (original to translation) function
+       * the Copy (original to translation) function
        */
       getSourceStringValue: function (entity, fallback) {
         if (entity.format !== 'ftl' || this.isComplexFTL()) {

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -107,6 +107,22 @@ var Pontoon = (function (my) {
   }
 
   /*
+   * Render textarea element with the given properties
+   */
+  function renderTextareaElement(id, value, maxlength) {
+    var element = '<textarea class="value" id="ftl-id-' + id + '"';
+
+    if (typeof maxlength !== 'undefined' && maxlength !== null) {
+      element += ' maxlength="' + maxlength + '"';
+    }
+
+    element += ' dir="' + Pontoon.locale.direction +
+      '" data-script="' + Pontoon.locale.script +
+      '" lang="' + Pontoon.locale.code + '">' + value + '</textarea>';
+    return element;
+  }
+
+  /*
    * Render original string element: simple string value or a variant.
    */
   function renderOriginalElement(value, elements) {
@@ -145,7 +161,7 @@ var Pontoon = (function (my) {
     }
 
     var value = isTranslated ? stringifyElements(elements) : '';
-    var textarea = Pontoon.fluent.getTextareaElement(title, value, maxlength);
+    var textarea = renderTextareaElement(title, value, maxlength);
 
     return '<li>' +
       '<label class="id" for="ftl-id-' + title + '">' +
@@ -509,23 +525,6 @@ var Pontoon = (function (my) {
         Pontoon.updateInPlaceTranslation();
 
         return true;
-      },
-
-
-      /*
-       * Generate textarea element with the given properties
-       */
-      getTextareaElement: function (id, value, maxlength) {
-        var base = '<textarea class="value" id="ftl-id-' + id + '"';
-
-        if (typeof maxlength !== 'undefined' && maxlength !== null) {
-          base += ' maxlength="' + maxlength + '"';
-        }
-
-        base += ' dir="' + Pontoon.locale.direction +
-          '" data-script="' + Pontoon.locale.script +
-          '" lang="' + Pontoon.locale.code + '">' + value + '</textarea>';
-        return base;
       },
 
 

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -53,31 +53,36 @@ var Pontoon = (function (my) {
   }
 
   /*
-   * Is ast of a message, supported in rich FTL editor?
+   * Are all elements supported in rich FTL editor?
    *
-   * Message is supported if it's valid and all value elements
-   * and all attribute elements are:
+   * Elements are supported if they are:
    * - simple elements or
    * - select expressions
    */
-  function isSupportedMessage(ast) {
-    function elementsSupported(elements) {
-      return elements.every(function(element) {
-        return (
-          isSimpleElement(element) ||
-          (element.expression && element.expression.type === 'SelectExpression')
-        );
-      });
-    }
+  function areSupportedElements(elements) {
+    return elements.every(function(element) {
+      return (
+        isSimpleElement(element) ||
+        (element.expression && element.expression.type === 'SelectExpression')
+      );
+    });
+  }
 
+  /*
+   * Is ast of a message, supported in rich FTL editor?
+   *
+   * Message is supported if it's valid and all value elements
+   * and all attribute elements are supported.
+   */
+  function isSupportedMessage(ast) {
     // Parse error
     if (ast.type === 'Junk') {
       return false;
     }
 
-    var valueSupported = !ast.value || elementsSupported(ast.value.elements);
+    var valueSupported = !ast.value || areSupportedElements(ast.value.elements);
     var attributesSupported = ast.attributes.every(function (attribute) {
-      return attribute.value && elementsSupported(attribute.value.elements);
+      return attribute.value && areSupportedElements(attribute.value.elements);
     });
 
     return valueSupported && attributesSupported;

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -1764,13 +1764,17 @@ var Pontoon = (function (my) {
           return;
         }
 
-        var textarea = $('#editor textarea:visible:focus, #editor textarea:visible:first'),
-            selectionStart = textarea.prop('selectionStart'),
-            selectionEnd = textarea.prop('selectionEnd'),
-            placeable = $(this).text(),
-            cursorPos = selectionStart + placeable.length,
-            before = textarea.val(),
-            after = before.substring(0, selectionStart) + placeable + before.substring(selectionEnd);
+        var textarea = $('#editor textarea:visible:focus');
+        if (!textarea.length) {
+          textarea = $('#editor textarea:visible:first');
+        }
+
+        var selectionStart = textarea.prop('selectionStart');
+        var selectionEnd = textarea.prop('selectionEnd');
+        var placeable = $(this).text();
+        var cursorPos = selectionStart + placeable.length;
+        var before = textarea.val();
+        var after = before.substring(0, selectionStart) + placeable + before.substring(selectionEnd);
 
         textarea.val(after).focus();
         textarea[0].setSelectionRange(cursorPos, cursorPos);

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -444,7 +444,7 @@ var Pontoon = (function (my) {
      * Update cached translation, needed for unsaved changes check
      */
     updateCachedTranslation: function () {
-      this.cachedTranslation = this.fluent.getTranslationSource();
+      this.cachedTranslation = this.fluent.getFTLEditorContentsAsSource();
     },
 
 
@@ -650,7 +650,7 @@ var Pontoon = (function (my) {
       }
 
       // FTL: Complex original string and translation
-      self.fluent.toggleOriginal();
+      self.fluent.renderOriginal();
       self.fluent.toggleEditor();
 
       if (self.fluent.isFTLEditorEnabled()) {
@@ -716,7 +716,7 @@ var Pontoon = (function (my) {
       }
 
       var before = this.cachedTranslation,
-          after = this.fluent.getTranslationSource();
+          after = this.fluent.getFTLEditorContentsAsSource();
 
       if ((before !== null) && (before !== after)) {
         $('#unsaved').show();
@@ -2605,7 +2605,7 @@ var Pontoon = (function (my) {
           }
 
           var pf = self.getPluralForm(true);
-          self.cachedTranslation = self.fluent.getTranslationSource();
+          self.cachedTranslation = self.fluent.getFTLEditorContentsAsSource();
           self.updateTranslation(entity, pf, data.translation);
           self.updateInPlaceTranslation(data.translation.string);
           self.updateFilterUI();

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -4222,6 +4222,7 @@ Pontoon.user = {
 Pontoon.attachMainHandlers();
 Pontoon.attachEntityListHandlers();
 Pontoon.attachEditorHandlers();
+Pontoon.fluent.attachFTLEditorHandlers();
 Pontoon.attachBatchEditorHandlers();
 
 Pontoon.updateInitialState();


### PR DESCRIPTION
A dozen or so fixes that should make `fluent_interface.js` easier to review and migrate to React. The refactor is limited to the plan outlined in [the bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1433499#c3).

Diff is unreadable, so I strongly suggest looking into each commit diff message separately.