### PR TITLE
Fix bug 1450265: Filter Translators by project

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -2437,6 +2437,7 @@ class Translation(DirtyFieldsMixin, models.Model):
         """
         translations = Translation.objects.filter(
             entity__obsolete=False,
+            entity__resource__project=project,
             locale=locale
         )
 


### PR DESCRIPTION
The Translation Time and Translation Authors sections of the filter menu in the translate view should only include translations of the project that is currenty being translated if "All Resources" is selected (i.e. `path` not specified).

Note that #922 will fix the issue for Translation Authors, but not for the Translation Time filter, which also depends on `for_locale_project_paths`.