### PR TITLE
Fix bug 1459596: Fix approval in suggest mode

### DIFF
--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -2686,7 +2686,7 @@ var Pontoon = (function (my) {
           self.endLoader(data, 'error');
         }
 
-        if (!data.warnings) {
+        if (!data.failedChecks) {
           self.approvedNotSubmitted = null;
         }
       }


### PR DESCRIPTION
When Make Suggestions is turned on and you approve a suggestion that
returns warnings and click `Save anyway`, suggestions needs to get
approved. Previously, `Same translation already exists` message was
getting displayed.