### PR TITLE
Fix bug 1452647: Add Tags tab to the Localization dashboard

### DIFF
--- a/pontoon/localizations/templates/localizations/includes/tags.html
+++ b/pontoon/localizations/templates/localizations/includes/tags.html
@@ -1,0 +1,15 @@
+{% import 'tags/widgets/tag_list.html' as TagList %}
+
+<div class="tags">
+  {{ TagList.header() }}
+
+  {% for tag in tags %}
+  {% set main_link = url('pontoon.translate', locale.code, project.slug, 'all-resources') + '?tag=' + tag.slug %}
+  {% set chart_link = main_link %}
+  {% set latest_activity = tag.latest_activity %}
+  {% set chart = tag.chart %}
+  {{ TagList.item(tag, main_link, chart_link, latest_activity, chart, link_parameter=True, has_params=True) }}
+  {% endfor %}
+
+  {{ TagList.footer() }}
+</div>

--- a/pontoon/localizations/templates/localizations/localization.html
+++ b/pontoon/localizations/templates/localizations/localization.html
@@ -71,6 +71,13 @@
           count = resource_count
         )
       }}
+      {% if project.tags_enabled and tags %}
+         {{ Menu.item(
+           'Tags',
+           url('pontoon.localizations.tags', locale.code, project.slug),
+           is_active = (current_page == 'tags'),
+           count = tags) }}
+      {% endif %}
       {{ Menu.item(
           'Contributors',
           url('pontoon.localizations.contributors', locale.code, project.slug),

--- a/pontoon/localizations/urls.py
+++ b/pontoon/localizations/urls.py
@@ -11,6 +11,11 @@ urlpatterns = [
         views.localization,
         name='pontoon.localizations.localization'),
 
+    # Localization tags
+    url(r'^(?P<code>[A-Za-z0-9\-\@\.]+)/(?P<slug>[\w-]+)/tags/$',
+        views.localization,
+        name='pontoon.localizations.tags'),
+
     # Localization contributors
     url(r'^(?P<code>[A-Za-z0-9\-\@\.]+)/(?P<slug>[\w-]+)/contributors/$',
         views.localization,
@@ -30,6 +35,11 @@ urlpatterns = [
     url(r'^(?P<code>[A-Za-z0-9\-\@\.]+)/(?P<slug>[\w-]+)/ajax/$',
         views.ajax_resources,
         name='pontoon.localizations.ajax.resources'),
+
+    # AJAX view: Localization tags
+    url(r'^(?P<code>[A-Za-z0-9\-\@\.]+)/(?P<slug>[\w-]+)/ajax/tags/$',
+        views.ajax_tags,
+        name='pontoon.localizations.ajax.tags'),
 
     # AJAX view: Localization contributors
     url(r'^(?P<code>[A-Za-z0-9\-\@\.]+)/(?P<slug>[\w-]+)/ajax/contributors/$',

--- a/pontoon/localizations/views.py
+++ b/pontoon/localizations/views.py
@@ -36,9 +36,7 @@ def localization(request, code, slug):
         'project_locale': project_locale,
         'resource_count': resource_count,
         'tags': (
-            len(
-                TagsTool(projects=[project], locales=[locale], priority=True)
-            ) or False
+            len(TagsTool(projects=[project], locales=[locale], priority=True))
             if project.tags_enabled
             else None
         )

--- a/pontoon/projects/templates/projects/includes/tags.html
+++ b/pontoon/projects/templates/projects/includes/tags.html
@@ -4,7 +4,7 @@
 
   {{ TagList.header() }}
   {% for tag in tags %}
-  {% set main_link = url('pontoon.tags.project.tag', project=project[0].slug, tag=tag.slug) %}
+  {% set main_link = url('pontoon.tags.project.tag', project=project.slug, tag=tag.slug) %}
   {% set latest_activity = tag.latest_activity %}
   {% set chart = tag.chart %}
   {{ TagList.item(tag, main_link, main_link, latest_activity, chart) }}

--- a/pontoon/projects/urls.py
+++ b/pontoon/projects/urls.py
@@ -1,8 +1,6 @@
 from django.conf.urls import url
 from django.views.generic import RedirectView
 
-from pontoon.tags import views as tags_views
-
 import views
 
 urlpatterns = [
@@ -51,7 +49,7 @@ urlpatterns = [
 
     # AJAX view: Project tags
     url(r'^projects/(?P<slug>[\w-]+)/ajax/tags/$',
-        tags_views.ajax_tags,
+        views.ajax_tags,
         name='pontoon.projects.ajax.tags'),
 
     # AJAX view: Project contributors

--- a/pontoon/projects/views.py
+++ b/pontoon/projects/views.py
@@ -4,7 +4,7 @@ from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.db import transaction
 from django.db.models import Q
-from django.http import JsonResponse
+from django.http import Http404, JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.views.generic.detail import DetailView
 
@@ -59,6 +59,25 @@ def ajax_teams(request, slug):
     return render(request, 'projects/includes/teams.html', {
         'project': project,
         'locales': locales,
+    })
+
+
+@require_AJAX
+def ajax_tags(request, slug):
+    """Tags tab."""
+    project = get_object_or_404(Project, slug=slug)
+
+    if not project.tags_enabled:
+        raise Http404
+
+    tags_tool = TagsTool(
+        projects=[project],
+        priority=True,
+    )
+
+    return render(request, 'projects/includes/tags.html', {
+        'project': project,
+        'tags': list(tags_tool),
     })
 
 

--- a/pontoon/projects/views.py
+++ b/pontoon/projects/views.py
@@ -39,7 +39,7 @@ def project(request, slug):
     return render(request, 'projects/project.html', {
         'project': project,
         'tags': (
-            len(TagsTool(projects=[project], priority=True)) or False
+            len(TagsTool(projects=[project], priority=True))
             if project.tags_enabled
             else None)
     })

--- a/pontoon/tags/templates/tags/widgets/tag_list.html
+++ b/pontoon/tags/templates/tags/widgets/tag_list.html
@@ -14,7 +14,7 @@
     <tbody>
 {% endmacro %}
 
-{% macro item(tag, main_link, chart_link, latest_activity, chart, class='limited', link_parameter=False) %}
+{% macro item(tag, main_link, chart_link, latest_activity, chart, class='limited', link_parameter=False, has_params=False) %}
   <tr class="{{ class }}">
     <td class="tag">
       <h4>
@@ -30,7 +30,7 @@
       {{ LatestActivity.span(latest_activity) }}
     </td>
     <td class="progress">
-      {{ ProgressChart.span(chart, chart_link, link_parameter) }}
+      {{ ProgressChart.span(chart, chart_link, link_parameter, has_params) }}
     </td>
   </tr>
 {% endmacro %}

--- a/pontoon/tags/views.py
+++ b/pontoon/tags/views.py
@@ -1,11 +1,7 @@
-
 from django.http import Http404
-from django.shortcuts import get_object_or_404, render
-
-from pontoon.base.models import Project
-from pontoon.base.utils import require_AJAX
 
 from .utils import TagsTool
+from pontoon.base.models import Project
 
 from django.views.generic import DetailView
 
@@ -31,28 +27,16 @@ class ProjectTagView(DetailView):
         try:
             tag = TagsTool(
                 projects=[self.object],
-                priority=True)[self.kwargs['tag']].get()
+                priority=True,
+            )[self.kwargs['tag']].get()
         except IndexError:
             raise Http404
+
         if self.request.is_ajax():
-            return dict(project=self.object, locales=list(tag.iter_locales()), tag=tag)
+            return dict(
+                project=self.object,
+                locales=list(tag.iter_locales()),
+                tag=tag,
+            )
+
         return dict(project=self.object, tag=tag)
-
-
-@require_AJAX
-def ajax_tags(request, slug=None):
-    """This view provides JSON view for retrieving results in the
-    /projects/$project/tags view
-    """
-    project = get_object_or_404(Project, slug=slug)
-    if project.tags_enabled:
-        project = [project]
-    else:
-        raise Http404
-    tags_tool = TagsTool(
-        projects=project,
-        priority=True)
-    return render(
-        request, 'projects/includes/tags.html', {
-            'project': project,
-            'tags': list(tags_tool)})


### PR DESCRIPTION
In https://github.com/mozilla/pontoon/commit/5c4152d2a33be7a0c28d766b8da922a9d1fd35f6 we landed support for the _Tags_ tab in the [project dashboard](https://mozilla-pontoon-staging.herokuapp.com/projects/firefox/tags/), which contains a list of tags and their stats for the project. This patch bring the _Tags_ tab to the [localization dashboard](https://mozilla-pontoon-staging.herokuapp.com/sl/firefox/tags/), which contains a list of tags for the project and their stats for the localization (project-locale).

[First commit](https://github.com/mozilla/pontoon/commit/43fc906227d8442d533b736b7e786553a8c0cf60) sets the stage by generalizing the code for Tags tab on the Project dashboard. The [second one](https://github.com/mozilla/pontoon/commit/4aeaa0b538e7012689bc067ce4c779687b56124a) is an actual bugfix. It will be easier to review them separtely.

Check out the [docs](https://github.com/mozilla-l10n/localizer-documentation/pull/120/) for more information about tags.