### PR TITLE
Fix bug 1448814: Add 3rd-party service copyright notice to Terms

### DIFF
--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -544,7 +544,7 @@ var Pontoon = (function (my) {
               quality: Math.round(this.quality) + '%',
               url: 'https://www.microsoft.com/Language/en-US/Search.aspx?sString=' + this.source + '&langID=' + self.locale.ms_terminology_code,
               title: 'Visit Microsoft Terminology Service API.\n' +
-                     '© 2014 Microsoft Corporation. All rights reserved.',
+                     '© 2018 Microsoft Corporation. All rights reserved.',
               source: 'Microsoft',
               translation: this.target
             });

--- a/pontoon/base/templates/terms.html
+++ b/pontoon/base/templates/terms.html
@@ -6,13 +6,13 @@
 {% block class %}terms{% endblock %}
 
 {% block heading %}
-  {{ Heading.heading(title='Pontoon Terms of Use', subtitle='Last updated: 6 March 2018') }}
+  {{ Heading.heading(title='Pontoon Terms of Use', subtitle='Last updated: 26 March 2018') }}
 {% endblock %}
 
 {% block bottom %}
 <section id="main">
   <div class="container">
-    <p>By using Pontoon you are indicating your agreement to the <a href="https://www.mozilla.org/about/governance/policies/participation/">Mozilla Community Participation Guidelines</a> and the terms set out in the <a href="https://www.mozilla.org/about/governance/policies/commit/requirements/">Mozilla Commit Access Requirements</a>. To sum up:</p>
+    <p>By using Pontoon, you are indicating your agreement to the <a href="https://www.mozilla.org/about/governance/policies/participation/">Mozilla Community Participation Guidelines</a> and the terms set out in the <a href="https://www.mozilla.org/about/governance/policies/commit/requirements/">Mozilla Commit Access Requirements</a>. To sum up:</p>
 
     <dl>
       <dt>License</dt>
@@ -24,6 +24,17 @@
     </dl>
 
     <p>Learn more at <a href="https://www.mozilla.org/about/governance/policies/commit/requirements/">Mozilla.org</a>.</p>
+
+    <dl>
+      <dt>Third-Party Services</dt>
+      <dd>Pontoon uses the following third-party services that are subject to the copyright notice:
+        <ul>
+          <li>Microsoft Terminology Service API. © 2018 Microsoft Corporation. All rights reserved.</li>
+          <li>Microsoft Translator API. © 2018 Microsoft Corporation. All rights reserved.</li>
+        </ul>
+      </dd>
+    </dl>
+
   </div>
 </section>
 {% endblock %}


### PR DESCRIPTION
@guerojeff Could you have a look at the English and legal in this patch?

![a-fullpage](https://user-images.githubusercontent.com/626716/37901161-bd764382-30f0-11e8-99f5-5c2382a36bd8.png)
