### PR TITLE
Fix bug 1453328: [FTL] Align key and value

### DIFF
--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -123,7 +123,7 @@ var Pontoon = (function (my) {
    * Render original string element with given title and ast elements
    */
   function renderOriginalElement(title, elements) {
-    return '<li>' +
+    return '<li class="clearfix">' +
       '<span class="id">' +
         title +
       '</span>' +
@@ -160,7 +160,7 @@ var Pontoon = (function (my) {
     var value = isTranslated ? stringifyElements(elements) : '';
     var textarea = renderTextareaElement(title, value, maxlength);
 
-    return '<li>' +
+    return '<li class="clearfix">' +
       '<label class="id" for="ftl-id-' + title + '">' +
         '<span>' + title + '</span>' +
         exampleSpan +


### PR DESCRIPTION
This is the problem we're fixing:
![attachment](https://user-images.githubusercontent.com/626716/39231221-a1225ee2-4869-11e8-8452-3f1a49f166ea.png)


For testing, you can use this string:
https://github.com/mozilla-l10n/pontoon-ftl/blob/master/en-US/preferences.ftl#L35