### PR TITLE
Fix migration 0120 for Fluent 0.7

### DIFF
--- a/pontoon/base/migrations/0120_bug_1423679_update_plurals_20180417_1135.py
+++ b/pontoon/base/migrations/0120_bug_1423679_update_plurals_20180417_1135.py
@@ -244,7 +244,7 @@ def update_plurals(apps, schema_editor):
                 # Keys of all variants of plural elements are either
                 # CLDR plurals or numbers
                 if all(
-                    isinstance(variant.key, ast.NumberExpression) or
+                    isinstance(variant.key, ast.NumberLiteral) or
                     (
                         isinstance(variant.key, ast.VariantName) and
                         variant.key.name in CLDR_PLURALS
@@ -259,7 +259,7 @@ def update_plurals(apps, schema_editor):
                     ]
 
                     for cldr_plural in locale_cldr_plurals:
-                        numeric_variants = [x.key.value for x in element.expression.variants if isinstance(x.key, ast.NumberExpression)]
+                        numeric_variants = [x.key.value for x in element.expression.variants if isinstance(x.key, ast.NumberLiteral)]
                         # Skip 'zero' if 0 exists
                         if cldr_plural == 'zero' and '0' in numeric_variants:
                             continue


### PR DESCRIPTION
Hey,
It looks like the latest update of Fluent broke one of migrations.
I see the following error: https://gist.github.com/jotes/6c15a57a152d478a53131772e9eb8f5a

@mathjazz could you confirm the issue and review this patch?