### PR TITLE
Fix bug 1443551: List custom plural forms

### DIFF
--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -85,10 +85,7 @@ var Pontoon = (function (my) {
    */
   function getPluralForms(element) {
     var customPluralForms = element.expression.variants.filter(function(item) {
-      if (item.key.type === 'NumberLiteral') {
-        return true;
-      }
-      return false;
+      return item.key.type === 'NumberLiteral';
     }).map(function (item) {
       return item.key.value;
     });

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -84,11 +84,16 @@ var Pontoon = (function (my) {
    *   - CLDR plurals of the locale
    */
   function getPluralForms(element) {
-    var customPluralForms = element.expression.variants.map(function (variant) {
-      return variant.key.value;  // can be undefined, so we filter it out below
+    var customPluralForms = element.expression.variants.filter(function(item) {
+      if (item.key.type === 'NumberLiteral') {
+        return true;
+      }
+      return false;
+    }).map(function (item) {
+      return item.key.value;
     });
 
-    return customPluralForms.filter(Boolean).concat(Pontoon.locale.cldr_plurals);
+    return customPluralForms.concat(Pontoon.locale.cldr_plurals);
   }
 
   /*

--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -78,6 +78,20 @@ var Pontoon = (function (my) {
   }
 
   /*
+   * Return a default list of plural forms to be displayed for untranslated strings.
+   * The list if a union of:
+   *   - any custom (numeric) plural forms specified in the original string (bug 1443551)
+   *   - CLDR plurals of the locale
+   */
+  function getPluralForms(element) {
+    var customPluralForms = element.expression.variants.map(function (variant) {
+      return variant.key.value;  // can be undefined, so we filter it out below
+    });
+
+    return customPluralForms.filter(Boolean).concat(Pontoon.locale.cldr_plurals);
+  }
+
+  /*
    * Return true when all elements are supported in rich FTL editor.
    *
    * Elements are supported if they are:
@@ -298,7 +312,7 @@ var Pontoon = (function (my) {
         content += '<li data-expression="' + expression + '"><ul>';
 
         if (isPluralElement(element) && !isTranslated) {
-          Pontoon.locale.cldr_plurals.forEach(function (pluralName) {
+          getPluralForms(element).forEach(function (pluralName) {
             content += renderEditorElement(pluralName, [], true, isTranslated, isCustomAttribute);
           });
         }


### PR DESCRIPTION
If source string contains custom (numeric) plural forms, list them as variants in untranslated, along with locale CLDR plurals.

Test case:
https://github.com/mozilla-l10n/pontoon-ftl/blob/master/en-US/demo.ftl#L30