### PR TITLE
Fix bug 1460238: Notification instead of failed check

### DIFF
--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -811,9 +811,7 @@ var Pontoon = (function (my) {
 
                 // Rich FTL editor does not support the translation
                 if (!isRichEditorSupported) {
-                  return Pontoon.renderFailedChecks({
-                    pErrors: ['Translation not supported in rich editor']
-                  }, true);
+                  return Pontoon.endLoader('Translation not supported in rich editor', 'error');
                 }
               }
               else {


### PR DESCRIPTION
If we cannot switch from source to rich editor, because the message is
not supported, we should show this information in a notification bar
instead of presenting it as a failed check.