### PR TITLE
Bug 1458345 sync checks

### DIFF
--- a/pontoon/base/migrations/0100_bug_1390805_create_missing_tm_entries.py
+++ b/pontoon/base/migrations/0100_bug_1390805_create_missing_tm_entries.py
@@ -9,7 +9,7 @@ def create_missing_translaton_memory_entries(apps, schema_editor):
     Translation = apps.get_model('base', 'Translation')
     TranslationMemoryEntry = apps.get_model('base', 'TranslationMemoryEntry')
 
-    translations_to_create_translaton_memory_entries_for = (
+    translations_to_create_translation_memory_entries_for = (
         Translation.objects
         .filter(approved=True, memory_entries__isnull=True)
         .prefetch_related('entity__resource__project')
@@ -22,7 +22,7 @@ def create_missing_translaton_memory_entries(apps, schema_editor):
         entity_id=t.entity.pk,
         translation_id=t.pk,
         project=t.entity.resource.project,
-    ) for t in translations_to_create_translaton_memory_entries_for]
+    ) for t in translations_to_create_translation_memory_entries_for]
 
     TranslationMemoryEntry.objects.bulk_create(memory_entries)
 

--- a/pontoon/base/migrations/0100_bug_1390805_create_missing_tm_entries.py
+++ b/pontoon/base/migrations/0100_bug_1390805_create_missing_tm_entries.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 from django.db import migrations
 
 
-def create_missing_translaton_memory_entries(apps, schema_editor):
+def create_missing_translation_memory_entries(apps, schema_editor):
     Translation = apps.get_model('base', 'Translation')
     TranslationMemoryEntry = apps.get_model('base', 'TranslationMemoryEntry')
 
@@ -35,7 +35,7 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunPython(
-            create_missing_translaton_memory_entries,
+            create_missing_translation_memory_entries,
             migrations.RunPython.noop
         ),
     ]

--- a/pontoon/base/utils.py
+++ b/pontoon/base/utils.py
@@ -512,7 +512,7 @@ def handle_upload_content(slug, code, part, f, user):
 
     changeset.bulk_create_translations()
     changeset.bulk_update_translations()
-    changeset.bulk_create_translaton_memory_entries()
+    changeset.bulk_create_translation_memory_entries()
     TranslatedResource.objects.get(resource=resource, locale=locale).calculate_stats()
 
     # Mark translations as changed

--- a/pontoon/checks/libraries/compare_locales.py
+++ b/pontoon/checks/libraries/compare_locales.py
@@ -173,7 +173,6 @@ def run_checks(entity, locale_code, string):
         checker.set_reference(references)
 
     errors = {}
-
     for severity, _, message, _ in checker.check(source_ent, translation_ent):
         messages = errors.setdefault('cl%ss' % severity.capitalize(), [])
         # Old-school duplicate prevention - set() is not JSON serializable

--- a/pontoon/checks/libraries/compare_locales.py
+++ b/pontoon/checks/libraries/compare_locales.py
@@ -173,6 +173,7 @@ def run_checks(entity, locale_code, string):
         checker.set_reference(references)
 
     errors = {}
+
     for severity, _, message, _ in checker.check(source_ent, translation_ent):
         messages = errors.setdefault('cl%ss' % severity.capitalize(), [])
         # Old-school duplicate prevention - set() is not JSON serializable

--- a/pontoon/checks/management/commands/run_checks.py
+++ b/pontoon/checks/management/commands/run_checks.py
@@ -9,7 +9,7 @@ from django.core.management.base import BaseCommand
 from pontoon.base.models import Translation
 from pontoon.checks import DB_FORMATS
 
-from pontoon.checks.tasks import bulk_run_checks
+from pontoon.checks.tasks import check_translations
 
 log = logging.getLogger(__name__)
 
