### PR TITLE
Always pass entities as a QuerySet to map_entities()

### DIFF
--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -248,11 +248,13 @@ def _get_paginated_entities(locale, project, form, entities):
     # If requested entity not on the first page
     if form.cleaned_data['entity']:
         entity_pk = form.cleaned_data['entity']
+        entities_to_map_pks = [e.pk for e in entities_to_map]
 
         # TODO: entities_to_map.values_list() doesn't return entities from selected page
-        if entity_pk not in [e.pk for e in entities_to_map]:
+        if entity_pk not in entities_to_map_pks:
             if entity_pk in entities.values_list('pk', flat=True):
-                entities_to_map = list(entities_to_map) + list(entities.filter(pk=entity_pk))
+                entities_to_map_pks.append(entity_pk)
+                entities_to_map = entities.filter(pk__in=entities_to_map_pks)
 
     return JsonResponse({
         'entities': Entity.map_entities(locale, entities_to_map, []),


### PR DESCRIPTION
In https://github.com/mozilla/pontoon/commit/b2f199d381d555055e38250ac49b4615182ec84d if requested entity not on the first page, we pass `entities` as a `list` instead of a `QuerySet` to `Entity.map_entities()`. Then we cannot prefetch.

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/django/core/handlers/exception.py", line 41, in inner
    response = get_response(request)
  File "/usr/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 249, in _legacy_get_response
    response = self._get_response(request)
  File "/usr/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python2.7/site-packages/django/views/decorators/csrf.py", line 58, in wrapped_view
    return view_func(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/django/views/decorators/http.py", line 40, in inner
    return func(request, *args, **kwargs)
  File "/app/pontoon/base/utils.py", line 285, in wrap
    return f(request, *args, **kwargs)
  File "/app/pontoon/base/views.py", line 307, in entities
    return _get_paginated_entities(locale, project, form, entities)
  File "/app/pontoon/base/views.py", line 258, in _get_paginated_entities
    'entities': Entity.map_entities(locale, entities_to_map, []),
  File "/app/pontoon/base/models.py", line 2280, in map_entities
    entities
AttributeError: 'list' object has no attribute 'prefetch_related'
```