### PR TITLE
Fix bug 1475922: Do not uppercase user names

### DIFF
--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -1971,6 +1971,10 @@ p#sign-in-required > a#sidebar-signin {
   padding-right: 0;
 }
 
+#helpers > section.history ul li > header .info a {
+  text-transform: none;
+}
+
 #helpers > section ul li > header button {
   background: no-repeat transparent;
   border: none;


### PR DESCRIPTION
We cannot reliably uppercase user names, because they may contain non-Latin characters, for which don't have a font support.

Since uppercase is used for cosmetic purposes at least here, I'm disabling it entirely for this use case.