### PR TITLE
Bug 1464802: File priority & deadline followup

### DIFF
--- a/pontoon/base/admin.py
+++ b/pontoon/base/admin.py
@@ -169,7 +169,7 @@ class ProjectAdmin(admin.ModelAdmin):
 
 class ResourceAdmin(admin.ModelAdmin):
     search_fields = ['path', 'format', 'project__name', 'project__slug']
-    list_display = ('pk', 'project', 'path', 'format')
+    list_display = ('pk', 'project', 'path', 'format', 'deadline')
 
 
 class TranslatedResourceAdmin(admin.ModelAdmin):

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -1820,14 +1820,6 @@ class Resource(models.Model):
     def __str__(self):
         return '%s: %s' % (self.project.name, self.path)
 
-    def save(self, *args, **kwargs):
-        super(Resource, self).save(*args, **kwargs)
-
-        if self.deadline and self.project.deadline:
-            if self.deadline < self.project.deadline:
-                self.project.deadline = self.deadline
-                self.project.save()
-
     @classmethod
     def get_path_format(self, path):
         filename, extension = os.path.splitext(path)

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -924,7 +924,7 @@ class Locale(AggregatedStats):
     def parts_stats(self, project):
         """Get locale-project pages/paths with stats."""
         def get_details(parts):
-            values = parts.order_by('title').values(
+            return parts.order_by('title').values(
                 'url',
                 'title',
                 'resource__path',
@@ -934,14 +934,6 @@ class Locale(AggregatedStats):
                 'unreviewed_strings',
                 'approved_strings',
             )
-
-            # Make output JSON serializable
-            for value in values:
-                deadline = value['resource__deadline']
-                if deadline:
-                    value['resource__deadline'] = str(deadline)
-
-            return values
 
         pages = project.subpage_set.all()
         translatedresources = TranslatedResource.objects.filter(

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -924,7 +924,7 @@ class Locale(AggregatedStats):
     def parts_stats(self, project):
         """Get locale-project pages/paths with stats."""
         def get_details(parts):
-            return parts.order_by('title').values(
+            values = parts.order_by('title').values(
                 'url',
                 'title',
                 'resource__path',
@@ -934,6 +934,14 @@ class Locale(AggregatedStats):
                 'unreviewed_strings',
                 'approved_strings',
             )
+
+            # Make output JSON serializable
+            for value in values:
+                deadline = value['resource__deadline']
+                if deadline:
+                    value['resource__deadline'] = str(deadline)
+
+            return values
 
         pages = project.subpage_set.all()
         translatedresources = TranslatedResource.objects.filter(

--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -34,6 +34,9 @@ class LazyObjectsJsonEncoder(json.JSONEncoder):
         if isinstance(obj, QuerySet):
             return list(map(str, obj))
 
+        if isinstance(obj, datetime.date):
+            return obj.isoformat()
+
         return json.JSONEncoder.default(self, obj)
 
 

--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -33,6 +33,7 @@ class DatetimeAwareJSONEncoder(json.JSONEncoder):
 
         return json.JSONEncoder.default(self, obj)
 
+
 class LazyObjectsJSONEncoder(DatetimeAwareJSONEncoder):
     """Default encoder isn't able to handle Django lazy-objects."""
     def default(self, obj):

--- a/pontoon/base/tests/test_helpers.py
+++ b/pontoon/base/tests/test_helpers.py
@@ -8,11 +8,11 @@ from datetime import timedelta
 from six import text_type
 
 from pontoon.base.templatetags.helpers import (
-    to_json,
+    as_simple_translation,
     format_datetime,
     format_timedelta,
     nospam,
-    as_simple_translation,
+    to_json,
 )
 from pontoon.base.utils import aware_datetime
 

--- a/pontoon/base/tests/test_helpers.py
+++ b/pontoon/base/tests/test_helpers.py
@@ -8,7 +8,12 @@ from datetime import timedelta
 from six import text_type
 
 from pontoon.base.templatetags.helpers import (
-    as_simple_translation, format_datetime, format_timedelta, nospam)
+    to_json,
+    format_datetime,
+    format_timedelta,
+    nospam,
+    as_simple_translation,
+)
 from pontoon.base.utils import aware_datetime
 
 
@@ -64,6 +69,15 @@ SIMPLE_TRANSLATION_TESTS = OrderedDict((
 def test_helper_as_simple_translation(k):
     string, expected = SIMPLE_TRANSLATION_TESTS[k]
     assert as_simple_translation(string) == expected
+
+
+def test_helper_to_json():
+    obj = {
+        'a': 'foo',
+        'b': aware_datetime(2015, 1, 1),
+    }
+    string = '{"a": "foo", "b": "2015-01-01T00:00:00+00:00"}'
+    assert to_json(obj) == string
 
 
 def test_helper_base_format_dt_none():

--- a/pontoon/localizations/views.py
+++ b/pontoon/localizations/views.py
@@ -2,6 +2,8 @@ from __future__ import division
 
 import math
 
+from datetime import datetime
+
 from django.db.models import Q
 from django.http import Http404
 from django.shortcuts import get_object_or_404, render
@@ -96,6 +98,10 @@ def ajax_resources(request, code, slug):
 
     for part in parts:
         part['resource__priority'] = resource_priority_map.get(part['title'], None)
+
+        deadline = part['resource__deadline']
+        if deadline:
+            part['resource__deadline'] = datetime.strptime(deadline, '%Y-%m-%d')
 
         translatedresource = translatedresources.get(part['title'], None)
         if translatedresource and translatedresource.latest_translation:

--- a/pontoon/localizations/views.py
+++ b/pontoon/localizations/views.py
@@ -2,8 +2,6 @@ from __future__ import division
 
 import math
 
-from datetime import datetime
-
 from django.db.models import Q
 from django.http import Http404
 from django.shortcuts import get_object_or_404, render
@@ -98,10 +96,6 @@ def ajax_resources(request, code, slug):
 
     for part in parts:
         part['resource__priority'] = resource_priority_map.get(part['title'], None)
-
-        deadline = part['resource__deadline']
-        if deadline:
-            part['resource__deadline'] = datetime.strptime(deadline, '%Y-%m-%d')
 
         translatedresource = translatedresources.get(part['title'], None)
         if translatedresource and translatedresource.latest_translation:


### PR DESCRIPTION
This is a collection of fixes and improvements that were discovered as part of landing the file-level priority and deadline information.

https://github.com/mozilla/pontoon/commit/5607c65c20f687c2e650778f5481942c0bb103a6 just exposes Resource deadline in the Django admin and
https://github.com/mozilla/pontoon/commit/fe10de397d01b23f29446e8cbd97306d32b36566 removes the foo code to set the project deadline based on resource deadlines.

The interesting one is https://github.com/mozilla/pontoon/commit/7357daa8477b1b9e78394dab13da6c09a2f6732e, which prevents the `TypeError: datetime.date(2018, 2, 20) is not JSON serializable` triggered in here:
https://github.com/mozilla/pontoon/blob/7357daa8477b1b9e78394dab13da6c09a2f6732e/pontoon/projects/templates/projects/widgets/project_selector.html#L24

So I changed `locale.parts_stats()` to return a JSON serializable data by converting a `datetime.datetime` instance to string and then back where it's required.

@adngdb @jotes I wonder if there's a more elegant way of making values of type `datetime.datetime`  
JSON serializable.