### PR TITLE
Add synchroneous sync projects

### DIFF
--- a/pontoon/sync/management/commands/sync_projects.py
+++ b/pontoon/sync/management/commands/sync_projects.py
@@ -43,11 +43,19 @@ class Command(BaseCommand):
         )
 
         parser.add_argument(
-            '--force',
+            '-f', '--force',
             action='store_true',
             dest='force',
             default=False,
             help='Always sync even if there are no changes'
+        )
+
+        parser.add_argument(
+            '-s', '--synchronous',
+            action='store_true',
+            dest='force',
+            default=False,
+            help='Run the task synchronously'
         )
 
     def handle(self, *args, **options):
@@ -91,11 +99,22 @@ class Command(BaseCommand):
                                   .format(project.name))
             else:
                 self.stdout.write(u'Scheduling sync for project {0}.'.format(project.name))
-                sync_project.delay(
-                    project.pk,
-                    sync_log.pk,
-                    locale=locale,
-                    no_pull=options['no_pull'],
-                    no_commit=options['no_commit'],
-                    force=options['force'],
-                )
+                if options['synchronous']:
+                    sync_project.apply(
+                        args=(project.pk, sync_log.pk),
+                        kwargs=dict(
+                            locale=locale,
+                            no_pull=options['no_pull'],
+                            no_commit=options['no_commit'],
+                            force=options['force'],
+                        )
+                    )
+                else:
+                    sync_project.delay(
+                        project.pk,
+                        sync_log.pk,
+                        locale=locale,
+                        no_pull=options['no_pull'],
+                        no_commit=options['no_commit'],
+                        force=options['force'],
+                    )

--- a/pontoon/sync/management/commands/sync_projects.py
+++ b/pontoon/sync/management/commands/sync_projects.py
@@ -53,7 +53,7 @@ class Command(BaseCommand):
         parser.add_argument(
             '-s', '--synchronous',
             action='store_true',
-            dest='force',
+            dest='synchronous',
             default=False,
             help='Run the task synchronously'
         )
@@ -99,22 +99,17 @@ class Command(BaseCommand):
                                   .format(project.name))
             else:
                 self.stdout.write(u'Scheduling sync for project {0}.'.format(project.name))
+
+                # Prepare task arguments.
+                args = (project.pk, sync_log.pk)
+                kwargs = dict(
+                    locale=locale,
+                    no_pull=options['no_pull'],
+                    no_commit=options['no_commit'],
+                    force=options['force'],
+                )
+
                 if options['synchronous']:
-                    sync_project.apply(
-                        args=(project.pk, sync_log.pk),
-                        kwargs=dict(
-                            locale=locale,
-                            no_pull=options['no_pull'],
-                            no_commit=options['no_commit'],
-                            force=options['force'],
-                        )
-                    )
+                    sync_project.apply(args=args, kwargs=kwargs)
                 else:
-                    sync_project.delay(
-                        project.pk,
-                        sync_log.pk,
-                        locale=locale,
-                        no_pull=options['no_pull'],
-                        no_commit=options['no_commit'],
-                        force=options['force'],
-                    )
+                    sync_project.delay(*args, **kwargs)

--- a/pontoon/sync/vcs/repositories.py
+++ b/pontoon/sync/vcs/repositories.py
@@ -1,4 +1,3 @@
-# -*- coding: utf8 -*-
 from __future__ import absolute_import
 
 import logging


### PR DESCRIPTION
At some point our AMQP calls stopped triggering the task.
We used this trick to force exec the task again.