### PR TITLE
Fix bug 1494280: Make (un)linking tag resources work again

### DIFF
--- a/pontoon/tags/tests/utils/test_resources.py
+++ b/pontoon/tags/tests/utils/test_resources.py
@@ -162,6 +162,8 @@ def test_util_tags_resources_tool_link(resource_a, tag_c):
 @pytest.mark.django_db
 def test_util_tags_resources_tool_link_project(resource_a, tag_c):
     resource_tool = TagsResourcesTool(projects=[resource_a.project])
+    tag_c.project = resource_a.project
+    tag_c.save()
     assert tag_c.resources.count() == 0
     resource_tool.link(tag_c.slug, '*')
     assert (

--- a/pontoon/tags/utils/resources.py
+++ b/pontoon/tags/utils/resources.py
@@ -1,3 +1,4 @@
+from django.db.models import Q
 
 from pontoon.base.utils import glob_to_regex
 
@@ -79,7 +80,8 @@ class TagsResourcesTool(TagsDataTool):
         either by passing a glob expression to match, or by passing a list
         of Resource paths
         """
-        tag = self.tag_manager.get(slug=tag)
+        query = Q(project__in=self.projects) if self.projects else Q()
+        tag = self.tag_manager.filter(query).get(slug=tag)
         if glob is not None:
             resources = list(self.find(glob, exclude=tag))
             for resource in resources:
@@ -100,9 +102,10 @@ class TagsResourcesTool(TagsDataTool):
         either by passing a glob expression to match, or by passing a list
         of Resource paths
         """
+        query = Q(project__in=self.projects) if self.projects else Q()
         if glob is not None:
             resources = list(self.find(glob, include=tag))
-            self.tag_manager.get(slug=tag).resources.remove(*resources)
+            self.tag_manager.filter(query).get(slug=tag).resources.remove(*resources)
             return resources
         if resources is not None:
             _resources = self.resource_manager.none()
@@ -110,7 +113,7 @@ class TagsResourcesTool(TagsDataTool):
                 _resources |= self.resource_manager.filter(
                     project=resource["project"],
                     path=resource["path"])
-            self.tag_manager.get(slug=tag).resources.remove(*list(_resources))
+            self.tag_manager.filter(query).get(slug=tag).resources.remove(*list(_resources))
 
     def _validate_resource(self, tag, resource_project):
         if tag.project_id and resource_project != tag.project_id:


### PR DESCRIPTION
Linking and unlinking resources is currently not possible for projects that use tags with same names (e.g. `Mozilla.org` and `Engagement`). On frontend you get the error seen in the bug, on backend you get the error seen below.

This issue looks similar to https://github.com/mozilla/pontoon/commit/1b6e3b40bfef7f1eb63430c7abac6c26c6ece092, but in doesn't look like a regression introduced by that commit.

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/django/core/handlers/exception.py", line 41, in inner
    response = get_response(request)
  File "/usr/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 249, in _legacy_get_response
    response = self._get_response(request)
  File "/usr/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python2.7/site-packages/django/views/generic/base.py", line 68, in view
    return self.dispatch(request, *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/django/views/generic/base.py", line 88, in dispatch
    return handler(request, *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/django/utils/decorators.py", line 67, in _wrapper
    return bound_func(*args, **kwargs)
  File "/app/pontoon/base/utils.py", line 285, in wrap
    return f(request, *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/django/utils/decorators.py", line 63, in bound_func
    return func.__get__(self, type(self))(*args2, **kwargs2)
  File "/usr/local/lib/python2.7/site-packages/django/utils/decorators.py", line 67, in _wrapper
    return bound_func(*args, **kwargs)
  File "/app/pontoon/base/utils.py", line 306, in wrap
    return protected(f)(request, *_args, **_kwargs)
  File "/usr/local/lib/python2.7/site-packages/guardian/decorators.py", line 126, in _wrapped_view
    return view_func(request, *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/django/utils/decorators.py", line 63, in bound_func
    return func.__get__(self, type(self))(*args2, **kwargs2)
  File "/app/pontoon/tags/admin/views.py", line 20, in post
    return super(ProjectTagAdminAjaxView, self).post(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/django/utils/decorators.py", line 67, in _wrapper
    return bound_func(*args, **kwargs)
  File "/app/pontoon/base/utils.py", line 285, in wrap
    return f(request, *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/django/utils/decorators.py", line 63, in bound_func
    return func.__get__(self, type(self))(*args2, **kwargs2)
  File "/app/pontoon/base/views.py", line 804, in post
    return super(AjaxFormView, self).post(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/django/views/generic/edit.py", line 183, in post
    return self.form_valid(form)
  File "/app/pontoon/base/views.py", line 812, in form_valid
    return JsonResponse(dict(data=form.save()))
  File "/app/pontoon/tags/admin/forms.py", line 107, in save
    self.cleaned_data['action'](self.cleaned_data['data'])
  File "/app/pontoon/tags/utils/tag.py", line 93, in unlink_resources
    return self.resource_tool.unlink(self.slug, resources=resources)
  File "/app/pontoon/tags/utils/resources.py", line 113, in unlink
    self.tag_manager.get(slug=tag).resources.remove(*list(_resources))
  File "/usr/local/lib/python2.7/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/django/db/models/query.py", line 384, in get
    (self.model._meta.object_name, num)
MultipleObjectsReturned: get() returned more than one Tag -- it returned 2!
```