### PR TITLE
Fix collectstatic by removing trailing comma

### DIFF
--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -288,7 +288,7 @@ var Pontoon = (function (my) {
               item.value.elements,
               isPluralElement(element),
               isTranslated,
-              isCustomAttribute,
+              isCustomAttribute
             );
           });
         }


### PR DESCRIPTION
It turns out we cannot use that trailing comma afterall 😩:
https://travis-ci.org/mozilla/pontoon/builds/397407562?utm_source=email&utm_medium=notification

```
The command "./node_modules/.bin/webpack" exited with 0.
14.53s$ python manage.py collectstatic -v0 --noinput
Traceback (most recent call last):
  File "manage.py", line 20, in <module>
    execute_from_command_line(sys.argv)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/django/core/management/__init__.py", line 364, in execute_from_command_line
    utility.execute()
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/django/core/management/__init__.py", line 356, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/django/core/management/base.py", line 283, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/django/core/management/base.py", line 330, in execute
    output = self.handle(*args, **options)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/django/contrib/staticfiles/management/commands/collectstatic.py", line 199, in handle
    collected = self.collect()
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/django/contrib/staticfiles/management/commands/collectstatic.py", line 139, in collect
    for original_path, processed_path, processed in processor:
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/pipeline/storage.py", line 33, in post_process
    packager.pack_javascripts(package)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/pipeline/packager.py", line 112, in pack_javascripts
    return self.pack(package, self.compressor.compress_js, js_compressed, templates=package.templates, **kwargs)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/pipeline/packager.py", line 106, in pack
    content = compress(paths, **kwargs)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/pipeline/compressors/__init__.py", line 67, in compress_js
    js = getattr(compressor(verbose=self.verbose), 'compress_js')(js)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/pipeline/compressors/yuglify.py", line 13, in compress_js
    return self.compress_common(js, 'js', settings.PIPELINE_YUGLIFY_JS_ARGUMENTS)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/pipeline/compressors/yuglify.py", line 10, in compress_common
    return self.execute_command(command, content)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/pipeline/compressors/__init__.py", line 244, in execute_command
    raise CompressorError(stderr)
pipeline.exceptions.CompressorError: 
/home/travis/build/mozilla/pontoon/node_modules/yuglify/bin/yuglify:77
                throw(err);
                ^
SyntaxError: Unexpected token: punc ())
    at JS_Parse_Error.get (eval at <anonymous> (/home/travis/build/mozilla/pontoon/node_modules/yuglify/node_modules/uglify-js/tools/node.js:21:1), <anonymous>:75:23)
```