### PR TITLE
Fix bug 1463073: Show tag priority in filter menu

### DIFF
--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -1026,10 +1026,22 @@ body > header aside p {
   content: "";
 }
 
-#filter .menu li .count {
+#filter .menu li .count,
+#filter .menu li .priority {
   position: absolute;
   right: 4px;
+}
+
+#filter .menu li .count {
   top: 4px;
+}
+
+#filter .menu li .priority {
+  top: 6px;
+}
+
+#filter .menu li .priority .fa-star {
+  float: left;
 }
 
 #filter .menu li.author .count {

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -173,9 +173,8 @@
 
             {% if tags %}
             <li class="horizontal-separator tags-header">Tags</li>
-
             {% for tag in tags %}
-            {{ Filter.item('tag-' + tag.slug, tag.name) }}
+            {{ Filter.item('tag-' + tag.slug, tag.name, priority=tag.priority) }}
             {% endfor %}
             {% endif %}
 

--- a/pontoon/base/templates/widgets/filter_item.html
+++ b/pontoon/base/templates/widgets/filter_item.html
@@ -1,9 +1,16 @@
-{% macro item(type, title, count=False) %}
+{% macro item(type, title, count=False, priority=None) %}
 <li class="{{ type }}" data-type="{{ type }}">
   <span class="status fa"></span>
   <span class="title">{{ title }}</span>
   {% if count %}
-    <span class="count"></span>
+  <span class="count"></span>
+  {% endif %}
+  {% if priority %}
+  <span class="priority">
+    {% for n in range(5) %}
+    <span class="fa fa-star{% if loop.index <= priority %}{{ ' active' }}{% endif %}"></span>
+    {% endfor %}
+  </span>
   {% endif %}
 </li>
 {% endmacro %}


### PR DESCRIPTION
This (alongside #969) is hopefully the last step before shipping Tags. You can test it on stage:
https://mozilla-pontoon-staging.herokuapp.com/sl/firefox/all-resources/?string=74127

@jotes r?