### PR TITLE
Fix bug 1492829: Include warnings in completion percent

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -1556,7 +1556,11 @@ class ProjectLocale(AggregatedStats):
                 'warnings_share': round(obj.strings_with_warnings / obj.total_strings * 100),
                 'unreviewed_share': round(obj.unreviewed_strings / obj.total_strings * 100),
                 'completion_percent': int(
-                    math.floor(obj.approved_strings / obj.total_strings * 100)
+                    math.floor(
+                        (obj.approved_strings + obj.strings_with_warnings) /
+                        obj.total_strings *
+                        100
+                    )
                 ),
             }
 

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -1555,7 +1555,7 @@ class ProjectLocale(AggregatedStats):
                 'errors_share': round(obj.strings_with_errors / obj.total_strings * 100),
                 'warnings_share': round(obj.strings_with_warnings / obj.total_strings * 100),
                 'unreviewed_share': round(obj.unreviewed_strings / obj.total_strings * 100),
-                'approved_percent': int(
+                'completion_percent': int(
                     math.floor(obj.approved_strings / obj.total_strings * 100)
                 ),
             }

--- a/pontoon/base/static/js/progress-chart.js
+++ b/pontoon/base/static/js/progress-chart.js
@@ -20,7 +20,7 @@ $(function() {
           errors: stats.all ? stats.errors / stats.all : 0,
           missing: stats.all ? stats.missing / stats.all : 1 /* Draw "empty" progress if no projects enabled */
         },
-        number = Math.floor(fraction.translated * 100);
+        number = Math.floor((fraction.translated + fraction.warnings) * 100);
 
     // Update graph
     var canvas = this,

--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -2526,7 +2526,7 @@ var Pontoon = (function (my) {
             errors: total ? errors / total : 0,
             missing: total ? missing / total : 0
           },
-          number = Math.floor(fraction.translated * 100),
+          number = Math.floor((fraction.translated + fraction.warnings) * 100),
           translatedOld = parseInt($('#progress .menu .details .translated p').html().replace(/,/g, ''));
 
       // Update graph

--- a/pontoon/base/templates/widgets/progress_chart.html
+++ b/pontoon/base/templates/widgets/progress_chart.html
@@ -1,7 +1,7 @@
 {% macro span(chart, link, link_parameter=False, has_params=False) %}
 {% if chart != None %}
   <div class="chart-wrapper">
-    <span class="percent">{{ chart.approved_percent }}%</span>
+    <span class="percent">{{ chart.completion_percent }}%</span>
     <span class="chart">
       <span class="translated" style="width:{{ chart.approved_share }}%;"></span>
       <span class="fuzzy" style="width:{{ chart.fuzzy_share }}%;"></span>

--- a/pontoon/localizations/templates/localizations/widgets/resource_list.html
+++ b/pontoon/localizations/templates/localizations/widgets/resource_list.html
@@ -35,7 +35,7 @@
 
     {% if deadline %}
     <td class="deadline">
-      {{ Deadline.deadline(resource.resource__deadline, chart.approved_percent == 100) }}
+      {{ Deadline.deadline(resource.resource__deadline, chart.completion_percent == 100) }}
     </td>
     {% endif %}
 

--- a/pontoon/localizations/tests.py
+++ b/pontoon/localizations/tests.py
@@ -69,7 +69,7 @@ class LocaleProjectTests(ViewTestCase):
                         'approved_share': 0.0,
                         'unreviewed_share': 100.0,
                         'fuzzy_share': 0.0,
-                        'approved_percent': 0
+                        'completion_percent': 0
                     }
                 },
                 {
@@ -88,7 +88,7 @@ class LocaleProjectTests(ViewTestCase):
                         'approved_share': 0.0,
                         'unreviewed_share': 0.0,
                         'fuzzy_share': 0.0,
-                        'approved_percent': 0
+                        'completion_percent': 0
                     }
                 }
             ])

