### PR TITLE
Fix bug 1456846 - Fix docker dev environment.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ tmp/*
 docs/_build
 venv
 /media/
+.cache/
+coverage/
 
 # For docker
 .docker-build

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,10 @@ help:
 	@echo "  build-frontend-w Watches the frontend static files and builds on change\n"
 
 .docker-build:
-	make dockerbuild
+	make build
+
+assets:
+	mkdir -p assets
 
 build:
 	cp ./docker/config/webapp.env.template ./docker/config/webapp.env
@@ -54,10 +57,10 @@ loaddb:
 	${DOCKER} exec -i `${DC} ps -q postgresql` createdb -U pontoon pontoon
 	${DOCKER} exec -i `${DC} ps -q postgresql` pg_restore -U pontoon -d pontoon -O < ${DB_DUMP_FILE}
 
-build-frontend:
+build-frontend: assets
 	${DC} run webapp npm run build
 
-build-frontend-w:
+build-frontend-w: assets
 	${DOCKER} run --rm \
 		-v `pwd`:/app \
 		--workdir /app \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,8 @@ services:
       - "8000:8000"
     volumes:
       - .:/app
+    entrypoint:
+      - ./docker/entrypoint_webapp.sh
 
   postgresql:
     build:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,6 +25,20 @@ RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 RUN DEBIAN_FRONTEND=noninteractive apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs
 
+# Create some folders and give them to the app user
+RUN mkdir -p /webapp-frontend-deps && chown app:app /webapp-frontend-deps
+RUN chown app:app /app
+
+# Create the folder for front-end assets
+RUN mkdir -p /app/assets/
+RUN chown app:app /app/assets
+
+# Link to the node modules installed with npm. We install those in a different folder because
+# when using this container in development, we replace the /app folder with a volume. By putting
+# those dependencies outside of /app, we can reuse them more easily.
+RUN ln -s /webapp-frontend-deps/node_modules /app/node_modules
+
+# Install node requirements
 COPY ./package.json /webapp-frontend-deps/package.json
 COPY ./package-lock.json /webapp-frontend-deps/package-lock.json
 RUN cd /webapp-frontend-deps/ && npm install
@@ -32,19 +46,20 @@ RUN cd /webapp-frontend-deps/ && npm install
 COPY . /app/
 COPY ./docker/config/webapp.env /app/.env
 
+# Python environment variables
 ENV PYTHONUNBUFFERED 1
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONPATH /app
 
 # JavaScript applications paths
-ENV WEBPACK_BINARY /webapp-frontend-deps/node_modules/.bin/webpack
-ENV NPM_ROOT_PATH /webapp-frontend-deps/
+ENV WEBPACK_BINARY /app/node_modules/.bin/webpack
+ENV YUGLIFY_BINARY /app/node_modules/.bin/yuglify
 
 # Run collectstatic in container which puts files in the default place for
 # static files.
 RUN cd /app/ && python manage.py collectstatic --noinput
 
-# Run webpack
+# Run webpack to compile JS files
 RUN cd /app/ && $WEBPACK_BINARY
 
 CMD ["/app/docker/run_webapp.sh"]

--- a/docker/entrypoint_webapp.sh
+++ b/docker/entrypoint_webapp.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Make sure a link to the node modules is created.
+ln -s /webapp-frontend-deps/node_modules /app/node_modules
+
+# Add local user
+# Either use the LOCAL_USER_ID if passed in at runtime or
+# fallback
+
+USER_ID=${LOCAL_USER_ID:-10001}
+
+echo "Starting with UID : $USER_ID"
+usermod -o -u $USER_ID app
+chown -R app:app /app
+export HOME=/home/app
+exec /usr/local/bin/gosu app "$@"

--- a/docker/run_tests.sh
+++ b/docker/run_tests.sh
@@ -37,9 +37,9 @@ $NPM test
 echo ""
 echo "--------------------------------------------------------------------------------------------"
 echo "Running Python tests with django"
-$PYTHON manage.py test --with-coverage
+$PYTHON manage.py test
 
 echo ""
 echo "--------------------------------------------------------------------------------------------"
 echo "Running Python tests with pytest"
-$PYTEST --cov-append --cov-report=term --cov=.
+$PYTEST

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -228,7 +228,9 @@ AUTHENTICATION_BACKENDS = [
 # App supports giving permissions for anonymous users.
 ANONYMOUS_USER_ID = -1
 GUARDIAN_RAISE_403 = True
-PIPELINE_YUGLIFY_BINARY = path('node_modules/.bin/yuglify')
+PIPELINE_YUGLIFY_BINARY = path(
+    os.environ.get('YUGLIFY_BINARY', 'node_modules/.bin/yuglify')
+)
 PIPELINE_BABEL_BINARY = path('node_modules/.bin/babel')
 PIPELINE_BABEL_ARGUMENTS = '--modules ignore'
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,7 +48,7 @@ module.exports = {
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('production'),
     }),
-    new BundleTracker({filename: path.resolve(__dirname, 'webpack-stats.json')}),
+    new BundleTracker({filename: './webpack-stats.json'}),
     new MiniCssExtractPlugin({
       // Options similar to the same options in webpackOptions.output
       // both options are optional

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,7 +36,10 @@ module.exports = {
   resolve: {
     // This allows you to import modules just like you would in a NodeJS app.
     extensions: ['.js', '.jsx'],
-    modules: [path.resolve(__dirname, 'pontoon/static/js/'), "node_modules"]
+    modules: [
+      path.resolve(__dirname, 'pontoon/static/js/'),
+      'node_modules',
+    ]
   },
 
   plugins: [
@@ -45,7 +48,7 @@ module.exports = {
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('production'),
     }),
-    new BundleTracker({filename: './webpack-stats.json'}),
+    new BundleTracker({filename: path.resolve(__dirname, 'webpack-stats.json')}),
     new MiniCssExtractPlugin({
       // Options similar to the same options in webpackOptions.output
       // both options are optional


### PR DESCRIPTION
This commit ensures that:
 - the assets/ folder is always created
 - dependencies (Python and node) do not pollute the user's repository. They are now installed in a different folder inside the container
 - webpack takes resources from the right place, and puts bundles in the right folder

This looks like a small patch but it was actually fairly complex. The reason is that our Dockerfile is made for a production deployment, meaning that it builds all the resources it needs to run in place. That's fine. However, when we run locally for development, using docker-compose, we override the /app folder with the user's local folder. That means all resources built during `make build` are lost. This patch puts those resources in a different folder, and then links to that folder from the user's repository. This allows to keep a clean production build process, while having a working dev environment, and a clean local folder.