### PR TITLE
[Experiment] Bug 1344457: Redesign main menu in translate view

### DIFF
--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -573,6 +573,7 @@ tfoot td a {
   display: none;
 }
 
+.project.select.all-projects > .button.breadcrumbs:after,
 .part.select > .button.breadcrumbs:after {
   display: none;
 }
@@ -590,16 +591,19 @@ tfoot td a {
   color: #272A2F;
 }
 
+.project.select.all-projects:not(.opened) > .button.breadcrumbs:hover,
 .part.select:not(.opened) > .button.breadcrumbs:hover {
   background: #4d5967;
 }
 
-.part.select > .button.breadcrumbs:hover {
-  color: #FFFFFF;
-}
-
+.project.select.all-projects:not(.opened) > .button.breadcrumbs:hover:after,
 .part.select:not(.opened) > .button.breadcrumbs:hover:after {
   border-left-color: #4d5967;
+}
+
+.project.select.all-projects > .button.breadcrumbs:hover,
+.part.select > .button.breadcrumbs:hover {
+  color: #FFFFFF;
 }
 
 .select.opened > .button.breadcrumbs {

--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -530,8 +530,10 @@ tfoot td a {
   z-index: 20; /* Must be higher than iframe-cover */
 }
 
-.select > .button.breadcrumbs,
-#go {
+#settings .menu {
+  width: 185px;
+}
+.select > .button.breadcrumbs {
   background: #3f4752;
   font-size: 16px;
   height: 20px;
@@ -542,16 +544,7 @@ tfoot td a {
   width: 200px;
 }
 
-#settings .menu {
-  width: 185px;
-}
-
-#go {
-  width: auto;
-}
-
-.select > .button.breadcrumbs:before,
-#go:before {
+.select > .button.breadcrumbs:before {
   content: "";
   border-top: 20px solid transparent;
   border-bottom: 20px solid transparent;
@@ -580,11 +573,32 @@ tfoot td a {
   display: none;
 }
 
+.part.select > .button.breadcrumbs:after {
+  display: none;
+}
+
 .select > .button.breadcrumbs:hover {
-  background: #4d5967;
+  background: #7BC876;
+  color: #272A2F;
 }
 
 .select > .button.breadcrumbs:hover:after {
+  border-left-color: #7BC876;
+}
+
+.locale.select > .button.breadcrumbs:hover .code {
+  color: #272A2F;
+}
+
+.part.select:not(.opened) > .button.breadcrumbs:hover {
+  background: #4d5967;
+}
+
+.part.select > .button.breadcrumbs:hover {
+  color: #FFFFFF;
+}
+
+.part.select:not(.opened) > .button.breadcrumbs:hover:after {
   border-left-color: #4d5967;
 }
 
@@ -594,17 +608,6 @@ tfoot td a {
 
 .select.opened > .button.breadcrumbs:after {
   border-left-color: #4d5967;
-}
-
-#go {
-  color: #FFFFFF;
-  float: left;
-}
-
-#go.active,
-#go:hover {
-  background: #7BC876;
-  color: #272A2F;
 }
 
 .project.select,

--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -262,12 +262,6 @@ body > header .locale.select {
   padding: 2px 4px;
 }
 
