### PR TITLE
Fix bug 1486816: Always prevent reject actions for unauthenticated users

### DIFF
--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -316,7 +316,7 @@ var Pontoon = (function (my) {
                 '" title="Copy Into Translation (Tab)">' +
                   '<header class="clearfix' +
                     ((!entity.readonly && self.user.canTranslate()) ? ' translator' :
-                      ((!entity.readonly && self.user.id === this.uid && !this.approved) ?
+                      ((!entity.readonly && self.user.id && self.user.id === this.uid && !this.approved) ?
                         ' own' : '')) +
                     '">' +
                     '<div class="info">' +

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -388,6 +388,7 @@ def unapprove_translation(request):
 
 
 @utils.require_AJAX
+@login_required(redirect_field_name='', login_url='/403')
 @transaction.atomic
 def reject_translation(request):
     """Reject given translation."""


### PR DESCRIPTION
_Note: this fixes a regression introduced by https://github.com/mozilla/pontoon/pull/1031/files._

Unauthenticated users can click the reject button for translations that are either fuzzy or unreviewed, and don't have an author assigned.

That is because we don't properly set the `own` class, which should only be set for authenticated users without permissions, in order to be able to reject their own translations.

I've also added the `login_required()` decorator, which is already used in similar functions.