### PR TITLE
Fix bug 1433763: [FTL] Render untranslated attributes

### DIFF
--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -562,6 +562,7 @@ var Pontoon = (function (my) {
         var value = '';
         var attributes = '';
         var attributesTree = [];
+        var translatedAttributes = [];
 
         var entityAST = fluentParser.parseEntry(entity.original);
         if (entityAST.attributes.length) {
@@ -573,6 +574,17 @@ var Pontoon = (function (my) {
         if (translation.pk) {
           translationAST = fluentParser.parseEntry(translation.string);
           attributesTree = translationAST.attributes;
+
+          // If translation doesn't include all entity attributes,
+          // we need to manually add them
+          translatedAttributes = attributesTree.map(function (attr) {
+            return attr.id.name;
+          });
+          entityAST.attributes.forEach(function (attr) {
+            if (translatedAttributes.indexOf(attr.id.name) === -1) {
+              attributesTree.push(attr);
+            }
+          });
         }
 
         // Reset default editor values
@@ -638,10 +650,13 @@ var Pontoon = (function (my) {
           attributesTree.forEach(function (attr) {
             var id = attr.id.name;
 
+            // Mark translated attributes
+            var isTranslated = translatedAttributes.indexOf(id) !== -1;
+
             attributes += (
               '<li data-id="' + id + '">' +
                 '<ul>' +
-                  renderEditorElements(attr.value.elements, id, translationAST) +
+                  renderEditorElements(attr.value.elements, id, isTranslated) +
                 '</ul>' +
               '</li>'
             );


### PR DESCRIPTION
If translation doesn't include all source string attributes, we need to render them in editor anyways. And make sure they are treated as untranslated (empty fields).

As outlined in the [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1433763), you can test by adding an attribute to a source string in a DB:
https://github.com/mozilla-services/screenshots/commit/31bbfb47a8a56def1836a0eff08a950716d19975