### PR TITLE
Fix bug 1453231: [FTL] Disable copy shortcut for complex strings

### DIFF
--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -1951,6 +1951,10 @@ var Pontoon = (function (my) {
       $('#copy').click(function (e) {
         e.preventDefault();
 
+        if (!$(this).is(':visible')) {
+          return;
+        }
+
         var entity = self.getEditorEntity(),
             original = entity['original' + self.isPluralized()],
             source = self.fluent.getSourceStringValue(entity, original);


### PR DESCRIPTION
When copy button is disabled (hidden), keyboard shortcut should be
disabled as well.

@jotes r?