### PR TITLE
Bug 1514691: Change wording of the empty translation warning

### DIFF
--- a/pontoon/checks/libraries/translate_toolkit.py
+++ b/pontoon/checks/libraries/translate_toolkit.py
@@ -58,7 +58,7 @@ def run_checks(original, string, locale_code, disabled_checks=None):
         'startwhitespace': 'Starting whitespace',
         'tabs': 'Tabs',
         'unchanged': 'Unchanged',
-        'untranslated': 'Untranslated',
+        'untranslated': 'Empty translation',
         'urls': 'URLs',
         'validchars': 'Valid characters',
         'variables': 'Placeholders',


### PR DESCRIPTION
I've deployed this to stage as the first step to fixing bug 1514691.

Could you please have a look, @flodolo?