### PR TITLE
Add portable docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Our [installation documentation](https://mozilla-pontoon.readthedocs.io/) is ava
 
 * For local development, see [developer setup](http://mozilla-pontoon.readthedocs.io/en/latest/dev/setup.html) using `Docker`
 * For production installation, see [deployment documentation](http://mozilla-pontoon.readthedocs.io/en/latest/admin/deployment.html)
+* There is also a productionized [Dockerfile](docker/Dockerfile.prod) that can be used to build an image to run outside of Heroku
+  * Read more [here](docker/README.md)
 * For quick and easy deployment on the `Heroku` platform, click this button:
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -1,0 +1,66 @@
+FROM node:10.14.1-alpine
+
+# Install build deps
+RUN set -ex \
+  && apk add --no-cache \
+  gcc \
+  make \
+  libc-dev \
+  musl-dev \
+  linux-headers \
+  pcre-dev \
+  postgresql-dev \
+  libxml2-dev \
+  libxslt \
+  libxslt-dev \
+  python2 \
+  py2-pip \
+  python2-dev \
+  git \
+  openssh-client \
+  build-base \
+  && pip install --upgrade pip \
+  && pip install virtualenv
+
+# Create the folder for frontend assets
+RUN mkdir -p /app/assets
+
+COPY requirements.txt /app
+
+# Install python deps
+RUN virtualenv /env \
+  && /env/bin/pip install -U 'pip>=8' -r /app/requirements.txt
+
+COPY . /app
+
+RUN cd /app && npm install
+RUN cd /app/frontend && yarn install
+
+# JavaScript applications paths
+ENV WEBPACK_BINARY /app/node_modules/.bin/webpack
+ENV YUGLIFY_BINARY /app/node_modules/.bin/yuglify
+
+# Run webpack to compile JS files
+RUN cd /app/ && $WEBPACK_BINARY
+
+# Build Translate.Next frontend resources
+RUN cd /app/frontend/ && yarn build
+
+# pontoon service port
+EXPOSE 8000
+
+# Python environment variables
+ENV PYTHONUNBUFFERED 1
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONPATH /app
+
+COPY docker/run_gunicorn.sh /app
+RUN chmod +x /app/run_gunicorn.sh
+
+WORKDIR /app
+
+# Call collectstatic (customize the following line with the minimal environment variables needed for manage.py to run):
+RUN DATABASE_URL=none SECRET_KEY=none SITE_URL=none /env/bin/python manage.py collectstatic --noinput
+
+# Start the django app
+CMD ["/app/run_gunicorn.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,8 @@
+# Docker
+
+The local development of Pontoon using docker is documented at [developer setup](http://mozilla-pontoon.readthedocs.io/en/latest/dev/setup.html).
+
+The portable Docker image for production use is in progress. You can find it in this folder as `Dockerfile.prod`.
+
+It should support all of the same environment variables supported by Heroku, with one caveat:
+* `SSH_KEY` is assumed to be an `id_rsa` file that has been base64 encoded. This permits the enviroment variable to live as a string in more contexts

--- a/docker/run_gunicorn.sh
+++ b/docker/run_gunicorn.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+if [ ! -z "$SSH_KEY" ]; then
+    echo "landing ssh key..."
+    mkdir /root/.ssh
+    chmod 700 /root/.ssh
+
+    # To preserve newlines, the env var is base64 encoded. Flip it back.
+    echo $SSH_KEY | base64 -d > /root/.ssh/id_rsa
+    chmod 400 /root/.ssh/id_rsa
+fi
+
+BIND="0.0.0.0:8000"
+NWORKERS=4
+TIMEOUT=30
+/env/bin/gunicorn --bind $BIND --workers $NWORKERS --timeout $TIMEOUT pontoon.wsgi:application --log-file -

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+
 # This requirements file is formatted to make it easy to see what are the
 # direct requirements of our application, and what are dependencies of
 # those requirements.
@@ -89,7 +90,8 @@ polib==1.0.6 \
     --hash=sha256:20d2a0d589a692c11df549bd7cda83c665eef2a83e017b843fecdf956edbad74
 psycopg2==2.7.3.2 \
     --hash=sha256:317612d5d0ca4a9f7e42afb2add69b10be360784d21ce4ecfbca19f1f5eadf43 \
-    --hash=sha256:7a9c6c62e6e05df5406e9b5235c31c376a22620ef26715a663cee57083b3c2ea
+    --hash=sha256:7a9c6c62e6e05df5406e9b5235c31c376a22620ef26715a663cee57083b3c2ea \
+    --hash=sha256:5c3213be557d0468f9df8fe2487eaf2990d9799202c5ff5cb8d394d09fad9b2a
 py-dateutil==2.2 \
     --hash=sha256:7efa2ca17159c590408cb624de9aa10d360f14097cb70dd7559e632f2cf4b048
 python-levenshtein==0.12.0 \


### PR DESCRIPTION
The Heroku approach at present requires environment variables to be landed in a file by the buildpacks. That means the dev docker approach today does the same. But that prevents being able to publish a Pontoon image to DockerHub that folks can run outside of Heroku. I wrote a new Dockerfile that is a tad smaller and portable. It uses the same environment variables, but gets them from docker at runtime so it can be shared.

I have this running on our Mesos cluster at Udacity. I am not using several of the add-ons though, so there is likely more work to do. I wanted to have a proposed solution for https://bugzilla.mozilla.org/show_bug.cgi?id=1513104 first though.

To review and test:
* build locally with `docker build -f docker/Dockerfile.prod -t mozilla/pontoon:latest .`
* replace the docker-compose config with that image
* deploy somewhere else? If someone could try using Heroku's new support for deploying Docker containers, that would be most excellent!