### PR TITLE
Fix bug 1471534: Do not truncate source string

### DIFF
--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -1169,7 +1169,6 @@ body > header aside p {
 #entitylist > .wrapper > ul > li.unreviewed p span.source-string,
 #entitylist > .wrapper > ul > li.fuzzy p span.source-string,
 #entitylist > .wrapper > ul > li.partial p span.source-string,
-#entitylist > .wrapper > ul > li.missing p span.source-string,
 #entitylist > .wrapper > ul > li p span.translation-string:not(:empty) {
   display: inline-block;
   width: 49%;


### PR DESCRIPTION
This is a fix for a regression introduced in:
https://github.com/mozilla/pontoon/commit/46ffcb913bf945492b61787949f3199582ac1c23#diff-0c410b8223d3fa920e760f5f27612999R1172