### PR TITLE
Fix bug 1460237: Do not error on empty FTL messages

### DIFF
--- a/pontoon/checks/libraries/__init__.py
+++ b/pontoon/checks/libraries/__init__.py
@@ -29,14 +29,14 @@ def run_checks(
         * JsonResponse - If there are errors
         * None - If there's no errors and non-omitted warnings.
     """
+    pontoon_checks = pontoon.run_checks(entity, string)
+
     try:
         cl_checks = compare_locales.run_checks(entity, locale_code, string)
     except compare_locales.UnsupportedStringError:
         cl_checks = None
     except compare_locales.UnsupportedResourceTypeError:
         cl_checks = None
-
-    pontoon_checks = pontoon.run_checks(entity, string)
 
     tt_checks = {}
     resource_ext = entity.resource.format

--- a/pontoon/checks/libraries/compare_locales.py
+++ b/pontoon/checks/libraries/compare_locales.py
@@ -108,9 +108,9 @@ def cast_to_compare_locales(resource_ext, entity, string):
         refEntity, = list(parser)
 
         parser.readUnicode(string)
-        trEntity, = list(parser)
+        trEntity = list(parser)[0] if list(parser) else None
 
-        if isinstance(trEntity, Junk):
+        if not trEntity or isinstance(trEntity, Junk):
             raise UnsupportedStringError(resource_ext)
 
         return (

--- a/pontoon/checks/libraries/pontoon.py
+++ b/pontoon/checks/libraries/pontoon.py
@@ -42,7 +42,7 @@ def run_checks(entity, string):
     # Prevent empty translation submissions if not supported
     if resource_ext not in {'properties', 'ini', 'dtd'} and string == '':
         checks['pErrors'].append(
-            'Empty translations cannot be submitted'
+            'Empty translations are not allowed'
         )
 
     # Newlines are not allowed in .lang files (bug 1190754)
@@ -52,7 +52,7 @@ def run_checks(entity, string):
         )
 
     # FTL checks
-    if resource_ext == 'ftl':
+    if resource_ext == 'ftl' and string != '':
         translation_ast = parser.parse_entry(string)
         entity_ast = parser.parse_entry(entity.string)
 

--- a/tests/checks/pontoon.py
+++ b/tests/checks/pontoon.py
@@ -77,7 +77,7 @@ def test_empty_translations(get_entity_mock):
         get_entity_mock('po'),
         ''
     ) == {
-        'pErrors': [u'Empty translations cannot be submitted']
+        'pErrors': [u'Empty translations are not allowed']
     }
 
     assert run_checks(


### PR DESCRIPTION
- Change message to `Empty translations are not allowed`: better when
  switching editors than `cannot be submitted`.
- Do not run FTL checks if translation empty to avoid similar messages
- Run internal Pontoon checks before compare-locales checks (no impact, just matching the order of messages as they are displayed)