### PR TITLE
Fix max length for contributors entries

### DIFF
--- a/pontoon/contributors/static/css/contributors.css
+++ b/pontoon/contributors/static/css/contributors.css
@@ -27,7 +27,7 @@ td.rank {
   padding-left: 2px;
   text-overflow: ellipsis;
   white-space: nowrap;
-  max-width: 462px;
+  max-width: 440px;
 
   -moz-box-sizing: border-box;
   box-sizing: border-box;


### PR DESCRIPTION
This fixes the following problem:

![screen shot 2018-06-15 at 12 08 43](https://user-images.githubusercontent.com/626716/41485284-c9a6a9a6-7094-11e8-9c0f-05d044114840.png)

r=me