### PR TITLE
Bug 1372151: sync l10n files for which source changes, read-only and changed locales only

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -1757,15 +1757,6 @@ class ResourceQuerySet(models.QuerySet):
     def asymmetric(self):
         return self.filter(format__in=Resource.ASYMMETRIC_FORMATS)
 
-    """
-    List of paths to remove translations of obsolete entities from
-    """
-
-    def obsolete_entities_paths(self, obsolete_vcs_entities):
-        return self.filter(
-            entities__pk__in=obsolete_vcs_entities
-        ).asymmetric().values_list('path', flat=True).distinct()
-
 
 @python_2_unicode_compatible
 class Resource(models.Model):

--- a/pontoon/sync/core.py
+++ b/pontoon/sync/core.py
@@ -32,7 +32,7 @@ def update_originals(db_project, now, full_scan=False):
         update_entities(db_project, vcs_project, changeset)
         changeset.execute()
 
-    return changeset.changes, added_paths, removed_paths, changed_paths
+    return added_paths, removed_paths, changed_paths
 
 
 def serial_task(timeout, lock_key="", on_error=None, **celery_args):

--- a/pontoon/sync/core.py
+++ b/pontoon/sync/core.py
@@ -67,7 +67,7 @@ def serial_task(timeout, lock_key="", on_error=None, **celery_args):
     return wrapper
 
 
-def collect_entities(db_project, vcs_project, unsynced_locales=None):
+def collect_entities(db_project, vcs_project, changed_resources):
     """
     Find all the entities in the database and on the filesystem and
     match them together, yielding tuples of the form
@@ -75,7 +75,6 @@ def collect_entities(db_project, vcs_project, unsynced_locales=None):
 
     When a match isn't found, the missing entity will be None.
     """
-    changed_resources = None if unsynced_locales else vcs_project.changed_files
     db_entities = get_db_entities(db_project, changed_resources)
     vcs_entities = get_vcs_entities(vcs_project)
     entity_keys = set().union(db_entities.keys(), vcs_entities.keys())
@@ -85,7 +84,8 @@ def collect_entities(db_project, vcs_project, unsynced_locales=None):
 
 
 def update_entities(db_project, vcs_project, changeset):
-    for key, db_entity, vcs_entity in collect_entities(db_project, vcs_project):
+    changed_resources = vcs_project.changed_files
+    for key, db_entity, vcs_entity in collect_entities(db_project, vcs_project, changed_resources):
         if vcs_entity is None:
             if db_entity is None:
                 # This should never happen. What? Hard abort.
@@ -129,10 +129,27 @@ def update_resources(db_project, vcs_project):
     return added_paths, removed_paths, changed_paths
 
 
+def get_changed_resources(db_project, vcs_project):
+    changed_resources = vcs_project.changed_files
+
+    if db_project.unsynced_locales:
+        changed_resources = None
+
+    if changed_resources is not None:
+        changed_resources = (
+            changed_resources.keys() +
+            list(vcs_project.added_paths) +
+            list(vcs_project.changed_paths)
+        )
+
+    return changed_resources
+
+
 def update_translations(db_project, vcs_project, locale, changeset):
-    all_entities = collect_entities(db_project, vcs_project, db_project.unsynced_locales)
+    changed_resources = get_changed_resources(db_project, vcs_project)
+    all_entities = collect_entities(db_project, vcs_project, changed_resources)
     for key, db_entity, vcs_entity in all_entities:
-        # If we don't have both the db_entity and cs_entity we can't
+        # If we don't have both the db_entity and vcs_entity we can't
         # do anything with the translations.
         if db_entity is None or vcs_entity is None:
             continue

--- a/pontoon/sync/tasks.py
+++ b/pontoon/sync/tasks.py
@@ -280,7 +280,8 @@ def sync_translations(
         locales=locales,
         repo_locales=repo_locales,
         obsolete_entities_paths=obsolete_entities_paths,
-        new_paths=added_paths,
+        added_paths=added_paths,
+        changed_paths=changed_paths,
         full_scan=full_scan
     )
 