@@ -66,7 +66,7 @@ class Command(BaseCommand):
         batch_size = int(options['batch_size'])
         tasks_result = group(
             signature(
-                bulk_run_checks,
+                check_translations,
                 args=(translations_pks[i:i + batch_size],)
             )
             for i in xrange(0, len(translations_pks), batch_size)

--- a/pontoon/checks/tasks.py
+++ b/pontoon/checks/tasks.py
@@ -5,52 +5,26 @@ from celery import shared_task
 
 from django.db import transaction
 
-from pontoon.base.models import Translation
-from pontoon.checks import libraries
-from pontoon.checks.utils import get_failed_checks_db_objects
-from pontoon.checks.models import (
-    Warning,
-    Error,
+from pontoon.checks.utils import (
+    bulk_run_checks,
+    get_translations,
 )
-
 
 log = logging.getLogger(__name__)
 
 
 @shared_task(bind=True)
-def bulk_run_checks(self, translations_pks):
+def check_translations(self, translations_pks):
     """
     Run checks on translations
     :arg list[int] translations_pks: list of primary keys for translations that should be processed
     """
     start_time = time.time()
+
     with transaction.atomic():
-        translations = list(
-            Translation.objects
-            .prefetch_related('entity', 'entity__resource__entities', 'locale')
-            .filter(pk__in=translations_pks)
-        )
+        translations = get_translations(pk__in=translations_pks)
 
-        warnings, errors = [], []
-        for translation in translations:
-            batch_warnings, batch_errors = get_failed_checks_db_objects(
-                translation,
-                libraries.run_checks(
-                    translation.entity,
-                    translation.locale.code,
-                    translation.entity.string,
-                    translation.string,
-                    use_tt_checks=False
-                )
-            )
-            warnings.extend(batch_warnings)
-            errors.extend(batch_errors)
-
-        Warning.objects.filter(translation__pk__in=translations_pks).delete()
-        Error.objects.filter(translation__pk__in=translations_pks).delete()
-
-        Warning.objects.bulk_create(warnings)
-        Error.objects.bulk_create(errors)
+        warnings, errors = bulk_run_checks(translations)
 
         log.info("Task[{}]: Processed items: {}, Warnings({}) Errors({}) in {}".format(
             self.request.id,

--- a/pontoon/checks/tests/test_models.py
+++ b/pontoon/checks/tests/test_models.py
@@ -2,11 +2,66 @@ from __future__ import absolute_import
 
 import pytest
 
-from pontoon.checks.utils import save_failed_checks
+from pontoon.base.models import Translation
+from pontoon.checks.utils import save_failed_checks, get_failed_checks_db_objects, bulk_run_checks
 from pontoon.checks.models import (
     Error,
     Warning,
 )
+
+
+@pytest.yield_fixture()
+def translation_properties(translation_a):
+    resource = translation_a.entity.resource
+    resource.path = 'test.properties'
+    resource.format = 'properties'
+    resource.save()
+
+    yield translation_a
+
+
+@pytest.yield_fixture
+def translation_compare_locales_warning(translation_properties):
+    # Create new instance
+    translation = Translation.objects.get(pk=translation_properties.pk)
+    translation.pk = None
+
+    translation.string = 'raise warning \q'
+    translation.save()
+
+    yield translation
+
+
+@pytest.yield_fixture
+def translation_compare_locales_error(translation_properties):
+    # Create new instance
+    translation = Translation.objects.get(pk=translation_properties.pk)
+    translation.pk = None
+
+    entity = translation.entity
+    entity.string = 'test %s %s'
+    entity.save()
+
+    translation.string = 'raise error %'
+    translation.save()
+
+    yield translation
+
+
+@pytest.yield_fixture
+def translation_pontoon_error(translation_a):
+    # Create new instance
+    translation = Translation.objects.get(pk=translation_a.pk)
+    translation.pk = None
+
+    resource = translation.entity.resource
+    resource.path = 'test.po'
+    resource.format = 'po'
+    resource.save()
+
+    translation.string = ''
+    translation.save()
+    yield translation
 
 
 @pytest.mark.django_db
@@ -47,3 +102,89 @@ def test_save_no_checks(translation_a):
     save_failed_checks(translation_a, {})
     assert not Warning.objects.all().exists()
     assert not Error.objects.all().exists()
+
+
+@pytest.mark.django_db
+def test_bulk_run_checks_no_translations():
+    """
+    Don't generate any warnings and errors without translations
+    """
+    assert bulk_run_checks([]) is None
+
+    assert Warning.objects.count() == 0
+    assert Error.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_bulk_run_checks(
+        translation_compare_locales_warning,
+        translation_compare_locales_error,
+        translation_pontoon_error,
+):
+    warnings, errors = bulk_run_checks([
+        translation_compare_locales_warning,
+        translation_pontoon_error,
+        translation_compare_locales_error,
+    ])
+
+    cl_warning, = warnings
+    p_error, cl_error = errors
+
+    assert cl_warning.pk is not None
+    assert cl_warning.library == 'cl'
+    assert cl_warning.message == 'unknown escape sequence, \q'
+    assert cl_warning.translation == translation_compare_locales_warning
+
+    assert cl_error.pk is not None
+    assert cl_error.library == 'cl'
+    assert cl_error.message == 'Found single %'
+    assert cl_error.translation == translation_compare_locales_error
+
+    assert p_error.pk is not None
+    assert p_error.library == 'p'
+    assert p_error.message == 'Empty translations are not allowed'
+    assert p_error.translation == translation_pontoon_error
+
+
+@pytest.mark.django_db
+def test_get_failed_checks_db_objects(translation_a):
+    """
+    Return model instances of warnings and errors
+    """
+    warnings, errors = get_failed_checks_db_objects(
+        translation_a, {
+            'clWarnings': [
+                'compare-locales warning 1',
+            ],
+
+            # Warnings from some libraries e.g. Translate Toolkit, shouldn't land in the database.
+            'ttWarnings': [
+                'translate-toolkit warning 1',
+            ],
+            'clErrors': [
+                'compare-locales error 1',
+            ],
+            'pErrors': [
+                'pontoon error 1'
+            ]
+        }
+    )
+
+    # Check if objects aren't saved in DB
+    assert all([w.pk is None for w in warnings])
+    assert all([e.pk is None for e in errors])
+
+    cl_warning, = warnings
+    p_error, cl_error = errors
+
+    assert cl_warning.library == 'cl'
+    assert cl_warning.message == 'compare-locales warning 1'
+    assert cl_warning.translation == translation_a
+
+    assert cl_error.library == 'cl'
+    assert cl_error.message == 'compare-locales error 1'
+    assert cl_error.translation == translation_a
+
+    assert p_error.library == 'p'
+    assert p_error.message == 'pontoon error 1'
+    assert p_error.translation == translation_a

--- a/pontoon/checks/tests/test_models.py
+++ b/pontoon/checks/tests/test_models.py
@@ -3,7 +3,11 @@ from __future__ import absolute_import
 import pytest
 
 from pontoon.base.models import Translation
-from pontoon.checks.utils import save_failed_checks, get_failed_checks_db_objects, bulk_run_checks
+from pontoon.checks.utils import (
+    save_failed_checks,
+    get_failed_checks_db_objects,
+    bulk_run_checks,
+)
 from pontoon.checks.models import (
     Error,
     Warning,

--- a/pontoon/checks/utils.py
+++ b/pontoon/checks/utils.py
@@ -54,7 +54,7 @@ def bulk_run_checks(translations):
         warnings.extend(warnings_)
         errors.extend(errors_)
 
-    # Remove old results
+    # Remove old warnings and errors
     Warning.objects.filter(
         translation__pk__in=[t.pk for t in translations]
     ).delete()

--- a/pontoon/checks/utils.py
+++ b/pontoon/checks/utils.py
@@ -1,5 +1,72 @@
-from pontoon.checks import DB_LIBRARIES
+from pontoon.base.models import Translation
+
+from pontoon.checks import (
+    DB_FORMATS,
+    DB_LIBRARIES,
+)
 from pontoon.checks.models import Warning, Error
+from pontoon.checks.libraries import run_checks
+
+
+def get_translations(**qs_filters):
+    """
+    Prefetch translations with fields required for bulk_run_checks
+    """
+    translations = (
+        Translation.objects
+        .filter(
+            entity__resource__format__in=DB_FORMATS,
+            **qs_filters
+
+        )
+        .prefetch_related(
+            'entity',
+            'entity__resource__entities',
+            'locale',
+        )
+    )
+    return translations
+
+
+def bulk_run_checks(translations):
+    """
+    Run checks on a list of translations
+
+    *Important*
+    To avoid performance problems, translations have to prefetch entities and locales objects.
+    """
+    warnings, errors = [], []
+    if not translations:
+        return
+
+    for translation in translations:
+        warnings_, errors_ = get_failed_checks_db_objects(
+            translation,
+            run_checks(
+                translation.entity,
+                translation.locale.code,
+                translation.entity.string,
+                translation.string,
+                use_tt_checks=False
+            )
+
+        )
+        warnings.extend(warnings_)
+        errors.extend(errors_)
+
+    # Remove old results
+    Warning.objects.filter(
+        translation__pk__in=[t.pk for t in translations]
+    ).delete()
+    Error.objects.filter(
+        translation__pk__in=[t.pk for t in translations]
+    ).delete()
+
+    # Insert new warnings and errors
+    Warning.objects.bulk_create(warnings)
+    Error.objects.bulk_create(errors)
+
+    return warnings, errors
 
 
 def get_failed_checks_db_objects(translation, failed_checks):

--- a/pontoon/sync/changeset.py
+++ b/pontoon/sync/changeset.py
@@ -430,4 +430,5 @@ class ChangeSet(object):
             .values_list('pk', flat=True)
             .order_by('pk')
         )
+
         return valid_translations

--- a/pontoon/sync/changeset.py
+++ b/pontoon/sync/changeset.py
@@ -14,6 +14,7 @@ from pontoon.base.models import (
     TranslationMemoryEntry
 )
 from pontoon.base.utils import match_attr
+from pontoon.checks import utils as checks_utils
 
 log = logging.getLogger(__name__)
 
@@ -106,7 +107,10 @@ class ChangeSet(object):
         self.bulk_update_entities()
         self.bulk_create_translations()
         self.bulk_update_translations()
-        self.bulk_create_translaton_memory_entries()
+
+        if self.changed_translations:
+            valid_translations = self.bulk_check_translations()
+            self.bulk_create_translation_memory_entries(valid_translations)
 
     def execute_update_vcs(self):
         resources = self.vcs_project.resources
@@ -368,17 +372,25 @@ class ChangeSet(object):
                 'extra'
             ])
 
-    def bulk_create_translaton_memory_entries(self):
+    def bulk_create_translation_memory_entries(self, valid_translations_pks):
         """
         Create Translation Memory entries for:
             - new approved translations
             - updated translations that are approved and don't have a TM entry yet
+
+        :arg list[int] valid_translations_pks: list of translations (their pks) without errors
         """
-        translations_to_create_translaton_memory_entries_for = (
-            [t for t in self.translations_to_create if t.approved] +
+        def is_valid(t):
+            """
+            Verify if a translation should land in the Translation Memory
+            """
+            return t.approved and t.pk in valid_translations_pks
+
+        translations_to_create_translation_memory_entries_for = (
+            [t for t in self.translations_to_create if is_valid(t)] +
             list(
                 Translation.objects.filter(
-                    pk__in=[pk for pk, t in self.translations_to_update.items() if t.approved],
+                    pk__in=[pk for pk, t in self.translations_to_update.items() if is_valid(t)],
                     memory_entries__isnull=True
                 )
             )
@@ -391,6 +403,31 @@ class ChangeSet(object):
             entity_id=t.entity.pk,
             translation_id=t.pk,
             project=self.db_project,
-        ) for t in translations_to_create_translaton_memory_entries_for]
+        ) for t in translations_to_create_translation_memory_entries_for]
 
         TranslationMemoryEntry.objects.bulk_create(memory_entries)
