### PR TITLE
Fix bug 1454003: [FTL] Add ability to manage Term attributes

### DIFF
--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -1617,7 +1617,7 @@ body > header aside p {
   width: 100%;
 }
 
-.ftl-area section sub.remove {
+.ftl-area section .remove {
   color: #AAAAAA;
   cursor: pointer;
   font-size: 14px;
@@ -1627,7 +1627,7 @@ body > header aside p {
   top: 3px;
 }
 
-.ftl-area section sub.remove:hover {
+.ftl-area section .remove:hover {
   color: #7BC876;
 }
 

--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -1602,7 +1602,7 @@ body > header aside p {
   border-color: #7BC876;
 }
 
-#ftl-area .attributes .template {
+#ftl-area .templates {
   display: none;
 }
 

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -288,7 +288,7 @@ var Pontoon = (function (my) {
               item.value.elements,
               isPluralElement(element),
               isTranslated,
-              isCustomAttribute
+              isCustomAttribute,
             );
           });
         }
@@ -952,7 +952,7 @@ var Pontoon = (function (my) {
               if (showFTLEditor) {
                 var isRichEditorSupported = self.renderEditor({
                   pk: translated, // An indicator that the string is translated
-                  string: translation
+                  string: translation,
                 });
 
                 // Rich FTL editor does not support the translation

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -456,6 +456,7 @@ var Pontoon = (function (my) {
        */
       toggleEditor: function (showFTL) {
         var entity = Pontoon.getEditorEntity();
+
         if (typeof showFTL === 'undefined' || showFTL === null) {
           showFTL = entity.format === 'ftl';
         }
@@ -464,11 +465,15 @@ var Pontoon = (function (my) {
           $('#ftl-area').show();
           $('#translation').hide();
           $('#ftl').removeClass('active');
+
+          var entityAST = fluentParser.parseEntry(entity.original);
+          $('#add-attribute').toggle(entityAST.type === 'Term');
         }
         else {
           $('#ftl-area').hide();
           $('#translation').show().focus();
           $('#ftl').addClass('active');
+          $('#add-attribute').hide();
         }
 
         toggleEditorToolbar();
@@ -923,7 +928,7 @@ var Pontoon = (function (my) {
               if (showFTLEditor) {
                 var isRichEditorSupported = self.renderEditor({
                   pk: translated, // An indicator that the string is translated
-                  string: translation,
+                  string: translation
                 });
 
                 // Rich FTL editor does not support the translation

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -1027,6 +1027,24 @@ var Pontoon = (function (my) {
             $('.accesskeys div:contains("' + accesskey + '")').addClass('active');
           }
         });
+
+        // Add an attribute
+        $('#add-attribute').click(function (e) {
+          e.preventDefault();
+
+          var attributeTemplate = $('#ftl-area .templates .attribute').html();
+          $('#ftl-area .attributes ul:first').append(attributeTemplate);
+
+          // Simple string: convert to complex
+          if (!self.isComplexFTL()) {
+            var value = $('#only-value').val();
+            var valueTemplate = $('#ftl-area .templates .value').html();
+
+            $('#ftl-area .main-value ul:first').append(valueTemplate);
+            $('#ftl-id-Value').val(value);
+            $('#only-value').parents('li').hide();
+          }
+        });
       }
 
     },

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -833,7 +833,8 @@ var Pontoon = (function (my) {
         // Attributes
         if (attributeElements.length) {
           attributeElements.each(function () {
-            var id = $(this).data('id');
+            // Entity or custom attribute
+            var id = $(this).data('id') || $(this).find('.id').val();
             var val = serializeFTLEditorElements($(this).find('ul:first > li'));
 
             if (id && val) {

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -1045,6 +1045,27 @@ var Pontoon = (function (my) {
             $('#only-value').parents('li').hide();
           }
         });
+
+        // Remove an attribute
+        $('#ftl-area .attributes').on('click', '.custom-attribute .remove', function (e) {
+          e.preventDefault();
+
+          $(this).parents('.custom-attribute').remove();
+
+          // Simple value only: convert to simple string
+          var valueElements = $('#ftl-area .main-value ul:first > li:visible');
+          var variants = valueElements.is('[data-expression]');
+          var attributeElements = $('#ftl-area .attributes ul:first > li:visible');
+
+          if (valueElements.length === 1 && !variants && !attributeElements.length) {
+            var value = $('#ftl-id-Value').val();
+
+            $('#ftl-id-Value').parents('li').remove();
+            $('#only-value')
+              .val(value)
+              .parents('li').show();
+          }
+        });
       }
 
     },

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -299,13 +299,26 @@
         </section>
         <section class="attributes">
           <ul></ul>
-          <ul class="template">
-            <li class="custom-attribute clearfix">
-              <div class="wrapper">
-                <textarea class="id" placeholder="enter-attribute-id"></textarea>
-                <sub class="fa fa-times remove" title="Remove"></sub>
-              </div>
-              <textarea class="value" placeholder="Enter attribute value"></textarea>
+        </section>
+        <section class="templates">
+          <ul class="value">
+            <li class="clearfix">
+              <label class="id" for="ftl-id-Value">
+                <span>Value</span>
+              </label>
+              <textarea class="value" id="ftl-id-Value"></textarea>
+            </li>
+          </ul>
+          <ul class="attribute">
+            <li data-id="enter-id">
+              <ul>
+                <li class="clearfix">
+                  <label class="id" for="ftl-id-enter-id">
+                    <span>attribute-id</span>
+                  </label>
+                  <textarea class="value" id="ftl-id-enter-id" placeholder="Enter attribute value"></textarea>
+                </li>
+              </ul>
             </li>
           </ul>
         </section>

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -310,12 +310,13 @@
             </li>
           </ul>
           <ul class="attribute">
-            <li data-id="enter-id">
+            <li class="custom-attribute" data-id="enter-id">
               <ul>
                 <li class="clearfix">
-                  <label class="id" for="ftl-id-enter-id">
-                    <span>attribute-id</span>
-                  </label>
+                  <div class="wrapper">
+                    <input type="text" class="id" placeholder="enter-attribute-id">
+                    <span class="fa fa-times remove" title="Remove attribute"></span>
+                  </div>
                   <textarea class="value" id="ftl-id-enter-id" placeholder="Enter attribute value"></textarea>
                 </li>
               </ul>

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -372,7 +372,7 @@
             </div>
           </div>
 
-          <button id="add-attribute" title="Add attribute">+Attribute</button>
+          <button id="add-attribute" title="Add attribute">Add Attribute</button>
           <button id="copy" title="Copy From Source (Ctrl + Shift + C)">Copy</button>
           <button id="clear" title="Clear Translation (Ctrl + Shift + Backspace)">Clear</button>
           <button id="save" title="Save Translation (Enter)"></button>

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -310,7 +310,7 @@
             </li>
           </ul>
           <ul class="attribute">
-            <li class="custom-attribute" data-id="enter-id">
+            <li class="custom-attribute">
               <ul>
                 <li class="clearfix">
                   <div class="wrapper">


### PR DESCRIPTION
Unlike regular Messages, Terms are allowed to contain custom attributes (i.e. attributes not present in source string).

This patch introduces the "Add attribute" button, together with the ability to remove custom attributes and edit their IDs.

![screen shot 2018-06-27 at 12 09 25](https://user-images.githubusercontent.com/626716/41967895-0d22cba2-7a03-11e8-88f7-6ae40dd8a401.png)

To learn more about Terms and attributes, see:
https://projectfluent.org/fluent/guide/terms.html

The doc also contains a few examples, but you can also use the following file for testing:
https://github.com/mozilla-l10n/pontoon-ftl/blob/master/en-US/brand.ftl