### PR TITLE
Replace django-sslify with SECURE_SSL_REDIRECT

### DIFF
--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -76,10 +76,6 @@ SITE_URL = os.environ.get('SITE_URL', 'http://localhost:8000')
 # Custom LD_LIBRARY_PATH environment variable for SVN
 SVN_LD_LIBRARY_PATH = os.environ.get('SVN_LD_LIBRARY_PATH', '')
 
-# Disable forced SSL if debug mode is enabled or if CI is running the
-# tests.
-SSLIFY_DISABLE = DEBUG or os.environ.get('CI', False)
-
 # URL to the RabbitMQ server
 BROKER_URL = os.environ.get('RABBITMQ_URL', None)
 
@@ -157,7 +153,6 @@ BLOCKED_IPS = os.environ.get('BLOCKED_IPS', '').split(',')
 MIDDLEWARE_CLASSES = (
     'django_cookies_samesite.middleware.CookiesSameSite',
     'django.middleware.gzip.GZipMiddleware',
-    'sslify.middleware.SSLifyMiddleware',
     'pontoon.base.middleware.RaygunExceptionMiddleware',
     'pontoon.base.middleware.BlockedIpMiddleware',
     'corsheaders.middleware.CorsMiddleware',
@@ -643,6 +638,9 @@ SECURE_CONTENT_TYPE_NOSNIFF = True
 # x-xss-protection: 1; mode=block
 # Activates the browser's XSS filtering and helps prevent XSS attacks
 SECURE_BROWSER_XSS_FILTER = True
+
+# Redirect non-HTTPS requests to HTTPS
+SECURE_SSL_REDIRECT = not (DEBUG or os.environ.get('CI', False))
 
 # Content-Security-Policy headers
 CSP_DEFAULT_SRC = ("'none'",)

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,8 +60,6 @@ django_guardian==1.4.9 \
 django-session-csrf==0.7.1 \
     --hash=sha256:e17177e6e2e6518ec7ce6693ad10a5c747f8571d09f4cfa9082599334421605d \
     --hash=sha256:ff8c10e30d312c77fc6a6db7710e22b9383e28c03b7fe958876ca96f39aa6cf2
-django-sslify==0.2.7 \
-    --hash=sha256:f6bfd21048c7dfc95b39659a3da77775d6db1c1f7a745805ccc6c6138f783b6d
 django-webpack-loader==0.5.0 \
     --hash=sha256:0a8536e36a30d719018cd4c5da6e9d2377771134e713c14e617bb484b4f0acce
 factory-boy==2.5.2 \


### PR DESCRIPTION
Turns out `django-sslify` is no longer needed.