### PR TITLE
Bug 1394194 - List of locales in Admin ordered by locale code

### DIFF
--- a/pontoon/administration/views.py
+++ b/pontoon/administration/views.py
@@ -231,9 +231,9 @@ def manage_project(request, slug=None, template='admin_project.html'):
     form.label_suffix = ''
 
     projects = []
-    for p in Project.objects.prefetch_related('locales').order_by('name'):
+    for p in Project.objects.prefetch_related('locales').order_by('code'):
         projects.append({
-            'name': p.name,
+            'name': p.code,
             # Cannot use values_list() here, because it hits the DB again
             'locales': [l.pk for l in p.locales.all()],
         })

--- a/pontoon/administration/views.py
+++ b/pontoon/administration/views.py
@@ -94,8 +94,8 @@ def manage_project(request, slug=None, template='admin_project.html'):
     repo_formset = RepositoryInlineFormSet()
     external_resource_formset = ExternalResourceInlineFormSet()
     tag_formset = TagInlineFormSet()
-    locales_readonly = []
-    locales_selected = []
+    locales_readonly = Locale.objects.none()
+    locales_selected = Locale.objects.none()
     subtitle = 'Add project'
     pk = None
     project = None

--- a/pontoon/administration/views.py
+++ b/pontoon/administration/views.py
@@ -103,10 +103,10 @@ def manage_project(request, slug=None, template='admin_project.html'):
     # Save project
     if request.method == 'POST':
         locales_readonly = Locale.objects.filter(
-            pk__in=request.POST.getlist('locales_readonly').order_by('code')
+            pk__in=request.POST.getlist('locales_readonly')
         )
         locales_selected = Locale.objects.filter(
-            pk__in=request.POST.getlist('locales').order_by('code')
+            pk__in=request.POST.getlist('locales')
         ).exclude(
             pk__in=locales_readonly
         )
@@ -231,9 +231,9 @@ def manage_project(request, slug=None, template='admin_project.html'):
     form.label_suffix = ''
 
     projects = []
-    for p in Project.objects.prefetch_related('locales').order_by('name'):
+    for p in Project.objects.prefetch_related('locales').order_by('code'):
         projects.append({
-            'name': p.name,
+            'name': p.code,
             # Cannot use values_list() here, because it hits the DB again
             'locales': [l.pk for l in p.locales.all()],
         })

--- a/pontoon/administration/views.py
+++ b/pontoon/administration/views.py
@@ -237,6 +237,11 @@ def manage_project(request, slug=None, template='admin_project.html'):
             # Cannot use values_list() here, because it hits the DB again
             'locales': [l.pk for l in p.locales.all()],
         })
+        
+    locales_readonly = locales_readonly.order_by('code')
+    locales_selected = locales_selected.order_by('code')
+    locales_available = Locale.objects.exclude(pk__in=locales_selected)
+    locales_available = locales_available.order_by('code')
 
     data = {
         'slug': slug,
@@ -247,7 +252,7 @@ def manage_project(request, slug=None, template='admin_project.html'):
         'external_resource_formset': external_resource_formset,
         'locales_readonly': locales_readonly,
         'locales_selected': locales_selected,
-        'locales_available': Locale.objects.exclude(pk__in=locales_selected),
+        'locales_available': locales_available,
         'subtitle': subtitle,
         'pk': pk,
         'project': project,

--- a/pontoon/administration/views.py
+++ b/pontoon/administration/views.py
@@ -238,9 +238,11 @@ def manage_project(request, slug=None, template='admin_project.html'):
             'locales': [l.pk for l in p.locales.all()],
         })
         
+    locales_available = Locale.objects.exclude(pk__in=locales_selected)
+    
+    # Admins reason in terms of locale codes (see bug 1394194)
     locales_readonly = locales_readonly.order_by('code')
     locales_selected = locales_selected.order_by('code')
-    locales_available = Locale.objects.exclude(pk__in=locales_selected)
     locales_available = locales_available.order_by('code')
 
     data = {

--- a/pontoon/administration/views.py
+++ b/pontoon/administration/views.py
@@ -103,10 +103,10 @@ def manage_project(request, slug=None, template='admin_project.html'):
     # Save project
     if request.method == 'POST':
         locales_readonly = Locale.objects.filter(
-            pk__in=request.POST.getlist('locales_readonly')
+            pk__in=request.POST.getlist('locales_readonly').order_by('code')
         )
         locales_selected = Locale.objects.filter(
-            pk__in=request.POST.getlist('locales')
+            pk__in=request.POST.getlist('locales').order_by('code')
         ).exclude(
             pk__in=locales_readonly
         )
@@ -231,9 +231,9 @@ def manage_project(request, slug=None, template='admin_project.html'):
     form.label_suffix = ''
 
     projects = []
-    for p in Project.objects.prefetch_related('locales').order_by('code'):
+    for p in Project.objects.prefetch_related('locales').order_by('name'):
         projects.append({
-            'name': p.code,
+            'name': p.name,
             # Cannot use values_list() here, because it hits the DB again
             'locales': [l.pk for l in p.locales.all()],
         })

--- a/pontoon/administration/views.py
+++ b/pontoon/administration/views.py
@@ -231,9 +231,9 @@ def manage_project(request, slug=None, template='admin_project.html'):
     form.label_suffix = ''
 
     projects = []
-    for p in Project.objects.prefetch_related('locales').order_by('code'):
+    for p in Project.objects.prefetch_related('locales').order_by('name'):
         projects.append({
-            'name': p.code,
+            'name': p.name,
             # Cannot use values_list() here, because it hits the DB again
             'locales': [l.pk for l in p.locales.all()],
         })


### PR DESCRIPTION
This fixes the locales ordered by locale code. I have used `order_by('code')` function for this bug. 