### PR TITLE
Render new lines in FTL attributes in source string panel

### DIFF
--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -1277,6 +1277,7 @@ body > header aside p {
 #editor p#original,
 #editor p.original,
 #ftl-original .main-value li,
+#ftl-original .attributes li,
 #editor p.translation,
 #editor p.translation-diff {
   text-align: start;


### PR DESCRIPTION
The source string panel collapses the new lines in FTL attributes, e.g.:
https://pontoon.mozilla.org/cy/firefox/all-resources/?string=191663

It should preserve them, same as it does for new lines in main values.