### PR TITLE
No bug - Enable running only changed frontend tests.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,5 +3,7 @@
 **/*.pyc
 __pycache__
 .cache
-venv
+assets
+node_modules
 static
+venv

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,8 @@ services:
       - ./frontend/src:/app/frontend/src
       - ./frontend/public:/app/frontend/public
       - ./tests:/app/tests
+      # git is used to run only tests that changed
+      - ./.git:/app/.git
 
   postgresql:
     build:

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -2,7 +2,8 @@ FROM python:2.7.13-slim
 
 RUN apt-get update && apt-get -y --no-install-recommends install \
     ca-certificates \
-    curl
+    curl \
+    git
 
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
 RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture | awk -F- '{ print $NF }')" \


### PR DESCRIPTION
This requires the container to have git, and the local .git folder. With those, running tests with jest automatically only runs the tests that have changed since the last commit.