### PR TITLE
Bug 1407016 - Remove calculate_stats() from Translation.save()

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -2843,6 +2843,7 @@ class Translation(DirtyFieldsMixin, models.Model):
         return self.string
 
     def save(self, update_stats=True, *args, **kwargs):
+        # We parametrize update of stats to make testing easier.
         if update_stats:
             stats_before = self.entity.get_stats(self.locale)
 
@@ -2896,8 +2897,9 @@ class Translation(DirtyFieldsMixin, models.Model):
         # Update latest translation where necessary
         self.update_latest_translation()
 
-        # Update stats AFTER changing approval status.
+        # We parametrize update of stats to make testing easier.
         if update_stats:
+            # Update stats AFTER changing approval status.
             stats_after = self.entity.get_stats(self.locale)
             stats_diff = Entity.get_stats_diff(stats_before, stats_after)
             translatedresource.adjust_all_stats(**stats_diff)

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -2892,8 +2892,11 @@ class Translation(DirtyFieldsMixin, models.Model):
         project = resource.project
         locale = self.locale
 
-        # In some places like e.g. tests, TranslationResource won't be created before the translation
-        translatedresource, _ = TranslatedResource.objects.get_or_create(resource=resource, locale=locale)
+        # TranslatedResource has to be created during a sync run and in the backend.
+        translatedresource, _ = TranslatedResource.objects.get_or_create(
+            resource=resource,
+            locale=locale
+        )
 
         # Update latest translation where necessary
         self.update_latest_translation(

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -2926,13 +2926,14 @@ class Translation(DirtyFieldsMixin, models.Model):
         self.unapproved_user = user
         self.unapproved_date = timezone.now()
 
-        if save:
-            self.save()
+        if not save:
+            return
 
+        self.save()
         TranslationMemoryEntry.objects.filter(translation=self).delete()
         self.entity.mark_changed(self.locale)
 
-    def reject(self, user):
+    def reject(self, user, save=True):
         """
         Reject translation.
         """
@@ -2949,7 +2950,9 @@ class Translation(DirtyFieldsMixin, models.Model):
         self.approved_user = None
         self.approved_date = None
         self.fuzzy = False
-        self.save()
+
+        if save:
+            self.save()
 
     def unreject(self, user):
         """

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -530,6 +530,7 @@ class AggregatedStats(models.Model):
             for stat_name in stats_before
             if stats_before[stat_name] != stats_after[stat_name]
         }
+
         return diff
 
     @classmethod
@@ -2406,7 +2407,7 @@ class Entity(DirtyFieldsMixin, models.Model):
         return {
             'approved_strings_diff': approved,
             'fuzzy_strings_diff': fuzzy,
-            'strings_with_errors__diff': errors,
+            'strings_with_errors_diff': errors,
             'strings_with_warnings_diff': warnings,
             'unreviewed_strings_diff': unrevieved_count
         }

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -3342,8 +3342,7 @@ class TranslatedResource(AggregatedStats):
         strings_with_warnings_diff = warnings - self.strings_with_warnings
         unreviewed_strings_diff = unreviewed - self.unreviewed_strings
 
-        # Translated Resource
-        self.adjust_stats(
+        self.adjust_all_stats(
             total_strings_diff,
             approved_strings_diff,
             fuzzy_strings_diff,
@@ -3351,41 +3350,3 @@ class TranslatedResource(AggregatedStats):
             strings_with_warnings_diff,
             unreviewed_strings_diff,
         )
-
-        # Project
-        project = resource.project
-        project.adjust_stats(
-            total_strings_diff,
-            approved_strings_diff,
-            fuzzy_strings_diff,
-            strings_with_errors_diff,
-            strings_with_warnings_diff,
-            unreviewed_strings_diff,
-        )
-
-        # Locale
-        if not project.system_project:
-            locale.adjust_stats(
-                total_strings_diff,
-                approved_strings_diff,
-                fuzzy_strings_diff,
-                strings_with_errors_diff,
-                strings_with_warnings_diff,
-                unreviewed_strings_diff,
-            )
-
-        # ProjectLocale
-        project_locale = utils.get_object_or_none(
-            ProjectLocale,
-            project=project,
-            locale=locale
-        )
-        if project_locale:
-            project_locale.adjust_stats(
-                total_strings_diff,
-                approved_strings_diff,
-                fuzzy_strings_diff,
-                strings_with_errors_diff,
-                strings_with_warnings_diff,
-                unreviewed_strings_diff,
-            )

--- a/pontoon/base/tests/managers/test_entity.py
+++ b/pontoon/base/tests/managers/test_entity.py
@@ -5,6 +5,7 @@ import pytest
 from pontoon.base.models import (
     Entity,
     Translation,
+    TranslatedResource,
 )
 from pontoon.test.factories import (
     EntityFactory,
@@ -281,6 +282,10 @@ def test_mgr_entity_filter_warnings(resource_a, locale_a):
     WarningFactory.create(
         translation=translations[2]
     )
+    translatedresource = TranslatedResource.objects.get(
+        resource=translations[2].entity.resource,
+        locale=translations[2].locale,
+    ).calculate_stats()
 
     translations[2].fuzzy = False
     translations[2].save()

--- a/pontoon/base/tests/managers/test_entity.py
+++ b/pontoon/base/tests/managers/test_entity.py
@@ -282,7 +282,7 @@ def test_mgr_entity_filter_warnings(resource_a, locale_a):
     WarningFactory.create(
         translation=translations[2]
     )
-    translatedresource = TranslatedResource.objects.get(
+    TranslatedResource.objects.get(
         resource=translations[2].entity.resource,
         locale=translations[2].locale,
     ).calculate_stats()

--- a/pontoon/base/tests/models/test_stats.py
+++ b/pontoon/base/tests/models/test_stats.py
@@ -1,0 +1,94 @@
+"""
+Test consistency of calculations between `calculate_stats` and `translation.save()`.
+"""
+import pytest
+from pontoon.base.models import TranslatedResource
+
+def recalculate_stats(translation):
+    translation.save(update_stats=False)
+    translated_resource = TranslatedResource.objects.get(
+        resource=translation.entity.resource,
+        locale=translation.locale,
+    )
+    translated_resource.calculate_stats()
+
+def diff_stats(t):
+    t.save()
+
+@pytest.fixture(
+    params=(
+        recalculate_stats,
+        diff_stats,
+    )
+)
+def stats_update(db, request):
+    return request.param
+
+@pytest.fixture
+def get_stats():
+    def f(translation):
+        return TranslatedResource.objects.stats(
+            translation.entity.resource.project,
+            None,
+            translation.locale,
+        )
+    return f
+
+@pytest.fixture
+def stats_dict():
+    def f(**override_stats):
+        stats = {
+            'approved': 0,
+            'fuzzy': 0,
+            'total': 0,
+            'unreviewed': 0,
+            'warnings': 0,
+            'errors': 0,
+        }
+        stats.update(override_stats)
+        return stats
+    return f
+
+def test_translation_approved(stats_update, get_stats, stats_dict, user_a, translation_a):
+    translation_a.approved = True
+    stats_update(translation_a)
+
+    assert get_stats(translation_a) == stats_dict(
+        approved=1,
+        total=1,
+    )
+
+    translation_a.unapprove(user_a, save=False)
+    stats_update(translation_a)
+
+    assert get_stats(translation_a) == stats_dict(
+        unreviewed=1,
+        total=1,
+    )
+
+def test_translation_fuzzy(stats_update):
+    assert False
+
+def test_translation_with_errors(stats_update):
+    assert False
+
+def test_translation_with_warnings(stats_update):
+    assert False
+
+def test_translation_unreviewed(stats_update):
+    assert False
+
+def test_plural_translation_approved(stats_update):
+    assert False
+
+def test_plural_translation_fuzzy(stats_update):
+    assert False
+
+def test_plural_translation_with_errors(stats_update):
+    assert False
+
+def test_plural_translation_with_warnings(stats_update):
+    assert False
+
+def test_plural_translation_unreviewed(stats_update):
+    assert False

--- a/pontoon/base/tests/models/test_stats.py
+++ b/pontoon/base/tests/models/test_stats.py
@@ -3,8 +3,36 @@ Test consistency of calculations between `calculate_stats` and `translation.save
 """
 import pytest
 from pontoon.base.models import TranslatedResource
+from pontoon.checks.models import (
+    Error,
+    Warning,
+)
+
+
+@pytest.fixture
+def translation_with_error(translation_a):
+    Error.objects.create(
+        translation=translation_a,
+        library='p',
+        message='error'
+    )
+    return translation_a
+
+
+@pytest.fixture
+def translation_with_warning(translation_a):
+    Warning.objects.create(
+        translation=translation_a,
+        library='p',
+        message='warning',
+    )
+    return translation_a
+
 
 def recalculate_stats(translation):
+    """
+    Make the full recalculate stats on a TranslatedResource.
+    """
     translation.save(update_stats=False)
     translated_resource = TranslatedResource.objects.get(
         resource=translation.entity.resource,
@@ -12,8 +40,13 @@ def recalculate_stats(translation):
     )
     translated_resource.calculate_stats()
 
+
 def diff_stats(t):
+    """
+    Update only necessary stats by calculating difference between stats.
+    """
     t.save()
+
 
 @pytest.fixture(
     params=(
@@ -22,10 +55,17 @@ def diff_stats(t):
     )
 )
 def stats_update(db, request):
+    """
+    Wrapper fixture which allows to test both implementations of stats calculations.
+    """
     return request.param
+
 
 @pytest.fixture
 def get_stats():
+    """
+    Fixture wrapper for function to get_stats of a TranslatedResource assigned to a translation.
+    """
     def f(translation):
         return TranslatedResource.objects.stats(
             translation.entity.resource.project,
@@ -33,6 +73,7 @@ def get_stats():
             translation.locale,
         )
     return f
+
 
 @pytest.fixture
 def stats_dict():
@@ -48,6 +89,7 @@ def stats_dict():
         stats.update(override_stats)
         return stats
     return f
+
 
 def test_translation_approved(stats_update, get_stats, stats_dict, user_a, translation_a):
     translation_a.approved = True
@@ -66,29 +108,55 @@ def test_translation_approved(stats_update, get_stats, stats_dict, user_a, trans
         total=1,
     )
 
-def test_translation_fuzzy(stats_update):
-    assert False
 
-def test_translation_with_errors(stats_update):
-    assert False
+def test_translation_fuzzy(stats_update, get_stats, stats_dict, user_a, translation_a):
+    translation_a.fuzzy = True
+    stats_update(translation_a)
 
-def test_translation_with_warnings(stats_update):
-    assert False
+    assert get_stats(translation_a) == stats_dict(
+        fuzzy=1,
+        total=1,
+    )
 
-def test_translation_unreviewed(stats_update):
-    assert False
+    translation_a.reject(user_a, save=False)
+    stats_update(translation_a)
 
-def test_plural_translation_approved(stats_update):
-    assert False
+    assert get_stats(translation_a) == stats_dict(
+        total=1,
+    )
 
-def test_plural_translation_fuzzy(stats_update):
-    assert False
 
-def test_plural_translation_with_errors(stats_update):
-    assert False
+def test_translation_with_error(stats_update, get_stats, stats_dict, translation_with_error):
+    translation_with_error.approved = True
+    stats_update(translation_with_error)
 
-def test_plural_translation_with_warnings(stats_update):
-    assert False
+    assert get_stats(translation_with_error) == stats_dict(
+        errors=1,
+        total=1,
+    )
 
-def test_plural_translation_unreviewed(stats_update):
-    assert False
+    translation_with_error.fuzzy = True
+    stats_update(translation_with_error)
+
+    assert get_stats(translation_with_error) == stats_dict(
+        errors=1,
+        total=1,
+    )
+
+
+def test_translation_with_warning(stats_update, get_stats, stats_dict, translation_with_warning):
+    translation_with_warning.approved = True
+    stats_update(translation_with_warning)
+
+    assert get_stats(translation_with_warning) == stats_dict(
+        warnings=1,
+        total=1,
+    )
+
+    translation_with_warning.fuzzy = True
+    stats_update(translation_with_warning)
+
+    assert get_stats(translation_with_warning) == stats_dict(
+        warnings=1,
+        total=1,
+    )

--- a/pontoon/batch/views.py
+++ b/pontoon/batch/views.py
@@ -22,6 +22,7 @@ from pontoon.base.models import (
     ProjectLocale,
     TranslationMemoryEntry,
     Translation,
+    TranslatedResource,
 )
 from pontoon.base.utils import (
     require_AJAX,

--- a/pontoon/batch/views.py
+++ b/pontoon/batch/views.py
@@ -22,7 +22,6 @@ from pontoon.base.models import (
     ProjectLocale,
     TranslationMemoryEntry,
     Translation,
-    TranslatedResource,
 )
 from pontoon.base.utils import (
     require_AJAX,


### PR DESCRIPTION
Howdy,

So, first of all -> I'm not good at naming things. Any suggestions are always welcome!

Main changes:
We don't make the full recalc of stats everytime a translaion is saved/approved/rejected and so on.
Instead of that, We create a small map with states of an entity before and after a translation.
Thanks to that, we're able to generate a diff and apply it to the all AggregatedStats objects. 
 
To give you more perspective, I've made some benchmarks: https://gist.github.com/jotes/c040baa84faab7ce68bbc7875590e9f4

If you have any additional questions/suggestions/metrics that could be useful -> feel free to suggest them.

Misc changes:
* removed missing variable from `calculate_stats` because it was unused.

TODO:
* [x] check total_strings 
* [x] check if the calculations works the same way 
* [x] move save_stats_diff to base.utils and use it in the calculate_stats
* [x] tests