### PR TITLE
Fix bug 1479771: Do not commit to read-only locales

### DIFF
--- a/pontoon/sync/tasks.py
+++ b/pontoon/sync/tasks.py
@@ -285,6 +285,7 @@ def sync_translations(
 
     synced_locales = set()
     failed_locales = set()
+    readonly_locales = db_project.locales.filter(project_locale__readonly=True)
 
     for locale in locales:
         try:
@@ -341,7 +342,11 @@ def sync_translations(
 
                 # Perform the commit last so that, if it succeeds, there is
                 # nothing after it to fail.
-                if not no_commit and locale in changeset.locales_to_commit:
+                if (
+                    not no_commit and
+                    locale in changeset.locales_to_commit and
+                    locale not in readonly_locales
+                ):
                     commit_changes(db_project, vcs_project, changeset, locale)
 
                 log.info(

--- a/pontoon/sync/tests/test_tasks.py
+++ b/pontoon/sync/tests/test_tasks.py
@@ -182,6 +182,33 @@ class SyncTranslationsTests(FakeCheckoutTestCase):
                           self.now, self.mock_changes, no_commit=True)
         assert_false(self.mock_commit_changes.called)
 
+    def test_readonly_locales(self):
+        """Don't call commit_changes for locales in read-only mode."""
+        project_locale = self.translated_locale.project_locale.get(
+            project=self.db_project,
+        )
+        project_locale.readonly = True
+        project_locale.save()
+
+        self.mock_pull_changes.return_value = [
+            True,
+            {
+                self.repository.pk: Locale.objects.filter(
+                    pk=self.translated_locale.pk,
+                ),
+            },
+        ]
+
+        sync_translations(
+            self.db_project.pk,
+            self.project_sync_log.pk,
+            self.now,
+            self.mock_changes,
+            no_commit=False,
+        )
+
+        assert_false(self.mock_commit_changes.called)
+
     def test_remove_duplicate_approvals(self):
         """
         Ensure that duplicate approvals are removed.


### PR DESCRIPTION
It should not be possible to make changes to read-only ProjectLocales through Pontoon, so Pontoon should never commit to these locales.

Still, it doesn't hurt to be extra cautious and add another check. And, it's necessary for cases like in [bug 1467978](https://bugzilla.mozilla.org/show_bug.cgi?id=1467978).