### PR TITLE
Fix bug 1470742: Restore clickable contributor links in History tab

### DIFF
--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -293,7 +293,7 @@ var Pontoon = (function (my) {
                     '">' +
                     '<div class="info">' +
                       ((!this.uid) ? '<span>' + this.user + '</span>' :
-                        '<a href="/contributors/' + this.username + '" title="' + self.getApproveButtonTitle(this) + '">' + this.user + '</a>') +
+                        '<a href="/contributors/' + this.username + '" title="' + self.getApproveButtonTitle(this) + '" target="_blank">' + this.user + '</a>') +
                       '<time dir="ltr" class="stress" datetime="' + this.date_iso + '">' + this.date + ' UTC</time>' +
                     '</div>' +
                     '<menu class="toolbar">' +

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -2049,8 +2049,6 @@ var Pontoon = (function (my) {
 
       // Copy helpers result to translation
       $('#helpers section').on('click', 'li:not(".disabled")', function (e) {
-        e.preventDefault();
-
         var source = $(this).find('.translation-clipboard').text();
 
         // Ignore clicks on links and buttons


### PR DESCRIPTION
We introduced the removed line while fixing bug 1453879: https://github.com/mozilla/pontoon/pull/944.

After we fixed bug 1462419, the line is no longer needed: https://github.com/mozilla/pontoon/pull/967.