### PR TITLE
Fix bug 1460597: Approving suggestions not working

### DIFF
--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -2076,7 +2076,7 @@ var Pontoon = (function (my) {
 
       // Approve and delete translations
       $('#helpers .history').on('click', 'menu .approve', function () {
-        $(this).parents('li').click();
+        $(this).parents('li').trigger('mousedown');
 
         var entity = self.getEditorEntity(),
             translation = $('#translation').val();


### PR DESCRIPTION
When fixing bug 1453879, we replaced the `click` event with `mouseover`,
but forgot to update the trigger. That caused the translation to be
treated as submitted instead of approved, which resulted in the
`Same translation already exists` erro message instead of approval.