### PR TITLE
Reduce fix_stats() log verbosity

### DIFF
--- a/pontoon/sync/models.py
+++ b/pontoon/sync/models.py
@@ -87,10 +87,6 @@ class SyncLog(BaseLog):
             )
             if count > 1:
                 for pl in ProjectLocale.objects.filter(project=p):
-                    log.info(
-                        "Fix stats: total_strings mismatch for {project}, {locale}."
-                        .format(project=pl.project, locale=pl.locale.code)
-                    )
                     pl.aggregate_stats()
 
         # approved + fuzzy + errors + warnings > total in TranslatedResource


### PR DESCRIPTION
total_strings mismatch in ProjectLocales of the same Project is
sometimes expected, because not all strings (files) need to be exposed
to all locales. So we shouldn't log every time we find such mismatch.