### PR TITLE
Fix bug 1501168: Upload FTL strings without comments

### DIFF
--- a/pontoon/base/utils.py
+++ b/pontoon/base/utils.py
@@ -475,7 +475,11 @@ def handle_upload_content(slug, code, part, f, user):
         for chunk in f.chunks():
             temp.write(chunk)
         temp.flush()
-        resource_file = formats.parse(temp.name)
+        # Bilingual file format parsers could rely on source resources being
+        # passed when parsing translated resource (see bug 1501168). Since we
+        # don't have a source resource here, we can fake it by using translated
+        # resource also as a source resource.
+        resource_file = formats.parse(temp.name, temp.name)
 
     # Update database objects from file
     changeset = ChangeSet(


### PR DESCRIPTION
We store FTL translations as serialized FTL messages with removed
comments (which are also part of the AST). Pontoon's FTL parser removes
comments from translations, and keeps them in source strings.

To detect whether a file contains translations or source strings, it
checks if the source resource has been provided. This patch makes sure
that is the case on file load, which means translations will be
imported without comments.