### PR TITLE
Fix bug 1491027 - Filter on project when searching for tags.

### DIFF
--- a/pontoon/tags/tests/utils/test_tags.py
+++ b/pontoon/tags/tests/utils/test_tags.py
@@ -200,7 +200,7 @@ def test_util_tags_tool_get_tags(glob_mock, tag_mock):
     filter_mock = MagicMock(
         **{'filter.return_value': 23})
     tag_mock.configure_mock(
-        **{'return_value.values.return_value': filter_mock})
+        **{'return_value.filter.return_value.values.return_value': filter_mock})
     tags_tool = TagsTool()
 
     # no slug provided, returns `values`
@@ -208,7 +208,7 @@ def test_util_tags_tool_get_tags(glob_mock, tag_mock):
     assert not filter_mock.called
     assert not glob_mock.called
     assert (
-        list(tag_mock.return_value.values.call_args)
+        list(tag_mock.return_value.filter.return_value.values.call_args)
         == [('pk', 'name', 'slug', 'priority', 'project'), {}])
 
     tag_mock.reset_mock()
@@ -220,5 +220,5 @@ def test_util_tags_tool_get_tags(glob_mock, tag_mock):
         == [(), {'slug__regex': 17}])
     assert list(glob_mock.call_args) == [('FOO',), {}]
     assert (
-        list(tag_mock.return_value.values.call_args)
+        list(tag_mock.return_value.filter.return_value.values.call_args)
         == [('pk', 'name', 'slug', 'priority', 'project'), {}])

--- a/pontoon/tags/utils/tags.py
+++ b/pontoon/tags/utils/tags.py
@@ -75,7 +75,7 @@ class TagsTool(Clonable):
     def get_tags(self, slug=None):
         """Get `values` of associated tags, filtering by slug if given
         """
-        tags = self.tag_manager.values(
+        tags = self.tag_manager.filter(project__in=self.projects).values(
             "pk", "name", "slug", "priority", "project")
         if slug:
             return tags.filter(slug__regex=glob_to_regex(slug))

--- a/pontoon/test/fixtures/base.py
+++ b/pontoon/test/fixtures/base.py
@@ -137,6 +137,10 @@ def tag_a(resource_a, project_a, locale_a):
     factories.TranslatedResourceFactory.create(
         resource=resource_a, locale=locale_a
     )
-    tag = factories.TagFactory.create(slug="tag", name="Tag")
+    tag = factories.TagFactory.create(
+        slug="tag",
+        name="Tag",
+        project=project_a,
+    )
     tag.resources.add(resource_a)
     return tag


### PR DESCRIPTION
The lack of filtering on projects means that before this patch, finding the tag that was being concerned only took the slug into consideration. Thus, if two tags, under different projects, used the same slug, one of them would show up for all projects, leading to an incorrect listing of resources, and impossibility to manage that tag.

Note that I didn't add a test case for this, because of the amount of energy it took me to just find the one line where the fix was needed. I might reconsider next week, but by that time my understanding of this code might have faded away (I hope) so it's also possible that I'll never add that test case.