### PR TITLE
Fix bug 1496449 - change the cache backend to fix issues with sign-in…

### DIFF
--- a/app.json
+++ b/app.json
@@ -21,7 +21,7 @@
        "as": "RABBITMQ"
      },
      {
-       "plan": "memcachedcloud",
+       "plan": "memcachier",
        "as": "MEMCACHE"
      },
      {

--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -172,7 +172,7 @@ recommended that, at a minimum, you run the "Standard 0" tier of Postgres.
 
 Cache Add-ons
 ~~~~~~~~~~~~~
-Pontoon uses `django-bmemcached`_, which expects the following environment
+Pontoon uses `django-pylibmc`_, which expects the following environment
 variables from the cache add-on:
 
 ``MEMCACHE_SERVERS``
@@ -197,7 +197,7 @@ variables from the cache add-on:
    addon you wish to use, such as ``memcachedcloud:30``. Use the
    ``heroku addons`` command to see a list of resource names that are available.
 
-.. _django-bmemcached: https://github.com/jaysonsantos/django-bmemcached
+.. _django-pylibmc: https://github.com/django-pylibmc/django-pylibmc/
 
 RabbitMQ Add-ons
 ~~~~~~~~~~~~~~~~

--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -172,7 +172,7 @@ recommended that, at a minimum, you run the "Standard 0" tier of Postgres.
 
 Cache Add-ons
 ~~~~~~~~~~~~~
-Pontoon uses `django-pylibmc`_, which expects the following environment
+Pontoon uses `django-bmemcached`_, which expects the following environment
 variables from the cache add-on:
 
 ``MEMCACHE_SERVERS``
@@ -197,7 +197,7 @@ variables from the cache add-on:
    addon you wish to use, such as ``memcachedcloud:30``. Use the
    ``heroku addons`` command to see a list of resource names that are available.
 
-.. _django-pylibmc: https://github.com/django-pylibmc/django-pylibmc/
+.. _django-bmemcached: https://github.com/jaysonsantos/django-bmemcached
 
 RabbitMQ Add-ons
 ~~~~~~~~~~~~~~~~

--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -164,7 +164,7 @@ Pontoon is designed to run with the following add-ons enabled:
 - Error Tracking: Raygun.io
 - Email: Sendgrid
 - Scheduled Jobs: Heroku Scheduler
-- Cache: Memcached Cloud
+- Cache: Memcachier
 - RabbitMQ: CloudAMQP
 
 It's possible to run with the free tiers of all of these add-ons, but it is
@@ -172,7 +172,7 @@ recommended that, at a minimum, you run the "Standard 0" tier of Postgres.
 
 Cache Add-ons
 ~~~~~~~~~~~~~
-Pontoon uses `django-pylibmc`_, which expects the following environment
+Pontoon uses `django-bmemcached`_, which expects the following environment
 variables from the cache add-on:
 
 ``MEMCACHE_SERVERS``
@@ -184,8 +184,8 @@ variables from the cache add-on:
 
 .. note::
 
-   By default, the environment variables added by Memcached Cloud are prefixed
-   with ``MEMCACHEDCLOUD`` instead of ``MEMCACHE``. You can "attach" the
+   By default, the environment variables added by Memcachier are prefixed
+   with ``MEMCACHIER`` instead of ``MEMCACHE``. You can "attach" the
    configuration variables with the correct prefix using the ``addons:attach``
    command:
 
@@ -194,10 +194,10 @@ variables from the cache add-on:
       heroku addons:attach resource_name --as MEMCACHE
 
    Replace ``resource_name`` with the name of the resource provided by the cache
-   addon you wish to use, such as ``memcachedcloud:30``. Use the
+   addon you wish to use, such as ``memcachier:100``. Use the
    ``heroku addons`` command to see a list of resource names that are available.
 
-.. _django-pylibmc: https://github.com/django-pylibmc/django-pylibmc/
+.. _django-bmemcached:: https://github.com/jaysonsantos/python-binary-memcached
 
 RabbitMQ Add-ons
 ~~~~~~~~~~~~~~~~

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -529,15 +529,13 @@ PIPELINE_JS = {
 
 # Cache config
 # If the environment contains configuration data for Memcached, use
-# PyLibMC for the cache backend. Otherwise, default to an in-memory
+# BMemcached for the cache backend. Otherwise, default to an in-memory
 # cache.
 if os.environ.get('MEMCACHE_SERVERS') is not None:
     CACHES = {
         'default': {
-            'BACKEND': 'django_pylibmc.memcached.PyLibMCCache',
-            'TIMEOUT': 500,
-            'BINARY': True,
-            'OPTIONS': {}
+            'BACKEND': 'django_bmemcached.memcached.BMemcached',
+            'OPTIONS': {},
         }
     }
 else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -339,6 +339,5 @@ django-bmemcached==0.2.3 \
 # Required by django-bmemcached
 python-binary-memcached==0.28.0 \
     --hash=sha256:8cc4e71c20a2d9e75c30669c4bef35ee407bbfc72a631fc7ad130a2957bd1ed1
-
 uhashring==1.1 \
     --hash=sha256:7bedeef34a0e1df21f7d4396c6657f9a2a0cfb0ce9f77bc18e06df7e28eecebe

--- a/requirements.txt
+++ b/requirements.txt
@@ -215,14 +215,6 @@ futures==3.0.4 \
     --hash=sha256:19485d83f7bd2151c0aeaf88fbba3ee50dadfb222ffc3b66a344ef4952b782a3
 
 # ----------------------------------------------------------------------------------
-django-pylibmc==0.6.1 \
-    --hash=sha256:9cffdee703aaf9ebc029d9dbdee8abdd0723564b95e4b2ac59e4a668b8e58f93
-
-# Required by django-pylibmc
-pylibmc==1.5.0 \
-    --hash=sha256:16255595616a6d78cd786a55cc6431da5b7accf46512df854712a0cdbb3acfaa
-
-# ----------------------------------------------------------------------------------
 graphene-django==2.0.0 \
     --hash=sha256:70d9358bc48c806b6a9458e8344f0a1211cd1f1ef923a092aa55e6bcacc2c3fc \
     --hash=sha256:5cabf46b59f242a533fe1df1912c87d5ad6606246937609be2e6c9086cfdf7a4
@@ -339,3 +331,14 @@ pytoml==0.1.14 \
 django-waffle==0.14.0 \
     --hash=sha256:f243a56db80bd28601222b1a8a0b1fa4e7e6ac1bbf809952c3725cb4cc0012d9 \
     --hash=sha256:f3db39cc17d6e388a485230b6029095e5d6fba4ceaff8d4fcc21f95c47fe2e97
+
+# ----------------------------------------------------------------------------------
+django-bmemcached==0.2.3 \
+    --hash=sha256:c9e4f5ca17417a26354e7d6a8899e44e34d541e8731ea0d987f2bf5a04df351a
+
+# Required by django-bmemcached
+python-binary-memcached==0.28.0 \
+    --hash=sha256:8cc4e71c20a2d9e75c30669c4bef35ee407bbfc72a631fc7ad130a2957bd1ed1
+
+uhashring==1.1 \
+    --hash=sha256:7bedeef34a0e1df21f7d4396c6657f9a2a0cfb0ce9f77bc18e06df7e28eecebe


### PR DESCRIPTION
# The Problem
Django app couldn't access the cache server and because of that couldn't do things like sessions.

# Log
```
2018-10-06T21:24:10.523350+00:00 app[web.1]: [ERROR:django.pylibmc] 2018-10-06 21:24:10,522 MemcachedError: error 40 from memcached_get(:1:f23971f8ccb7f755e0dd0c80854d7): (0x562327090440) FAILED TO SEND AUTHENTICATION TO SERVER, no mechanism available,  host: memcached-17056.c85.us-east-1-2.ec2.cloud.redislabs.com:17056 -> libmemcached/sasl.cc:238
2018-10-06T21:24:10.523363+00:00 app[web.1]: Traceback (most recent call last):
2018-10-06T21:24:10.523365+00:00 app[web.1]: File "/app/.heroku/python/lib/python2.7/site-packages/django_pylibmc/memcached.py", line 130, in get
2018-10-06T21:24:10.523367+00:00 app[web.1]: return super(PyLibMCCache, self).get(key, default, version)
2018-10-06T21:24:10.523376+00:00 app[web.1]: File "/app/.heroku/python/lib/python2.7/site-packages/django/core/cache/backends/memcached.py", line 79, in get
2018-10-06T21:24:10.523379+00:00 app[web.1]: val = self._cache.get(key)
2018-10-06T21:24:10.523383+00:00 app[web.1]: File "/app/.heroku/python/lib/python2.7/site-packages/newrelic/api/datastore_trace.py", line 135, in _nr_datastore_trace_wrapper_
2018-10-06T21:24:10.523385+00:00 app[web.1]: return return_value(trace, lambda: wrapped(*args, **kwargs))
2018-10-06T21:24:10.523386+00:00 app[web.1]: File "/app/.heroku/python/lib/python2.7/site-packages/newrelic/api/coroutine_trace.py", line 171, in return_value
2018-10-06T21:24:10.523388+00:00 app[web.1]: return fn()
2018-10-06T21:24:10.523390+00:00 app[web.1]: File "/app/.heroku/python/lib/python2.7/site-packages/newrelic/api/datastore_trace.py", line 135, in <lambda>
2018-10-06T21:24:10.523391+00:00 app[web.1]: return return_value(trace, lambda: wrapped(*args, **kwargs))
2018-10-06T21:24:10.523393+00:00 app[web.1]: Error: error 40 from memcached_get(:1:f23971f8ccb7f755e0dd0c80854d7): (0x562327090440) FAILED TO SEND AUTHENTICATION TO SERVER, no mechanism available,  host: memcached-17056.c85.us-east-1-2.ec2.cloud.redislabs.com:17056 -> libmemcached/sasl.cc:238
2018-10-06T21:24:10.525362+00:00 app[web.1]: [ERROR:django.pylibmc] 2018-10-06 21:24:10,525 MemcachedError: error 47 from memcached_set: (0x562327090440) SERVER HAS FAILED AND IS DISABLED UNTIL TIMED RETRY,  host: memcached-17056.c85.us-east-1-2.ec2.cloud.redislabs.com:17056 -> libmemcached/connect.cc:720
2018-10-06T21:24:10.525365+00:00 app[web.1]: Traceback (most recent call last):
2018-10-06T21:24:10.525367+00:00 app[web.1]: File "/app/.heroku/python/lib/python2.7/site-packages/django_pylibmc/memcached.py", line 140, in set
2018-10-06T21:24:10.525369+00:00 app[web.1]: **COMPRESS_KWARGS)
2018-10-06T21:24:10.525370+00:00 app[web.1]: File "/app/.heroku/python/lib/python2.7/site-packages/newrelic/api/datastore_trace.py", line 135, in _nr_datastore_trace_wrapper_
2018-10-06T21:24:10.525372+00:00 app[web.1]: return return_value(trace, lambda: wrapped(*args, **kwargs))
2018-10-06T21:24:10.525374+00:00 app[web.1]: File "/app/.heroku/python/lib/python2.7/site-packages/newrelic/api/coroutine_trace.py", line 171, in return_value
2018-10-06T21:24:10.525375+00:00 app[web.1]: return fn()
2018-10-06T21:24:10.525377+00:00 app[web.1]: File "/app/.heroku/python/lib/python2.7/site-packages/newrelic/api/datastore_trace.py", line 135, in <lambda>
2018-10-06T21:24:10.525379+00:00 app[web.1]: return return_value(trace, lambda: wrapped(*args, **kwargs))
2018-10-06T21:24:10.525385+00:00 app[web.1]: ServerDown: error 47 from memcached_set: (0x562327090440) SERVER HAS FAILED AND IS DISABLED UNTIL TIMED RETRY,  host: memcached-17056.c85.us-east-1-2.ec2.cloud.redislabs.com:17056 -> libmemcached/connect.cc:720
2018-10-06T21:24:10.527378+00:00 app[web.1]: [WARNING:django.security.csrf] 2018-10-06 21:24:10,527 Forbidden (CSRF token missing or incorrect.): /a/login/
```

# Research
I couldn't force pylibmc to use USERNAME and PASSWORD provided by Heroku, so I've started to search through the internet and I found these issues:
* [heroku/heroku-buildpack-python#201](https://github.com/heroku/heroku-buildpack-python/issues/201)
* [mozilla/standup#334](https://github.com/mozilla/standup/issues/334)

I decided to check `django-bmemcached` as the suggested solution by Memcachecloud. 
It works like a charm for every new heroku app I've deployed since yesterday.

I'm not sure how django-bmemcached  will work on the production (pontoon.mozilla.org). Alternatively, I can add this dependency and use it only when `HEROKU_DEMO` is on.

Also, I'm not sure why the staging and the production aren't affected (maybe there's another memcache addon in-place?), currently our Heroku demo uses MemcachedCloud.

@mathjazz r?
