### PR TITLE
Bug 1465824: Encode non-Raygun exceptions as utf-8

### DIFF
--- a/pontoon/base/middleware.py
+++ b/pontoon/base/middleware.py
@@ -11,7 +11,7 @@ class RaygunExceptionMiddleware(Provider):
         # of these.
         if not isinstance(exception, (Http404, PermissionDenied)):
             return (super(RaygunExceptionMiddleware, self)
-                    .process_exception(request, exception))
+                    .process_exception(request, unicode(exception).encode('utf-8')))
 
 
 class BlockedIpMiddleware(object):


### PR DESCRIPTION
In [bug 1459939](https://bugzilla.mozilla.org/show_bug.cgi?id=1459939#c1) an exception was raised that contained a non-ASCII character. Which raised another exception, that prevented us to see the actual one.

This patch prevents that 2nd exception.

@jotes r?

Before:
```
Internal Server Error: /download/ 
Traceback (most recent call last): 
  File "/app/.heroku/python/lib/python2.7/site-packages/django/core/handlers/exception.py", line 41, in inner 
 response = get_response(request) 
  File "/app/.heroku/python/lib/python2.7/site-packages/django/core/handlers/base.py", line 249, in _legacy_get_response 
 response = self._get_response(request) 
  File "/app/.heroku/python/lib/python2.7/site-packages/django/core/handlers/base.py", line 187, in _get_response 
 response = self.process_exception_by_middleware(e, request) 
  File "/app/.heroku/python/lib/python2.7/site-packages/django/core/handlers/base.py", line 227, in process_exception_by_middleware 
 response = middleware_method(request, exception) 
  File "/app/.heroku/python/lib/python2.7/site-packages/newrelic/hooks/framework_django.py", line 325, in wrapper 
 return wrapped(*args, **kwargs) 
  File "/app/pontoon/base/middleware.py", line 14, in process_exception 
 .process_exception(request, exception)) 
  File "/app/.heroku/python/lib/python2.7/site-packages/raygun4py/middleware/django.py", line 21, in process_exception 
 self.sender.send_exception(exception=exception, request=raygunRequest, extra_environment_data=env) 
  File "/app/.heroku/python/lib/python2.7/site-packages/raygun4py/raygunprovider.py", line 95, in send_exception 
 errorMessage = raygunmsgs.RaygunErrorMessage(type(exception), exception, exc_traceback, options) 
  File "/app/.heroku/python/lib/python2.7/site-packages/raygun4py/raygunmsgs.py", line 137, in __init__ 
 self.message = "%s: %s" % (exc_type.__name__, exc_value) 
UnicodeEncodeError: 'ascii' codec can't encode character u'\xa0' in position 175: ordinal not in range(128)
```

After:
```
Internal Server Error: /download/ 
Traceback (most recent call last): 
  File "/app/.heroku/python/lib/python2.7/site-packages/django/core/handlers/exception.py", line 41, in inner 
    response = get_response(request) 
  File "/app/.heroku/python/lib/python2.7/site-packages/django/core/handlers/base.py", line 249, in _legacy_get_response 
    response = self._get_response(request) 
  File "/app/.heroku/python/lib/python2.7/site-packages/django/core/handlers/base.py", line 187, in _get_response 
    response = self.process_exception_by_middleware(e, request) 
  File "/app/.heroku/python/lib/python2.7/site-packages/django/core/handlers/base.py", line 185, in _get_response 
    response = wrapped_callback(request, *callback_args, **callback_kwargs) 
  File "/app/.heroku/python/lib/python2.7/site-packages/newrelic/hooks/framework_django.py", line 544, in wrapper 
    return wrapped(*args, **kwargs) 
  File "/app/.heroku/python/lib/python2.7/site-packages/django/views/decorators/http.py", line 40, in inner 
    return func(request, *args, **kwargs) 
  File "/app/.heroku/python/lib/python2.7/site-packages/django/utils/decorators.py", line 185, in inner 
    return func(*args, **kwargs) 
  File "/app/pontoon/base/views.py", line 737, in download 
    content, filename = utils.get_download_content(slug, code, part) 
  File "/app/pontoon/base/utils.py", line 399, in get_download_content 
    resource_file = formats.parse(locale_path, source_path) 
  File "/app/pontoon/sync/formats/__init__.py", line 52, in parse 
    return SUPPORTED_FORMAT_PARSERS[extension](path, source_path=source_path, locale=locale) 
  File "/app/pontoon/sync/formats/lang.py", line 194, in parse 
    children = LangVisitor().parse(content) 
  File "/app/.heroku/python/lib/python2.7/site-packages/parsimonious/nodes.py", line 244, in parse 
    return self._parse_or_match(text, pos, 'parse') 
  File "/app/.heroku/python/lib/python2.7/site-packages/parsimonious/nodes.py", line 278, in _parse_or_match 
    return self.visit(getattr(self.grammar, method_name)(text, pos=pos)) 
  File "/app/.heroku/python/lib/python2.7/site-packages/parsimonious/nodes.py", line 208, in visit 
    return method(node, [self.visit(n) for n in node]) 
  File "/app/.heroku/python/lib/python2.7/site-packages/parsimonious/nodes.py", line 208, in visit 
    return method(node, [self.visit(n) for n in node]) 
  File "/app/.heroku/python/lib/python2.7/site-packages/parsimonious/exceptions.py", line 81, in __init__ 
    node.prettily(error=node))) 
  File "/app/.heroku/python/lib/python2.7/site-packages/parsimonious/utils.py", line 16, in __str__ 
    return self.__unicode__().encode('utf-8') 
  File "/app/.heroku/python/lib/python2.7/site-packages/parsimonious/exceptions.py", line 16, in __unicode__ 
    rule_name = ((u"'%s'" % self.expr.name) if self.expr.name else 
ParseError: Failed to parse /tmp/tmplUuLvv.lang: AttributeError: 'NoneType' object has no attribute 'name' 
Parse tree: 
<Node matching ";VP, Advocacy 
\xa0 
">  <-- *** We were here. *** 
    <Node called "entity" matching ";VP, Advocacy 
    \xa0 
    "> 
        <Node called "string" matching ";VP, Advocacy 
        "> 
            <Node matching ";"> 
            <RegexNode called "line_content" matching "VP, Advocacy"> 
            <RegexNode called "line_ending" matching " 
            "> 
        <Node called "translation" matching "\xa0 
        "> 
            <RegexNode called "line_content" matching "\xa0"> 
            <RegexNode called "line_ending" matching " 
            "> 
```