### PR TITLE
Fix bug 1453319: [FTL] Add support for missing expression types

### DIFF
--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -8,8 +8,8 @@ var Pontoon = (function (my) {
   /*
    * Is ast element of type that can be presented as a simple string:
    * - TextElement
-   * - Placeable with expression type CallExpression, ExternalArgument
-   *   or MessageReference
+   * - Placeable with expression type CallExpression, StringExpression,
+   *   ExternalArgument or MessageReference
    */
   function isSimpleElement(element) {
     if (element.type === 'TextElement') {
@@ -21,6 +21,7 @@ var Pontoon = (function (my) {
       element.expression &&
       [
         'CallExpression',
+        'StringExpression',
         'ExternalArgument',
         'MessageReference'
       ].indexOf(element.expression.type) >= 0
@@ -339,9 +340,15 @@ var Pontoon = (function (my) {
           }
           string += startMarker + '{' + element.expression.id.name + '}' + endMarker;
         }
-        else if (element.expression.type === 'CallExpression') {
+        else if (
+          [
+            'CallExpression',
+            'StringExpression',
+          ].indexOf(element.expression.type) >= 0
+        ) {
+          var title = element.expression.type.split('Expression')[0] + ' Expression';
           if (markPlaceables) {
-            startMarker = '<mark class="placeable" title="Call Expression">';
+            startMarker = '<mark class="placeable" title="' + title + '">';
             endMarker = '</mark>';
           }
           var expression = fluentSerializer.serializeExpression(element.expression);

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -352,7 +352,7 @@ var Pontoon = (function (my) {
             'AttributeExpression',
           ].indexOf(element.expression.type) >= 0
         ) {
-          var title = element.expression.type.split('Expression')[0] + ' Expression';
+          var title = element.expression.type.replace('Expression', ' Expression');
           if (markPlaceables) {
             startMarker = '<mark class="placeable" title="' + title + '">';
             endMarker = '</mark>';

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -9,7 +9,7 @@ var Pontoon = (function (my) {
    * Is ast element of type that can be presented as a simple string:
    * - TextElement
    * - Placeable with expression type CallExpression, StringExpression, NumberExpression,
-   *   VariantExpression, ExternalArgument or MessageReference
+   *   VariantExpression, AttributeExpression, ExternalArgument or MessageReference
    */
   function isSimpleElement(element) {
     if (element.type === 'TextElement') {
@@ -24,6 +24,7 @@ var Pontoon = (function (my) {
         'StringExpression',
         'NumberExpression',
         'VariantExpression',
+        'AttributeExpression',
         'ExternalArgument',
         'MessageReference'
       ].indexOf(element.expression.type) >= 0
@@ -348,6 +349,7 @@ var Pontoon = (function (my) {
             'StringExpression',
             'NumberExpression',
             'VariantExpression',
+            'AttributeExpression',
           ].indexOf(element.expression.type) >= 0
         ) {
           var title = element.expression.type.split('Expression')[0] + ' Expression';

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -8,7 +8,7 @@ var Pontoon = (function (my) {
   /*
    * Is ast element of type that can be presented as a simple string:
    * - TextElement
-   * - Placeable with expression type CallExpression, StringExpression,
+   * - Placeable with expression type CallExpression, StringExpression, NumberExpression,
    *   ExternalArgument or MessageReference
    */
   function isSimpleElement(element) {
@@ -22,6 +22,7 @@ var Pontoon = (function (my) {
       [
         'CallExpression',
         'StringExpression',
+        'NumberExpression',
         'ExternalArgument',
         'MessageReference'
       ].indexOf(element.expression.type) >= 0
@@ -344,6 +345,7 @@ var Pontoon = (function (my) {
           [
             'CallExpression',
             'StringExpression',
+            'NumberExpression',
           ].indexOf(element.expression.type) >= 0
         ) {
           var title = element.expression.type.split('Expression')[0] + ' Expression';

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -9,7 +9,7 @@ var Pontoon = (function (my) {
    * Is ast element of type that can be presented as a simple string:
    * - TextElement
    * - Placeable with expression type CallExpression, StringExpression, NumberExpression,
-   *   ExternalArgument or MessageReference
+   *   VariantExpression, ExternalArgument or MessageReference
    */
   function isSimpleElement(element) {
     if (element.type === 'TextElement') {
@@ -23,6 +23,7 @@ var Pontoon = (function (my) {
         'CallExpression',
         'StringExpression',
         'NumberExpression',
+        'VariantExpression',
         'ExternalArgument',
         'MessageReference'
       ].indexOf(element.expression.type) >= 0
@@ -346,6 +347,7 @@ var Pontoon = (function (my) {
             'CallExpression',
             'StringExpression',
             'NumberExpression',
+            'VariantExpression',
           ].indexOf(element.expression.type) >= 0
         ) {
           var title = element.expression.type.split('Expression')[0] + ' Expression';

--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -273,6 +273,7 @@ def _serialize_elements(elements):
                 ast.CallExpression,
                 ast.StringExpression,
                 ast.NumberExpression,
+                ast.VariantExpression,
             )):
                 response += '{ ' + serializer.serialize_expression(element.expression) + ' }'
 

--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -274,6 +274,7 @@ def _serialize_elements(elements):
                 ast.StringExpression,
                 ast.NumberExpression,
                 ast.VariantExpression,
+                ast.AttributeExpression,
             )):
                 response += '{ ' + serializer.serialize_expression(element.expression) + ' }'
 

--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -269,7 +269,10 @@ def _serialize_elements(elements):
             elif isinstance(element.expression, ast.MessageReference):
                 response += '{ ' + element.expression.id.name + ' }'
 
-            elif isinstance(element.expression, ast.CallExpression):
+            elif isinstance(element.expression, (
+                ast.CallExpression,
+                ast.StringExpression,
+            )):
                 response += '{ ' + serializer.serialize_expression(element.expression) + ' }'
 
             elif hasattr(element.expression, 'variants'):

--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -272,6 +272,7 @@ def _serialize_elements(elements):
             elif isinstance(element.expression, (
                 ast.CallExpression,
                 ast.StringExpression,
+                ast.NumberExpression,
             )):
                 response += '{ ' + serializer.serialize_expression(element.expression) + ' }'
 

--- a/tests/base/helpers.py
+++ b/tests/base/helpers.py
@@ -54,6 +54,7 @@ SIMPLE_TRANSLATION_TESTS = OrderedDict((
          '{ LINK("Link text", title: "Link title") }Simple String')
     ),
     ('string-expression', ('key = { "" }', '{ "" }')),
+    ('number-expression', ('key = { 1 }', '{ 1 }')),
 ))
 
 

--- a/tests/base/helpers.py
+++ b/tests/base/helpers.py
@@ -55,6 +55,7 @@ SIMPLE_TRANSLATION_TESTS = OrderedDict((
     ),
     ('string-expression', ('key = { "" }', '{ "" }')),
     ('number-expression', ('key = { 1 }', '{ 1 }')),
+    ('variant-expression', ('key = { -foo[bar] }', '{ -foo[bar] }')),
 ))
 
 

--- a/tests/base/helpers.py
+++ b/tests/base/helpers.py
@@ -56,6 +56,7 @@ SIMPLE_TRANSLATION_TESTS = OrderedDict((
     ('string-expression', ('key = { "" }', '{ "" }')),
     ('number-expression', ('key = { 1 }', '{ 1 }')),
     ('variant-expression', ('key = { -foo[bar] }', '{ -foo[bar] }')),
+    ('attribute-expression', ('key = { foo.bar }', '{ foo.bar }')),
 ))
 
 

--- a/tests/base/helpers.py
+++ b/tests/base/helpers.py
@@ -48,9 +48,13 @@ SIMPLE_TRANSLATION_TESTS = OrderedDict((
     ('attribute', (ATTRIBUTE_SOURCE, 'Simple String')),
     ('attributes', (ATTRIBUTES_SOURCE, 'Simple String')),
     ('attributes-select-expression', (ATTRIBUTE_SELECT_SOURCE, 'Other Simple String')),
-    ('other-ftl',
-     ('warning-upgrade = { LINK("Link text", title: "Link title") }Simple String',
-      '{ LINK("Link text", title: "Link title") }Simple String'))))
+    (
+        'call-expression',
+        ('warning-upgrade = { LINK("Link text", title: "Link title") }Simple String',
+         '{ LINK("Link text", title: "Link title") }Simple String')
+    ),
+    ('string-expression', ('key = { "" }', '{ "" }')),
+))
 
 
 @pytest.mark.parametrize("k", SIMPLE_TRANSLATION_TESTS)


### PR DESCRIPTION
This is similar to [bug 1437857](https://bugzilla.mozilla.org/show_bug.cgi?id=1437857), where we added support for `CallExpressions`: https://github.com/mozilla/pontoon/pull/910/commits/2edbadd13d9f305b7cc80fd0901bdb83dc7f6a8f.

Now we're adding support for 4 remaining `*Expression` types.