### PR TITLE
Fix bug 1463364: Always generate tag slug

### DIFF
--- a/pontoon/administration/static/js/admin_project.js
+++ b/pontoon/administration/static/js/admin_project.js
@@ -84,7 +84,7 @@ $(function() {
     });
   });
 
-  $("[id^=id_tag_set-][id$=-name]").blur(function() {
+  $("body").on("blur", "[id^=id_tag_set-][id$=-name]", function() {
     var target = $('input#' + $(this).attr('id').replace('-name', '-slug'));
     var $this = this;
     if (target.val() || !$(this).val()) {


### PR DESCRIPTION
Tag slug is only generated for the first tag. If you add more tags, it's not.