### PR TITLE
Bug 1458347: Move Fluent checks to backend

### DIFF
--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -1616,6 +1616,7 @@ body > header aside p {
 
 .warning-overlay {
   background: #272A2F;
+  border-top: 1px solid #5E6475;
   bottom: 0;
   display: none;
   left: 0;

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -666,7 +666,6 @@ var Pontoon = (function (my) {
           return translation;
         }
 
-        var entityAST = fluentParser.parseEntry(entity.original);
         var content = entity.key + ' = ';
         var valueElements = $('#ftl-area .main-value ul:first > li:visible');
         var attributeElements = $('#ftl-area .attributes ul:first > li:visible');
@@ -823,8 +822,7 @@ var Pontoon = (function (my) {
               }
 
               self.toggleEditor(showFTLEditor);
-            },
-            error: function(error) {}
+            }
           });
         });
 

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -466,11 +466,6 @@ var Pontoon = (function (my) {
 
         var translation = this.serializeTranslation(entity, fallback);
 
-        // If translation broken, incomplete or empty
-        if (translation.error) {
-          return translation.error;
-        }
-
         // Special case: empty translations in rich FTL editor don't serialize properly
         if (this.isFTLEditorEnabled()) {
           var richTranslation = $.map(

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -362,17 +362,7 @@ var Pontoon = (function (my) {
   /*
    * Perform error checks for provided translationAST and entityAST
    */
-  function runChecks(translationAST, entityAST) {
-    // Parse error
-    if (translationAST.type === 'Junk') {
-      return translationAST.annotations[0].message;
-    }
-
-    // Detect Message ID mismatch
-    else if (entityAST.id.name !== translationAST.id.name) {
-      return 'Please make sure the translation key matches the source string key';
-    }
-  }
+  function runChecks(translationAST, entityAST) {}
 
   /*
    * Toggle translation length and Copy button in editor toolbar

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -368,21 +368,6 @@ var Pontoon = (function (my) {
       return translationAST.annotations[0].message;
     }
 
-    // TODO: Should be removed by bug 1237667
-    // Detect missing values
-    else if (entityAST.value && !translationAST.value) {
-      return 'Please make sure to fill in the value';
-    }
-
-    // Detect missing attributes
-    else if (
-      entityAST.attributes &&
-      translationAST.attributes &&
-      entityAST.attributes.length !== translationAST.attributes.length
-    ) {
-      return 'Please make sure to fill in all the attributes';
-    }
-
     // Detect Message ID mismatch
     else if (entityAST.id.name !== translationAST.id.name) {
       return 'Please make sure the translation key matches the source string key';

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -2549,11 +2549,12 @@ var Pontoon = (function (my) {
 
 
     /*
-     * Show failing checks
+     * Show failed check type
      *
-     * failedChecks Array of warnings or errors
+     * type 'error' or 'warning'
+     * failedChecks Array of errors or warnings
      */
-    showFailedChecks: function(type, failedChecks) {
+    showFailedCheckType: function(type, failedChecks) {
       $(failedChecks).each(function() {
         $('#quality ul').append(
           '<li class="' + type + '">' +
@@ -2562,6 +2563,40 @@ var Pontoon = (function (my) {
           '</li>'
         );
       });
+    },
+
+
+    /*
+     * Render failed checks panel
+     *
+     * failedChecks Array of errors or warnings
+     */
+    renderFailedChecks: function(failedChecks, messageOnly) {
+      if (!messageOnly) {
+        $('#save-anyway').show();
+      }
+
+      $('#quality ul').empty();
+
+      if (failedChecks.clErrors) {
+        $('#save-anyway').hide();
+        this.showFailedCheckType('error', failedChecks.clErrors);
+      }
+
+      if (failedChecks.pErrors) {
+        $('#save-anyway').hide();
+        this.showFailedCheckType('error', failedChecks.pErrors);
+      }
+
+      if (failedChecks.clWarnings) {
+        this.showFailedCheckType('warning', failedChecks.clWarnings);
+      }
+
+      if (failedChecks.ttWarnings) {
+        this.showFailedCheckType('warning', failedChecks.ttWarnings);
+      }
+
+      $('#quality').show();
     },
 
 
@@ -2632,30 +2667,8 @@ var Pontoon = (function (my) {
 
         } else if (data.failedChecks) {
           self.endLoader();
-          var failedChecks = data.failedChecks;
+          self.renderFailedChecks(data.failedChecks);
 
-          $('#save-anyway').show();
-          $('#quality ul').empty();
-
-          if (failedChecks.clErrors) {
-            $('#save-anyway').hide();
-            self.showFailedChecks('error', failedChecks.clErrors);
-          }
-
-          if (failedChecks.pErrors) {
-            $('#save-anyway').hide();
-            self.showFailedChecks('error', failedChecks.pErrors);
-          }
-
-          if (failedChecks.clWarnings) {
-            self.showFailedChecks('warning', failedChecks.clWarnings);
-          }
-
-          if (failedChecks.ttWarnings) {
-            self.showFailedChecks('warning', failedChecks.ttWarnings);
-          }
-
-          $('#quality').show();
         } else {
           self.endLoader(data, 'error');
         }

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -2678,13 +2678,6 @@ var Pontoon = (function (my) {
         self.XHRupdateOnServer.abort();
       }
 
-      // If Fluent translation contains error, display it and abort
-      var serializedTranslation = self.fluent.serializeTranslation(entity, translation);
-      if (serializedTranslation.error) {
-        self.endLoader(serializedTranslation.error, 'error', 5000);
-        return self.reattachSaveButtonHandler();
-      }
-
       self.XHRupdateOnServer = $.ajax({
         url: '/update/',
         type: 'POST',
@@ -2692,7 +2685,7 @@ var Pontoon = (function (my) {
           csrfmiddlewaretoken: $('#server').data('csrf'),
           locale: self.locale.code,
           entity: entity.pk,
-          translation: serializedTranslation,
+          translation: self.fluent.serializeTranslation(entity, translation),
           plural_form: submittedPluralForm,
           original: entity['original' + self.isPluralized()],
           ignore_warnings: $('#quality').is(':visible') || !syncLocalStorage,

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -2872,6 +2872,14 @@ var Pontoon = (function (my) {
           self.navigateToEntity('previous');
           return false;
         }
+
+        // Esc: Close warning overlay
+        if (key === 27) {
+          if ($('.warning-overlay').is(':visible')) {
+            $('.warning-overlay .cancel').click();
+          }
+          return false;
+        }
       });
 
       // iFrame fix on hiding menus

--- a/pontoon/base/urls.py
+++ b/pontoon/base/urls.py
@@ -63,6 +63,8 @@ urlpatterns = [
         name='pontoon.entities'),
     url(r'^update/', views.update_translation,
         name='pontoon.update'),
+    url(r'^perform-checks/', views.perform_checks,
+        name='pontoon.perform.checks'),
     url(r'^get-history/', views.get_translation_history,
         name='pontoon.get_history'),
     url(r'^unapprove-translation/', views.unapprove_translation,

--- a/pontoon/checks/libraries/__init__.py
+++ b/pontoon/checks/libraries/__init__.py
@@ -9,7 +9,7 @@ from . import pontoon
 
 def run_checks(
     entity,
-    locale,
+    locale_code,
     original,
     string,
     use_tt_checks,
@@ -19,7 +19,7 @@ def run_checks(
     Main function that performs all quality checks from frameworks handled in Pontoon.
 
     :arg pontoon.base.models.Entity entity: Source entity
-    :arg pontoon.base.models.Locale locale: Locale of a translation
+    :arg basestring locale_code: Locale code of a translation
     :arg basestring original: an original string
     :arg basestring string: a translation
     :arg bool use_tt_checks: use Translate Toolkit checks
@@ -30,7 +30,7 @@ def run_checks(
         * None - If there's no errors and non-omitted warnings.
     """
     try:
-        cl_checks = compare_locales.run_checks(entity, locale.code, string)
+        cl_checks = compare_locales.run_checks(entity, locale_code, string)
     except compare_locales.UnsupportedStringError:
         cl_checks = None
     except compare_locales.UnsupportedResourceTypeError:
@@ -61,7 +61,7 @@ def run_checks(
             tt_disabled_checks.add('untranslated')
 
         tt_checks = translate_toolkit.run_checks(
-            original, string, locale, tt_disabled_checks
+            original, string, locale_code, tt_disabled_checks
         )
 
     checks = dict(

--- a/pontoon/checks/libraries/__init__.py
+++ b/pontoon/checks/libraries/__init__.py
@@ -31,6 +31,8 @@ def run_checks(
     """
     try:
         cl_checks = compare_locales.run_checks(entity, locale.code, string)
+    except compare_locales.UnsupportedStringError:
+        cl_checks = None
     except compare_locales.UnsupportedResourceTypeError:
         cl_checks = None
 

--- a/pontoon/checks/libraries/compare_locales.py
+++ b/pontoon/checks/libraries/compare_locales.py
@@ -3,11 +3,13 @@ from __future__ import absolute_import
 from collections import namedtuple
 
 from compare_locales.checks import getChecker
+from compare_locales.parser.base import Junk
 from compare_locales.parser.fluent import FluentParser
 from compare_locales.parser.properties import PropertiesEntityMixin
 from compare_locales.parser.dtd import DTDEntityMixin
 
 from compare_locales.paths import File
+
 
 CommentEntity = namedtuple(
     'Comment', (
@@ -53,6 +55,11 @@ class CompareDTDEntity(DTDEntityMixin):
 
 class UnsupportedResourceTypeError(Exception):
     """Raise if compare-locales doesn't support given resource-type."""
+    pass
+
+
+class UnsupportedStringError(Exception):
+    """Raise if compare-locales doesn't support given string."""
     pass
 
 
@@ -103,6 +110,10 @@ def cast_to_compare_locales(resource_ext, entity, string):
 
         parser.readUnicode(string)
         trEntity, = list(parser)
+
+        if isinstance(trEntity, Junk):
+            raise UnsupportedStringError(resource_ext)
+
         return (
             refEntity,
             trEntity,

--- a/pontoon/checks/libraries/compare_locales.py
+++ b/pontoon/checks/libraries/compare_locales.py
@@ -18,7 +18,7 @@ CommentEntity = namedtuple(
 )
 
 
-# Because we can't pass the context to all entities passed to compare locales,
+# Because we can't pass the context to all entities passed to compare-locales,
 # we have to create our equivalents of compare-locale's internal classes.
 
 class ComparePropertiesEntity(PropertiesEntityMixin):
@@ -70,7 +70,6 @@ def cast_to_compare_locales(resource_ext, entity, string):
     :arg basestring resource_ext: extension of a resource.
     :arg pontoon.base.models.Entity entity: Source entity
     :arg basestring string: a translation
-    :arg pontoon.base.models.Locale locale: Locale of a translation
     :return: source entity and translation entity that will be compatible with
         a compare-locales checker. Type of those entities depends on the resource_ext.
     """
@@ -122,12 +121,12 @@ def cast_to_compare_locales(resource_ext, entity, string):
     raise UnsupportedResourceTypeError(resource_ext)
 
 
-def run_checks(entity, locale, string):
+def run_checks(entity, locale_code, string):
     """
     Run all compare-locales checks on provided translation and entity.
     :arg pontoon.base.models.Entity entity: Source entity instance
+    :arg basestring locale_code: Locale of a translation
     :arg basestring string: translation string
-    :arg pontoon.base.models.Locale locale: Locale of a translation
 
     :return: Dictionary with the following structure:
         {
@@ -149,7 +148,7 @@ def run_checks(entity, locale, string):
     )
 
     checker = getChecker(
-        File(entity.resource.path, entity.resource.path, locale=locale),
+        File(entity.resource.path, entity.resource.path, locale=locale_code),
         {'android-dtd'}
     )
 

--- a/pontoon/checks/libraries/pontoon.py
+++ b/pontoon/checks/libraries/pontoon.py
@@ -35,19 +35,19 @@ def run_checks(entity, string):
 
     if max_length and len(string) > max_length:
         checks['pErrors'].append(
-            'Translation too long.'
+            'Translation too long'
         )
 
     # Prevent empty translation submissions if not supported
     if resource_ext not in {'properties', 'ini', 'dtd'} and string == '':
         checks['pErrors'].append(
-            'Empty translations cannot be submitted.'
+            'Empty translations cannot be submitted'
         )
 
     # Newlines are not allowed in .lang files (bug 1190754)
     if resource_ext == 'lang' and '\n' in string:
         checks['pErrors'].append(
-            'Newline characters are not allowed.'
+            'Newline characters are not allowed'
         )
 
     # FTL checks

--- a/pontoon/checks/libraries/pontoon.py
+++ b/pontoon/checks/libraries/pontoon.py
@@ -33,6 +33,7 @@ def run_checks(entity, string):
     resource_ext = entity.resource.format
     max_length = get_max_length(entity.comment)
 
+    # Prevent translations exceeding the given length limit
     if max_length and len(string) > max_length:
         checks['pErrors'].append(
             'Translation too long'

--- a/pontoon/checks/libraries/translate_toolkit.py
+++ b/pontoon/checks/libraries/translate_toolkit.py
@@ -5,7 +5,7 @@ from translate.lang import data as lang_data
 from translate.storage import base as storage_base
 
 
-def run_checks(original, string, locale, disabled_checks=None):
+def run_checks(original, string, locale_code, disabled_checks=None):
     """Check for obvious errors like blanks and missing interpunction."""
     original = lang_data.normalized_unicode(original)
     string = lang_data.normalized_unicode(string)
@@ -14,7 +14,7 @@ def run_checks(original, string, locale, disabled_checks=None):
     unit = storage_base.TranslationUnit(original)
     unit.target = string
     checker = checks.StandardChecker(
-        checkerconfig=checks.CheckerConfig(targetlanguage=locale.code),
+        checkerconfig=checks.CheckerConfig(targetlanguage=locale_code),
         excludefilters=disabled_checks
     )
 

--- a/tests/checks/compare_locales.py
+++ b/tests/checks/compare_locales.py
@@ -46,7 +46,7 @@ def mock_quality_check_args(
 
     return {
         'entity': entity,
-        'locale': 'en-US',
+        'locale_code': 'en-US',
         'string': translation,
     }
 

--- a/tests/checks/libraries.py
+++ b/tests/checks/libraries.py
@@ -93,23 +93,15 @@ def entity_ftl_mock():
     yield mock
 
 
-@pytest.yield_fixture()
-def locale_mock():
-    mock = MagicMock()
-    mock.code = 'en-US'
-    yield mock
-
-
 def test_ignore_warnings(
     entity_properties_plurals_mock,
-    locale_mock
 ):
     """
     Check if logic of ignore_warnings works when there are errors.
     """
     assert run_checks(
         entity_properties_plurals_mock,
-        locale_mock,
+        'en-US',
         entity_properties_plurals_mock.string,
         'plural1;plural2;plural3;plural4;plural5',
         True,
@@ -124,7 +116,7 @@ def test_ignore_warnings(
     # Warnings can be ignored for Translate Toolkit if user decides to do so
     assert run_checks(
         entity_properties_plurals_mock,
-        locale_mock,
+        'en-US',
         entity_properties_plurals_mock.string,
         'plural1;plural2;plural3;plural4;plural5',
         False,
@@ -138,14 +130,13 @@ def test_ignore_warnings(
 
 def test_invalid_resource_compare_locales(
     entity_invalid_resource_mock,
-    locale_mock,
 ):
     """
     Unsupported resource shouldn't raise an error.
     """
     assert run_checks(
         entity_invalid_resource_mock,
-        locale_mock,
+        'en-US',
         entity_invalid_resource_mock.string,
         'Translation',
         False,
@@ -156,15 +147,14 @@ def test_invalid_resource_compare_locales(
 def test_tt_disabled_checks(
     entity_properties_mock,
     entity_dtd_mock,
-    locale_mock,
-    run_tt_checks_mock
+    run_tt_checks_mock,
 ):
     """
     Check if overlapping checks are disabled in Translate Toolkit.
     """
     assert run_checks(
         entity_properties_mock,
-        locale_mock,
+        'en-US',
         entity_properties_mock.string,
         'invalid translation \q',
         True,
@@ -185,7 +175,7 @@ def test_tt_disabled_checks(
 
     assert run_checks(
         entity_dtd_mock,
-        locale_mock,
+        'en-US',
         entity_properties_mock.string,
         'Translated string',
         True,

--- a/tests/checks/pontoon.py
+++ b/tests/checks/pontoon.py
@@ -65,7 +65,7 @@ def test_too_long_translation_invalid_length(get_entity_mock):
     assert run_checks(
         get_entity_mock('lang', 'MAX_LENGTH: 2'),
         '0123'
-    ) == {'pErrors': ['Translation too long.']}
+    ) == {'pErrors': ['Translation too long']}
 
 
 def test_empty_translations(get_entity_mock):
@@ -76,7 +76,7 @@ def test_empty_translations(get_entity_mock):
         get_entity_mock('po'),
         ''
     ) == {
-        'pErrors': [u'Empty translations cannot be submitted.']
+        'pErrors': [u'Empty translations cannot be submitted']
     }
 
     assert run_checks(
@@ -91,7 +91,7 @@ def test_lang_newlines(get_entity_mock):
         get_entity_mock('lang'),
         'aaa\nbbb'
     ) == {
-        'pErrors': [u'Newline characters are not allowed.']
+        'pErrors': [u'Newline characters are not allowed']
     }
 
     assert run_checks(


### PR DESCRIPTION
The gist of this PR is what [bug 1458347](https://bugzilla.mozilla.org/show_bug.cgi?id=1458347) says: [removing](https://github.com/mozilla/pontoon/commit/b60aa5dfa1ae27cb306f302c8fe44ef237097520) the checks that are already included in compare-locales and [moving](https://github.com/mozilla/pontoon/commit/95ddc691c63d9653835dceb063b1bb9db3be05d0) the rest to `pontoon.checks.libraries.pontoon`. I also made a few other related enhancements along the way ([1](https://github.com/mozilla/pontoon/commit/50dd35ec510417bad14dd1d044729759e88f11d9), [2](https://github.com/mozilla/pontoon/commit/d936b66b3ba0ba81c6ad49eab68a071348eacf1e), [3](https://github.com/mozilla/pontoon/commit/bb0fe9b1f2d2ea608d9c2f71be1860906419282c)). This part if pretty straightforward.

A slightly more complex beast is https://github.com/mozilla/pontoon/commit/16bc1052bb2d0067b21971183ab5d5647d635592, where I changed the logic for switching between the rich and source editor. That's needed because on editor switch we also run checks (to avoid losing content if it's broken). More details in commit message.

@jotes r?