### PR TITLE
Fix bug 1464802: Show resource priority and deadline in localization dashboard

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -1320,6 +1320,26 @@ class Project(AggregatedStats):
     def avg_string_count(self):
         return int(self.total_strings / self.enabled_locales)
 
+    def resource_priority_map(self):
+        """
+        Returns a map of resource paths and highest priorities of resource tags.
+        """
+        resource_priority = {}
+
+        resource_priority_qs = (
+            self.tag_set
+            .prefetch_related('resources')
+            .values('resources__path', 'priority')
+        )
+
+        for item in resource_priority_qs:
+            path = item['resources__path']
+            if path in resource_priority and resource_priority[path] >= item['priority']:
+                continue
+            resource_priority[path] = item['priority']
+
+        return resource_priority
+
 
 @python_2_unicode_compatible
 class ExternalResource(models.Model):

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -928,6 +928,7 @@ class Locale(AggregatedStats):
                 'url',
                 'title',
                 'resource__path',
+                'resource__deadline',
                 'resource__total_strings',
                 'fuzzy_strings',
                 'unreviewed_strings',
@@ -963,6 +964,7 @@ class Locale(AggregatedStats):
                     locale_pages.annotate(
                         title=F('name'),
                         resource__path=F('resources__path'),
+                        resource__deadline=F('resources__deadline'),
                         resource__total_strings=F('resources__total_strings'),
                         fuzzy_strings=F('resources__translatedresources__fuzzy_strings'),
                         unreviewed_strings=F('resources__translatedresources__unreviewed_strings'),
@@ -980,6 +982,7 @@ class Locale(AggregatedStats):
                     locale_pages.annotate(
                         title=F('name'),
                         resource__path=F('project__resources__path'),
+                        resource__deadline=F('project__resources__deadline'),
                         resource__total_strings=F('project__resources__total_strings'),
                         fuzzy_strings=F('project__resources__translatedresources__fuzzy_strings'),
                         unreviewed_strings=F(
@@ -1005,6 +1008,7 @@ class Locale(AggregatedStats):
         details_list.append({
             'title': 'all-resources',
             'resource__path': [],
+            'resource__deadline': [],
             'resource__total_strings': all_resources.total_strings,
             'fuzzy_strings': all_resources.fuzzy_strings,
             'unreviewed_strings': all_resources.unreviewed_strings,

--- a/pontoon/base/static/css/table.css
+++ b/pontoon/base/static/css/table.css
@@ -28,8 +28,16 @@ table.table {
   width: 420px;
 }
 
-.table th.resource.with-priority {
+.table th.resource.with-deadline:not(.with-priority) {
+  width: 310px;
+}
+
+.table th.resource.with-priority:not(.with-deadline) {
   width: 330px;
+}
+
+.table th.resource.with-deadline.with-priority {
+  width: 220px;
 }
 
 .table th.tag {
@@ -86,8 +94,16 @@ table.table {
   width: 419px;
 }
 
-.table .resource.with-priority h4 {
+.table .resource.with-deadline:not(.with-priority) h4 {
+  width: 309px;
+}
+
+.table .resource.with-priority:not(.with-deadline) h4 {
   width: 329px;
+}
+
+.table .resource.with-deadline.with-priority h4 {
+  width: 219px;
 }
 
 .table h4 a {

--- a/pontoon/base/static/css/table.css
+++ b/pontoon/base/static/css/table.css
@@ -28,6 +28,10 @@ table.table {
   width: 420px;
 }
 
+.table th.resource.with-priority {
+  width: 330px;
+}
+
 .table th.tag {
   width: 330px;
 }
@@ -80,6 +84,10 @@ table.table {
 
 .table .resource h4 {
   width: 419px;
+}
+
+.table .resource.with-priority h4 {
+  width: 329px;
 }
 
 .table h4 a {

--- a/pontoon/base/templates/widgets/deadline.html
+++ b/pontoon/base/templates/widgets/deadline.html
@@ -1,0 +1,5 @@
+{% macro deadline(deadline, complete) %}
+  <time datetime="{% if deadline %}{{ deadline.isoformat() }}{% endif %}" class="{{ deadline|date_status(complete) }}">
+  {{ deadline|format_datetime('short_date', default='―') }}
+  </time>
+{% endmacro %}

--- a/pontoon/base/templates/widgets/heading_info.html
+++ b/pontoon/base/templates/widgets/heading_info.html
@@ -1,3 +1,5 @@
+{% import 'widgets/deadline.html' as Deadline %}
+
 {% macro heading_item(title, link, class=None) %}
 <a class="{{ class }}" href="{{ link }}">{{ title }}</a>
 {% endmacro %}
@@ -28,7 +30,7 @@
 <li class="deadline">
   <span class="title">Deadline</span>
   <span class="value">
-    <time datetime="{% if deadline %}{{ deadline.isoformat() }}{% endif %}" class="{{ deadline|date_status(complete) }}">{{ deadline|format_datetime('short_date', default='―') }}</time>
+    {{ Deadline.deadline(deadline, complete) }}
   </span>
 </li>
 {% endmacro %}

--- a/pontoon/base/templates/widgets/heading_info.html
+++ b/pontoon/base/templates/widgets/heading_info.html
@@ -1,4 +1,5 @@
 {% import 'widgets/deadline.html' as Deadline %}
+{% import 'widgets/priority.html' as Priority %}
 
 {% macro heading_item(title, link, class=None) %}
 <a class="{{ class }}" href="{{ link }}">{{ title }}</a>
@@ -19,9 +20,7 @@
 <li class="priority">
   <span class="title">{{ title }}</span>
   <span class="value">
-    {% for n in range(5) %}
-      <span class="fa fa-star{% if loop.index <= priority %}{{ ' active' }}{% endif %}"></span>
-    {% endfor %}
+    {{ Priority.priority(priority) }}
   </span>
 </li>
 {% endmacro %}

--- a/pontoon/base/templates/widgets/priority.html
+++ b/pontoon/base/templates/widgets/priority.html
@@ -1,0 +1,5 @@
+{% macro priority(priority) %}
+  {% for n in range(5) %}
+  <span class="fa fa-star{% if loop.index <= priority %}{{ ' active' }}{% endif %}"></span>
+  {% endfor %}
+{% endmacro %}

--- a/pontoon/localizations/templates/localizations/includes/resources.html
+++ b/pontoon/localizations/templates/localizations/includes/resources.html
@@ -8,7 +8,7 @@
     </div>
   </menu>
 
-  {{ ResourceList.header(priority) }}
+  {{ ResourceList.header(deadline, priority) }}
 
   {% for resource in resources %}
     {% if not loop.last %}
@@ -16,7 +16,7 @@
       {% set chart_link = main_link %}
       {% set latest_activity = resource.latest_activity %}
       {% set chart = resource.chart %}
-      {{ ResourceList.item(resource, main_link, chart_link, latest_activity, chart, priority) }}
+      {{ ResourceList.item(resource, main_link, chart_link, latest_activity, chart, deadline, priority) }}
     {% endif %}
   {% endfor %}
 

--- a/pontoon/localizations/templates/localizations/includes/resources.html
+++ b/pontoon/localizations/templates/localizations/includes/resources.html
@@ -8,7 +8,7 @@
     </div>
   </menu>
 
-  {{ ResourceList.header() }}
+  {{ ResourceList.header(priority) }}
 
   {% for resource in resources %}
     {% if not loop.last %}
@@ -16,7 +16,7 @@
       {% set chart_link = main_link %}
       {% set latest_activity = resource.latest_activity %}
       {% set chart = resource.chart %}
-      {{ ResourceList.item(resource, main_link, chart_link, latest_activity, chart) }}
+      {{ ResourceList.item(resource, main_link, chart_link, latest_activity, chart, priority) }}
     {% endif %}
   {% endfor %}
 

--- a/pontoon/localizations/templates/localizations/widgets/resource_list.html
+++ b/pontoon/localizations/templates/localizations/widgets/resource_list.html
@@ -1,11 +1,15 @@
 {% import 'widgets/latest_activity.html' as LatestActivity %}
 {% import 'widgets/progress_chart.html' as ProgressChart %}
 
-{% macro header(priority) %}
+{% macro header(deadline, priority) %}
   <table class="table table-sort project-list">
     <thead>
       <tr>
-        <th class="resource{% if priority %} with-priority{% endif %} asc">Resource<i class="fa"></i></th>
+        <th class="resource{% if deadline %} with-deadline{% endif %}{% if priority %} with-priority{% endif %} asc">Resource<i class="fa"></i></th>
+
+        {% if deadline %}
+        <th class="deadline">Deadline<i class="fa"></i></th>
+        {% endif %}
 
         {% if priority %}
         <th class="priority">Priority<i class="fa"></i></th>
@@ -19,13 +23,19 @@
     <tbody>
 {% endmacro %}
 
-{% macro item(resource, main_link, chart_link, latest_activity, chart, priority) %}
+{% macro item(resource, main_link, chart_link, latest_activity, chart, deadline, priority) %}
   <tr class="{{ class }}">
-    <td class="resource{% if priority %} with-priority{% endif %}">
+    <td class="resource{% if deadline %} with-deadline{% endif %}{% if priority %} with-priority{% endif %}">
       <h4>
         <a href="{{ main_link }}">{{ resource.title }}</a>
       </h4>
     </td>
+
+    {% if deadline %}
+    <td class="deadline">
+      <time datetime="{% if resource.resource__deadline %}{{ resource.resource__deadline.isoformat() }}{% endif %}" class="{{ resource.resource__deadline|date_status(chart.approved_percent == 100) }}">{{ resource.resource__deadline|format_datetime('short_date', default='―') }}</time>
+    </td>
+    {% endif %}
 
     {% if priority %}
     <td class="priority">

--- a/pontoon/localizations/templates/localizations/widgets/resource_list.html
+++ b/pontoon/localizations/templates/localizations/widgets/resource_list.html
@@ -26,7 +26,7 @@
 {% endmacro %}
 
 {% macro item(resource, main_link, chart_link, latest_activity, chart, deadline, priority) %}
-  <tr class="{{ class }}">
+  <tr class="limited">
     <td class="resource{% if deadline %} with-deadline{% endif %}{% if priority %} with-priority{% endif %}">
       <h4>
         <a href="{{ main_link }}">{{ resource.title }}</a>
@@ -49,7 +49,7 @@
       {{ LatestActivity.span(latest_activity) }}
     </td>
     <td class="progress" colspan="2">
-      {{ ProgressChart.span(chart, chart_link, link_parameter) }}
+      {{ ProgressChart.span(chart, chart_link, True) }}
     </td>
   </tr>
 {% endmacro %}

--- a/pontoon/localizations/templates/localizations/widgets/resource_list.html
+++ b/pontoon/localizations/templates/localizations/widgets/resource_list.html
@@ -1,5 +1,6 @@
 {% import 'widgets/latest_activity.html' as LatestActivity %}
 {% import 'widgets/progress_chart.html' as ProgressChart %}
+{% import 'widgets/deadline.html' as Deadline %}
 
 {% macro header(deadline, priority) %}
   <table class="table table-sort project-list">
@@ -33,7 +34,7 @@
 
     {% if deadline %}
     <td class="deadline">
-      <time datetime="{% if resource.resource__deadline %}{{ resource.resource__deadline.isoformat() }}{% endif %}" class="{{ resource.resource__deadline|date_status(chart.approved_percent == 100) }}">{{ resource.resource__deadline|format_datetime('short_date', default='―') }}</time>
+      {{ Deadline.deadline(resource.resource__deadline, chart.approved_percent == 100) }}
     </td>
     {% endif %}
 

--- a/pontoon/localizations/templates/localizations/widgets/resource_list.html
+++ b/pontoon/localizations/templates/localizations/widgets/resource_list.html
@@ -1,6 +1,7 @@
 {% import 'widgets/latest_activity.html' as LatestActivity %}
 {% import 'widgets/progress_chart.html' as ProgressChart %}
 {% import 'widgets/deadline.html' as Deadline %}
+{% import 'widgets/priority.html' as Priority %}
 
 {% macro header(deadline, priority) %}
   <table class="table table-sort project-list">
@@ -40,9 +41,7 @@
 
     {% if priority %}
     <td class="priority">
-      {% for n in range(5) %}
-        <span class="fa fa-star{% if loop.index <= resource.resource__priority %}{{ ' active' }}{% endif %}"></span>
-      {% endfor %}
+      {{ Priority.priority(resource.resource__priority) }}
     </td>
     {% endif %}
 

--- a/pontoon/localizations/templates/localizations/widgets/resource_list.html
+++ b/pontoon/localizations/templates/localizations/widgets/resource_list.html
@@ -1,11 +1,16 @@
 {% import 'widgets/latest_activity.html' as LatestActivity %}
 {% import 'widgets/progress_chart.html' as ProgressChart %}
 
-{% macro header() %}
+{% macro header(priority) %}
   <table class="table table-sort project-list">
     <thead>
       <tr>
-        <th class="resource asc">Resource<i class="fa"></i></th>
+        <th class="resource{% if priority %} with-priority{% endif %} asc">Resource<i class="fa"></i></th>
+
+        {% if priority %}
+        <th class="priority">Priority<i class="fa"></i></th>
+        {% endif %}
+
         <th class="latest-activity">Latest Activity<i class="fa"></i></th>
         <th class="progress">Progress<i class="fa"></i></th>
         <th class="unreviewed-status" title="Unreviewed strings"><span class="fa fa-lightbulb"></span><i class="fa"></i></th>
@@ -14,13 +19,22 @@
     <tbody>
 {% endmacro %}
 
-{% macro item(resource, main_link, chart_link, latest_activity, chart, class='limited', link_parameter=True) %}
+{% macro item(resource, main_link, chart_link, latest_activity, chart, priority) %}
   <tr class="{{ class }}">
-    <td class="resource">
+    <td class="resource{% if priority %} with-priority{% endif %}">
       <h4>
         <a href="{{ main_link }}">{{ resource.title }}</a>
       </h4>
     </td>
+
+    {% if priority %}
+    <td class="priority">
+      {% for n in range(5) %}
+        <span class="fa fa-star{% if loop.index <= resource.resource__priority %}{{ ' active' }}{% endif %}"></span>
+      {% endfor %}
+    </td>
+    {% endif %}
+
     <td class="latest-activity">
       {{ LatestActivity.span(latest_activity) }}
     </td>

--- a/pontoon/localizations/views.py
+++ b/pontoon/localizations/views.py
@@ -92,7 +92,11 @@ def ajax_resources(request, code, slug):
     translatedresources = dict(translatedresources.items() + pages.items())
     parts = locale.parts_stats(project)
 
+    resource_priority_map = project.resource_priority_map()
+
     for part in parts:
+        part['resource__priority'] = resource_priority_map.get(part['title'], None)
+
         translatedresource = translatedresources.get(part['title'], None)
         if translatedresource and translatedresource.latest_translation:
             part['latest_activity'] = translatedresource.latest_translation.latest_activity
@@ -120,6 +124,7 @@ def ajax_resources(request, code, slug):
         'locale': locale,
         'project': project,
         'resources': parts,
+        'priority': any(part['resource__priority'] for part in parts),
     })
 
 

--- a/pontoon/localizations/views.py
+++ b/pontoon/localizations/views.py
@@ -124,6 +124,7 @@ def ajax_resources(request, code, slug):
         'locale': locale,
         'project': project,
         'resources': parts,
+        'deadline': any(part['resource__deadline'] for part in parts),
         'priority': any(part['resource__priority'] for part in parts),
     })
 

--- a/pontoon/projects/templates/projects/widgets/project_list.html
+++ b/pontoon/projects/templates/projects/widgets/project_list.html
@@ -1,5 +1,6 @@
 {% import 'widgets/latest_activity.html' as LatestActivity %}
 {% import 'widgets/progress_chart.html' as ProgressChart %}
+{% import 'widgets/deadline.html' as Deadline %}
 
 {% macro header(request=False) %}
   <table class="table table-sort project-list">
@@ -28,7 +29,7 @@
       </h4>
     </td>
     <td class="deadline">
-      <time datetime="{% if project.deadline %}{{ project.deadline.isoformat() }}{% endif %}" class="{{ project.deadline|date_status(chart.approved_percent == 100) }}">{{ project.deadline|format_datetime('short_date', default='―') }}</time>
+      {{ Deadline.deadline(project.deadline, chart.approved_percent == 100) }}
     </td>
     <td class="priority">
       {% for n in range(5) %}

--- a/pontoon/projects/templates/projects/widgets/project_list.html
+++ b/pontoon/projects/templates/projects/widgets/project_list.html
@@ -1,6 +1,7 @@
 {% import 'widgets/latest_activity.html' as LatestActivity %}
 {% import 'widgets/progress_chart.html' as ProgressChart %}
 {% import 'widgets/deadline.html' as Deadline %}
+{% import 'widgets/priority.html' as Priority %}
 
 {% macro header(request=False) %}
   <table class="table table-sort project-list">
@@ -32,9 +33,7 @@
       {{ Deadline.deadline(project.deadline, chart.approved_percent == 100) }}
     </td>
     <td class="priority">
-      {% for n in range(5) %}
-        <span class="fa fa-star{% if loop.index <= project.priority %}{{ ' active' }}{% endif %}"></span>
-      {% endfor %}
+      {{ Priority.priority(project.priority) }}
     </td>
     <td class="latest-activity">
       {{ LatestActivity.span(latest_activity) }}

--- a/pontoon/tags/templates/tags/widgets/tag_list.html
+++ b/pontoon/tags/templates/tags/widgets/tag_list.html
@@ -1,5 +1,6 @@
 {% import 'widgets/latest_activity.html' as LatestActivity %}
 {% import 'widgets/progress_chart.html' as ProgressChart %}
+{% import 'widgets/priority.html' as Priority %}
 
 {% macro header() %}
   <table class="table table-sort project-list">
@@ -23,9 +24,7 @@
       </h4>
     </td>
     <td class="priority">
-      {% for n in range(5) %}
-      <span class="fa fa-star{% if loop.index <= tag.priority %}{{ ' active' }}{% endif %}"></span>
-      {% endfor %}
+      {{ Priority.priority(tag.priority) }}
     </td>
     <td class="latest-activity">
       {{ LatestActivity.span(latest_activity) }}


### PR DESCRIPTION
This patch makes the most critical piece of information coming from the tags feature (priority) more visible, because ATM [not many people see it](https://bugzilla.mozilla.org/show_bug.cgi?id=1464802#c5).

It does that by introducing the priority column to the Resources tab (default) of the Localization dashboard. Note that the column only appears in at least one file is assigned to a tag (which sets the priority).

Since it's touching the same code and serving a similar purpose, we're also adding a deadline column to the localization dashboard. And, factoring out the deadline and priority field code, so that it can be reused easily.

Check out the behaviour on stage...

Priority only:
https://mozilla-pontoon-staging.herokuapp.com/sl/firefox/

Deadline only:
https://mozilla-pontoon-staging.herokuapp.com/ar/appstores/

Priority and deadline:
https://mozilla-pontoon-staging.herokuapp.com/it/engagement/

No priority and no deadline:
https://mozilla-pontoon-staging.herokuapp.com/fr/amo/