### PR TITLE
Fix Bug 1450464: prevent tags view failing where latest translation is None

### DIFF
--- a/pontoon/tags/utils/latest_activity.py
+++ b/pontoon/tags/utils/latest_activity.py
@@ -43,8 +43,7 @@ class LatestActivity(object):
 
     @property
     def translation(self):
-        if self.activity.get('string'):
-            return dict(string=self.activity.get('string'))
+        return dict(string=self.activity.get('string', ''))
 
     @property
     def user(self):

--- a/tests/tags/utils/tagged.py
+++ b/tests/tags/utils/tagged.py
@@ -93,7 +93,7 @@ def test_util_latest_activity():
     activity = LatestActivity(dict(foo='bar'))
     assert activity.activity == dict(foo='bar')
     assert activity.type == 'submitted'
-    assert activity.translation is None
+    assert activity.translation == dict(string='')
     assert activity.user is None
 
     # check approved_date


### PR DESCRIPTION
Im not sure how this situation is created - but this fixes the issue for the tags view, and works the same as in other views