### PR TITLE
Fix bug 1518828: [Translate.Next] Implement delete option in History tab

### DIFF
--- a/frontend/public/static/locale/en-US/translate.ftl
+++ b/frontend/public/static/locale/en-US/translate.ftl
@@ -66,6 +66,8 @@ history-history-no-translations = No translations available.
 ## History Translation
 ## Shows a specific translation for an entity, and actions around it
 
+history-translation-button-delete =
+    .title = Delete
 history-translation-button-approve =
     .title = Approve
 

--- a/frontend/public/static/locale/es/translate.ftl
+++ b/frontend/public/static/locale/es/translate.ftl
@@ -36,6 +36,8 @@ history-history-no-translations = No hay traducciones.
 ## History Translation
 ## Shows a specific translation for an entity, and actions around it
 
+history-translation-button-delete =
+    .title = Eliminar
 history-translation-button-approve =
     .title = Aprobar
 history-translation-button-unapprove =

--- a/frontend/public/static/locale/fr/translate.ftl
+++ b/frontend/public/static/locale/fr/translate.ftl
@@ -66,6 +66,8 @@ history-history-no-translations = Pas de traduction disponible.
 ## History Translation
 ## Shows a specific translation for an entity, and actions around it
 
+history-translation-button-delete =
+    .title = Supprimer
 history-translation-button-approve =
     .title = Approuver
 

--- a/frontend/src/core/api/translation.js
+++ b/frontend/src/core/api/translation.js
@@ -69,4 +69,16 @@ export default class TranslationAPI extends APIBase {
     unreject(id: number, resource: string) {
         return this._changeStatus('/unreject-translation/', id, resource);
     }
+
+    delete(id: number) {
+        const payload = new URLSearchParams();
+        payload.append('translation', id.toString());
+
+        const headers = new Headers();
+        const csrfToken = this.getCSRFToken();
+        headers.append('X-Requested-With', 'XMLHttpRequest');
+        headers.append('X-CSRFToken', csrfToken);
+
+        return this.fetch('/delete-translation/', 'POST', payload, headers);
+    }
 }

--- a/frontend/src/modules/history/actions.js
+++ b/frontend/src/modules/history/actions.js
@@ -117,10 +117,20 @@ export function updateStatus(
 }
 
 
+export function deleteTranslation(
+    translation: number,
+): Function {
+    return async dispatch => {
+        await api.translation.delete(translation);
+    }
+}
+
+
 export default {
     get,
     receive,
     request,
     reset,
     updateStatus,
+    deleteTranslation,
 };

--- a/frontend/src/modules/history/actions.js
+++ b/frontend/src/modules/history/actions.js
@@ -118,10 +118,14 @@ export function updateStatus(
 
 
 export function deleteTranslation(
+    entity: number,
+    locale: string,
+    pluralForm: number,
     translation: number,
 ): Function {
     return async dispatch => {
         await api.translation.delete(translation);
+        dispatch(get(entity, locale, pluralForm));
     }
 }
 

--- a/frontend/src/modules/history/components/History.js
+++ b/frontend/src/modules/history/components/History.js
@@ -59,8 +59,11 @@ export class HistoryBase extends React.Component<InternalProps> {
     }
 
     deleteTranslation = (translation: DBTranslation) => {
-        const { dispatch } = this.props;
+        const { parameters, pluralForm, dispatch } = this.props;
         dispatch(actions.deleteTranslation(
+            parameters.entity,
+            parameters.locale,
+            pluralForm,
             translation.pk,
         ));
     }

--- a/frontend/src/modules/history/components/History.js
+++ b/frontend/src/modules/history/components/History.js
@@ -58,6 +58,13 @@ export class HistoryBase extends React.Component<InternalProps> {
         ));
     }
 
