### PR TITLE
Fix bug 1447231: [FTL] Use simple string UI for messages with 1 simple attribute

### DIFF
--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -693,25 +693,45 @@ var Pontoon = (function (my) {
 
         // Attributes
         if (attributesTree.length) {
-          attributesTree.forEach(function (attr) {
-            var id = attr.id.name;
+          // Simple single-attribute string: only attribute
+          if (
+            (translationAST && isSimpleSingleAttributeMessage(translationAST)) ||
+            (!translationAST && isSimpleSingleAttributeMessage(entityAST))
+          ) {
+            value = '';
 
-            // Mark translated attributes
-            var isTranslated = translatedAttributes.indexOf(id) !== -1;
+            if (translationAST) {
+              value = stringifyElements(translationAST.attributes[0].value.elements);
+            }
 
-            attributes += (
-              '<li data-id="' + id + '">' +
-                '<ul>' +
-                  renderEditorElements(attr.value.elements, id, isTranslated) +
-                '</ul>' +
-              '</li>'
-            );
-          });
+            $('#only-value')
+              .val(value)
+              .parents('li')
+              .show();
 
-          $('#ftl-area .attributes ul:first').append(attributes);
+            $('#ftl-area > .main-value').show();
+          }
+          else {
+            attributesTree.forEach(function (attr) {
+              var id = attr.id.name;
 
-          // Update access keys presentation
-          $('#ftl-area textarea.value').keyup();
+              // Mark translated attributes
+              var isTranslated = translatedAttributes.indexOf(id) !== -1;
+
+              attributes += (
+                '<li data-id="' + id + '">' +
+                  '<ul>' +
+                    renderEditorElements(attr.value.elements, id, isTranslated) +
+                  '</ul>' +
+                '</li>'
+              );
+            });
+
+            $('#ftl-area .attributes ul:first').append(attributes);
+
+            // Update access keys presentation
+            $('#ftl-area textarea.value').keyup();
+          }
         }
 
         // Ignore editing for anonymous users

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -469,8 +469,9 @@ var Pontoon = (function (my) {
 
 
       /*
-       * Get source string value of a simple FTL message to be used in
-       * the Copy (original to translation) function
+       * Get source string value of a simple FTL message or a simple
+       * single attribute FTL message to be used in the Copy (original
+       * to translation) function.
        */
       getSourceStringValue: function (entity, fallback) {
         if (entity.format !== 'ftl' || this.isComplexFTL()) {
@@ -478,7 +479,18 @@ var Pontoon = (function (my) {
         }
 
         var ast = fluentParser.parseEntry(entity.original);
-        return stringifyElements(ast.value.elements);
+        var tree;
+
+        // Simple string
+        if (ast.value) {
+          tree = ast;
+        }
+        // Simple single-attribute string
+        else {
+          tree = ast.attributes[0];
+        }
+
+        return stringifyElements(tree.value.elements);
       },
 
 

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -792,6 +792,12 @@ var Pontoon = (function (my) {
             value = '\n  ' + value.replace(/\n/g, '\n  ');
           }
 
+          // Simple single-attribute string
+          var attribute = $('#metadata .attribute .content').text();
+          if (attribute) {
+            value = '\n  .' + attribute + ' = ' + value;
+          }
+
           content += value;
         }
 

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -516,6 +516,25 @@ var Pontoon = (function (my) {
 
 
       /*
+       * Get attribute, if ast of the entity is a simple single attribute message.
+       * Else: return false.
+       */
+      getSimpleSingleAttribute: function (entity) {
+        if (entity.format !== 'ftl') {
+          return false;
+        }
+
+        var ast = fluentParser.parseEntry(entity.original);
+
+        if (!isSimpleSingleAttributeMessage(ast)) {
+          return false;
+        }
+
+        return ast.attributes[0];
+      },
+
+
+      /*
        * Render original string of FTL and non-FTL messages.
        */
       renderOriginal: function () {

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -112,6 +112,23 @@ var Pontoon = (function (my) {
   }
 
   /*
+   * Is ast of a message without value and with 1 attribute,
+   * which only contains simple elements?
+   */
+  function isSimpleSingleAttributeMessage(ast) {
+    if (
+      ast &&
+      !ast.value &&
+      ast.attributes.length === 1 &&
+      ast.attributes[0].value.elements.every(isSimpleElement)
+    ) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /*
    * Render textarea element with the given properties
    */
   function renderTextareaElement(id, value, maxlength) {
@@ -544,9 +561,17 @@ var Pontoon = (function (my) {
 
         // Attributes
         if (ast.attributes.length && !unsupported) {
-          ast.attributes.forEach(function (attr) {
-            attributes += renderOriginalElements(attr.value.elements, attr.id.name);
-          });
+          // Simple single-attribute string
+          if (isSimpleSingleAttributeMessage(ast)) {
+            attributes = '<li><p>' +
+              stringifyElements(ast.attributes[0].value.elements, true) +
+            '</p></li>';
+          }
+          else {
+            ast.attributes.forEach(function (attr) {
+              attributes += renderOriginalElements(attr.value.elements, attr.id.name);
+            });
+          }
         }
 
         $('#ftl-original .attributes ul').append(attributes);

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -36,7 +36,7 @@ var Pontoon = (function (my) {
   }
 
   /*
-   * Is ast element representing a pluralized string?
+   * Return true when AST element represents a pluralized string.
    *
    * Keys of all variants of such elements are either
    * CLDR plurals or numbers.
@@ -57,7 +57,7 @@ var Pontoon = (function (my) {
   }
 
   /*
-   * Are all elements supported in rich FTL editor?
+   * Return true when all elements are supported in rich FTL editor.
    *
    * Elements are supported if they are:
    * - simple elements or
@@ -73,7 +73,7 @@ var Pontoon = (function (my) {
   }
 
   /*
-   * Is ast of a message, supported in rich FTL editor?
+   * Return true when AST represents a message, supported in rich FTL editor.
    *
    * Message is supported if it's valid and all value elements
    * and all attribute elements are supported.
@@ -93,7 +93,7 @@ var Pontoon = (function (my) {
   }
 
   /*
-   * Is ast of a simple message?
+   * Return true when AST represents a simple message.
    *
    * A simple message has no attributes and all value
    * elements are simple.
@@ -112,8 +112,8 @@ var Pontoon = (function (my) {
   }
 
   /*
-   * Is ast of a message without value and with 1 attribute,
-   * which only contains simple elements?
+   * Return true when AST has no value
+   * and a single attribute with only simple elements.
    */
   function isSimpleSingleAttributeMessage(ast) {
     if (

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -370,11 +370,17 @@ var Pontoon = (function (my) {
      * link Metadata link (optional)
      */
     appendMetaData: function (title, text, link, linkClass) {
+      var className = title.trim().toLowerCase();
+
       if (link) {
         text = '<a href="' + link + '" class="' + linkClass + '">' + this.doNotRender(text) + '</a>';
       }
 
-      $('#metadata').append('<p><span class="title">' + title + '</span> <span class="content">' + text + '</span></p>');
+      $('#metadata').append(
+        '<p class="' + className + '">' +
+          '<span class="title">' + title + '</span> ' +
+          '<span class="content">' + text + '</span>' +
+        '</p>');
     },
 
 

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -579,6 +579,12 @@ var Pontoon = (function (my) {
         });
       }
 
+      // Metadata: attribute
+      var attribute = self.fluent.getSimpleSingleAttribute(entity);
+      if (attribute) {
+        self.appendMetaData('Attribute', attribute.id.name);
+      }
+
       // Metadata: key
       if (entity.key) {
         self.appendMetaData('Context', entity.key);


### PR DESCRIPTION
This patch adds a special case for FTL messages with 1 simple attribute and no value to:
* source string panel
* editor
* serialization

A test case:
https://github.com/mozilla-l10n/pontoon-ftl/blob/master/en-US/demo.ftl#L10

Diff looks bigger than it could, due to change indentation. I suggest reviewing on a commit-by-commit basis.