### PR TITLE
Fix false warnings for android files 

### DIFF
--- a/pontoon/checks/libraries/compare_locales.py
+++ b/pontoon/checks/libraries/compare_locales.py
@@ -146,6 +146,7 @@ def run_checks(entity, locale_code, string):
 
     if 'mobile/android/base' in entity.resource.path:
         extra_tests = {'android-dtd'}
+        entity.string = escape_quotes(entity.string)
         string = escape_quotes(string)
 
     source_ent, translation_ent = cast_to_compare_locales(


### PR DESCRIPTION
I noticed this issue during my work on bug 1458345.
`compare-locale` check return some false warnings for some of strings from Android-related .dtd files. 

* Steps to reproduce *
If you'll try to translate this string:
https://pontoon.mozilla.org/en-GB/firefox-for-android/mobile/android/base/android_strings.dtd/?search=link&string=146163
You'll get compare-locales warning:
"can't parse en-US value"

@mathjazz could you look at this?