### PR TITLE
Fix bug 1505825 - Rework language negotiation.

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
     "connected-react-router": "4.5.0",
     "flow-bin": "0.84.0",
     "fluent": "0.9.1",
+    "fluent-langneg": "0.1.0",
     "fluent-react": "0.8.2",
     "intl-pluralrules": "0.2.1",
     "linkify-it": "2.0.3",

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ lang }}">
+<html{% if locale %} lang="{{ locale }}"{% endif %}>
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/frontend/src/core/l10n/components/AppLocalizationProvider.js
+++ b/frontend/src/core/l10n/components/AppLocalizationProvider.js
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { LocalizationProvider } from 'fluent-react';
+import { negotiateLanguages } from 'fluent-langneg';
 import 'intl-pluralrules';
 
 import * as l10n from 'core/l10n';
@@ -29,9 +30,21 @@ type InternalProps = {|
  */
 export class AppLocalizationProviderBase extends React.Component<InternalProps> {
     componentDidMount() {
-        // $FLOW_IGNORE: we count on the 'lang' attribute being set.
-        const locale = document.documentElement.lang;
-        this.props.dispatch(l10n.actions.get([locale]));
+        if (document.documentElement && document.documentElement.lang) {
+            // The user has chosen a specific locale, show that.
+            this.props.dispatch(
+                l10n.actions.get([ document.documentElement.lang ])
+            );
+        }
+        else {
+            // No specified locale, let's figure out the user's preferences.
+            const languages = negotiateLanguages(
+                navigator.languages,
+                ['fr', 'es', 'en-US'],  // available locales
+                { defaultLocale: 'en-US' },
+            );
+            this.props.dispatch(l10n.actions.get(languages));
+        }
     }
 
     render() {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3870,6 +3870,11 @@ flow-bin@0.84.0:
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.84.0.tgz#4cb2364c750fb37a7840524fa62456b53f64cdcb"
   integrity sha512-ocji8eEYp+YfICsm+F6cIHUcD7v5sb0/ADEXm6gyUKdjQzmSckMrPUdZtyfP973t3YGHKliUMxMvIBHyR5LbXQ==
 
+fluent-langneg@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/fluent-langneg/-/fluent-langneg-0.1.0.tgz#aa12054fbfa4b728daec38331efc12f01faae93a"
+  integrity sha512-SzRtXNaIcCyRabIpcv+AQd0gn+tXv1wfDDvej3wtBo1/XV0iDnCw5XzbARRRmZMW+IEg+Q26jup6vYgnDam4dg==
+
 fluent-react@0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/fluent-react/-/fluent-react-0.8.2.tgz#481455116e04c6f1c7b1f5b99600515333853897"

--- a/pontoon/translate/tests/test_views.py
+++ b/pontoon/translate/tests/test_views.py
@@ -38,35 +38,17 @@ def test_translate_template(client):
 
 @pytest.mark.django_db
 def test_get_preferred_locale_from_user_prefs(rf, user_arabic):
-    # This user has 'ar' set as their favorite locale. That should take
-    # precedence over other ways of choosing a locale.
+    # This user has 'ar' set as their favorite locale.
     rf.user = user_arabic
-    rf.META = {
-        'HTTP_ACCEPT_LANGUAGE': 'fr',
-    }
     locale = get_preferred_locale(rf)
 
     assert locale == 'ar'
 
 
 @pytest.mark.django_db
-def test_get_preferred_locale_from_headers(rf, user_a):
-    # This user has no preferred locale set, so we'll choose the locale based
-    # on the metadata of the request.
-    rf.user = user_a
-    rf.META = {
-        'HTTP_ACCEPT_LANGUAGE': 'fr',
-    }
-    locale = get_preferred_locale(rf)
-
-    assert locale == 'fr'
-
-
-@pytest.mark.django_db
 def test_get_preferred_locale_default(rf, user_a):
-    # This user has no preferred locale set, and the request has no metadata.
+    # This user has no preferred locale set.
     rf.user = user_a
-    rf.META = {}
     locale = get_preferred_locale(rf)
 
-    assert locale == 'en-US'
+    assert locale is None


### PR DESCRIPTION
This fixes passing the preferred locale of the user to the template for production. It also changes the language negotiation logic: now if the user has defined a preferred locale, they will be shown the UI in that locale, otherwise we use simple langneg in the client.