### PR TITLE
Fix bug 1410619: Disable acronym checks

### DIFF
--- a/pontoon/checks/libraries/__init__.py
+++ b/pontoon/checks/libraries/__init__.py
@@ -40,7 +40,13 @@ def run_checks(
     resource_ext = entity.resource.format
 
     if use_tt_checks and resource_ext != 'ftl':
-        tt_disabled_checks = set()
+        # Always disable checks we don't use. For details, see:
+        # https://bugzilla.mozilla.org/show_bug.cgi?id=1410619
+        tt_disabled_checks = {
+            'acronyms',
+            'gconf',
+            'kdecomments',
+        }
 
         # Some compare-locales checks overlap with Translate Toolkit checks
         if cl_checks is not None:

--- a/pontoon/checks/libraries/translate_toolkit.py
+++ b/pontoon/checks/libraries/translate_toolkit.py
@@ -25,7 +25,6 @@ def run_checks(original, string, locale, disabled_checks=None):
 
     check_names = {
         'accelerators': 'Accelerators',
-        'acronyms': 'Acronyms',
         'blank': 'Blank',
         'brackets': 'Brackets',
         'compendiumconflicts': 'Compendium conflict',
@@ -39,8 +38,6 @@ def run_checks(original, string, locale, disabled_checks=None):
         'escapes': 'Escapes',
         'filepaths': 'File paths',
         'functions': 'Functions',
-        'gconf': 'GConf values',
-        'kdecomments': 'Old KDE comment',
         'long': 'Long',
         'musttranslatewords': 'Must translate words',
         'newlines': 'Newlines',

--- a/tests/checks/libraries.py
+++ b/tests/checks/libraries.py
@@ -195,5 +195,5 @@ def test_tt_disabled_checks(
         ANY,
         ANY,
         ANY,
-        set()
+        {'acronyms', 'gconf', 'kdecomments'}
     )


### PR DESCRIPTION
Also disable KDE and Gnome specific checks.

@jotes r?