+    deleteTranslation = (translation: DBTranslation) => {
+        const { dispatch } = this.props;
+        dispatch(actions.deleteTranslation(
+            translation.pk,
+        ));
+    }
+
     renderNoResults() {
         return <section className="history">
             <Localized id="history-history-no-translations">
@@ -91,6 +98,7 @@ export class HistoryBase extends React.Component<InternalProps> {
                         locale={ locale }
                         user={ user }
                         updateTranslationStatus={ this.updateTranslationStatus }
+                        deleteTranslation={ this.deleteTranslation }
                         key={ key }
                     />;
                 }) }

--- a/frontend/src/modules/history/components/Translation.css
+++ b/frontend/src/modules/history/components/Translation.css
@@ -116,7 +116,6 @@
 }
 
 .translation > header button.delete {
-    display: none;
     margin-right: 1px;
 }
 
@@ -129,8 +128,4 @@
 
 .translation > header button.delete:hover:before {
     color: #F36;
-}
-
-.translation.rejected.can-reject > header button.delete {
-    display: inline-block;
 }

--- a/frontend/src/modules/history/components/Translation.css
+++ b/frontend/src/modules/history/components/Translation.css
@@ -134,9 +134,3 @@
 .translation.rejected.can-reject > header button.delete {
     display: inline-block;
 }
-
-/* MANDATORY, or transitionend is triggered too late */
-.translation.deleted {
-    transform: scale(0);
-    -webkit-transform: scale(0);
-}

--- a/frontend/src/modules/history/components/Translation.css
+++ b/frontend/src/modules/history/components/Translation.css
@@ -63,6 +63,7 @@
     width: 22px;
 }
 
+.translation.rejected.can-reject header button.delete,
 .translation.can-approve header button.approve,
 .translation.can-approve header button.unapprove,
 .translation.can-reject header button.reject,
@@ -112,4 +113,30 @@
 .translation > header button.reject:not(:hover):before,
 .translation > header button.unreject:hover:before {
     font-weight: 400;
+}
+
+.translation > header button.delete {
+    display: none;
+    margin-right: 1px;
+}
+
+.translation > header button.delete:before {
+    content: "";
+    float: left;
+    font-size: 19px;
+    margin-top: -1px;
+}
+
+.translation > header button.delete:hover:before {
+    color: #F36;
+}
+
+.translation.rejected.can-reject > header button.delete {
+    display: inline-block;
+}
+
+/* MANDATORY, or transitionend is triggered too late */
+.translation.deleted {
+    transform: scale(0);
+    -webkit-transform: scale(0);
 }

