### PR TITLE
Fix bug 1450505: [FTL] Re-enable Tab to copy from helpers

### DIFF
--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -1883,8 +1883,12 @@ var Pontoon = (function (my) {
         // Tab: Select suggestions
         if (!$('.menu').is(':visible') && key === 9 && !e.ctrlKey) {
 
-          // Rich FTL editor with complex message: ignore tab key
-          if (self.fluent.isFTLEditorEnabled() && self.fluent.isComplexFTL()) {
+          // Rich FTL editor with complex message and last element not focused: ignore tab key
+          if (
+            self.fluent.isFTLEditorEnabled() &&
+            self.fluent.isComplexFTL() &&
+            !$('#editor textarea:visible:last').is(":focus")
+          ) {
             return;
           }
 
@@ -1914,6 +1918,11 @@ var Pontoon = (function (my) {
           section
             .find('li.suggestion').removeClass('hover').end()
             .find('li.suggestion:eq(' + index + ')').addClass('hover').click();
+
+          // Needed to keep the experience smooth in rich FTL editor with complex messages.
+          // Without this, the first field gets focus and the subsequent Tab takes you to
+          // the next field.
+          $('#editor textarea:visible:last').focus();
 
           self.updateScroll(section);
           return false;

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -1887,7 +1887,7 @@ var Pontoon = (function (my) {
           if (
             self.fluent.isFTLEditorEnabled() &&
             self.fluent.isComplexFTL() &&
-            !$('#editor textarea:visible:last').is(":focus")
+            !$('#editor textarea:visible:last').is(':focus')
           ) {
             return;
           }


### PR DESCRIPTION
In complex FTL strings, multiple fields are present, and we use Tab to
navigate between them, as this is the browser default shortcut. We also
use Tab to navigate between helper suggestions (history, machinery,
locales), as many other CAT tools do.

This patch re-enables Tab for navigating helper suggestions for complex
FTL strings when the focus is in the last field. After the suggestion
is copied, we keep the focus in the last field to make moving to next
suggestion with subsequent Tabs easier.

@jotes r?