### PR TITLE
Update mercurial to 4.7.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -78,8 +78,8 @@ jsonfield==1.0.3 \
     --hash=sha256:7e7f73a675c518712badd783279e26d164140f3fc2ed7a32102c3d08a6a2a4a7
 lxml==3.4.4 \
     --hash=sha256:b3d362bac471172747cda3513238f115cbd6c5f8b8e6319bf6a97a7892724099
-mercurial==4.5.2 \
-    --hash=sha256:a44a9ffd1c9502a4f97298a6bbcb8a79fc8192424c760c67f17b45c12114e390
+mercurial==4.7.2 \
+    --hash=sha256:97f0594216f2348a2e37b2ad8a56eade044e741153fee8c584487e9934ca09fb
 newrelic==2.106.1.88 \
     --hash=sha256:0594dd63d7883d30c560e292d063a8dbc7b2ae11b889bec1e8eb9d0f11ab73a6
 parsimonious==0.6.2 \


### PR DESCRIPTION
Mercurial 4.6 introduces remote bundles, which should be much more performant.