### PR TITLE
Fix bug 1472995: Dynamically update tags in the filters menu

### DIFF
--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -1258,6 +1258,7 @@ var Pontoon = (function (my) {
             var node = $('#filter .menu [data-type="time-range"]');
             node.addClass('selected');
             placeholder.push(node.find('.title').text());
+
           } else {
             markTagFilters(type);
           }
@@ -3166,6 +3167,34 @@ var Pontoon = (function (my) {
 
 
     /*
+     * Update tag list in filter menu
+     */
+    updateTagFilters: function() {
+      var tags = this.project.tags;
+      $('#filter .menu li[class^="tag-"]').remove();
+
+      tags.forEach(function(tag) {
+        var priority = '';
+
+        for (var i=0; i<5; i++) {
+          priority += '<span class="fa fa-star' + (i < tag.priority ? ' active' : '') + '"></span>';
+        }
+
+        $('#filter .menu li.for-tags, #filter .menu li[class^="tag-"]').last().after(
+          '<li class="tag-' + tag.slug +'" data-type="' + tag.slug + '">' +
+            '<span class="status fa"></span>' +
+            '<span class="title">' + tag.name + '</span>' +
+            '<span class="priority">' + priority + '</span>' +
+          '</li>'
+        );
+      });
+
+      $('#filter .menu li[class^="tag-"], #filter .menu li.for-tags')
+        .toggle(!!tags.length && this.currentPart.title === 'all-resources');
+    },
+
+
+    /*
      * Reset Time range filter to default
      */
     resetTimeRange: function() {
@@ -3315,6 +3344,7 @@ var Pontoon = (function (my) {
       self.updateTextareaAttributes();
       self.resetTimeRange();
       self.updateFilterUI();
+      self.updateTagFilters();
       self.renderEntityList();
       self.updateProgress();
 
@@ -3693,7 +3723,8 @@ var Pontoon = (function (my) {
         info: self.getProjectData('info') || '',
         width: self.getProjectWidth(),
         links: self.getProjectData('links') === 'True' ? true : false,
-        langpack_url: self.getProjectData('langpack_url') || ''
+        langpack_url: self.getProjectData('langpack_url') || '',
+        tags: self.getProjectData('tags')
       };
 
       /* Copy of User.can_translate(), used on client to improve performance */
@@ -3881,6 +3912,7 @@ var Pontoon = (function (my) {
           self.updateProgress();
           self.updateFilterUI();
           self.createObject(true);
+          self.updateTagFilters(true);
           return;
         }
       } else {
@@ -4170,9 +4202,6 @@ var Pontoon = (function (my) {
       } else {
         this.currentPart = matchingParts[0];
       }
-
-      $('#filter .menu li[class^="tag-"], #filter .menu li.tags-header')
-        .toggle(this.currentPart.title === 'all-resources');
 
       this.updatePartSelector(this.currentPart.title);
     },

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -173,12 +173,7 @@
             {{ Filter.item('translated', 'Translated', count=True) }}
             {{ Filter.item('unreviewed', 'Unreviewed', count=True) }}
 
-            {% if tags %}
-            <li class="horizontal-separator tags-header">Tags</li>
-            {% for tag in tags %}
-            {{ Filter.item('tag-' + tag.slug, tag.name, priority=tag.priority) }}
-            {% endfor %}
-            {% endif %}
+            <li class="horizontal-separator for-tags">Tags</li>
 
             <li class="horizontal-separator">Extra Filters</li>
 

--- a/pontoon/base/templates/widgets/filter_item.html
+++ b/pontoon/base/templates/widgets/filter_item.html
@@ -1,16 +1,9 @@
-{% macro item(type, title, count=False, priority=None) %}
+{% macro item(type, title, count=False) %}
 <li class="{{ type }}" data-type="{{ type }}">
   <span class="status fa"></span>
   <span class="title">{{ title }}</span>
   {% if count %}
   <span class="count"></span>
-  {% endif %}
-  {% if priority %}
-  <span class="priority">
-    {% for n in range(5) %}
-    <span class="fa fa-star{% if loop.index <= priority %}{{ ' active' }}{% endif %}"></span>
-    {% endfor %}
-  </span>
   {% endif %}
 </li>
 {% endmacro %}

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -42,7 +42,6 @@ from pontoon.base.models import (
     Translation,
     UserProfile,
 )
-from pontoon.tags.utils.tags import TagsTool
 from pontoon.checks.libraries import run_checks
 from pontoon.checks.utils import (
     save_failed_checks,
@@ -88,7 +87,7 @@ def translate(request, locale, slug, part):
 
     projects = (
         Project.objects.available()
-        .prefetch_related('subpage_set')
+        .prefetch_related('subpage_set', 'tag_set')
         .order_by('name')
     )
 
@@ -108,10 +107,6 @@ def translate(request, locale, slug, part):
         'part': part,
         'project': project,
         'projects': projects,
-        'tags': (
-            TagsTool(projects=[project], priority=True)
-            if project.tags_enabled
-            else None)
     })
 
 
@@ -246,8 +241,6 @@ def _get_paginated_entities(locale, project, form, entities):
         return JsonResponse({
             'has_next': False,
             'stats': {},
-            'authors': [],
-            'counts_per_minute': [],
         })
 
     has_next = entities_page.has_next()

--- a/pontoon/projects/templates/projects/widgets/project_selector.html
+++ b/pontoon/projects/templates/projects/widgets/project_selector.html
@@ -17,6 +17,9 @@
             {% for key, value in p.serialize().iteritems() %}
               data-{{ key }}="{{ value }}"
             {% endfor %}
+
+            data-tags="{{ p.tag_set.all().serialize()|to_json }}"
+
             {% if project == p %}
               data-parts="{{ {locale.code: locale.parts_stats(p)}|to_json }}"
             {% endif %}

--- a/pontoon/tags/models.py
+++ b/pontoon/tags/models.py
@@ -4,6 +4,11 @@ from django.db import models
 from pontoon.base.models import PRIORITY_CHOICES, Project, Resource
 
 
+class TagQuerySet(models.QuerySet):
+    def serialize(self):
+        return [tag.serialize() for tag in self]
+
+
 class Tag(models.Model):
     slug = models.CharField(max_length=20)
     name = models.CharField(max_length=30)
@@ -14,5 +19,14 @@ class Tag(models.Model):
         null=True,
         choices=PRIORITY_CHOICES)
 
+    objects = TagQuerySet.as_manager()
+
     class Meta(object):
         unique_together = [['slug', 'project']]
+
+    def serialize(self):
+        return {
+            'slug': self.slug,
+            'name': self.name,
+            'priority': self.priority,
+        }

--- a/pontoon/tags/tests/test_models.py
+++ b/pontoon/tags/tests/test_models.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import pytest
 
 from pontoon.tags.models import Tag

--- a/pontoon/tags/tests/test_models.py
+++ b/pontoon/tags/tests/test_models.py
@@ -1,0 +1,37 @@
+from __future__ import absolute_import
+
+import pytest
+
+from pontoon.tags.models import Tag
+from pontoon.test.factories import TagFactory
+
+
+@pytest.mark.django_db
+def test_serialize_tags():
+    # tests serialization of a QuerySet of Tags
+    tag1 = TagFactory.create()
+    tag2 = TagFactory.create()
+    tag3 = TagFactory.create()
+
+    pks = [tag1.pk, tag2.pk, tag3.pk]
+    queryset = Tag.objects.filter(pk__in=pks)
+
+    expected = [
+        {
+            'slug': tag1.slug,
+            'name': tag1.name,
+            'priority': tag1.priority,
+        },
+        {
+            'slug': tag2.slug,
+            'name': tag2.name,
+            'priority': tag2.priority,
+        },
+        {
+            'slug': tag3.slug,
+            'name': tag3.name,
+            'priority': tag3.priority,
+        }
+    ]
+
+    assert queryset.serialize() == expected


### PR DESCRIPTION
Steps to reproduce:

1. Go to https://pontoon.mozilla.org/sl/firefox/all-resources/.
2. Open the filter menu.
3. Observe Tags.
4. Select AMO from the Project menu and click Go.
5. Open the filter menu.
6. Observe Tags.

Expected result: 
There are no tags in step 6.

Actual result:
Tags from step 3 (belonging to Firefox) are displayed in step 6 (when AMO is being translated).