--- a/frontend/src/modules/history/components/Translation.js
+++ b/frontend/src/modules/history/components/Translation.js
@@ -136,7 +136,7 @@ export default class Translation extends React.Component<Props> {
                             className='delete far'
                             title='Delete'
                             onClick={ this.delete }
-                        ></button>
+                        />
                     </Localized>
                     :
                     null
@@ -151,7 +151,7 @@ export default class Translation extends React.Component<Props> {
                             className='unapprove fa'
                             title='Unapprove'
                             onClick={ this.unapprove }
-                        ></button>
+                        />
                     </Localized>
                     :
                     // Approve Button
@@ -163,7 +163,7 @@ export default class Translation extends React.Component<Props> {
                             className='approve fa'
                             title='Approve'
                             onClick={ this.approve }
-                        ></button>
+                        />
                     </Localized>
                 }
                 { translation.rejected ?
@@ -176,7 +176,7 @@ export default class Translation extends React.Component<Props> {
                             className='unreject fa'
                             title='Unreject'
                             onClick={ this.unreject }
-                        ></button>
+                        />
                     </Localized>
                     :
                     // Reject Button
@@ -188,7 +188,7 @@ export default class Translation extends React.Component<Props> {
                             className='reject fa'
                             title='Reject'
                             onClick={ this.reject }
-                        ></button>
+                        />
                     </Localized>
                 }
                 </menu>

--- a/frontend/src/modules/history/components/Translation.js
+++ b/frontend/src/modules/history/components/Translation.js
@@ -115,6 +115,8 @@ export default class Translation extends React.Component<Props> {
             className += ' can-reject';
         }
 
+        let canDelete = canReview || ownTranslation;
+
         return <li className={ className }>
             <header className="clearfix">
                 <div className="info">
@@ -126,7 +128,7 @@ export default class Translation extends React.Component<Props> {
                     />
                 </div>
                 <menu className="toolbar">
-                { !translation.rejected ? null :
+                { (!translation.rejected || !canDelete ) ? null :
                     // Delete Button
                     <Localized
                         id="history-translation-button-delete"

--- a/frontend/src/modules/history/components/Translation.js
+++ b/frontend/src/modules/history/components/Translation.js
@@ -17,6 +17,7 @@ type Props = {|
     locale: Locale,
     user: UserState,
     updateTranslationStatus: Function,
+    deleteTranslation: Function,
 |};
 
 /**
@@ -43,6 +44,10 @@ export default class Translation extends React.Component<Props> {
 
     unreject = () => {
         this.props.updateTranslationStatus(this.props.translation, 'unreject');
+    }
+
+    delete = () => {
+        this.props.deleteTranslation(this.props.translation);
     }
 
     getStatus() {
@@ -121,6 +126,21 @@ export default class Translation extends React.Component<Props> {
                     />
                 </div>
                 <menu className="toolbar">
+                { translation.rejected ?
+                    // Delete Button
+                    <Localized
+                        id="history-translation-button-delete"
+                        attrs={{ title: true }}
+                    >
+                        <button
+                            className='delete far'
+                            title='Delete'
+                            onClick={ this.delete }
+                        ></button>
+                    </Localized>
+                    :
+                    null
+                }
                 { translation.approved ?
                     // Unapprove Button
                     <Localized

--- a/frontend/src/modules/history/components/Translation.js
+++ b/frontend/src/modules/history/components/Translation.js
@@ -126,7 +126,7 @@ export default class Translation extends React.Component<Props> {
                     />
                 </div>
                 <menu className="toolbar">
-                { translation.rejected ?
+                { !translation.rejected ? null :
                     // Delete Button
                     <Localized
                         id="history-translation-button-delete"
@@ -138,8 +138,6 @@ export default class Translation extends React.Component<Props> {
                             onClick={ this.delete }
                         />
                     </Localized>
-                    :
-                    null
                 }
                 { translation.approved ?
                     // Unapprove Button

--- a/frontend/src/modules/history/components/Translation.test.js
+++ b/frontend/src/modules/history/components/Translation.test.js
@@ -159,7 +159,6 @@ describe('<Translation>', () => {
             expect(wrapper.find('.unapprove')).toHaveLength(1);
             expect(wrapper.find('.reject')).toHaveLength(1);
             expect(wrapper.find('.unreject')).toHaveLength(0);
-            expect(wrapper.find('.delete')).toHaveLength(0);
         });
 
         it('shows the correct status for rejected translations', () => {
@@ -176,7 +175,6 @@ describe('<Translation>', () => {
             expect(wrapper.find('.unapprove')).toHaveLength(0);
             expect(wrapper.find('.reject')).toHaveLength(0);
             expect(wrapper.find('.unreject')).toHaveLength(1);
-            expect(wrapper.find('.delete')).toHaveLength(1);
         });
 
         it('shows the correct status for unreviewed translations', () => {
@@ -189,7 +187,6 @@ describe('<Translation>', () => {
             expect(wrapper.find('.unapprove')).toHaveLength(0);
             expect(wrapper.find('.reject')).toHaveLength(1);
             expect(wrapper.find('.unreject')).toHaveLength(0);
-            expect(wrapper.find('.delete')).toHaveLength(0);
         });
     });
 
@@ -217,7 +214,7 @@ describe('<Translation>', () => {
             expect(wrapper.find('.can-approve')).toHaveLength(0);
         });
 
-        it('allows translators to review the translation ', () => {
+        it('allows translators to review the translation', () => {
             const wrapper = shallow(<Translation
                 translation={ DEFAULT_TRANSLATION }
                 locale={ DEFAULT_LOCALE }
@@ -226,6 +223,49 @@ describe('<Translation>', () => {
 
             expect(wrapper.find('.can-reject')).toHaveLength(1);
             expect(wrapper.find('.can-approve')).toHaveLength(1);
+        });
+
+        it('allows translators to delete the rejected translation', () => {
+            const translation = { ...DEFAULT_TRANSLATION, rejected: true };
+            const wrapper = shallow(<Translation
+                translation={ translation }
+                locale={ DEFAULT_LOCALE }
+                canReview={ true }
+            />);
+
+            expect(wrapper.find('.delete')).toHaveLength(1);
+        });
+
+        it('forbids translators to delete non-rejected translation', () => {
+            const translation = { ...DEFAULT_TRANSLATION, rejected: false };
+            const wrapper = shallow(<Translation
+                translation={ translation }
+                locale={ DEFAULT_LOCALE }
+                canReview={ true }
+            />);
+
+            expect(wrapper.find('.delete')).toHaveLength(0);
+        });
+
+        it('allows the user to delete their own rejected translation', () => {
+            const translation = { ...DEFAULT_TRANSLATION, rejected: true };
+            const wrapper = shallow(<Translation
+                translation={ translation }
+                locale={ DEFAULT_LOCALE }
+                user={ DEFAULT_USER }
+            />);
+
+            expect(wrapper.find('.delete')).toHaveLength(1);
+        });
+
+        it('forbids the user to delete rejected translation of another user', () => {
+            const translation = { ...DEFAULT_TRANSLATION, rejected: true };
+            const wrapper = shallow(<Translation
+                translation={ translation }
+                locale={ DEFAULT_LOCALE }
+            />);
+
+            expect(wrapper.find('.delete')).toHaveLength(0);
         });
     });
 });

--- a/frontend/src/modules/history/components/Translation.test.js
+++ b/frontend/src/modules/history/components/Translation.test.js
@@ -159,6 +159,7 @@ describe('<Translation>', () => {
             expect(wrapper.find('.unapprove')).toHaveLength(1);
             expect(wrapper.find('.reject')).toHaveLength(1);
             expect(wrapper.find('.unreject')).toHaveLength(0);
+            expect(wrapper.find('.delete')).toHaveLength(0);
         });
 
         it('shows the correct status for rejected translations', () => {
@@ -175,6 +176,7 @@ describe('<Translation>', () => {
             expect(wrapper.find('.unapprove')).toHaveLength(0);
             expect(wrapper.find('.reject')).toHaveLength(0);
             expect(wrapper.find('.unreject')).toHaveLength(1);
+            expect(wrapper.find('.delete')).toHaveLength(1);
         });
 
         it('shows the correct status for unreviewed translations', () => {
@@ -187,6 +189,7 @@ describe('<Translation>', () => {
             expect(wrapper.find('.unapprove')).toHaveLength(0);
             expect(wrapper.find('.reject')).toHaveLength(1);
             expect(wrapper.find('.unreject')).toHaveLength(0);
+            expect(wrapper.find('.delete')).toHaveLength(0);
         });
     });
 

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -566,7 +566,9 @@ def delete_translation(request):
 
     translation.delete()
 
-    return HttpResponse('ok')
+    return JsonResponse({
+        'status': True,
+    })
 
 
 @utils.require_AJAX


### PR DESCRIPTION
This is a WIP patch which:
1. Shows the delete button when needed.
2. Deletes the translation on click.

This is the work that remains to be migrated:
https://github.com/mozilla/pontoon/blob/ba838fa88b787a9323f563987c35a4904fcab942/pontoon/base/static/js/translate.js#L2325-L2347

@adngdb I need some help:

1. How am I doing so far?
2. How do I reference the button to apply the `delete` class to it? Should I do that in `actions.js`?
3. How do I update count? Do I need to update `history.translations` first and then use length?