+
+    def bulk_check_translations(self):
+        """
+        Run checks on all changed translations from supported resources
+
+        :return: primary keys of translations without warnings and errors.
+        """
+        changed_pks = {t.pk for t in self.changed_translations}
+
+        checks_utils.bulk_run_checks(
+            checks_utils.get_translations(
+                pk__in=changed_pks
+            )
+        )
+
+        valid_translations = set(
+            Translation.objects
+            .filter(
+                pk__in=changed_pks,
+                errors__isnull=True,
+            )
+            .values_list('pk', flat=True)
+            .order_by('pk')
+        )
+        return valid_translations

--- a/pontoon/sync/tests/test_checks.py
+++ b/pontoon/sync/tests/test_checks.py
@@ -1,0 +1,101 @@
+from mock import patch, PropertyMock
+
+from django_nose.tools import assert_equal
+
+from pontoon.base.utils import aware_datetime
+from pontoon.base.tests import TranslationFactory
+from pontoon.checks.models import (
+    Warning,
+    Error,
+)
+from pontoon.sync.tests import FakeCheckoutTestCase
+
+
+class TestChangesetTranslationsChecks(FakeCheckoutTestCase):
+    """
+    Semi-integration tests for translation checks during a sync.
+    """
+    def setUp(self):
+        super(TestChangesetTranslationsChecks, self).setUp()
+
+        changed_translation_patch = patch(
+            'pontoon.sync.changeset.ChangeSet.changed_translations',
+            new_callable=PropertyMock
+        )
+
+        self.mock_changed_translations = changed_translation_patch.start()
+        self.addCleanup(changed_translation_patch.stop)
+
+    def test_bulk_check_translations_no_translations(self):
+        self.mock_changed_translations.return_value = []
+
+        assert_equal(self.changeset.bulk_check_translations(), set())
+        assert_equal(Error.objects.count(), 0)
+        assert_equal(Warning.objects.count(), 0)
+
+    def test_bulk_check_valid_translations(self):
+        translation1, translation2 = TranslationFactory.create_batch(
+            2,
+            locale=self.translated_locale,
+            entity=self.main_db_entity,
+            approved=True,
+            date=aware_datetime(2015, 1, 1)
+        )
+
+        self.mock_changed_translations.return_value = [
+            translation1,
+            translation2,
+        ]
+        assert_equal(
+            self.changeset.bulk_check_translations(),
+            {
+                translation1.pk,
+                translation2.pk,
+            }
+        )
+        assert_equal(Error.objects.count(), 0)
+        assert_equal(Warning.objects.count(), 0)
+
+    def test_bulk_check_invalid_translations(self):
+        """
+        Test scenario:
+        * check if errors are detected
+        * check if only valid translation will land in the Translate Memory
+        """
+        invalid_translation, valid_translation = TranslationFactory.create_batch(
+            2,
+            locale=self.translated_locale,
+            entity=self.main_db_entity,
+            approved=True,
+            date=aware_datetime(2015, 1, 1)
+        )
+        invalid_translation.string = 'a\nb'
+        invalid_translation.save()
+
+        # Clear TM entries for those translations
+        invalid_translation.memory_entries.all().delete()
+        valid_translation.memory_entries.all().delete()
+
+        self.mock_changed_translations.return_value = [
+            invalid_translation,
+            valid_translation,
+        ]
+
+        valid_translations = self.changeset.bulk_check_translations()
+
+        assert_equal(valid_translations, {valid_translation.pk})
+
+        error, = Error.objects.all()
+
+        assert_equal(error.library, 'p')
+        assert_equal(error.message, 'Newline characters are not allowed')
+        assert_equal(error.translation, invalid_translation)
+
+        self.changeset.translations_to_update = {
+            valid_translation.pk: valid_translation
+        }
+
+        self.changeset.bulk_create_translation_memory_entries(valid_translations)
+
+        assert_equal(invalid_translation.memory_entries.count(), 0)
+        assert_equal(valid_translation.memory_entries.count(), 1)


### PR DESCRIPTION
Hey,
So this is the next PR for https://bugzilla.mozilla.org/show_bug.cgi?id=1458345

In this one, We finally run checks on translations during the sync process. 

TODO:
* [x] Discuss the feature scope with @mathjazz
* [x] Rebase against master
* [x] Refactor bulk_run_checks tasks from the previous PR
* [x] Add tests


*Discussion/Questions* 
1. Do We want to ignore Translate Toolkit warnings here?
1. I wonder if the sync process should create TranslateMemory entries for the translations with errors?
1. Do we want to approve translations (from vcs) with errors? (I don't know if every VCS repo is protected with `compare-locales`)