### PR TITLE
implement Microsoft translator API v3 support

### DIFF
--- a/pontoon/machinery/tests/conftest.py
+++ b/pontoon/machinery/tests/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+
+
+@pytest.fixture
+def ms_api_key(settings):
+    """Set the settings.MICROSOFT_TRANSLATOR_API_KEY for this test"""
+    key = '1fffff'
+    settings.MICROSOFT_TRANSLATOR_API_KEY = key
+    return key
+
+
+@pytest.fixture
+def ms_locale(locale_a):
+    """Set the Microsoft API locale code for locale_a"""
+    locale_a.ms_translator_code = 'gb'
+    locale_a.save()
+    return locale_a

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -81,7 +81,6 @@ BROKER_URL = os.environ.get('RABBITMQ_URL', None)
 
 # Microsoft Translator API Key
 MICROSOFT_TRANSLATOR_API_KEY = os.environ.get('MICROSOFT_TRANSLATOR_API_KEY', '')
-MICROSOFT_TRANSLATOR_API_VERSION = os.environ.get('MICROSOFT_TRANSLATOR_API_VERSION', '2.0')
 
 # Google Analytics Key
 GOOGLE_ANALYTICS_KEY = os.environ.get('GOOGLE_ANALYTICS_KEY', '')

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -81,6 +81,7 @@ BROKER_URL = os.environ.get('RABBITMQ_URL', None)
 
 # Microsoft Translator API Key
 MICROSOFT_TRANSLATOR_API_KEY = os.environ.get('MICROSOFT_TRANSLATOR_API_KEY', '')
+MICROSOFT_TRANSLATOR_API_VERSION = os.environ.get('MICROSOFT_TRANSLATOR_API_VERSION', '2.0')
 
 # Google Analytics Key
 GOOGLE_ANALYTICS_KEY = os.environ.get('GOOGLE_ANALYTICS_KEY', '')


### PR DESCRIPTION
Seems like v2 is deprecated.
This PR implements the basic support for v3 version of Microsoft translator.

I've just made a copy of `machine_translation` handler and adjusted it to
use the new v3 API, so now `machine_translation` is calling the `machine_translation_v3` if `MICROSOFT_TRANSLATOR_API_VERSION` equals to `3.0`.