-.menu .static-links .internal {
-  border-bottom: 1px solid #5E6475;
-  margin-bottom: 5px;
-  padding-bottom: 5px;
-}
-
 .menu ul li.current,
 .menu .static-links .all-projects.current,
 .menu .static-links .all-resources.current {

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -2881,6 +2881,7 @@ var Pontoon = (function (my) {
 
       // Hide part menu for All Projects
       $('.part.select').toggleClass('hidden', project === 'all-projects');
+      $('.project.select').toggleClass('all-projects', project === 'all-projects');
     },
 
 
@@ -2963,9 +2964,13 @@ var Pontoon = (function (my) {
 
       // Show only projects available for the selected locale
       $('.project .selector').click(function (e) {
-        e.stopPropagation();
+        if ($(this).parents('.all-projects').length) {
+          e.preventDefault();
+        } else {
+          e.stopPropagation();
+          return;
+        }
 
-        /*
         var projects = Pontoon.getLocaleData('projects'),
             $menu = $(this).parents('.select').find('.menu');
 
@@ -2982,11 +2987,12 @@ var Pontoon = (function (my) {
               .toggleClass('limited', true)
               .toggle(true);
         });
-        */
       });
 
-      /* Project menu handler
-      $('.project .menu li:not(".no-match"), .static-links .all-projects').click(function () {
+      // Project menu handler
+      $('.project .menu li:not(".no-match"), .static-links .all-projects').click(function (e) {
+        e.preventDefault();
+
         var project = $(this).find('.name'),
             name = project.html(),
             slug = project.data('slug'),
@@ -3025,8 +3031,10 @@ var Pontoon = (function (my) {
               }
             });
           }
+
+          $('#project-url').attr('href', '/' + locale + '/' + slug + '/');
         }
-      });*/
+      });
 
       // Show only parts available for the selected project
       $('.part .selector').click(function () {
@@ -3065,7 +3073,7 @@ var Pontoon = (function (my) {
       });
 
       // Parts menu handler
-      $('.part .menu').on('click', 'li:not(".no-match"), .static-links .all-resources', function () {
+      $('.part .menu').on('click', 'li:not(".no-match"), .static-links .all-resources, .static-links .all-projects', function () {
         var title = $(this).find('span:first').html();
         self.updatePartSelector(title);
 

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -2840,18 +2840,6 @@ var Pontoon = (function (my) {
 
 
     /*
-     * Mark Go button as active if main menu doesn't fully resemble
-     * locale, project, part combination currently being translated
-     */
-    updateGoButton: function () {
-      var toggle = this.getSelectedLocale() !== this.locale.code ||
-                   this.getSelectedProject() !== this.project.slug ||
-                   this.getSelectedPart() !== this.currentPart.title;
-      $('#go').toggleClass('active', toggle);
-    },
-
-
-    /*
      * Update project and (if needed) part menu
      */
     updateProjectMenu: function () {
@@ -2873,8 +2861,6 @@ var Pontoon = (function (my) {
         resource__path: []
       }];
       $('.project .menu .all-projects .name').data('parts', parts);
-
-      this.updateGoButton();
     },
 
 
@@ -2895,8 +2881,6 @@ var Pontoon = (function (my) {
 
       // Hide part menu for All Projects
       $('.part.select').toggleClass('hidden', project === 'all-projects');
-
-      this.updateGoButton();
     },
 
 
@@ -2944,7 +2928,7 @@ var Pontoon = (function (my) {
         $('#iframe-cover').hide();
       });
 
-      // Locale menu handler
+      /* Locale menu handler
       $('.locale .menu li:not(".no-match")').click(function () {
         var menuItem = $(this),
             locale = menuItem.find('.language').data('code'),
@@ -2970,9 +2954,18 @@ var Pontoon = (function (my) {
           self.updateProjectMenu();
         }
       });
+      */
 
       // Show only projects available for the selected locale
-      $('.project .selector').click(function () {
+      $('.locale .selector').click(function (e) {
+        e.stopPropagation();
+      });
+
+      // Show only projects available for the selected locale
+      $('.project .selector').click(function (e) {
+        e.stopPropagation();
+
+        /*
         var projects = Pontoon.getLocaleData('projects'),
             $menu = $(this).parents('.select').find('.menu');
 
@@ -2989,9 +2982,10 @@ var Pontoon = (function (my) {
               .toggleClass('limited', true)
               .toggle(true);
         });
+        */
       });
 
-      // Project menu handler
+      /* Project menu handler
       $('.project .menu li:not(".no-match"), .static-links .all-projects').click(function () {
         var project = $(this).find('.name'),
             name = project.html(),
@@ -3032,7 +3026,7 @@ var Pontoon = (function (my) {
             });
           }
         }
-      });
+      });*/
 
       // Show only parts available for the selected project
       $('.part .selector').click(function () {
@@ -3074,14 +3068,9 @@ var Pontoon = (function (my) {
       $('.part .menu').on('click', 'li:not(".no-match"), .static-links .all-resources', function () {
         var title = $(this).find('span:first').html();
         self.updatePartSelector(title);
-        self.updateGoButton();
-      });
 
-      // Open selected project (part) and locale combination
-      $('#go').click(function (e) {
-        e.preventDefault();
+        // Open selected project (part) and locale combination
         self.jumpToPart(self.getSelectedPart());
-
         self.closeNotification();
       });
 
@@ -3240,8 +3229,6 @@ var Pontoon = (function (my) {
         .parent().attr('href', '/projects/' + this.project.slug);
       $('.static-links .current-localization')
         .parent().attr('href', '/' + this.locale.code + '/' + this.project.slug);
-
-      this.updateGoButton();
     },
 
 
@@ -4124,8 +4111,7 @@ var Pontoon = (function (my) {
      * Get data-* attribute value of the currently selected locale
      */
     getLocaleData: function(attribute) {
-      var code = this.getSelectedLocale();
-      return $('.locale .menu li .language[data-code=' + code + ']').data(attribute);
+      return $('.locale .selector .language').data(attribute);
     },
 
 

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -37,16 +37,19 @@
 <!-- Main toolbar -->
 <header>
   <div class="container clearfix">
-    {% include 'teams/widgets/team_selector.html' %}
+    <a id="locale-url" href="{{ url('pontoon.teams.team', locale.code) }}">
+      <div class="locale select">
+        <div class="button breadcrumbs selector noselect">
+          <span class="language" {{ locale.serialize() | dict_html_attrs }}>{{ locale.name }}</span><span class="code">{{ locale.code }}</span>
+        </div>
+      </div>
+    </a>
 
+    <a id="project-url" href="{{ url('pontoon.localizations.localization', locale.code, project.slug) }}">
     {% include 'projects/widgets/project_selector.html' %}
+    </a>
 
     {% include 'localizations/widgets/resource_selector.html' %}
-
-    <!-- Go -->
-    <div class="go select">
-      <a id="go" class="noselect" href="#">Go</a>
-    </div>
 
     <!-- Progress indicator -->
     <div id="progress" class="select">

--- a/pontoon/localizations/templates/localizations/widgets/resource_selector.html
+++ b/pontoon/localizations/templates/localizations/widgets/resource_selector.html
@@ -21,8 +21,7 @@
           <span class="percent"></span>
         </div>
         <div class="all-projects">
-          <span class="title">All Projects</span>
-          <span class="percent"></span>
+          <span class="name title" data-name="All Projects" data-slug="all-projects" data-parts="{{ {locale.code: locale.stats()}|to_json }}">All Projects</span>
         </div>
       </section>
     </div>

--- a/pontoon/localizations/templates/localizations/widgets/resource_selector.html
+++ b/pontoon/localizations/templates/localizations/widgets/resource_selector.html
@@ -20,13 +20,11 @@
           <span class="title">All Resources</span>
           <span class="percent"></span>
         </div>
-      </section>
-      <a href="{{ url('pontoon.localizations.localization', locale.code, project.slug) }}">
-        <div class="current-localization">
-          <span class="title">Current Localization Dashboard</span>
+        <div class="all-projects">
+          <span class="title">All Projects</span>
           <span class="percent"></span>
         </div>
-      </a>
+      </section>
     </div>
   </div>
 </div>

--- a/pontoon/projects/templates/projects/widgets/project_selector.html
+++ b/pontoon/projects/templates/projects/widgets/project_selector.html
@@ -1,5 +1,5 @@
 <!-- Project selector -->
-<div class="project select">
+<div class="project select{% if project.slug == 'all-projects' %} all-projects{% endif %}">
   <div class="button breadcrumbs selector">
     <span class="title noselect" data-slug="{{ project.slug }}">{{ project.name }}</span>
   </div>
@@ -27,5 +27,13 @@
       {% endfor %}
       <li class="no-match">No results</li>
     </ul>
+
+    <div class="static-links">
+      <section class="internal">
+        <div class="all-projects">
+          <span class="name title" data-name="All Projects" data-slug="all-projects" data-parts="{{ {locale.code: locale.stats()}|to_json }}">All Projects</span>
+        </div>
+      </section>
+    </div>
   </div>
 </div>

--- a/pontoon/projects/templates/projects/widgets/project_selector.html
+++ b/pontoon/projects/templates/projects/widgets/project_selector.html
@@ -27,23 +27,5 @@
       {% endfor %}
       <li class="no-match">No results</li>
     </ul>
-
-    <div class="static-links">
-      <section class="internal">
-        <div class="all-projects">
-          <span class="name title" data-name="All Projects" data-slug="all-projects" {% if project.slug == 'all-projects' %}data-parts="{{ {locale.code: locale.stats()}|to_json }}"{% endif %}>All Projects</span>
-        </div>
-      </section>
-      <a href="{{ url('pontoon.projects') }}">
-        <div>
-          <span class="title">Projects Dashboard</span>
-        </div>
-      </a>
-      <a href="{{ url('pontoon.projects.project', project.slug) }}">
-        <div class="current-project">
-          <span class="title">Current Project Dashboard</span>
-        </div>
-      </a>
-    </div>
   </div>
 </div>


### PR DESCRIPTION
This is a quick attempt at improving the main menu in the translate view by making it work more like it looks like - a breadcrumbs menu.

That means the first two "menus" (locale and project) are no longer menus. Instead, they take you to the locale page (e.g. `/de/`) and the localization page (e.g. `/de/firefox/`) of the current translate view.

The resources menu looks more or less the same, but since it's the only menu now, it takes action immediatelly after you make a selection, so the `Go` button is gone.

The main motivation for the change is the hypothesis (partly proved by analytics) that localizers mostly leave the translate view for their team page or localization page, but rarely switch locales, projects or go to `/teams/` and `/projects/` pages.

TODO:
- [ ] The behaviour changed, but the look didn't. It will take a while before people get used to the new UX. To help with that, we should take a bolder step in differentiating links from dropdowns (add a caret to the dropdown and consider changing the background color of links).
- [ ] Consider blocking the release on [new homepage](https://bugzilla.mozilla.org/show_bug.cgi?id=1378471) to prevent the inability of getting from the homepage to dashboards.
- [ ] Add tooltips to all three items in the main menu.