### PR TITLE
Fix bug 1505714 - Do not inline javascript during frontend build.

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -5,4 +5,10 @@ NODE_PATH = 'src/'
 # but we don't want to worry about it as collisions should not happen.
 # Note that we will want, in time, to unify our build systems, so this
 # problem will likely disappear.
-SKIP_PREFLIGHT_CHECK=true
+SKIP_PREFLIGHT_CHECK = true
+
+# By default, Create React App will embed the runtime script into index.html
+# during the production build. When set to false, the script will not be
+# embedded and will be imported as usual. This is required for us because of
+# our CSP rules.
+INLINE_RUNTIME_CHUNK = false


### PR DESCRIPTION
Doing that breaks our CSP rules, that explicitly reject inlined javascript code (inside a <script> tag). That is the default behavior of create-react-app 2 but it can be turned off with configuration, which is what this patch does.