### PR TITLE
Fix bug 1493137: Prevent duplicate translation submissions

### DIFF
--- a/pontoon/base/static/js/translate.js
+++ b/pontoon/base/static/js/translate.js
@@ -2859,8 +2859,9 @@ var Pontoon = (function (my) {
         submittedPluralForm = 0;
       }
 
+      // Prevent duplicate translation submissions
       if (self.XHRupdateOnServer) {
-        self.XHRupdateOnServer.abort();
+        return;
       }
 
       self.XHRupdateOnServer = $.ajax({
@@ -2910,6 +2911,7 @@ var Pontoon = (function (my) {
           }
         },
         complete: function() {
+          self.XHRupdateOnServer = undefined;
           self.reattachSaveButtonHandler();
         }
       });


### PR DESCRIPTION
The existing pattern to prevent duplicate translation submission is insufficient ([details in the bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1493137)). Apparenty it aborts the request when the translation is already saved.

Note that the majority of the request time is occupied by the stats calculation, which takes places after saving the translation.