### PR TITLE
Fix bug 1475603: If updating source repo fails, exit script

### DIFF
--- a/bin/mozilla-en-US.py
+++ b/bin/mozilla-en-US.py
@@ -109,6 +109,13 @@ def push(path):
     elif len(error):
         write(text_type(error))
 
+
+def quit_or_pass(code):
+    # In case of a non-zero error code, quit early (bug 1475603)
+    if code != 0:
+        quit(code)
+
+
 # Change working directory to where script is located
 abspath = os.path.abspath(__file__)
 dname = os.path.dirname(abspath)
@@ -119,9 +126,7 @@ url = 'https://hg.mozilla.org/l10n/gecko-strings/'
 target = 'source'
 code = pull(url, target)
 
-# In case of a failure, quit early (bug 1475603)
-if code != 0:
-    quit()
+quit_or_pass(code)
 
 for repo in TARGET_REPOS.keys():
     ending = repo + '-central'
@@ -131,9 +136,7 @@ for repo in TARGET_REPOS.keys():
     # Clone or update target repository
     code = pull(url, target)
 
-    # In case of a failure, continue to next repo
-    if code != 0:
-        continue
+    quit_or_pass(code)
 
     # Prune all subdirectories in target repository in case they get removed from source
     for subdir in os.listdir(target):

--- a/bin/mozilla-en-US.py
+++ b/bin/mozilla-en-US.py
@@ -90,6 +90,8 @@ def pull(url, target):
         else:
             write(text_type(error))
 
+    return code
+
 
 def push(path):
     # Add new and remove missing
@@ -115,7 +117,11 @@ os.chdir(dname)
 # Clone or update source repository
 url = 'https://hg.mozilla.org/l10n/gecko-strings/'
 target = 'source'
-pull(url, target)
+code = pull(url, target)
+
+# In case of a failure, quit early (bug 1475603)
+if code != 0:
+    quit()
 
 for repo in TARGET_REPOS.keys():
     ending = repo + '-central'

--- a/bin/mozilla-en-US.py
+++ b/bin/mozilla-en-US.py
@@ -129,7 +129,11 @@ for repo in TARGET_REPOS.keys():
     target = os.path.join('target', ending)
 
     # Clone or update target repository
-    pull(url, target)
+    code = pull(url, target)
+
+    # In case of a failure, continue to next repo
+    if code != 0:
+        continue
 
     # Prune all subdirectories in target repository in case they get removed from source
     for subdir in os.listdir(target):


### PR DESCRIPTION
Firefox, Firefox for Android, Thunderbird, Lightning and Seamonkey are special projects, because they store source strings in a single source repository (https://hg.mozilla.org/l10n/gecko-strings/). Pontoon doesn't support that [yet](https://bugzilla.mozilla.org/show_bug.cgi?id=1385834), so it needs to create its own per-project [*-central](https://hg.mozilla.org/users/m_owca.info) repositories.

The `mozilla-en-US.py` script does that job. It runs every 10 minutes, before each sync cycle.

Before this patch, if cloning of the source repository [failed](https://bugzilla.mozilla.org/show_bug.cgi?id=1475603#c0), all files were [removed](https://hg.mozilla.org/users/m_owca.info/firefox-for-android-central/rev/ab7cd3e0902a) from the per-project repositories. On next sync Pontoon then detected the removed files, deleted ([bug 1468840](https://bugzilla.mozilla.org/show_bug.cgi?id=1468840)) corresponding `Resource` objects, and in cascade also `TranslatedResource`, `Entity` and `Translation` objects. That means all source strings and translations were lost and needed to be restored from the DB dump.

We only had one case where this happenned (last Friday), and to minimize the risk, we disabled the `mozilla-en-US.py` script until we fix it, which is the goal of this patch.