### PR TITLE
No bug: Allow empty translations in inc format

### DIFF
--- a/pontoon/checks/libraries/pontoon.py
+++ b/pontoon/checks/libraries/pontoon.py
@@ -65,7 +65,7 @@ def run_checks(entity, string):
                 )
 
     # Prevent empty translation submissions if not supported
-    if resource_ext not in {'properties', 'ini', 'dtd'} and string == '':
+    if resource_ext not in {'properties', 'ini', 'dtd', 'inc'} and string == '':
         checks['pErrors'].append(
             'Empty translations are not allowed'
         )


### PR DESCRIPTION
Turns out the `inc` format allows empty translations:
https://hg.mozilla.org/users/m_owca.info/seamonkey-central/file/65cd9bcb5f50/suite/profile/bookmarks.inc#l80

So we shouldn't raise an error when an empty string is submitted as a translation in Pontoon.