### PR TITLE
Fix bug 1521523: [FTL] Hardcode - in front of Term keys

### DIFF
--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -104,7 +104,15 @@ var Pontoon = (function (my) {
     return elements.every(function(element) {
       return (
         isSimpleElement(element) ||
-        (element.type === 'Placeable' && element.expression.type === 'SelectExpression')
+        (
+          element.type === 'Placeable' &&
+          element.expression.type === 'SelectExpression' &&
+          element.expression.variants.every(function(variant) {
+            return variant.value.elements.every(function(element) {
+              return isSimpleElement(element);
+            });
+          })
+        )
       );
     });
   }

--- a/pontoon/sync/formats/ftl.py
+++ b/pontoon/sync/formats/ftl.py
@@ -79,6 +79,11 @@ class FTLResource(ParsedResource):
         for obj in self.structure.body:
             if isinstance(obj, localizable_entries):
                 key = obj.id.name
+
+                # Bug 1521523: Term keys start with -
+                if isinstance(obj, ast.Term):
+                    key = '-' + key
+
                 comment = [obj.comment.content] if obj.comment else []
 
                 # Do not store comments in the string column


### PR DESCRIPTION
This is how the non-imported strings from prod look on stage:
https://mozilla-pontoon-staging.herokuapp.com/ru/firefox/browser/browser/branding/sync-brand.ftl/
https://mozilla-pontoon-staging.herokuapp.com/uk/firefox/browser/browser/branding/sync-brand.ftl/