### PR TITLE
Fix bug 1463173 - Run checks during batch actions

### DIFF
--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -2398,13 +2398,19 @@ var Pontoon = (function (my) {
               if ('count' in data) {
                 var itemsText = data.count === 1 ? 'string' : 'strings';
                 var actionText = action + 'd';
+                var invalidTranslationsCount = data['invalid_translation_count'] || 0;
+                var skippedText = '';
 
                 if (action === 'reject') {
                   itemsText = 'suggestion' + (data.count === 1 ? '' : 's');
                   actionText = 'rejected';
                 }
 
-                message = data.count + ' ' + itemsText + ' ' + actionText;
+                if (invalidTranslationsCount > 0) {
+                  skippedText = ', ' + invalidTranslationsCount + ' skipped (due to errors)';
+                }
+
+                message = data.count + ' ' + itemsText + ' ' + actionText + skippedText;
 
                 // Update UI (entity list, progress, in-place)
                 if (data.count > 0) {

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -2399,7 +2399,7 @@ var Pontoon = (function (my) {
                 var itemsText = data.count === 1 ? 'string' : 'strings';
                 var actionText = action + 'd';
                 var invalidTranslationsCount = data['invalid_translation_count'] || 0;
-                var skippedText = '';
+                var failedText = '';
 
                 if (action === 'reject') {
                   itemsText = 'suggestion' + (data.count === 1 ? '' : 's');
@@ -2407,10 +2407,10 @@ var Pontoon = (function (my) {
                 }
 
                 if (invalidTranslationsCount > 0) {
-                  skippedText = ', ' + invalidTranslationsCount + ' skipped (due to errors)';
+                  failedText = ', ' + invalidTranslationsCount + ' failed';
                 }
 
-                message = data.count + ' ' + itemsText + ' ' + actionText + skippedText;
+                message = data.count + ' ' + itemsText + ' ' + actionText + failedText;
 
                 // Update UI (entity list, progress, in-place)
                 if (data.count > 0) {

--- a/pontoon/batch/actions.py
+++ b/pontoon/batch/actions.py
@@ -139,21 +139,16 @@ def replace_translations(form, user, translations, locale):
     replace = form.cleaned_data['replace']
     latest_translation_pk = None
 
-    try:
-        old_translations, changed_translations, invalid_translation_pks = utils.find_and_replace(
-            translations,
-            find,
-            replace,
-            user
-        )
-        changed_translation_pks = [c.pk for c in changed_translations]
+    old_translations, changed_translations, invalid_translation_pks = utils.find_and_replace(
+        translations,
+        find,
+        replace,
+        user
+    )
+    changed_translation_pks = [c.pk for c in changed_translations]
 
-        if changed_translation_pks:
-            latest_translation_pk = max(changed_translation_pks)
-    except Translation.NotAllowed:
-        return {
-            'error': 'Empty translations not allowed',
-        }
+    if changed_translation_pks:
+        latest_translation_pk = max(changed_translation_pks)
 
     # Unapprove old translations
     old_translations.update(

--- a/pontoon/batch/tests/test_views.py
+++ b/pontoon/batch/tests/test_views.py
@@ -2,7 +2,75 @@ import pytest
 
 from django.urls import reverse
 
+from pontoon.checks.utils import bulk_run_checks
+from pontoon.test.factories import TranslationFactory, ProjectLocaleFactory
 
+
+@pytest.yield_fixture
+def batch_action(client, admin_client):
+    """
+    Shortcut function to make API-call more readable in tests.
+    """
+    def _action(admin=False, **opts):
+        """
+        :param bool admin: when true then uses admin_client to make api calls.
+        :param opts: options passed to the batch action view.
+        """
+        if admin:
+            client_ = admin_client
+        else:
+            client_ = client
+
+        response = client_.post(
+            reverse('pontoon.batch.edit.translations'),
+            opts,
+            HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+        )
+        return response
+
+    return _action
+
+
+@pytest.yield_fixture
+def translation_dtd_unapproved():
+    translation = TranslationFactory.create(
+        string='Test Translation',
+        approved=False,
+        entity__key='test',
+        entity__resource__format='dtd',
+        entity__resource__path='test.dtd',
+    )
+    bulk_run_checks([translation])
+
+    ProjectLocaleFactory.create(
+        project=translation.entity.resource.project,
+        locale=translation.locale,
+    )
+
+    yield translation
+
+
+@pytest.yield_fixture
+def translation_dtd_invalid_unapproved():
+    # Provide invalid characters in translation to cause checks
+    translation = TranslationFactory.create(
+        string='!@#$""\'',
+        approved=False,
+        entity__key='test',
+        entity__resource__format='dtd',
+        entity__resource__path='test.dtd',
+    )
+    bulk_run_checks([translation])
+
+    ProjectLocaleFactory.create(
+        project=translation.entity.resource.project,
+        locale=translation.locale,
+    )
+
+    yield translation
+
+
+@pytest.yield_fixture
 def test_batch_edit_translations_no_user(client):
     """If there are no logged in users, the view redirects to the login page.
     """
@@ -11,39 +79,31 @@ def test_batch_edit_translations_no_user(client):
 
 
 @pytest.mark.django_db
-def test_batch_edit_translations_bad_request(client, member, locale_a):
+def test_batch_edit_translations_bad_request(batch_action, member, locale_a):
     # No `locale` parameter.
-    response = client.post(
-        reverse('pontoon.batch.edit.translations'),
-        {'action': 'reject'},
-        HTTP_X_REQUESTED_WITH='XMLHttpRequest',
-    )
+    response = batch_action(action='reject')
     assert response.status_code == 400
     assert 'locale' in response.content
 
     # No `action` parameter.
-    response = client.post(
-        reverse('pontoon.batch.edit.translations'),
-        {'locale': locale_a.code},
-        HTTP_X_REQUESTED_WITH='XMLHttpRequest',
-    )
+    response = batch_action(locale=locale_a.code)
+
     assert response.status_code == 400
     assert 'action' in response.content
 
     # Incorrect `action` parameter.
-    response = client.post(
-        reverse('pontoon.batch.edit.translations'),
-        {'action': 'unknown', 'locale': locale_a.code},
-        HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+    response = batch_action(
+        action='unknown',
+        locale=locale_a.code,
     )
+
     assert response.status_code == 400
     assert 'action' in response.content
 
     # Incorrect `locale` parameter.
-    response = client.post(
-        reverse('pontoon.batch.edit.translations'),
-        {'action': 'reject', 'locale': 'unknown'},
-        HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+    response = batch_action(
+        action='reject',
+        locale='unknown',
     )
     assert response.status_code == 404
     assert 'action' in response.content
@@ -51,16 +111,119 @@ def test_batch_edit_translations_bad_request(client, member, locale_a):
 
 @pytest.mark.django_db
 def test_batch_edit_translations_no_permissions(
-    client, member, locale_a, entity_a, project_locale_a
+    batch_action, member, locale_a, entity_a, project_locale_a
 ):
-    response = client.post(
-        reverse('pontoon.batch.edit.translations'),
-        {
-            'action': 'reject',
-            'locale': locale_a.code,
-            'entities': entity_a.id,
-        },
-        HTTP_X_REQUESTED_WITH='XMLHttpRequest',
+    response = batch_action(
+        action='reject',
+        locale=locale_a.code,
+        entities=entity_a.id,
     )
+
     assert response.status_code == 403
     assert 'Forbidden' in response.content
+
+
+@pytest.mark.django_db
+def test_batch_approve_valid_translations(
+    batch_action,
+    member,
+    translation_dtd_unapproved,
+):
+    """
+    Approve translations without errors.
+    """
+    response = batch_action(
+        admin=True,
+        action='approve',
+        locale=translation_dtd_unapproved.locale.code,
+        entities=translation_dtd_unapproved.entity.pk,
+    )
+    assert response.json() == {
+        'count': 1,
+        'invalid_translation_count': 0,
+    }
+
+    translation_dtd_unapproved.refresh_from_db()
+    assert translation_dtd_unapproved.approved
+
+
+@pytest.mark.django_db
+def test_batch_approve_invalid_translations(
+    batch_action,
+    member,
+    translation_dtd_invalid_unapproved,
+):
+    """
+    Translations with errors can't be approved.
+    """
+
+    response = batch_action(
+        admin=True,
+        action='approve',
+        locale=translation_dtd_invalid_unapproved.locale.code,
+        entities=translation_dtd_invalid_unapproved.entity.pk
+    )
+
+    assert response.json() == {
+        'count': 0,
+        'invalid_translation_count': 1,
+    }
+
+    translation_dtd_invalid_unapproved.refresh_from_db()
+
+    assert not translation_dtd_invalid_unapproved.approved
+
+
+@pytest.mark.django_db
+def test_batch_find_and_replace_valid_translations(
+    batch_action,
+    member,
+    translation_dtd_unapproved,
+):
+    response = batch_action(
+        admin=True,
+        action='replace',
+        locale=translation_dtd_unapproved.locale.code,
+        entities=translation_dtd_unapproved.entity.pk,
+        find='Translation',
+        replace='Replaced translation',
+    )
+
+    assert response.json() == {
+        'count': 1,
+        'invalid_translation_count': 0,
+    }
+
+    new_translation = translation_dtd_unapproved.entity.translation_set.last()
+
+    assert new_translation.string == 'Test Replaced translation'
+    assert new_translation.approved
+
+
+@pytest.mark.django_db
+def test_batch_find_and_replace_invalid_translations(
+    batch_action,
+    member,
+    translation_dtd_unapproved,
+):
+    """
+    The `find & replace` action can't produce invalid translations.
+    """
+    response = batch_action(
+        admin=True,
+        action='replace',
+        locale=translation_dtd_unapproved.locale.code,
+        entities=translation_dtd_unapproved.entity.pk,
+        find='Translation',
+        replace='%$#%>',
+    )
+
+    assert response.json() == {
+        'count': 0,
+        'invalid_translation_count': 1,
+    }
+
+    translation_dtd_unapproved.refresh_from_db()
+
+    assert translation_dtd_unapproved.string == 'Test Translation'
+    assert not translation_dtd_unapproved.approved

--- a/pontoon/batch/tests/test_views.py
+++ b/pontoon/batch/tests/test_views.py
@@ -52,7 +52,7 @@ def translation_dtd_unapproved():
 
 @pytest.yield_fixture
 def translation_dtd_invalid_unapproved():
-    # Provide invalid characters in translation to cause checks
+    # Provide invalid characters in translation to cause checks to fail
     translation = TranslationFactory.create(
         string='!@#$""\'',
         approved=False,
@@ -194,10 +194,10 @@ def test_batch_find_and_replace_valid_translations(
         'invalid_translation_count': 0,
     }
 
-    new_translation = translation_dtd_unapproved.entity.translation_set.last()
+    translation = translation_dtd_unapproved.entity.translation_set.last()
 
-    assert new_translation.string == 'Test Replaced translation'
-    assert new_translation.approved
+    assert translation.string == 'Test Replaced translation'
+    assert translation.approved
 
 
 @pytest.mark.django_db
@@ -223,7 +223,7 @@ def test_batch_find_and_replace_invalid_translations(
         'invalid_translation_count': 1,
     }
 
-    translation_dtd_unapproved.refresh_from_db()
+    translation = translation_dtd_unapproved.entity.translation_set.last()
 
-    assert translation_dtd_unapproved.string == 'Test Translation'
-    assert not translation_dtd_unapproved.approved
+    assert translation.string == 'Test Translation'
+    assert not translation.approved

--- a/pontoon/batch/views.py
+++ b/pontoon/batch/views.py
@@ -166,8 +166,12 @@ def batch_edit_translations(request):
     if action_status.get('error'):
         return JsonResponse(action_status)
 
+    invalid_translations_count = len(action_status.get('invalid_translation_pks', []))
     if action_status['count'] == 0:
-        return JsonResponse({'count': 0})
+        return JsonResponse({
+            'count': 0,
+            'invalid_translation_count': invalid_translations_count,
+        })
 
     update_stats(action_status['translated_resources'], entity, locale)
     mark_changed_translation(action_status['changed_entities'], locale)
@@ -185,5 +189,6 @@ def batch_edit_translations(request):
     )
 
     return JsonResponse({
-        'count': action_status['count']
+        'count': action_status['count'],
+        'invalid_translation_count': invalid_translations_count,
     })

--- a/pontoon/batch/views.py
+++ b/pontoon/batch/views.py
@@ -166,11 +166,11 @@ def batch_edit_translations(request):
     if action_status.get('error'):
         return JsonResponse(action_status)
 
-    invalid_translations_count = len(action_status.get('invalid_translation_pks', []))
+    invalid_translation_count = len(action_status.get('invalid_translation_pks', []))
     if action_status['count'] == 0:
         return JsonResponse({
             'count': 0,
-            'invalid_translation_count': invalid_translations_count,
+            'invalid_translation_count': invalid_translation_count,
         })
 
     update_stats(action_status['translated_resources'], entity, locale)
@@ -190,5 +190,5 @@ def batch_edit_translations(request):
 
     return JsonResponse({
         'count': action_status['count'],
-        'invalid_translation_count': invalid_translations_count,
+        'invalid_translation_count': invalid_translation_count,
     })

--- a/pontoon/checks/tasks.py
+++ b/pontoon/checks/tasks.py
@@ -5,10 +5,8 @@ from celery import shared_task
 
 from django.db import transaction
 
-from pontoon.checks.utils import (
-    bulk_run_checks,
-    get_translations,
-)
+from pontoon.base.models import Translation
+from pontoon.checks.utils import bulk_run_checks
 
 log = logging.getLogger(__name__)
 
@@ -22,7 +20,11 @@ def check_translations(self, translations_pks):
     start_time = time.time()
 
     with transaction.atomic():
-        translations = get_translations(pk__in=translations_pks)
+        translations = (
+            Translation.object
+            .for_checks()
+            .filter(pk__in=translations_pks)
+        )
 
         warnings, errors = bulk_run_checks(translations)
 

--- a/pontoon/checks/utils.py
+++ b/pontoon/checks/utils.py
@@ -1,41 +1,8 @@
-from pontoon.base.models import Translation
-
 from pontoon.checks import (
-    DB_FORMATS,
     DB_LIBRARIES,
 )
 from pontoon.checks.models import Warning, Error
 from pontoon.checks.libraries import run_checks
-
-
-def prefetch_translations():
-    """
-    Prefetch translations with fields required for run_checks
-    """
-
-    translations = (
-        Translation.objects
-        .prefetch_related(
-            'entity',
-            'entity__resource__entities',
-            'locale',
-        )
-    )
-    return translations
-
-
-def get_translations(**qs_filters):
-    """
-    Prefetch translations with fields required for bulk_run_checks
-    """
-    translations = (
-        prefetch_translations()
-        .filter(
-            entity__resource__format__in=DB_FORMATS,
-            **qs_filters
-        )
-    )
-    return translations
 
 
 def bulk_run_checks(translations):

--- a/pontoon/checks/utils.py
+++ b/pontoon/checks/utils.py
@@ -8,21 +8,31 @@ from pontoon.checks.models import Warning, Error
 from pontoon.checks.libraries import run_checks
 
 
+def prefetch_translations():
+    """
+    Prefetch translations with fields required for run_checks
+    """
+
+    translations = (
+        Translation.objects
+        .prefetch_related(
+            'entity',
+            'entity__resource__entities',
+            'locale',
+        )
+    )
+    return translations
+
+
 def get_translations(**qs_filters):
     """
     Prefetch translations with fields required for bulk_run_checks
     """
     translations = (
-        Translation.objects
+        prefetch_translations()
         .filter(
             entity__resource__format__in=DB_FORMATS,
             **qs_filters
-
-        )
-        .prefetch_related(
-            'entity',
-            'entity__resource__entities',
-            'locale',
         )
     )
     return translations

--- a/pontoon/sync/changeset.py
+++ b/pontoon/sync/changeset.py
@@ -14,7 +14,7 @@ from pontoon.base.models import (
     TranslationMemoryEntry
 )
 from pontoon.base.utils import match_attr
-from pontoon.checks import utils as checks_utils
+from pontoon.checks.utils import bulk_run_checks
 
 log = logging.getLogger(__name__)
 
@@ -415,10 +415,10 @@ class ChangeSet(object):
         """
         changed_pks = {t.pk for t in self.changed_translations}
 
-        checks_utils.bulk_run_checks(
-            checks_utils.get_translations(
-                pk__in=changed_pks
-            )
+        bulk_run_checks(
+            Translation.objects
+            .for_checks()
+            .filter(pk__in=changed_pks)
         )
 
         valid_translations = set(


### PR DESCRIPTION
# TODO
* [x] Discuss the feature scope
* [x] Implement changes
* [x] Add tests

# Discussion points
* How `find&replace` action should work? I thought about the following approaches:
  * Allow to create suggestions with errors but don't mark them as approved
  * Don't create suggestions at all if the change could create generate errors. This approach could require additional UI changes (to display errors etc.)
* Batch Approve should approve only translations without any errors (?)
* I think that batch reject operation doesn't require checks (feel free to correct me)

@mathjazz @pike hey, could you look at these discussion points?

Thanks in advance!