### PR TITLE
Fix errors and warnings stats calculation, r=me

### DIFF
--- a/pontoon/base/migrations/0133_calculate_strings_with_errors_warnings.py
+++ b/pontoon/base/migrations/0133_calculate_strings_with_errors_warnings.py
@@ -70,14 +70,14 @@ def calculate_stats(self, apps):
             Q(Q(approved=True) | Q(fuzzy=True)) &
             Q(errors__isnull=False)
         ),
-    ).count()
+    ).distinct().count()
 
     warnings = translations.filter(
         Q(
             Q(Q(approved=True) | Q(fuzzy=True)) &
             Q(warnings__isnull=False)
         ),
-    ).count()
+    ).distinct().count()
 
     unreviewed = translations.filter(
         approved=False,
@@ -117,14 +117,14 @@ def calculate_stats(self, apps):
                     Q(Q(approved=True) | Q(fuzzy=True)) &
                     Q(errors__isnull=False)
                 ),
-            ).count()
+            ).distinct().count()
 
             plural_warnings_count = translations.filter(
                 Q(
                     Q(Q(approved=True) | Q(fuzzy=True)) &
                     Q(warnings__isnull=False)
                 ),
-            ).count()
+            ).distinct().count()
 
             if plural_errors_count:
                 errors += 1

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -2989,14 +2989,14 @@ class TranslatedResource(AggregatedStats):
                 Q(Q(approved=True) | Q(fuzzy=True)) &
                 Q(errors__isnull=False)
             ),
-        ).count()
+        ).distinct().count()
 
         warnings = translations.filter(
             Q(
                 Q(Q(approved=True) | Q(fuzzy=True)) &
                 Q(warnings__isnull=False)
             ),
-        ).count()
+        ).distinct().count()
 
         unreviewed = translations.filter(
             approved=False,
@@ -3036,14 +3036,14 @@ class TranslatedResource(AggregatedStats):
                         Q(Q(approved=True) | Q(fuzzy=True)) &
                         Q(errors__isnull=False)
                     ),
-                ).count()
+                ).distinct().count()
 
                 plural_warnings_count = translations.filter(
                     Q(
                         Q(Q(approved=True) | Q(fuzzy=True)) &
                         Q(warnings__isnull=False)
                     ),
-                ).count()
+                ).distinct().count()
 
                 if plural_errors_count:
                     errors += 1


### PR DESCRIPTION
We must use .distinct() in order to avoid counting translation twice.