### PR TITLE
Fix bug 1475927: Center-align header of the percentage column

### DIFF
--- a/pontoon/base/static/css/table.css
+++ b/pontoon/base/static/css/table.css
@@ -59,6 +59,10 @@ table.table {
   width: 140px;
 }
 
+.table th.progress {
+  padding-right: 39px;
+}
+
 .table th.unreviewed-status {
   position: relative;
   width: 16px;
@@ -72,10 +76,6 @@ table.table {
   position: absolute;
   font-size: 18px;
   margin: -15px 0 0 -5px;
-}
-
-.table .progress {
-  text-align: left;
 }
 
 .table h4 {


### PR DESCRIPTION
Column header is now center aligned with the progress line:

<img width="1015" alt="screen shot 2018-07-16 at 13 52 36" src="https://user-images.githubusercontent.com/626716/42757238-88964aa6-88ff-11e8-9cda-71fe4220f981.png">

It looks odd if center-aligned within the entire column width.