### PR TITLE
Fix bug 1486517 - Add support for plurals to Translate.Next.

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import './App.css';
 
 import { Lightbox } from 'core/lightbox';
+import * as locales from 'core/locales';
 import { selectors as navSelectors } from 'core/navigation';
 import { UserAutoUpdater } from 'core/user';
 import { EntitiesList } from 'modules/entitieslist';
@@ -28,6 +29,10 @@ type InternalProps = {|
  * Main entry point to the application. Will render the structure of the page.
  */
 class App extends React.Component<InternalProps> {
+    componentDidMount() {
+        this.props.dispatch(locales.actions.get());
+    }
+
     render() {
         return <div id="app">
             <UserAutoUpdater />

--- a/frontend/src/core/api/entity.js
+++ b/frontend/src/core/api/entity.js
@@ -38,12 +38,12 @@ export default class EntityAPI extends APIBase {
     async getHistory(
         entity: number,
         locale: string,
-        plural_form: string = '-1',
+        pluralForm: number = -1,
     ) {
         const payload = new URLSearchParams();
         payload.append('entity', entity.toString());
         payload.append('locale', locale);
-        payload.append('plural_form', plural_form);
+        payload.append('plural_form', pluralForm.toString());
 
         const headers = new Headers();
         headers.append('X-Requested-With', 'XMLHttpRequest');

--- a/frontend/src/core/api/index.js
+++ b/frontend/src/core/api/index.js
@@ -1,12 +1,14 @@
 /* @flow */
 
 import EntityAPI from './entity';
+import LocaleAPI from './locale';
 import TranslationAPI from './translation';
 import UserAPI from './user';
 
 
 export default {
     entity: new EntityAPI(),
+    locale: new LocaleAPI(),
     translation: new TranslationAPI(),
     user: new UserAPI(),
 };

--- a/frontend/src/core/api/locale.js
+++ b/frontend/src/core/api/locale.js
@@ -1,0 +1,25 @@
+/* @flow */
+
+import APIBase from './base';
+
+
+export default class LocaleAPI extends APIBase {
+    async getAll() {
+        const query = `{
+            locales {
+                code
+                name
+                cldrPlurals
+                pluralRule
+                direction
+            }
+        }`;
+        const payload = new URLSearchParams();
+        payload.append('query', query);
+
+        const headers = new Headers();
+        headers.append('X-Requested-With', 'XMLHttpRequest');
+
+        return await this.fetch('/graphql/', 'GET', payload, headers);
+    }
+}

--- a/frontend/src/core/api/translation.js
+++ b/frontend/src/core/api/translation.js
@@ -14,7 +14,7 @@ export default class TranslationAPI extends APIBase {
         entity: number,
         translation: string,
         locale: string,
-        plural_form: string,
+        pluralForm: number,
         original: string
     ) {
         const csrfToken = this.getCSRFToken();
@@ -23,7 +23,7 @@ export default class TranslationAPI extends APIBase {
         payload.append('entity', entity.toString());
         payload.append('translation', translation);
         payload.append('locale', locale);
-        payload.append('plural_form', '0');
+        payload.append('plural_form', pluralForm.toString());
         payload.append('original', original);
         payload.append('csrfmiddlewaretoken', csrfToken);
 

--- a/frontend/src/core/locales/actions.js
+++ b/frontend/src/core/locales/actions.js
@@ -1,0 +1,59 @@
+/* @flow */
+
+import api from 'core/api';
+
+export const RECEIVE: 'locales/RECEIVE' = 'locales/RECEIVE';
+export const REQUEST: 'locales/REQUEST' = 'locales/REQUEST';
+
+export type Locale = {|
+    +code: string,
+    +cldrPlurals: Array<number>,
+    +pluralRule: string,
+    +direction: string,
+    +name: string,
+|};
+
+
+export type RequestAction = {|
+    type: typeof REQUEST,
+|};
+export function request() {
+    return {
+        type: REQUEST,
+    };
+}
+
+
+export type ReceiveAction = {|
+    type: typeof RECEIVE,
+    locales: { [string]: Locale },
+|};
+export function receive(locales: { [string]: Locale }) {
+    return {
+        type: RECEIVE,
+        locales,
+    };
+}
+
+
+export function get(): Function {
+    return async dispatch => {
+        dispatch(request());
+
+        const results = await api.locale.getAll();
+        const locales = {};
+        results.data.locales.forEach(locale => {
+            locales[locale.code] = {
+                ...locale,
+                cldrPlurals: locale.cldrPlurals.split(',').map(i => parseInt(i, 10)),
+            };
+        });
+
+        dispatch(receive(locales));
+    }
+}
+
+export default {
+    request,
+    get,
+};

--- a/frontend/src/core/locales/index.js
+++ b/frontend/src/core/locales/index.js
@@ -1,11 +1,13 @@
 /* @flow */
 
 export { default as actions } from './actions';
+export { default as reducer } from './reducer';
 export { default as selectors } from './selectors';
 
-export { default as EntityDetails } from './components/EntityDetails';
+export type { Locale } from './actions';
+export type { LocalesState } from './reducer';
 
 
 // Name of this module.
 // Used as the key to store this module's reducer.
-export const NAME: string = 'entitydetails';
+export const NAME: string = 'locales';

--- a/frontend/src/core/locales/reducer.js
+++ b/frontend/src/core/locales/reducer.js
@@ -1,0 +1,42 @@
+/* @flow */
+
+import { RECEIVE, REQUEST } from './actions';
+import type { Locale, ReceiveAction, RequestAction } from './actions';
+
+
+type Action =
+    | ReceiveAction
+    | RequestAction
+;
+
+export type LocalesState = {|
+    +fetching: boolean,
+    +locales: { [string]: Locale },
+|};
+
+
+const initial: LocalesState = {
+    fetching: false,
+    locales: {},
+};
+
+export default function reducer(
+    state: LocalesState = initial,
+    action: Action,
+): LocalesState {
+    switch (action.type) {
+        case RECEIVE:
+            return {
+                ...state,
+                fetching: false,
+                locales: action.locales,
+            };
+        case REQUEST:
+            return {
+                ...state,
+                fetching: true,
+            };
+        default:
+            return state;
+    }
+}

--- a/frontend/src/core/locales/reducer.test.js
+++ b/frontend/src/core/locales/reducer.test.js
@@ -1,0 +1,29 @@
+import reducer from './reducer';
+import { RECEIVE, REQUEST } from './actions';
+
+
+describe('reducer', () => {
+    it('returns the initial state', () => {
+        const res = reducer(undefined, {});
+        const expected = {
+            fetching: false,
+            locales: {},
+        }
+        expect(res).toEqual(expected);
+    });
+
+    it('handles the REQUEST action', () => {
+        const res = reducer({}, { type: REQUEST });
+        expect(res.fetching).toEqual(true);
+    });
+
+    it('handles the RECEIVE action', () => {
+        const LOCALES = { 'kg': { code: 'kg' } };
+        const res = reducer({}, { type: RECEIVE, locales: LOCALES });
+        const expected = {
+            fetching: false,
+            locales: LOCALES,
+        };
+        expect(res).toEqual(expected);
+    });
+});

--- a/frontend/src/core/locales/selectors.js
+++ b/frontend/src/core/locales/selectors.js
@@ -1,0 +1,39 @@
+/* @flow */
+
+import { createSelector } from 'reselect';
+
+import * as navigation from 'core/navigation';
+
+import { NAME } from '.';
+
+import type { Navigation } from 'core/navigation';
+import type { Locale, LocalesState } from '.';
+
+
+const localesSelector = (state): LocalesState => state[NAME].locales;
+
+
+export function _getCurrentLocaleData(
+    locales: LocalesState,
+    parameters: Navigation
+): ?Locale {
+    if (locales && parameters.locale && locales[parameters.locale]) {
+        return locales[parameters.locale];
+    }
+    return null;
+}
+
+
+/**
+ * Return metadata about the currently selected locale.
+ */
+export const getCurrentLocaleData: Function = createSelector(
+    localesSelector,
+    navigation.selectors.getNavigation,
+    _getCurrentLocaleData
+);
+
+
+export default {
+    getCurrentLocaleData,
+};

--- a/frontend/src/core/locales/selectors.test.js
+++ b/frontend/src/core/locales/selectors.test.js
@@ -1,0 +1,30 @@
+import { _getCurrentLocaleData } from './selectors';
+
+
+describe('getCurrentLocaleData', () => {
+    it('returns null when data is missing', () => {
+        expect(
+            _getCurrentLocaleData({}, {})
+        ).toBeNull();
+
+        expect(
+            _getCurrentLocaleData({'kg': { code: 'kg' }}, {})
+        ).toBeNull();
+
+        expect(
+            _getCurrentLocaleData({'kg': { code: 'kg' }}, { locale: 'kr' })
+        ).toBeNull();
+    });
+
+    it('returns the correct locale', () => {
+        const LOCALES = {
+            'kr': { code: 'kr' },
+            'kg': { code: 'kg' },
+            'un': { code: 'un' },
+        };
+
+        expect(
+            _getCurrentLocaleData(LOCALES, { locale: 'kr' })
+        ).toEqual(LOCALES['kr']);
+    });
+});

--- a/frontend/src/core/plural/actions.js
+++ b/frontend/src/core/plural/actions.js
@@ -1,0 +1,32 @@
+/* @flow */
+
+export const RESET: 'plural/RESET' = 'plural/RESET';
+export const SELECT: 'plural/SELECT' = 'plural/SELECT';
+
+
+export type ResetAction = {|
+    type: typeof RESET,
+|};
+export function reset() {
+    return {
+        type: RESET,
+    };
+}
+
+
+export type SelectAction = {|
+    type: typeof SELECT,
+    pluralForm: number,
+|};
+export function select(pluralForm: number) {
+    return {
+        type: SELECT,
+        pluralForm,
+    };
+}
+
+
+export default {
+    reset,
+    select,
+};

--- a/frontend/src/core/plural/components/PluralSelector.css
+++ b/frontend/src/core/plural/components/PluralSelector.css
@@ -1,0 +1,35 @@
+.plural-selector ul {
+    display: table;
+    line-height: 22px;
+    table-layout: fixed;
+    width: 100%;
+}
+
+.plural-selector ul li {
+    background: #4D5967;
+    border: 1px solid #5E6475;
+    border-left: none;
+    display: table-cell;
+    text-align: center;
+    text-transform: uppercase;
+}
+
+.plural-selector ul li.active,
+.plural-selector ul li:hover {
+    background: #3F4752;
+    border-bottom: none;
+}
+
+.plural-selector ul li a {
+    color: #ccc;
+    cursor: pointer;
+    display: block;
+    padding: 10px;
+}
+
+.plural-selector ul li a sup {
+    color: #7BC876;
+    font-size: 11px;
+    font-weight: 400;
+    padding-left: 1px;
+}

--- a/frontend/src/core/plural/components/PluralSelector.css
+++ b/frontend/src/core/plural/components/PluralSelector.css
@@ -17,6 +17,8 @@
 .plural-selector ul li.active,
 .plural-selector ul li:hover {
     background: #3F4752;
+}
+.plural-selector ul li.active {
     border-bottom: none;
 }
 

--- a/frontend/src/core/plural/components/PluralSelector.js
+++ b/frontend/src/core/plural/components/PluralSelector.js
@@ -1,0 +1,102 @@
+/* @flow */
+
+import * as React from 'react';
+import { connect } from 'react-redux';
+
+import './PluralSelector.css';
+
+import { actions, selectors } from '..';
+import * as locales from 'core/locales';
+
+import type { Locale } from 'core/locales';
+
+
+type Props = {|
+    pluralForm: number,
+    locale: Locale,
+|};
+
+type InternalProps = {|
+    ...Props,
+    dispatch: Function,
+|};
+
+
+const CLDR_PLURALS: Array<string> = [
+    'zero',
+    'one',
+    'two',
+    'few',
+    'many',
+    'other',
+];
+
+
+/**
+ * Plural form picker component.
+ *
+ * Shows a list of available plural forms for the current locale, and allows
+ * to change selected plural form.
+ */
+export class PluralSelectorBase extends React.Component<InternalProps> {
+    selectPluralForm(pluralForm: number) {
+        if (this.props.pluralForm === pluralForm) {
+            return;
+        }
+
+        this.props.dispatch(actions.select(pluralForm));
+    }
+
+    render() {
+        const { pluralForm, locale } = this.props;
+
+        if (pluralForm === -1 || !locale || locale.cldrPlurals.length <= 1) {
+            return null;
+        }
+
+        const nbPlurals = locale.cldrPlurals.length;
+        const examples = {};
+
+        if (nbPlurals === 2) {
+            examples[locale.cldrPlurals[0]] = 1;
+            examples[locale.cldrPlurals[1]] = 2;
+        }
+        else {
+            // This variable is used in the pluralRule we eval in the while block.
+            let n = 0;
+            while (Object.keys(examples).length < nbPlurals) {
+                // This `eval` is not so much evil. The pluralRule we parse
+                // comes from our database and is not a user input.
+                // eslint-disable-next-line
+                const rule = eval(locale.pluralRule);
+                if (!examples[locale.cldrPlurals[rule]]) {
+                    examples[locale.cldrPlurals[rule]] = n;
+                }
+                n++;
+            }
+        }
+
+        return <nav className="plural-selector">
+            <ul>
+                { locale.cldrPlurals.map((item, i) => {
+                    return <li key={ item } className={ i === pluralForm ? 'active' : '' }>
+                        <a onClick={ () => this.selectPluralForm(i) }>
+                            <span>{ CLDR_PLURALS[item] }</span>
+                            <sup>{ examples[item] }</sup>
+                        </a>
+                    </li>;
+                }) }
+            </ul>
+        </nav>;
+    }
+}
+
+
+const mapStateToProps = (state: Object): Props => {
+    return {
+        pluralForm: selectors.getPluralForm(state),
+        locale: locales.selectors.getCurrentLocaleData(state),
+    };
+};
+
+export default connect(mapStateToProps)(PluralSelectorBase);

--- a/frontend/src/core/plural/components/PluralSelector.test.js
+++ b/frontend/src/core/plural/components/PluralSelector.test.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+
+import { createReduxStore } from 'test/store';
+import { shallowUntilTarget } from 'test/utils';
+
+import { actions } from '..';
+
+import PluralSelector, { PluralSelectorBase } from './PluralSelector';
+
+
+function createShallowPluralSelector(plural, locale) {
+    return shallow(<PluralSelectorBase
+        pluralForm={ plural }
+        locale={ locale }
+    />);
+}
+
+
+describe('<PluralSelectorBase>', () => {
+    it('returns null when the locale is missing', () => {
+        const wrapper = createShallowPluralSelector(0, null);
+        expect(wrapper.type()).toBeNull();
+    });
+
+    it('returns null when the locale has only one plural form', () => {
+        const wrapper = createShallowPluralSelector(0, { cldrPlurals: [5] });
+        expect(wrapper.type()).toBeNull();
+    });
+
+    it('returns null when the selected plural form is -1', () => {
+        // If pluralForm is -1, it means the entity has no plural string.
+        const wrapper = createShallowPluralSelector(-1, { cldrPlurals: [1, 5] });
+        expect(wrapper.type()).toBeNull();
+    });
+
+    it('shows the correct list of plural choices for locale with 2 forms', () => {
+        const wrapper = createShallowPluralSelector(0, { cldrPlurals: [1, 5] });
+
+        expect(wrapper.find('li')).toHaveLength(2);
+        expect(wrapper.find('ul').text()).toEqual('one1other2');
+    });
+
+    it('shows the correct list of plural choices for locale with all 6 forms', () => {
+        const wrapper = createShallowPluralSelector(
+            0,
+            {
+                cldrPlurals: [0, 1, 2, 3, 4, 5],
+                // This is the pluralRule for Arabic.
+                pluralRule: '(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5)'
+            },
+        );
+
+        expect(wrapper.find('li')).toHaveLength(6);
+        expect(wrapper.find('ul').text()).toEqual('zero0one1two2few3many11other100');
+    });
+
+    it('marks the right choice as active', () => {
+        const wrapper = createShallowPluralSelector(1, { cldrPlurals: [1, 5] });
+
+        expect(wrapper.find('li.active').text()).toEqual('other2');
+    });
+});
+
+
+describe('<PluralSelector>', () => {
+    it('selects the correct form when clicking a choice', () => {
+        const initialState = {
+            plural: {
+                pluralForm: 1,
+            },
+            locales: {
+                locales: {
+                    'kg': {
+                        cldrPlurals: [1, 5],
+                    }
+                },
+            },
+            router: {
+                location: {
+                    pathname: '/kg/pro/all/',
+                    search: '?string=42',
+                }
+            },
+        }
+        const store = createReduxStore(initialState);
+        const dispatchSpy = sinon.spy(store, 'dispatch');
+
+        const wrapper = shallowUntilTarget(
+            <PluralSelector store={ store } />,
+            PluralSelectorBase
+        );
+
+        wrapper.find('a').first().simulate('click');
+
+        const expectedAction = actions.select(0);
+        expect(dispatchSpy.calledWith(expectedAction)).toBeTruthy();
+    });
+});

--- a/frontend/src/core/plural/index.js
+++ b/frontend/src/core/plural/index.js
@@ -1,0 +1,14 @@
+/* @flow */
+
+export { default as actions } from './actions';
+export { default as reducer } from './reducer';
+export { default as selectors } from './selectors';
+
+export { default as PluralSelector } from './components/PluralSelector';
+
+export type { PluralState } from './reducer';
+
+
+// Name of this module.
+// Used as the key to store this module's reducer.
+export const NAME: string = 'plural';

--- a/frontend/src/core/plural/reducer.js
+++ b/frontend/src/core/plural/reducer.js
@@ -1,0 +1,39 @@
+/* @flow */
+
+import { RESET, SELECT } from './actions';
+import type { ResetAction, SelectAction } from './actions';
+
+
+type Action =
+    | ResetAction
+    | SelectAction
+;
+
+export type PluralState = {|
+    +pluralForm: number,
+|};
+
+
+const initial: PluralState = {
+    pluralForm: -1,
+};
+
+export default function reducer(
+    state: PluralState = initial,
+    action: Action,
+): PluralState {
+    switch (action.type) {
+        case SELECT:
+            return {
+                ...state,
+                pluralForm: action.pluralForm,
+            };
+        case RESET:
+        case '@@router/LOCATION_CHANGE':
+            return {
+                ...initial,
+            };
+        default:
+            return state;
+    }
+}

--- a/frontend/src/core/plural/reducer.test.js
+++ b/frontend/src/core/plural/reducer.test.js
@@ -1,0 +1,23 @@
+import reducer from './reducer';
+import { RESET, SELECT } from './actions';
+
+
+describe('reducer', () => {
+    it('returns the initial state', () => {
+        const res = reducer(undefined, {});
+        const expected = {
+            pluralForm: -1,
+        }
+        expect(res).toEqual(expected);
+    });
+
+    it('handles the SELECT action', () => {
+        const res = reducer({}, { type: SELECT, pluralForm: 2 });
+        expect(res).toEqual({ pluralForm: 2 });
+    });
+
+    it('handles the RESET action', () => {
+        const res = reducer({}, { type: RESET });
+        expect(res).toEqual({ pluralForm: -1 });
+    });
+});

--- a/frontend/src/core/plural/selectors.js
+++ b/frontend/src/core/plural/selectors.js
@@ -1,0 +1,36 @@
+/* @flow */
+
+import { createSelector } from 'reselect';
+
+import * as entitieslist from 'modules/entitieslist';
+
+import type { DbEntity } from 'modules/entitieslist';
+
+
+const pluralSelector = (state): number => state.plural.pluralForm;
+
+
+export function _getPluralForm(pluralForm: number, entity: ?DbEntity): number {
+    if (pluralForm === -1 && entity && entity.original_plural) {
+        return 0;
+    }
+    return pluralForm;
+}
+
+/**
+ * Return the plural form to use for the currently selected entity.
+ *
+ * If the entity has a plural form, and the current plural form is -1,
+ * this will correctly return 0 instead of -1. In all other cases, return
+ * the plural form as stored in the state.
+ */
+export const getPluralForm: Function = createSelector(
+    pluralSelector,
+    entitieslist.selectors.getSelectedEntity,
+    _getPluralForm
+);
+
+
+export default {
+    getPluralForm,
+};

--- a/frontend/src/core/plural/selectors.test.js
+++ b/frontend/src/core/plural/selectors.test.js
@@ -1,0 +1,16 @@
+import { _getPluralForm } from './selectors';
+
+
+describe('getPluralForm', () => {
+    it('returns the plural form', () => {
+        expect(_getPluralForm(3, null)).toEqual(3);
+        expect(_getPluralForm(-1, null)).toEqual(-1);
+        expect(_getPluralForm(-1, { original_plural: '' })).toEqual(-1);
+    });
+
+    it('corrects the plural number', () => {
+        expect(
+            _getPluralForm(-1, { original_plural: 'I have a plural!' })
+        ).toEqual(0);
+    });
+});

--- a/frontend/src/modules/entitieslist/actions.js
+++ b/frontend/src/modules/entitieslist/actions.js
@@ -47,15 +47,18 @@ export function receive(entities: Array<Object>, hasMore: boolean): ReceiveActio
 export type UpdateAction = {
     type: typeof UPDATE,
     entity: number,
+    pluralForm: number,
     translation: Translation,
 };
 export function updateEntityTranslation(
    entity: number,
+   pluralForm: number,
    translation: Translation
 ): UpdateAction {
     return {
         type: UPDATE,
         entity,
+        pluralForm,
         translation,
     };
 }

--- a/frontend/src/modules/entitieslist/reducer.js
+++ b/frontend/src/modules/entitieslist/reducer.js
@@ -41,15 +41,27 @@ export type State = {
 };
 
 
-function updateEntities(state: Object, entity: number, translation: Translation): Entities {
+function updateEntityTranslation(
+    state: Object,
+    entity: number,
+    pluralForm: number,
+    translation: Translation
+): Entities {
     return state.entities.map(item => {
         if (item.pk !== entity) {
             return item;
         }
 
+        const translations = [ ...item.translation ];
+
+        // If the plural form is -1, then there's no plural and we should
+        // simply update the first translation.
+        const plural = pluralForm === -1 ? 0 : pluralForm;
+        translations[plural] = translation;
+
         return {
             ...item,
-            translation: [translation]
+            translation: translations,
         };
     })
 }
@@ -90,7 +102,12 @@ export default function reducer(
         case UPDATE:
             return {
                 ...state,
-                entities: updateEntities(state, action.entity, action.translation),
+                entities: updateEntityTranslation(
+                    state,
+                    action.entity,
+                    action.pluralForm,
+                    action.translation
+                ),
             };
         default:
             return state;

--- a/frontend/src/modules/entitieslist/reducer.js
+++ b/frontend/src/modules/entitieslist/reducer.js
@@ -21,6 +21,7 @@ export type Translation = {
 export type DbEntity = {
     +pk: number,
     +original: string,
+    +original_plural: string,
     +comment: string,
     +key: string,
     +path: string,

--- a/frontend/src/modules/entitieslist/selectors.js
+++ b/frontend/src/modules/entitieslist/selectors.js
@@ -2,7 +2,7 @@
 
 import { createSelector } from 'reselect';
 
-import { selectors as navSelectors } from 'core/navigation';
+import * as navigation from 'core/navigation';
 import type { Navigation } from 'core/navigation';
 
 import { NAME } from '.';
@@ -10,32 +10,6 @@ import type { Entities, DbEntity } from './reducer';
 
 
 const entitiesSelector = (state): string => state[NAME].entities;
-
-
-export function _getTranslationForSelectedEntity(
-    entities: Entities,
-    params: Navigation,
-): string {
-    const entityId = params.entity;
-    const entity = entities.find(element => element.pk === entityId);
-    if (entity && entity.translation[0].string && !entity.translation[0].rejected) {
-        return entity.translation[0].string;
-    }
-    return '';
-}
-
-
-/**
- * Return the active translation string for the currently selected Entity.
- *
- * The active translation is either the approved one, the fuzzy one, or the
- * most recent non-rejected one.
- */
-export const getTranslationForSelectedEntity: Function = createSelector(
-    entitiesSelector,
-    navSelectors.getNavigation,
-    _getTranslationForSelectedEntity
-);
 
 
 export function _getSelectedEntity(
@@ -51,12 +25,11 @@ export function _getSelectedEntity(
  */
 export const getSelectedEntity: Function = createSelector(
     entitiesSelector,
-    navSelectors.getNavigation,
+    navigation.selectors.getNavigation,
     _getSelectedEntity
 );
 
 
 export default {
-    getTranslationForSelectedEntity,
     getSelectedEntity,
 };

--- a/frontend/src/modules/entitieslist/selectors.test.js
+++ b/frontend/src/modules/entitieslist/selectors.test.js
@@ -1,59 +1,9 @@
 import {
     _getSelectedEntity,
-    _getTranslationForSelectedEntity,
 } from './selectors';
 
 
 describe('selectors', () => {
-    describe('getTranslationForSelectedEntity', () => {
-
-        const entities = [
-            {
-                pk: 1,
-                translation: [
-                    {
-                        string: 'hello',
-                    },
-                ],
-            },
-            {
-                pk: 2,
-                translation: [
-                    {
-                        string: 'world',
-                    },
-                ],
-            },
-            {
-                pk: 3,
-                translation: [
-                    {
-                        string: 'wat',
-                        rejected: true,
-                    },
-                ],
-            },
-        ];
-
-        it('returns the correct string', () => {
-            const navigation = {
-                entity: 2,
-            };
-            const res = _getTranslationForSelectedEntity(entities, navigation);
-
-            expect(res).toEqual('world');
-        });
-
-        it('does not return rejected translations', () => {
-            const navigation = {
-                entity: 3,
-            };
-            const res = _getTranslationForSelectedEntity(entities, navigation);
-
-            expect(res).toEqual('');
-        });
-    });
-
     describe('getSelectedEntity', () => {
         const entities = [
             {

--- a/frontend/src/modules/entitydetails/actions.js
+++ b/frontend/src/modules/entitydetails/actions.js
@@ -10,13 +10,14 @@ export function suggest(
     translation: string,
     locale: string,
     original: string,
+    pluralForm: number,
 ): Function {
     return async dispatch => {
         const content = await api.translation.updateTranslation(
             entity,
             translation,
             locale,
-            '0',  // plural_form
+            pluralForm,
             original,
         );
 
@@ -30,6 +31,7 @@ export function suggest(
             dispatch(
                 entitiesActions.updateEntityTranslation(
                     entity,
+                    pluralForm,
                     content.translation
                 )
             );

--- a/frontend/src/modules/entitydetails/components/Editor.js
+++ b/frontend/src/modules/entitydetails/components/Editor.js
@@ -4,13 +4,16 @@ import * as React from 'react';
 
 import './Editor.css';
 
+import { PluralSelector } from 'core/plural';
+
 import type { DbEntity } from 'modules/entitieslist';
 
 
 type Props = {|
-    activeTranslation: string,
-    selectedEntity: ?DbEntity,
+    translation: string,
+    entity: ?DbEntity,
     sendSuggestion: Function,
+    pluralForm: number,
 |};
 
 type State = {|
@@ -22,48 +25,52 @@ type State = {|
  * Editor for translation strings.
  */
 export default class Editor extends React.Component<Props, State> {
-    constructor(props: Props): void {
+    constructor(props: Props) {
         super(props);
         this.state = {
-            translation: props.activeTranslation,
+            translation: props.translation,
         };
     }
 
-    componentDidUpdate(prevProps: Props): void {
-        if (this.props.activeTranslation !== prevProps.activeTranslation) {
+    componentDidUpdate(prevProps: Props) {
+        if (this.props.translation !== prevProps.translation) {
             this.setState({
-                translation: this.props.activeTranslation,
+                translation: this.props.translation,
             });
         }
     }
 
-    handleChange = (event: SyntheticInputEvent<HTMLTextAreaElement>): void => {
+    handleChange = (event: SyntheticInputEvent<HTMLTextAreaElement>) => {
         this.setState({
             translation: event.currentTarget.value,
         });
     }
 
-    copyOriginalIntoEditor = (): void => {
-        const { selectedEntity } = this.props;
-        if (selectedEntity) {
-            this.setState({
-                translation: selectedEntity.original,
-            });
+    copyOriginalIntoEditor = () => {
+        const { entity, pluralForm } = this.props;
+        if (entity) {
+            if (pluralForm === -1 || pluralForm === 1) {
+                this.setState({ translation: entity.original });
+            }
+            else {
+                this.setState({ translation: entity.original_plural });
+            }
         }
     }
 
-    clearEditor = (): void => {
+    clearEditor = () => {
         this.setState({
             translation: '',
         });
     }
 
-    sendSuggestion = (): void => {
+    sendSuggestion = () => {
         this.props.sendSuggestion(this.state.translation);
     }
 
-    render(): React.Node {
+    render() {
         return <div className="editor">
+            <PluralSelector />
             <textarea
                 value={ this.state.translation }
                 onChange={ this.handleChange }

--- a/frontend/src/modules/entitydetails/components/Editor.test.js
+++ b/frontend/src/modules/entitydetails/components/Editor.test.js
@@ -6,18 +6,24 @@ import Editor from './Editor';
 
 
 const TRANSLATION = 'test';
+const TRANSLATION_PLURAL = 'test plural';
 const SELECTED_ENTITY = {
     pk: 42,
     original: 'le test',
-    translation: [{string: TRANSLATION}],
+    original_plural: 'les tests',
+    translation: [
+        { string: TRANSLATION },
+        { string: TRANSLATION_PLURAL },
+    ],
 };
 
 
-function createShallowEditor(suggestMock = null) {
+function createShallowEditor(suggestMock = null, pluralForm = -1) {
     return shallow(<Editor
-        activeTranslation={ TRANSLATION }
-        selectedEntity={ SELECTED_ENTITY }
+        translation={ (Math.abs(pluralForm) !== 1) ? TRANSLATION_PLURAL : TRANSLATION }
+        entity={ SELECTED_ENTITY }
         sendSuggestion={ suggestMock }
+        pluralForm={ pluralForm }
     />);
 }
 
@@ -52,6 +58,14 @@ describe('<Editor>', () => {
         expect(wrapper.state('translation')).toEqual(TRANSLATION);
         wrapper.find('.action-copy').simulate('click');
         expect(wrapper.state('translation')).toEqual(SELECTED_ENTITY.original);
+    });
+
+    it('copies the plural original string in the textarea when the Copy button is clicked', () => {
+        const wrapper = createShallowEditor(null, 5);
+
+        expect(wrapper.state('translation')).toEqual(TRANSLATION_PLURAL);
+        wrapper.find('.action-copy').simulate('click');
+        expect(wrapper.state('translation')).toEqual(SELECTED_ENTITY.original_plural);
     });
 
     it('calls the suggest action when the Suggest button is clicked', () => {

--- a/frontend/src/modules/entitydetails/components/EntityDetails.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.js
@@ -61,6 +61,7 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
             translation,
             state.locale.code,
             state.selectedEntity.original,
+            state.pluralForm,
         ));
     }
 

--- a/frontend/src/modules/entitydetails/components/EntityDetails.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.js
@@ -6,14 +6,18 @@ import { connect } from 'react-redux';
 import { suggest } from '../actions';
 
 import { actions as lightboxActions } from 'core/lightbox';
-import { selectors as navSelectors } from 'core/navigation';
+import * as locales from 'core/locales';
+import * as navigation from 'core/navigation';
+import * as plural from 'core/plural';
 import * as entitieslist from 'modules/entitieslist';
 import { History } from 'modules/history';
 
+import { selectors } from '..';
 import Editor from './Editor';
 import Metadata from './Metadata';
 
 import type { DbEntity } from 'modules/entitieslist';
+import type { Locale } from 'core/locales';
 import type { Navigation } from 'core/navigation';
 
 
@@ -21,6 +25,8 @@ type Props = {|
     activeTranslation: string,
     navigation: Navigation,
     selectedEntity: ?DbEntity,
+    pluralForm: number,
+    locale: ?Locale,
 |};
 
 type InternalProps = {|
@@ -44,32 +50,42 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
     }
 
     sendSuggestion = (translation: string) => {
-        const { navigation, selectedEntity } = this.props;
+        const state = this.props;
 
-        if (!selectedEntity) {
+        if (!state.selectedEntity || !state.locale) {
             return;
         }
 
         this.props.dispatch(suggest(
-            selectedEntity.pk,
+            state.selectedEntity.pk,
             translation,
-            navigation.locale,
-            selectedEntity.original,
+            state.locale.code,
+            state.selectedEntity.original,
         ));
     }
 
     render() {
-        const { activeTranslation, navigation, selectedEntity } = this.props;
+        const state = this.props;
 
-        if (!selectedEntity) {
+        if (!state.locale) {
+            return null;
+        }
+
+        if (!state.selectedEntity) {
             return <section className="entity-details">Select an entity</section>;
         }
 
         return <section className="entity-details">
-            <Metadata entity={ selectedEntity } locale={ navigation.locale } openLightbox={ this.openLightbox } />
+            <Metadata
+                entity={ state.selectedEntity }
+                locale={ state.locale }
+                pluralForm={ state.pluralForm }
+                openLightbox={ this.openLightbox }
+            />
             <Editor
-                activeTranslation={ activeTranslation}
-                selectedEntity={ selectedEntity }
+                translation={ state.activeTranslation}
+                entity={ state.selectedEntity }
+                pluralForm= { state.pluralForm }
                 sendSuggestion={ this.sendSuggestion }
             />
             <History />
@@ -80,9 +96,11 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
 
 const mapStateToProps = (state: Object): Props => {
     return {
-        activeTranslation: entitieslist.selectors.getTranslationForSelectedEntity(state),
+        activeTranslation: selectors.getTranslationForSelectedEntity(state),
         selectedEntity: entitieslist.selectors.getSelectedEntity(state),
-        navigation: navSelectors.getNavigation(state),
+        navigation: navigation.selectors.getNavigation(state),
+        pluralForm: plural.selectors.getPluralForm(state),
+        locale: locales.selectors.getCurrentLocaleData(state),
     };
 };
 

--- a/frontend/src/modules/entitydetails/components/EntityDetails.test.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.test.js
@@ -20,6 +20,9 @@ const NAVIGATION = {
     entity: 42,
     locale: 'kg',
 };
+const PARAMETERS = {
+    pluralForm: 0,
+};
 
 
 function createShallowEntityDetails(selectedEntity = SELECTED_ENTITY) {
@@ -27,6 +30,8 @@ function createShallowEntityDetails(selectedEntity = SELECTED_ENTITY) {
         activeTranslation={ TRANSLATION }
         navigation={ NAVIGATION }
         selectedEntity={ selectedEntity }
+        parameters={ PARAMETERS }
+        locale={ { code: 'kg' } }
     />);
 }
 
@@ -79,6 +84,13 @@ describe('<EntityDetails>', () => {
                 location: {
                     pathname: '/kg/pro/all/',
                     search: '?string=' + ENTITIES[0].pk,
+                },
+            },
+            locales: {
+                locales: {
+                    'kg': {
+                        code: 'kg',
+                    },
                 },
             },
         };

--- a/frontend/src/modules/entitydetails/components/Metadata.css
+++ b/frontend/src/modules/entitydetails/components/Metadata.css
@@ -7,6 +7,16 @@
     padding: 10px;
 }
 
+.metadata h2 {
+    font-style: normal;
+    font-size: 11px;
+    font-weight: 300;
+    line-height: 11px;
+    margin-top: 6px;
+    text-transform: uppercase;
+    padding-bottom: 2px;
+}
+
 .metadata .title {
     color: #888;
     text-transform: uppercase;

--- a/frontend/src/modules/entitydetails/components/Metadata.js
+++ b/frontend/src/modules/entitydetails/components/Metadata.js
@@ -7,13 +7,16 @@ import Linkify from 'react-linkify';
 import './Metadata.css';
 
 import Screenshots from './Screenshots';
+
+import type { Locale } from 'core/locales';
 import type { DbEntity } from 'modules/entitieslist';
 
 
 type PropertyProps = {|
-    title: string,
-    children: React.Node,
+    +title: string,
+    +children: React.Node,
 |};
+
 
 /**
  * Component to dislay a property of an entity.
@@ -33,9 +36,10 @@ class Property extends React.Component<PropertyProps> {
 
 
 type Props = {|
-    entity: DbEntity,
-    locale: string,
-    openLightbox: Function,
+    +entity: DbEntity,
+    +locale: Locale,
+    +pluralForm: number,
+    +openLightbox: Function,
 |};
 
 
@@ -51,6 +55,27 @@ type Props = {|
  *  - a link to the project
  */
 export default class Metadata extends React.Component<Props> {
+    renderOriginal(entity: DbEntity): React.Node {
+        const { pluralForm, locale } = this.props;
+
+        if (pluralForm === -1) {
+            return <p className="original">{ entity.original }</p>;
+        }
+
+        let title = 'Plural';
+        let original = entity.original_plural;
+
+        if (locale.cldrPlurals[pluralForm] === 1) {
+            title = 'Singular';
+            original = entity.original;
+        }
+
+        return <React.Fragment>
+            <h2>{ title }</h2>
+            <p className="original">{ original }</p>
+        </React.Fragment>;
+    }
+
     renderComment(entity: DbEntity): React.Node {
         if (!entity.comment) {
             return null;
@@ -127,20 +152,20 @@ export default class Metadata extends React.Component<Props> {
         return <div className="metadata">
             <Screenshots
                 source={ entity.comment }
-                locale={ locale }
+                locale={ locale.code }
                 openLightbox={ openLightbox }
             />
-            <p className="original">{ entity.original }</p>
+            { this.renderOriginal(entity) }
             { this.renderComment(entity) }
             { this.renderContext(entity) }
             { this.renderSources(entity) }
             <Property title='Resource'>
-                <Link to={ `/${locale}/${entity.project.slug}/${entity.path}/` }>
+                <Link to={ `/${locale.code}/${entity.project.slug}/${entity.path}/` }>
                     { entity.path }
                 </Link>
             </Property>
             <Property title='Project'>
-                <a href={ `/${locale}/${entity.project.slug}/` }>
+                <a href={ `/${locale.code}/${entity.project.slug}/` }>
                     { entity.project.name }
                 </a>
             </Property>

--- a/frontend/src/modules/entitydetails/components/Metadata.test.js
+++ b/frontend/src/modules/entitydetails/components/Metadata.test.js
@@ -7,23 +7,32 @@ import Metadata from './Metadata';
 const ENTITY = {
     pk: 42,
     original: 'le test',
+    original_plural: 'les tests',
     comment: 'my comment',
     path: 'path/to/RESOURCE',
     source: [
         ['file_source.rs', '31'],
     ],
-    translation: [{string: 'the test'}],
+    translation: [
+        { string: 'the test' },
+        { string: 'plural' },
+    ],
     project: {
         slug: 'callme',
         name: 'CallMe',
     },
 };
+const LOCALE = {
+    code: 'kg',
+    cldrPlurals: [1, 3, 5],
+};
 
 
-function createShallowMetadata(entity = ENTITY) {
+function createShallowMetadata(entity = ENTITY, pluralForm = -1) {
     return shallow(<Metadata
         entity={ entity }
-        locale="kg"
+        locale={ LOCALE }
+        pluralForm={ pluralForm }
     />);
 }
 
@@ -41,6 +50,22 @@ describe('<Metadata>', () => {
         expect(content).toContain(ENTITY.comment);
 
         expect(wrapper.find('Link').props().to).toContain(ENTITY.path);
+    });
+
+    it('renders the selected plural form as original string', () => {
+        const wrapper = createShallowMetadata(ENTITY, 2);
+
+        const text = wrapper.text();
+        expect(text).toContain('Plural');
+        expect(text).toContain(ENTITY.original_plural);
+    });
+
+    it('renders the selected singular form as original string', () => {
+        const wrapper = createShallowMetadata(ENTITY, 0);
+
+        const text = wrapper.text();
+        expect(text).toContain('Singular');
+        expect(text).toContain(ENTITY.original);
     });
 
     it('does not require a comment', () => {

--- a/frontend/src/modules/entitydetails/selectors.js
+++ b/frontend/src/modules/entitydetails/selectors.js
@@ -1,0 +1,50 @@
+/* @flow */
+
+import { createSelector } from 'reselect';
+
+import * as navigation from 'core/navigation';
+import * as plural from 'core/plural';
+import * as entitieslist from 'modules/entitieslist';
+
+import type { Navigation } from 'core/navigation';
+import type { Entities } from 'modules/entitieslist';
+
+
+const entitiesSelector = (state): string => state[entitieslist.NAME].entities;
+
+
+export function _getTranslationForSelectedEntity(
+    entities: Entities,
+    params: Navigation,
+    pluralForm: number,
+): string {
+    const entityId = params.entity;
+    const entity = entities.find(element => element.pk === entityId);
+    if (pluralForm === -1) {
+        pluralForm = 0;
+    }
+    if (entity && entity.translation[pluralForm].string && !entity.translation[pluralForm].rejected) {
+        return entity.translation[pluralForm].string;
+    }
+    return '';
+}
+
+
+/**
+ * Return the active translation string for the currently selected entity
+ * and plural form.
+ *
+ * The active translation is either the approved one, the fuzzy one, or the
+ * most recent non-rejected one.
+ */
+export const getTranslationForSelectedEntity: Function = createSelector(
+    entitiesSelector,
+    navigation.selectors.getNavigation,
+    plural.selectors.getPluralForm,
+    _getTranslationForSelectedEntity
+);
+
+
+export default {
+    getTranslationForSelectedEntity,
+};

--- a/frontend/src/modules/entitydetails/selectors.test.js
+++ b/frontend/src/modules/entitydetails/selectors.test.js
@@ -1,0 +1,55 @@
+import {
+    _getTranslationForSelectedEntity,
+} from './selectors';
+
+
+describe('selectors', () => {
+    describe('getTranslationForSelectedEntity', () => {
+
+        const entities = [
+            {
+                pk: 1,
+                translation: [
+                    {
+                        string: 'hello',
+                    },
+                ],
+            },
+            {
+                pk: 2,
+                translation: [
+                    {
+                        string: 'world',
+                    },
+                ],
+            },
+            {
+                pk: 3,
+                translation: [
+                    {
+                        string: 'wat',
+                        rejected: true,
+                    },
+                ],
+            },
+        ];
+
+        it('returns the correct string', () => {
+            const navigation = {
+                entity: 2,
+            };
+            const res = _getTranslationForSelectedEntity(entities, navigation, -1);
+
+            expect(res).toEqual('world');
+        });
+
+        it('does not return rejected translations', () => {
+            const navigation = {
+                entity: 3,
+            };
+            const res = _getTranslationForSelectedEntity(entities, navigation, -1);
+
+            expect(res).toEqual('');
+        });
+    });
+});

--- a/frontend/src/modules/history/actions.js
+++ b/frontend/src/modules/history/actions.js
@@ -32,11 +32,11 @@ export function request(entity: number): RequestAction {
 }
 
 
-export function get(entity: number, locale: string): Function {
+export function get(entity: number, locale: string, pluralForm: number): Function {
     return async dispatch => {
         dispatch(request(entity));
 
-        const content = await api.entity.getHistory(entity, locale);
+        const content = await api.entity.getHistory(entity, locale, pluralForm);
 
         dispatch(receive(entity, content));
     }

--- a/frontend/src/modules/history/components/History.js
+++ b/frontend/src/modules/history/components/History.js
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import './History.css';
 
 import { selectors as navSelectors } from 'core/navigation';
+import * as plural from 'core/plural';
 
 import Translation from './Translation';
 import { actions, NAME } from '..';
@@ -17,6 +18,7 @@ import type { Navigation } from 'core/navigation';
 type Props = {|
     history: HistoryState,
     parameters: Navigation,
+    pluralForm: number,
 |};
 
 type InternalProps = {|
@@ -31,21 +33,28 @@ type InternalProps = {|
  */
 export class HistoryBase extends React.Component<InternalProps> {
     fetchHistory() {
-        const { history, parameters, dispatch } = this.props;
+        const { parameters, pluralForm, dispatch } = this.props;
 
-        if (history.entity !== parameters.entity) {
-            // This is a newly selected entity, remove the previous history
-            // then fetch the history of the new entity.
-            dispatch(actions.get(parameters.entity, parameters.locale));
-        }
+        // This is a newly selected entity, remove the previous history
+        // then fetch the history of the new entity.
+        dispatch(actions.get(
+            parameters.entity,
+            parameters.locale,
+            pluralForm,
+        ));
     }
 
     componentDidMount() {
         this.fetchHistory();
     }
 
-    componentDidUpdate() {
-        this.fetchHistory();
+    componentDidUpdate(prevProps: InternalProps) {
+        if (
+            this.props.parameters.entity !== prevProps.parameters.entity ||
+            this.props.pluralForm !== prevProps.pluralForm
+        ) {
+            this.fetchHistory();
+        }
     }
 
     renderNoResults() {
@@ -56,6 +65,10 @@ export class HistoryBase extends React.Component<InternalProps> {
 
     render() {
         const { history } = this.props;
+
+        if (history.fetching) {
+            return <p>Loading...</p>;
+        }
 
         if (!history.translations.length) {
             return this.renderNoResults();
@@ -76,6 +89,7 @@ const mapStateToProps = (state: Object): Props => {
     return {
         history: state[NAME],
         parameters: navSelectors.getNavigation(state),
+        pluralForm: plural.selectors.getPluralForm(state),
     };
 };
 

--- a/frontend/src/modules/history/components/History.js
+++ b/frontend/src/modules/history/components/History.js
@@ -67,7 +67,7 @@ export class HistoryBase extends React.Component<InternalProps> {
         const { history } = this.props;
 
         if (history.fetching) {
-            return <p>Loading...</p>;
+            return null;
         }
 
         if (!history.translations.length) {

--- a/frontend/src/modules/history/components/History.test.js
+++ b/frontend/src/modules/history/components/History.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { shallow } from 'enzyme';
 import sinon from 'sinon';
 
 import { createReduxStore } from 'test/store';
@@ -7,26 +6,6 @@ import { shallowUntilTarget } from 'test/utils';
 
 import { actions } from '..';
 import History, { HistoryBase } from './History';
-
-
-describe('<HistoryBase>', () => {
-    it('shows the correct number of translations', () => {
-        const history = {
-            entity: 42,
-            translations: [
-                { pk: 1 },
-                { pk: 2 },
-                { pk: 3 },
-            ],
-        };
-        const parameters = {
-            entity: 42,
-        };
-        const wrapper = shallow(<HistoryBase history={ history } parameters={ parameters } />);
-
-        expect(wrapper.find('Translation')).toHaveLength(3);
-    });
-});
 
 
 describe('<History>', () => {
@@ -37,8 +16,38 @@ describe('<History>', () => {
         });
     });
 
+    afterEach(() => {
+        actions.get.resetHistory();
+    });
+
     afterAll(() => {
         actions.get.restore();
+    });
+
+    it('shows the correct number of translations', () => {
+        const initialState = {
+            router: {
+                location: {
+                    pathname: '/kg/pro/all/',
+                    search: '?string=42',
+                },
+            },
+            history: {
+                entity: 42,
+                translations: [
+                    { pk: 1 },
+                    { pk: 2 },
+                    { pk: 3 },
+                ],
+            },
+            plural: {
+                pluralForm: -1,
+            }
+        };
+        const store = createReduxStore(initialState);
+        const wrapper = shallowUntilTarget(<History store={ store } />, HistoryBase);
+
+        expect(wrapper.find('Translation')).toHaveLength(3);
     });
 
     it('gets a new history when the entity is created', () => {

--- a/frontend/src/modules/history/reducer.js
+++ b/frontend/src/modules/history/reducer.js
@@ -26,14 +26,12 @@ export type DBTranslation = {|
 |};
 
 export type HistoryState = {|
-    +entity: ?number,
     +fetching: boolean,
     +translations: Array<DBTranslation>,
 |};
 
 
 const initialState = {
-    entity: null,
     fetching: true,
     translations: [],
 };
@@ -46,17 +44,10 @@ export default function reducer(
         case REQUEST:
             return {
                 ...state,
-                entity: action.entity,
                 fetching: true,
                 translations: [],
             };
         case RECEIVE:
-            if (action.entity !== state.entity) {
-                // The selected entity changed since the request was sent,
-                // those results are not pertinent anymore. Do nothing.
-                return state;
-            }
-
             return {
                 ...state,
                 fetching: false,

--- a/frontend/src/rootReducer.js
+++ b/frontend/src/rootReducer.js
@@ -3,15 +3,18 @@
 import { combineReducers } from 'redux';
 
 import * as lightbox from 'core/lightbox';
+import * as locales from 'core/locales';
+import * as plural from 'core/plural';
 import * as user from 'core/user';
 import * as entitieslist from 'modules/entitieslist';
 import * as history from 'modules/history';
 
 
-// Combine reducers from all modules, using their
-// NAME constant as key.
+// Combine reducers from all modules, using their NAME constant as key.
 export default combineReducers({
     [lightbox.NAME]: lightbox.reducer,
+    [locales.NAME]: locales.reducer,
+    [plural.NAME]: plural.reducer,
     [user.NAME]: user.reducer,
     [entitieslist.NAME]: entitieslist.reducer,
     [history.NAME]: history.reducer,

--- a/pontoon/api/schema.py
+++ b/pontoon/api/schema.py
@@ -64,6 +64,8 @@ class Locale(DjangoObjectType, Stats):
             'name',
             'code',
             'direction',
+            'cldr_plurals',
+            'plural_rule',
             'script',
             'population',
             'total_strings',

--- a/pontoon/base/templates/django/base.html
+++ b/pontoon/base/templates/django/base.html
@@ -14,7 +14,7 @@
     <meta name="author" content="Mozilla">
     <link rel="stylesheet" href="{% static 'css/fontawesome-all.css' %}" title="" type="text/css" />
     <link rel="stylesheet" href="{% static 'css/nprogress.css' %}" title="" type="text/css" />
-    <link rel="stylesheet" href="{% static 'css/reset.css' %}" title="" type="text/css" />
+    <link rel="stylesheet" href="{% static 'css/fonts.css' %}" title="" type="text/css" />
     <link rel="stylesheet" href="{% static 'css/boilerplate.css' %}" title="" type="text/css" />
     <link rel="stylesheet" href="{% static 'css/style.css' %}" title="" type="text/css" />
 


### PR DESCRIPTION
For entities that have a plural form, the History tab shows only translations for the selected plural form. The Editor allows a user to change the plural form, which updates the History and the content of the Editor. Plural examples are loaded from the backend, through the graphql API (yay! ).