--- a/pontoon/localizations/views.py
+++ b/pontoon/localizations/views.py
@@ -126,7 +126,11 @@ def ajax_resources(request, code, slug):
                 part['strings_with_warnings'] / part['resource__total_strings'] * 100
             ),
             'completion_percent': int(
-                math.floor(part['approved_strings'] / part['resource__total_strings'] * 100)
+                math.floor(
+                    (part['approved_strings'] + part['strings_with_warnings']) /
+                    part['resource__total_strings'] *
+                    100
+                )
             ),
         }
 

--- a/pontoon/localizations/views.py
+++ b/pontoon/localizations/views.py
@@ -125,7 +125,7 @@ def ajax_resources(request, code, slug):
             'warnings_share': round(
                 part['strings_with_warnings'] / part['resource__total_strings'] * 100
             ),
-            'approved_percent': int(
+            'completion_percent': int(
                 math.floor(part['approved_strings'] / part['resource__total_strings'] * 100)
             ),
         }

--- a/pontoon/projects/templates/projects/widgets/project_list.html
+++ b/pontoon/projects/templates/projects/widgets/project_list.html
@@ -30,7 +30,7 @@
       </h4>
     </td>
     <td class="deadline">
-      {{ Deadline.deadline(project.deadline, chart.approved_percent == 100) }}
+      {{ Deadline.deadline(project.deadline, chart.completion_percent == 100) }}
     </td>
     <td class="priority">
       {{ Priority.priority(project.priority) }}

--- a/pontoon/projects/views.py
+++ b/pontoon/projects/views.py
@@ -154,8 +154,8 @@ def ajax_notifications(request, slug):
     incomplete = []
     complete = []
     for available_locale in available_locales:
-        approved_percent = available_locale.get_chart(project)['approved_percent']
-        if approved_percent == 100:
+        completion_percent = available_locale.get_chart(project)['completion_percent']
+        if completion_percent == 100:
             complete.append(available_locale.pk)
         else:
             incomplete.append(available_locale.pk)

--- a/pontoon/tags/tests/utils/test_tagged.py
+++ b/pontoon/tags/tests/utils/test_tagged.py
@@ -176,6 +176,6 @@ def test_util_tag_chart():
         approved_strings=13,
         unreviewed_strings=23)
     assert chart.approved_share == 18.0
-    assert chart.approved_percent == 17
     assert chart.fuzzy_share == 10.0
     assert chart.unreviewed_share == 32.0
+    assert chart.completion_percent == 17

--- a/pontoon/tags/tests/utils/test_tagged.py
+++ b/pontoon/tags/tests/utils/test_tagged.py
@@ -174,6 +174,7 @@ def test_util_tag_chart():
         total_strings=73,
         fuzzy_strings=7,
         approved_strings=13,
+        strings_with_warnings=0,
         unreviewed_strings=23)
     assert chart.approved_share == 18.0
     assert chart.fuzzy_share == 10.0

--- a/pontoon/tags/utils/chart.py
+++ b/pontoon/tags/utils/chart.py
@@ -13,7 +13,7 @@ class TagChart(object):
         self.unreviewed_strings = kwargs.get('unreviewed_strings')
 
     @property
-    def approved_percent(self):
+    def completion_percent(self):
         return int(
             math.floor(self.approved_strings / float(self.total_strings) * 100)
         )

--- a/pontoon/tags/utils/chart.py
+++ b/pontoon/tags/utils/chart.py
@@ -15,7 +15,11 @@ class TagChart(object):
     @property
     def completion_percent(self):
         return int(
-            math.floor(self.approved_strings / float(self.total_strings) * 100)
+            math.floor(
+                (self.approved_strings + self.strings_with_warnings) /
+                float(self.total_strings) *
+                100
+            )
         )
 
     @property


### PR DESCRIPTION
We're change the calculation of the completion percentage visible in progress charts on dashboards and the translate view.

**From:**
The number of Translated strings divided by the number of All strings [in %].

**To:**
The number of Translated strings and Strings with warnings divided by the number of All strings [in %].

That's because Warnings (unlike Errors) actually end up in product on build and are often false positives.