### PR TITLE
Set background colour at beginning of html load

### DIFF
--- a/pontoon/base/templates/base.html
+++ b/pontoon/base/templates/base.html
@@ -15,6 +15,13 @@
     <link rel="icon" href="{{ static('img/favicon.ico') }}">
 
     {% block site_css %}
+    <!-- Inlining CSS mitigates/prevents fouc. -->
+    <style>
+      body {
+         background: #333941;
+      }
+    </style>
+
       {% stylesheet 'base' %}
 
       {% block extend_css %}

--- a/pontoon/base/templates/django/base.html
+++ b/pontoon/base/templates/django/base.html
@@ -19,6 +19,12 @@
     {% include "tracker.html" %}
 
     {% block extend_css %}
+    <!-- Inlining CSS mitigates/prevents fouc. -->
+    <style>
+      body {
+         background: #333941;
+      }
+    </style>
     {% endblock %}
     {% block extend_js %}
     {% endblock extend_js %}


### PR DESCRIPTION
This ~prevents/mitigates a fouc. Currently the body background is not set untill the css file is loaded - which means the browser paints the bg white initially - causing a fouc.

This doesnt entirely fix the problem but makes it much less noticable