--- a/pontoon/sync/tests/test_tasks.py
+++ b/pontoon/sync/tests/test_tasks.py
@@ -39,7 +39,7 @@ class SyncProjectTests(TestCase):
 
         self.mock_update_originals = self.patch(
             'pontoon.sync.tasks.update_originals',
-            return_value=[[], [], []]
+            return_value=[[], [], [], []]
         )
 
         self.mock_source_directory_path = self.patch(

--- a/pontoon/sync/tests/test_tasks.py
+++ b/pontoon/sync/tests/test_tasks.py
@@ -39,7 +39,7 @@ class SyncProjectTests(TestCase):
 
         self.mock_update_originals = self.patch(
             'pontoon.sync.tasks.update_originals',
-            return_value=[[], [], [], []]
+            return_value=[[], [], []]
         )
 
         self.mock_source_directory_path = self.patch(
@@ -140,11 +140,6 @@ class SyncTranslationsTests(FakeCheckoutTestCase):
         self.mock_repo_checkout_path = self.patch_object(
             Repository, 'checkout_path', new_callable=PropertyMock,
             return_value=FAKE_CHECKOUT_PATH)
-        self.mock_changes = {
-            'update_db': [],
-            'obsolete_db': [],
-            'create_db': []
-        }
 
     def test_clear_changed_entities(self):
         """
@@ -166,7 +161,7 @@ class SyncTranslationsTests(FakeCheckoutTestCase):
         changed_after.save()
 
         sync_translations(self.db_project.pk, self.project_sync_log.pk,
-                          self.now, self.mock_changes)
+                          self.now)
         with assert_raises(ChangedEntityLocale.DoesNotExist):
             changed1.refresh_from_db()
         with assert_raises(ChangedEntityLocale.DoesNotExist):
@@ -179,7 +174,7 @@ class SyncTranslationsTests(FakeCheckoutTestCase):
             self.repository.pk: Locale.objects.filter(pk=self.translated_locale.pk)
         }]
         sync_translations(self.db_project.pk, self.project_sync_log.pk,
-                          self.now, self.mock_changes, no_commit=True)
+                          self.now, no_commit=True)
         assert_false(self.mock_commit_changes.called)
 
     def test_readonly_locales(self):
@@ -203,7 +198,6 @@ class SyncTranslationsTests(FakeCheckoutTestCase):
             self.db_project.pk,
             self.project_sync_log.pk,
             self.now,
-            self.mock_changes,
             no_commit=False,
         )
 
@@ -233,7 +227,7 @@ class SyncTranslationsTests(FakeCheckoutTestCase):
 
         with patch('pontoon.sync.tasks.VCSProject', return_value=self.vcs_project):
             sync_translations(self.db_project.pk, self.project_sync_log.pk,
-                              self.now, self.mock_changes)
+                              self.now)
 
         # Only one translation should be approved: the duplicate_translation.
         assert_equal(self.main_db_entity.translation_set.filter(approved=True).count(), 1)
@@ -258,7 +252,7 @@ class SyncTranslationsTests(FakeCheckoutTestCase):
         }]
 
         sync_translations(self.db_project.pk, self.project_sync_log.pk,
-                          self.now, self.mock_changes)
+                          self.now)
 
         log = RepositorySyncLog.objects.get(repository=repo.pk)
         assert_equal(log.repository, repo)

--- a/pontoon/sync/vcs/models.py
+++ b/pontoon/sync/vcs/models.py
@@ -62,7 +62,7 @@ class VCSProject(object):
     SOURCE_DIR_NAMES = SOURCE_DIR_SCORES.keys()
 
     def __init__(
-        self, db_project, now=None, locales=None, repo_locales=None, obsolete_entities_paths=None,
+        self, db_project, now=None, locales=None, repo_locales=None,
         added_paths=None, changed_paths=None, full_scan=False
     ):
         """
@@ -81,8 +81,6 @@ class VCSProject(object):
         :param dict repo_locales:
             A dict of repository PKs and their currently checked out locales
             (not neccessarily matching the ones stored in the DB).
-        :param list obsolete_entities_paths:
-            List of paths to remove translations of obsolete entities from
         :param list added_paths:
             List of added source file paths
         :param list changed_paths:
@@ -94,7 +92,6 @@ class VCSProject(object):
         self.now = now
         self.locales = locales if locales is not None else db_project.locales.all()
         self.repo_locales = repo_locales
-        self.obsolete_entities_paths = obsolete_entities_paths or []
         self.added_paths = added_paths or []
         self.changed_paths = changed_paths or []
         self.full_scan = full_scan
@@ -315,7 +312,6 @@ class VCSProject(object):
                     self.changed_files is not None and
                     (
                         (not self.changed_files or path not in self.changed_files) and
-                        path not in self.obsolete_entities_paths and
                         path not in self.added_paths and
                         path not in self.changed_paths
                     )
@@ -327,7 +323,6 @@ class VCSProject(object):
                 else:
                     if (
                         self.changed_files is None or
-                        path in self.obsolete_entities_paths or
                         path in self.added_paths or
                         path in self.changed_paths
                     ):

--- a/pontoon/sync/vcs/models.py
+++ b/pontoon/sync/vcs/models.py
@@ -63,7 +63,7 @@ class VCSProject(object):
 
     def __init__(
         self, db_project, now=None, locales=None, repo_locales=None, obsolete_entities_paths=None,
-        new_paths=None, full_scan=False
+        added_paths=None, changed_paths=None, full_scan=False
     ):
         """
         Load resource paths from the given db_project and parse them
@@ -83,8 +83,10 @@ class VCSProject(object):
             (not neccessarily matching the ones stored in the DB).
         :param list obsolete_entities_paths:
             List of paths to remove translations of obsolete entities from
-        :param list new_paths:
-            List of newly added files paths
+        :param list added_paths:
+            List of added source file paths
+        :param list changed_paths:
+            List of changed source file paths
         :param bool full_scan:
             Scans all resources in repository
         """
@@ -93,7 +95,8 @@ class VCSProject(object):
         self.locales = locales if locales is not None else db_project.locales.all()
         self.repo_locales = repo_locales
         self.obsolete_entities_paths = obsolete_entities_paths or []
-        self.new_paths = new_paths or []
+        self.added_paths = added_paths or []
+        self.changed_paths = changed_paths or []
         self.full_scan = full_scan
         self.synced_locales = set()
 
@@ -313,7 +316,8 @@ class VCSProject(object):
                     (
                         (not self.changed_files or path not in self.changed_files) and
                         path not in self.obsolete_entities_paths and
-                        path not in self.new_paths
+                        path not in self.added_paths and
+                        path not in self.changed_paths
                     )
                 ):
                     if not locales:
@@ -324,7 +328,8 @@ class VCSProject(object):
                     if (
                         self.changed_files is None or
                         path in self.obsolete_entities_paths or
-                        path in self.new_paths
+                        path in self.added_paths or
+                        path in self.changed_paths
                     ):
                         locales += self.locales
                     else:


### PR DESCRIPTION
Firefox source strings are first pushed to the so called `quarantine` repository, which is only used by 2 or 3 locales (e.g. Italian) that translate Firefox offline (without Pontoon). The purpose of `quarantine` is to test the quality of source strings and potentially back them out before they are exposed to all localizers in the `gecko-strings` repository used by Pontoon.

In https://github.com/mozilla/pontoon/commit/dd51a3db9ebc09c17c55fb7fe5600ec8bbffe107 we introduced read-only locales, which allow us to enable all locales in Pontoon. Including the ones working with the `quarantine` repository. However, when new source strings land in `gecko-strings`, Pontoon properly detects changed files and imports source strings, but it doesn't import [existing Italian translations](https://hg.mozilla.org/l10n-central/it/file/2b3f24666485/toolkit/crashreporter/aboutcrashes.ftl) into [Pontoon](https://pontoon.mozilla.org/it/firefox/toolkit/crashreporter/aboutcrashes.ftl/?string=189278), submitted in the past, because they aren't detected as changed since the last sync.

This patch syncs l10n files for which source changes, but only for read-only and changed locales. To fully fix the bug, we should sync these files for all locales, but that would have a pretty substantial negative impact on sync performance (because we'd need to clone all locale repositories).

Commit messages starting with "Bug 1372151" are the actual bugfix, the other two are slight refactorings which should make the code easier to understand.

@Pike @jotes r?