### PR TITLE
Fix bug 1460073: Ignore Android DTD escaping checks

### DIFF
--- a/pontoon/checks/libraries/compare_locales.py
+++ b/pontoon/checks/libraries/compare_locales.py
@@ -148,8 +148,7 @@ def run_checks(entity, locale_code, string):
     )
 
     checker = getChecker(
-        File(entity.resource.path, entity.resource.path, locale=locale_code),
-        {'android-dtd'}
+        File(entity.resource.path, entity.resource.path, locale=locale_code)
     )
 
     # Currently, references are required only by DTD files but that may change in the future.

--- a/pontoon/checks/libraries/compare_locales.py
+++ b/pontoon/checks/libraries/compare_locales.py
@@ -148,7 +148,8 @@ def run_checks(entity, locale_code, string):
     )
 
     checker = getChecker(
-        File(entity.resource.path, entity.resource.path, locale=locale_code)
+        File(entity.resource.path, entity.resource.path, locale=locale_code),
+        {'android-dtd'}
     )
 
     # Currently, references are required only by DTD files but that may change in the future.

--- a/pontoon/checks/libraries/compare_locales.py
+++ b/pontoon/checks/libraries/compare_locales.py
@@ -10,6 +10,8 @@ from compare_locales.parser.dtd import DTDEntityMixin
 
 from compare_locales.paths import File
 
+from pontoon.sync.utils import escape_quotes
+
 
 CommentEntity = namedtuple(
     'Comment', (
@@ -88,6 +90,9 @@ def cast_to_compare_locales(resource_ext, entity, string):
         )
 
     elif resource_ext == '.dtd':
+        if 'mobile/android/base' in entity.resource.path:
+            string = escape_quotes(string)
+
         return (
             CompareDTDEntity(
                 entity.key,

--- a/pontoon/checks/libraries/compare_locales.py
+++ b/pontoon/checks/libraries/compare_locales.py
@@ -90,9 +90,6 @@ def cast_to_compare_locales(resource_ext, entity, string):
         )
 
     elif resource_ext == '.dtd':
-        if 'mobile/android/base' in entity.resource.path:
-            string = escape_quotes(string)
-
         return (
             CompareDTDEntity(
                 entity.key,
@@ -145,6 +142,11 @@ def run_checks(entity, locale_code, string):
         Both keys are optional.
     """
     resource_ext = '.{}'.format(entity.resource.format)
+    extra_tests = None
+
+    if 'mobile/android/base' in entity.resource.path:
+        extra_tests = {'android-dtd'}
+        string = escape_quotes(string)
 
     source_ent, translation_ent = cast_to_compare_locales(
         resource_ext,
@@ -154,7 +156,7 @@ def run_checks(entity, locale_code, string):
 
     checker = getChecker(
         File(entity.resource.path, entity.resource.path, locale=locale_code),
-        {'android-dtd'}
+        extra_tests
     )
 
     # Currently, references are required only by DTD files but that may change in the future.

--- a/pontoon/sync/formats/silme.py
+++ b/pontoon/sync/formats/silme.py
@@ -16,6 +16,7 @@ from silme.format.inc import FormatParser as IncParser
 from silme.format.properties import FormatParser as PropertiesParser
 
 from pontoon.sync import SyncError
+from pontoon.sync.utils import escape_quotes, unescape_quotes
 from pontoon.sync.formats.base import ParsedResource
 from pontoon.sync.vcs.models import VCSTranslation
 
@@ -110,7 +111,7 @@ class SilmeResource(ParsedResource):
             if isinstance(obj, silme.core.entity.Entity):
 
                 if self.escape_quotes_on:
-                    obj.value = self.unescape_quotes(obj.value)
+                    obj.value = unescape_quotes(obj.value)
 
                 entity = SilmeEntity(obj, comments, current_order)
                 self.entities[entity.key] = entity
@@ -126,27 +127,6 @@ class SilmeResource(ParsedResource):
     @property
     def translations(self):
         return self.entities.values()
-
-    def escape_quotes(self, value):
-        """
-        DTD files can use single or double quotes for identifying strings,
-        so &quot; and &apos; are the safe bet that will work in both cases.
-        """
-        value = value.replace('"', '\\&quot;')
-        value = value.replace("'", '\\&apos;')
-
-        return value
-
-    def unescape_quotes(self, value):
-        value = value.replace('\\&quot;', '"')
-        value = value.replace('\\u0022', '"')  # Bug 1390111
-        value = value.replace('\\"', '"')
-
-        value = value.replace('\\&apos;', "'")
-        value = value.replace('\\u0027', "'")  # Bug 1390111
-        value = value.replace("\\'", "'")
-
-        return value
 
     def save(self, locale):
         """
@@ -177,7 +157,7 @@ class SilmeResource(ParsedResource):
                 translation = translated_entity.strings[None]
 
                 if self.escape_quotes_on:
-                    translation = self.escape_quotes(translation)
+                    translation = escape_quotes(translation)
 
                 new_structure.modify_entity(key, translation)
             else:

--- a/pontoon/sync/utils.py
+++ b/pontoon/sync/utils.py
@@ -125,3 +125,26 @@ def source_to_locale_path(path):
     if path.endswith('pot'):
         path = path[:-1]
     return path
+
+
+def escape_quotes(value):
+    """
+    DTD files can use single or double quotes for identifying strings,
+    so &quot; and &apos; are the safe bet that will work in both cases.
+    """
+    value = value.replace('"', '\\&quot;')
+    value = value.replace("'", '\\&apos;')
+
+    return value
+
+
+def unescape_quotes(value):
+    value = value.replace('\\&quot;', '"')
+    value = value.replace('\\u0022', '"')  # Bug 1390111
+    value = value.replace('\\"', '"')
+
+    value = value.replace('\\&apos;', "'")
+    value = value.replace('\\u0027', "'")  # Bug 1390111
+    value = value.replace("\\'", "'")
+
+    return value


### PR DESCRIPTION
Pontoon takes care of escaping quotes and apostrophes on serialization.
See: pontoon.sync.formats.silme.SilmeResource:escape_quotes()

@jotes r?