### PR TITLE
Fix bug 1470633: Add locales to the bottom of the list

### DIFF
--- a/pontoon/base/static/js/multiple_locale_selector.js
+++ b/pontoon/base/static/js/multiple_locale_selector.js
@@ -15,10 +15,12 @@ $(function() {
 
   // Choose locales
   $('body').on('click', '.multiple-locale-selector .locale.select li', function () {
-    var target = $(this).parents('.locale.select').siblings('.locale.select').find('ul'),
-        clone = $(this).remove();
+    var ls = $(this).parents('.locale.select'),
+        target = ls.siblings('.locale.select').find('ul'),
+        item = $(this).remove();
 
-    target.prepend(clone);
+    target.append(item);
+    target.scrollTop(target[0].scrollHeight);
     updateSelectedLocales();
   });
 
@@ -29,7 +31,8 @@ $(function() {
         target = ls.siblings('.locale.select').find('ul'),
         items = ls.find('li:visible:not(".no-match")').remove();
 
-    target.prepend(items);
+    target.append(items);
+    target.scrollTop(target[0].scrollHeight);
     updateSelectedLocales();
   });
 


### PR DESCRIPTION
In multiple locale selector, we used to prepend locales to the list
when they were selected. Now we append them.

Affected pages are Settings, Project Admin and Project Notificaions.

The benefit is especially useful on the Setting page, where preferred
locales are selected for which the order is important. The one selected
first will now also be the one on top of the list in the Locales tab in
translate view.

@jotes r?