### PR TITLE
Make sure related entities data is always prefetched

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -2266,7 +2266,16 @@ class Entity(DirtyFieldsMixin, models.Model):
         if project.slug == 'all-projects':
             order_fields = ('resource__project__name',) + order_fields
 
-        # Prefetch data needed for Entity.map_entities()
+        entities = entities.prefetch_translations(locale)
+
+        return entities.order_by(*order_fields)
+
+    @classmethod
+    def map_entities(cls, locale, entities, visible_entities=None):
+        entities_array = []
+        visible_entities = visible_entities or []
+
+        # Prefetch related Resource, Project and ProjectLocale data
         entities = (
             entities
             .prefetch_related(
@@ -2276,15 +2285,7 @@ class Entity(DirtyFieldsMixin, models.Model):
                     to_attr='projectlocale',
                 )
             )
-            .prefetch_translations(locale)
         )
-
-        return entities.order_by(*order_fields)
-
-    @classmethod
-    def map_entities(cls, locale, entities, visible_entities=None):
-        entities_array = []
-        visible_entities = visible_entities or []
 
         for entity in entities:
             translation_array = []

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -191,7 +191,6 @@ def _get_entities_list(locale, project, form):
     """
     entities = (
         Entity.objects.filter(pk__in=form.cleaned_data['entity_ids'])
-        .prefetch_related('resource')
         .prefetch_translations(locale)
         .distinct()
         .order_by('order')


### PR DESCRIPTION
Moving the `Prefetch` clause required for `map_entities` to `map_entities`, so that required data is always prefetched.

Fixes a bug which prevents string status from updating in the UI immediatelly after batch approval.

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/django/core/handlers/exception.py", line 41, in inner
    response = get_response(request)
  File "/usr/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 249, in _legacy_get_response
    response = self._get_response(request)
  File "/usr/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python2.7/site-packages/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/django/views/decorators/http.py", line 40, in inner
    return func(request, *args, **kwargs)
  File "/app/pontoon/base/utils.py", line 285, in wrap
    return f(request, *args, **kwargs)
  File "/app/pontoon/base/views.py", line 287, in entities
    return _get_entities_list(locale, project, form)
  File "/app/pontoon/base/views.py", line 201, in _get_entities_list
    'entities': Entity.map_entities(locale, entities),
  File "/app/pontoon/base/models.py", line 2314, in map_entities
    'readonly': entity.resource.project.projectlocale[0].readonly,
AttributeError: 'Project' object has no attribute 'projectlocale'
```