### PR TITLE
Fix bug 1500854: Fix display of grouped Machinery results

### DIFF
--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -1152,9 +1152,9 @@ body > form,
   padding-right: 3px;
 }
 
-#helpers > section.machinery ul li > header .sources li[data-source='Google Translate']:before,
-#helpers > section.machinery ul li > header .sources li[data-source='Microsoft Translator']:before,
-#helpers > section.machinery ul li > header .sources li[data-source='Caighdean']:before {
+#helpers > section.machinery ul li > header .sources li[data-source='Google Translate']:only-child:before,
+#helpers > section.machinery ul li > header .sources li[data-source='Microsoft Translator']:only-child:before,
+#helpers > section.machinery ul li > header .sources li[data-source='Caighdean']:only-child:before {
   content: "";
   padding-right: 0;
 }

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -364,6 +364,10 @@ var Pontoon = (function (my) {
             '</a></li>'
           );
 
+          if (data.quality && sources.find('.stress').length === 0) {
+            sources.prepend('<span class="stress">' + data.quality + '</span>');
+          }
+
         } else {
           if (data.source !== 'Caighdean') {
             var originalTextForDiff = originalText;


### PR DESCRIPTION
If MT suggestion gets grouped with suggestions from other Machinery sources, and is returned first, it:
- causes the sources list to lack "percent match" at the beginning
- lacks a `&middot;` separating it from the other source titles

The bug is not easy to reproduce (at least not without `time.sleep()`), so I'm attaching a screenshot:
<img width="425" alt="screen shot 2018-10-22 at 10 21 01" src="https://user-images.githubusercontent.com/626716/47283563-326c0580-d5e4-11e8-8dab-2560d4222866.png">