### PR TITLE
Fix bug 1500777: Exclude system projects from All Projects

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -2391,7 +2391,9 @@ class Entity(DirtyFieldsMixin, models.Model):
             obsolete=False
         )
 
-        if project.slug != 'all-projects':
+        if project.slug == 'all-projects':
+            entities = entities.filter(resource__project__system_project=False)
+        else:
             entities = entities.filter(resource__project=project)
 
         # Filter by path
@@ -2938,7 +2940,11 @@ class TranslatedResourceQuerySet(models.QuerySet):
             resource__project__disabled=False,
         )
 
-        if project.slug != 'all-projects':
+        if project.slug == 'all-projects':
+            translated_resources = translated_resources.filter(
+                resource__project__system_project=False,
+            )
+        else:
             translated_resources = translated_resources.filter(
                 resource__project=project,
             )


### PR DESCRIPTION
This patch excludes strings from system projects (e.g. Tutorial) from filters and translate page stats when "All Projects" is selected as the Project.

Steps to reproduce:
1. Go to https://pontoon.mozilla.org/en-CA/.
2. Click on Missing (0).
3. Surprise! 🎉  There are (more than 0) strings in the string list!