### PR TITLE
Fix bug 1407180: unchanged filter only on active translations

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -2021,8 +2021,9 @@ class EntityQuerySet(models.QuerySet):
         return Q(
             pk__in=self.get_filtered_entities(
                 locale,
-                Q(Q(string=F('entity__string')) | Q(string=F('entity__string_plural'))),
-                lambda x: x.string == x.entity.string,
+                Q(Q(approved=True) &
+                  Q(Q(string=F('entity__string')) | Q(string=F('entity__string_plural')))),
+                lambda x: x.approved and x.string == x.entity.string,
                 match_all=False,
             )
         )
@@ -2417,7 +2418,7 @@ class Translation(DirtyFieldsMixin, models.Model):
         User, related_name='unrejected_translations', null=True, blank=True)
     unrejected_date = models.DateTimeField(null=True, blank=True)
 
-    # Field contains a concatenated state of the  entity for faster search lookups.
+    # Field contains a concatenated state of the entity for faster search lookups.
     # Due to the nature of sql queries, it's faster to perform `icontains` filter on the same table
     # than OR condition for The Entity and The Translation class joined together.
     entity_document = models.TextField(blank=True)

--- a/pontoon/base/tests/managers/test_entity.py
+++ b/pontoon/base/tests/managers/test_entity.py
@@ -371,12 +371,13 @@ def test_mgr_entity_filter_unchanged(resource_a, locale_a):
         locale=locale_a,
         entity=entities[2],
         fuzzy=True,
+        approved=False,
         string='Unchanged string',
     )
     assert (
         set(Entity.objects.filter(
             Entity.objects.unchanged(locale_a)
-        )) == {entities[0], entities[2]}
+        )) == {entities[0]}
     )
 
 
@@ -500,6 +501,7 @@ def test_mgr_entity_filter_unchanged_plural(resource_a, locale_a):
         locale=locale_a,
         entity=entities[2],
         fuzzy=True,
+        approved=False,
         plural_form=0,
         string='Unchanged string',
     )
@@ -507,13 +509,14 @@ def test_mgr_entity_filter_unchanged_plural(resource_a, locale_a):
         locale=locale_a,
         entity=entities[2],
         fuzzy=True,
+        approved=False,
         plural_form=1,
         string='Unchanged plural string',
     )
     assert (
         set(Entity.objects.filter(
             Entity.objects.unchanged(locale_a)
-        )) == {entities[0], entities[2]}
+        )) == {entities[0]}
     )
 
 


### PR DESCRIPTION
Fix for https://bugzilla.mozilla.org/show_bug.cgi?id=1407180

Unchanged filter will check only active translations to avoid false positives that have historically had been translated with unchanged string but have been changed (fixed) since

Added check for "active" attribute of the translation object

Also adjusted tests to match the current state of the application

Tested with tests and on pontoon-intro project by approving some non-identical string and checking that the entry disappears from list of unchanged strings. 