### PR TITLE
Bug 1461630 - Set SameSite attributes for `sessionid` and `csrftoken`…

### DIFF
--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -152,6 +152,7 @@ INSTALLED_APPS = (
 BLOCKED_IPS = os.environ.get('BLOCKED_IPS', '').split(',')
 
 MIDDLEWARE_CLASSES = (
+    'django_cookies_samesite.middleware.CookiesSameSite',
     'django.middleware.gzip.GZipMiddleware',
     'sslify.middleware.SSLifyMiddleware',
     'pontoon.base.middleware.RaygunExceptionMiddleware',
@@ -217,6 +218,8 @@ TEMPLATES = [
         }
     },
 ]
+
+SESSION_COOKIE_SAMESITE = 'Strict'
 
 AUTHENTICATION_BACKENDS = [
     'django.contrib.auth.backends.ModelBackend',

--- a/requirements.txt
+++ b/requirements.txt
@@ -324,3 +324,5 @@ compare-locales==3.2.2 \
 # Required by compare-locales
 pytoml==0.1.14 \
     --hash=sha256:aff69147d436c3ba8c7f3bc1b3f4aa3d7e47d305a495f2631872e6429694aabf
+django-cookies-samesite==0.1.1 \
+    --hash=sha256:5426ca30e64205451cabd7ecff08dac03070424d658caf54f64025e04ed431e7


### PR DESCRIPTION
… cookies in the custom middleware.

Django 1.11.x won't receive ability to set SameSite attribute in cookies.
That will be possible with Django 2.0, but that also would require to migrate Pontoon into Python3 (and that will take some time).

As a temporary solution Pontoon will use CookiesSameSiteStrict middleware which will be removed after Pontoon will migrate into Django 2.0.

@mathjazz @psiinon could you review/check  if the whole approach is acceptable?