### PR TITLE
Fix bug 1486496 - Add a Machinery tab to Translate.Next. 

### DIFF
--- a/frontend/public/static/locale/en-US/translate.ftl
+++ b/frontend/public/static/locale/en-US/translate.ftl
@@ -22,19 +22,37 @@ editor-settings-force-suggestions = <glyph></glyph>Make Suggestions
 editor-settings-change-all = Change All Settings
 
 
+## Machinery
+## Shows a list of translations from machines.
+
+machinery-machinery-search-placeholder =
+    .placeholder = Type to search machinery
+
+machinery-translation-copy =
+    .title = Copy Into Translation (Tab)
+
+machinery-translation-number-occurrences =
+    .title = Number of translation occurrences
+
+
 ## Metadata
 ## Shows metadata about an entity (original string)
 
 entitydetails-metadata-plural = Plural
 entitydetails-metadata-singular = Singular
+
 entitydetails-metadata-comment =
     .title = Comment
+
 entitydetails-metadata-context =
     .title = Context
+
 entitydetails-metadata-placeholder =
     .title = Placeholder Examples
+
 entitydetails-metadata-resource =
     .title = Resource
+
 entitydetails-metadata-project =
     .title = Project
 
@@ -50,9 +68,12 @@ history-history-no-translations = No translations available.
 
 history-translation-button-approve =
     .title = Approve
+
 history-translation-button-unapprove =
     .title = Unapprove
+
 history-translation-button-reject =
     .title = Reject
+
 history-translation-button-unreject =
     .title = Unreject

--- a/frontend/public/static/locale/fr/translate.ftl
+++ b/frontend/public/static/locale/fr/translate.ftl
@@ -22,19 +22,37 @@ editor-settings-force-suggestions = <glyph></glyph>Faire des suggestions
 editor-settings-change-all = Changer tous les paramètres
 
 
+## Machinery
+## Shows a list of translations from machines.
+
+machinery-machinery-search-placeholder =
+    .placeholder = Saisir pour rechercher la machinerie
+
+machinery-translation-copy =
+    .title = Copier la traduction (Tab)
+
+machinery-translation-number-occurrences =
+    .title = Nombre d'occurrences de la traduction
+
+
 ## Metadata
 ## Shows metadata about an entity (original string)
 
 entitydetails-metadata-plural = Pluriel
 entitydetails-metadata-singular = Singulier
+
 entitydetails-metadata-comment =
     .title = Commentaire
+
 entitydetails-metadata-context =
     .title = Contexte
+
 entitydetails-metadata-placeholder =
     .title = Exemples bouche-trous
+
 entitydetails-metadata-resource =
     .title = Ressource
+
 entitydetails-metadata-project =
     .title = Projet
 
@@ -50,9 +68,12 @@ history-history-no-translations = Pas de traduction disponible.
 
 history-translation-button-approve =
     .title = Approuver
+
 history-translation-button-unapprove =
     .title = Désapprouver
+
 history-translation-button-reject =
     .title = Rejeter
+
 history-translation-button-unreject =
     .title = Dérejeter

--- a/frontend/src/core/api/index.js
+++ b/frontend/src/core/api/index.js
@@ -3,6 +3,7 @@
 import EntityAPI from './entity';
 import LocaleAPI from './locale';
 import L10nAPI from './l10n';
+import Machinery from './machinery';
 import TranslationAPI from './translation';
 import UserAPI from './user';
 
@@ -13,6 +14,7 @@ export default {
     entity: new EntityAPI(),
     locale: new LocaleAPI(),
     l10n: new L10nAPI(),
+    machinery: new Machinery(),
     translation: new TranslationAPI(),
     user: new UserAPI(),
     types,

--- a/frontend/src/core/api/locale.js
+++ b/frontend/src/core/api/locale.js
@@ -13,6 +13,10 @@ export default class LocaleAPI extends APIBase {
                 pluralRule
                 direction
                 script
+                googleTranslateCode
+                msTranslatorCode
+                msTerminologyCode
+                transvision
             }
         }`;
         const payload = new URLSearchParams();

--- a/frontend/src/core/api/machinery.js
+++ b/frontend/src/core/api/machinery.js
@@ -63,19 +63,19 @@ export default class MachineryAPI extends APIBase {
 
         const result = await this._get(url, params);
 
-        if (result.translation) {
-            return [{
-                sources: [{
-                    type: 'Google Translate',
-                    url: 'https://translate.google.com/',
-                    title: 'Visit Google Translate',
-                }],
-                original: entity.original,
-                translation: result.translation,
-            }];
+        if (!result.translation) {
+            return [];
         }
 
-        return [];
+        return [{
+            sources: [{
+                type: 'Google Translate',
+                url: 'https://translate.google.com/',
+                title: 'Visit Google Translate',
+            }],
+            original: entity.original,
+            translation: result.translation,
+        }];
     }
 
     /**
@@ -90,19 +90,19 @@ export default class MachineryAPI extends APIBase {
 
         const result = await this._get(url, params);
 
-        if (result.translation) {
-            return [{
-                sources: [{
-                    type: 'Microsoft Translator',
-                    url: 'https://www.bing.com/translator',
-                    title: 'Visit Bing Translator',
-                }],
-                original: entity.original,
-                translation: result.translation,
-            }];
+        if (!result.translation) {
+            return [];
         }
 
-        return [];
+        return [{
+            sources: [{
+                type: 'Microsoft Translator',
+                url: 'https://www.bing.com/translator',
+                title: 'Visit Bing Translator',
+            }],
+            original: entity.original,
+            translation: result.translation,
+        }];
     }
 
     /**
@@ -179,18 +179,18 @@ export default class MachineryAPI extends APIBase {
 
         const result = await this._get(url, params);
 
-        if (result.translation) {
-            return [{
-                sources: [{
-                    type: 'Caighdean',
-                    url: 'https://github.com/kscanne/caighdean',
-                    title: 'Visit Caighdean Machine Translation',
-                }],
-                original: result.original,
-                translation: result.translation,
-            }];
+        if (!result.translation) {
+            return [];
         }
 
-        return [];
+        return [{
+            sources: [{
+                type: 'Caighdean',
+                url: 'https://github.com/kscanne/caighdean',
+                title: 'Visit Caighdean Machine Translation',
+            }],
+            original: result.original,
+            translation: result.translation,
+        }];
     }
 }

--- a/frontend/src/core/api/machinery.js
+++ b/frontend/src/core/api/machinery.js
@@ -1,0 +1,180 @@
+/* @flow */
+
+import APIBase from './base';
+
+import type { Locale } from 'core/locales';
+import type { DbEntity } from 'modules/entitieslist';
+import type { MachineryTranslation } from './types';
+
+
+type Translations = Array<MachineryTranslation>;
+
+
+export default class MachineryAPI extends APIBase {
+    async _get(url: string, params: Object) {
+        const payload = new URLSearchParams();
+        for (let param in params) {
+            payload.append(param, params[param]);
+        }
+
+        const headers = new Headers();
+        headers.append('X-Requested-With', 'XMLHttpRequest');
+
+        return await this.fetch(url, 'GET', payload, headers);
+    }
+
+    /**
+     * Return translations from Pontoon's memory.
+     */
+    async getTranslationMemory(entity: DbEntity, locale: Locale): Promise<Translations> {
+        const url = '/translation-memory/';
+        const params = {
+            text: entity.original,
+            locale: locale.code,
+            pk: entity.pk,
+        };
+
+        const results = await this._get(url, params);
+
+        return results.map(item => {
+            return {
+                source: 'Translation memory',
+                url: '/',
+                title: 'Pontoon Homepage',
+                original: entity.original,
+                translation: item.target,
+                quality: Math.round(item.quality) + '%',
+                count: item.count,
+            };
+        });
+    }
+
+    /**
+     * Return translation by Google Translate.
+     */
+    async getGoogleTranslation(entity: DbEntity, locale: Locale): Promise<Translations> {
+        const url = '/google-translate/';
+        const params = {
+            text: entity.original,
+            locale: locale.googleTranslateCode,
+        };
+
+        const result = await this._get(url, params);
+
+        if (result.translation) {
+            return [{
+                source: 'Google Translate',
+                url: 'https://translate.google.com/',
+                title: 'Visit Google Translate',
+                original: entity.original,
+                translation: result.translation,
+            }];
+        }
+
+        return [];
+    }
+
+    /**
+     * Return translation by Microsoft Translator.
+     */
+    async getMicrosoftTranslation(entity: DbEntity, locale: Locale): Promise<Translations> {
+        const url = '/microsoft-translator/';
+        const params = {
+            text: entity.original,
+            locale: locale.msTranslatorCode,
+        };
+
+        const result = await this._get(url, params);
+
+        if (result.translation) {
+            return [{
+                source: 'Microsoft Translator',
+                url: 'https://www.bing.com/translator',
+                title: 'Visit Bing Translator',
+                original: entity.original,
+                translation: result.translation,
+            }];
+        }
+
+        return [];
+    }
+
+    /**
+     * Return translations from Microsoft Terminology.
+     */
+    async getMicrosoftTerminology(entity: DbEntity, locale: Locale): Promise<Translations> {
+        const url = '/microsoft-terminology/';
+        const params = {
+            text: entity.original,
+            locale: locale.msTerminologyCode,
+        };
+
+        const results = await this._get(url, params);
+
+        return results.map(item => {
+            return {
+                source: 'Microsoft',
+                url: 'https://www.microsoft.com/Language/en-US/Search.aspx?sString=' +
+                     item.source + '&langID=' + locale.msTerminologyCode,
+                title: 'Visit Microsoft Terminology Service API.\n' +
+                       '© 2018 Microsoft Corporation. All rights reserved.',
+                original: item.source,
+                translation: item.target,
+                quality: Math.round(item.quality) + '%',
+            };
+        });
+    }
+
+    /**
+     * Return translations from Transvision.
+     */
+    async getTransvisionMemory(entity: DbEntity, locale: Locale): Promise<Translations> {
+        const url = '/transvision/';
+        const params = {
+            text: entity.original,
+            locale: locale.code,
+        };
+
+        const results = await this._get(url, params);
+
+        return results.map(item => {
+            return {
+                source: 'Mozilla',
+                url: 'https://transvision.mozfr.org/?repo=global' +
+                     '&recherche=' + encodeURIComponent(entity.original) +
+                     '&locale=' + locale.code,
+                title: 'Visit Transvision',
+                original: item.source,
+                translation: item.target,
+                quality: Math.round(item.quality) + '%',
+            };
+        });
+    }
+
+    /**
+     * Return translation by Caighdean Machine Translation.
+     *
+     * Works only for the `ga-IE` locale.
+     */
+    async getCaighdeanTranslation(entity: DbEntity, locale: Locale): Promise<Translations> {
+        const url = '/caighdean/';
+        const params = {
+            id: entity.pk,
+            locale: locale.code,
+        };
+
+        const result = await this._get(url, params);
+
+        if (result.translation) {
+            return [{
+                source: 'Caighdean',
+                url: 'https://github.com/kscanne/caighdean',
+                title: 'Visit Caighdean Machine Translation',
+                original: result.original,
+                translation: result.translation,
+            }];
+        }
+
+        return [];
+    }
+}

--- a/frontend/src/core/api/machinery.js
+++ b/frontend/src/core/api/machinery.js
@@ -38,13 +38,15 @@ export default class MachineryAPI extends APIBase {
 
         return results.map(item => {
             return {
-                source: 'Translation memory',
-                url: '/',
-                title: 'Pontoon Homepage',
+                sources: [{
+                    type: 'Translation memory',
+                    url: '/',
+                    title: 'Pontoon Homepage',
+                    count: item.count,
+                }],
                 original: item.source,
                 translation: item.target,
-                quality: Math.round(item.quality) + '%',
-                count: item.count,
+                quality: Math.round(item.quality),
             };
         });
     }
@@ -63,9 +65,11 @@ export default class MachineryAPI extends APIBase {
 
         if (result.translation) {
             return [{
-                source: 'Google Translate',
-                url: 'https://translate.google.com/',
-                title: 'Visit Google Translate',
+                sources: [{
+                    type: 'Google Translate',
+                    url: 'https://translate.google.com/',
+                    title: 'Visit Google Translate',
+                }],
                 original: entity.original,
                 translation: result.translation,
             }];
@@ -88,9 +92,11 @@ export default class MachineryAPI extends APIBase {
 
         if (result.translation) {
             return [{
-                source: 'Microsoft Translator',
-                url: 'https://www.bing.com/translator',
-                title: 'Visit Bing Translator',
+                sources: [{
+                    type: 'Microsoft Translator',
+                    url: 'https://www.bing.com/translator',
+                    title: 'Visit Bing Translator',
+                }],
                 original: entity.original,
                 translation: result.translation,
             }];
@@ -111,16 +117,22 @@ export default class MachineryAPI extends APIBase {
 
         const results = await this._get(url, params);
 
-        return results.map(item => {
+        if (!results.translations) {
+            return [];
+        }
+
+        return results.translations.map(item => {
             return {
-                source: 'Microsoft',
-                url: 'https://www.microsoft.com/Language/en-US/Search.aspx?sString=' +
-                     item.source + '&langID=' + locale.msTerminologyCode,
-                title: 'Visit Microsoft Terminology Service API.\n' +
-                       '© 2018 Microsoft Corporation. All rights reserved.',
+                sources: [{
+                    type: 'Microsoft',
+                    url: 'https://www.microsoft.com/Language/en-US/Search.aspx?sString=' +
+                        item.source + '&langID=' + locale.msTerminologyCode,
+                    title: 'Visit Microsoft Terminology Service API.\n' +
+                        '© 2018 Microsoft Corporation. All rights reserved.',
+                }],
                 original: item.source,
                 translation: item.target,
-                quality: Math.round(item.quality) + '%',
+                quality: Math.round(item.quality),
             };
         });
     }
@@ -139,14 +151,16 @@ export default class MachineryAPI extends APIBase {
 
         return results.map(item => {
             return {
-                source: 'Mozilla',
-                url: 'https://transvision.mozfr.org/?repo=global' +
-                     '&recherche=' + encodeURIComponent(entity.original) +
-                     '&locale=' + locale.code,
-                title: 'Visit Transvision',
+                sources: [{
+                    type: 'Mozilla',
+                    url: 'https://transvision.mozfr.org/?repo=global' +
+                        '&recherche=' + encodeURIComponent(entity.original) +
+                        '&locale=' + locale.code,
+                    title: 'Visit Transvision',
+                }],
                 original: item.source,
                 translation: item.target,
-                quality: Math.round(item.quality) + '%',
+                quality: Math.round(item.quality),
             };
         });
     }
@@ -167,9 +181,11 @@ export default class MachineryAPI extends APIBase {
 
         if (result.translation) {
             return [{
-                source: 'Caighdean',
-                url: 'https://github.com/kscanne/caighdean',
-                title: 'Visit Caighdean Machine Translation',
+                sources: [{
+                    type: 'Caighdean',
+                    url: 'https://github.com/kscanne/caighdean',
+                    title: 'Visit Caighdean Machine Translation',
+                }],
                 original: result.original,
                 translation: result.translation,
             }];

--- a/frontend/src/core/api/machinery.js
+++ b/frontend/src/core/api/machinery.js
@@ -41,7 +41,7 @@ export default class MachineryAPI extends APIBase {
                 source: 'Translation memory',
                 url: '/',
                 title: 'Pontoon Homepage',
-                original: entity.original,
+                original: item.source,
                 translation: item.target,
                 quality: Math.round(item.quality) + '%',
                 count: item.count,

--- a/frontend/src/core/api/types.js
+++ b/frontend/src/core/api/types.js
@@ -10,3 +10,18 @@ export type OtherLocaleTranslation = {|
     +script: string,
     +translation: string,
 |};
+
+
+/*
+ * Translation that comes from a machine (Machine Translation,
+ * Translation Memory... ).
+ */
+export type MachineryTranslation = {|
+    source: string,
+    url: string,
+    title: string,
+    original: string,
+    translation: string,
+    quality?: string,
+    count?: number,
+|};

--- a/frontend/src/core/api/types.js
+++ b/frontend/src/core/api/types.js
@@ -17,11 +17,13 @@ export type OtherLocaleTranslation = {|
  * Translation Memory... ).
  */
 export type MachineryTranslation = {|
-    source: string,
-    url: string,
-    title: string,
+    sources: Array<{|
+        type: string,
+        url: string,
+        title: string,
+        count?: number,
+    |}>,
     original: string,
     translation: string,
-    quality?: string,
-    count?: number,
+    quality?: number,
 |};

--- a/frontend/src/core/locales/actions.js
+++ b/frontend/src/core/locales/actions.js
@@ -13,6 +13,10 @@ export type Locale = {|
     +direction: string,
     +name: string,
     +script: string,
+    +googleTranslateCode: string,
+    +msTranslatorCode: string,
+    +msTerminologyCode: string,
+    +transvision: boolean,
 |};
 
 

--- a/frontend/src/modules/entitydetails/components/EntityDetails.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.js
@@ -25,6 +25,7 @@ import type { NavigationParams } from 'core/navigation';
 import type { UserState } from 'core/user';
 import type { DbEntity } from 'modules/entitieslist';
 import type { HistoryState } from 'modules/history';
+import type { MachineryState } from 'modules/machinery';
 import type { LocalesState } from 'modules/otherlocales';
 
 
@@ -32,6 +33,7 @@ type Props = {|
     activeTranslation: string,
     history: HistoryState,
     locale: ?Locale,
+    machinery: MachineryState,
     nextEntity: ?DbEntity,
     otherlocales: LocalesState,
     parameters: NavigationParams,
@@ -142,6 +144,7 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
             <Tools
                 parameters={ state.parameters }
                 history={ state.history }
+                machinery={ state.machinery }
                 otherlocales={ state.otherlocales }
             />
         </section>;
@@ -154,6 +157,7 @@ const mapStateToProps = (state: Object): Props => {
         activeTranslation: selectors.getTranslationForSelectedEntity(state),
         history: state[history.NAME],
         locale: locales.selectors.getCurrentLocaleData(state),
+        machinery: state[machinery.NAME],
         nextEntity: entitieslist.selectors.getNextEntity(state),
         otherlocales: state[otherlocales.NAME],
         parameters: navigation.selectors.getNavigationParams(state),

--- a/frontend/src/modules/entitydetails/components/EntityDetails.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.js
@@ -12,6 +12,7 @@ import * as plural from 'core/plural';
 import * as user from 'core/user';
 import * as entitieslist from 'modules/entitieslist';
 import * as history from 'modules/history';
+import * as machinery from 'modules/machinery';
 import * as otherlocales from 'modules/otherlocales';
 import { Editor } from 'modules/editor';
 
@@ -61,20 +62,26 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
     }
 
     componentDidUpdate(prevProps: InternalProps) {
-        const { parameters, pluralForm } = this.props;
+        const { parameters, pluralForm, selectedEntity } = this.props;
 
         if (
             parameters.entity !== prevProps.parameters.entity ||
-            pluralForm !== prevProps.pluralForm
+            pluralForm !== prevProps.pluralForm ||
+            selectedEntity !== prevProps.selectedEntity
         ) {
             this.fetchHelpersData();
         }
     }
 
     fetchHelpersData() {
-        const { dispatch, parameters, pluralForm } = this.props;
+        const { dispatch, locale, parameters, pluralForm, selectedEntity } = this.props;
+
+        if (!parameters.entity || !selectedEntity || !locale) {
+            return;
+        }
 
         dispatch(history.actions.get(parameters.entity, parameters.locale, pluralForm));
+        dispatch(machinery.actions.get(selectedEntity, locale));
         dispatch(otherlocales.actions.get(parameters.entity, parameters.locale));
     }
 

--- a/frontend/src/modules/entitydetails/components/MachineryCount.js
+++ b/frontend/src/modules/entitydetails/components/MachineryCount.js
@@ -1,0 +1,47 @@
+/* @flow */
+
+import * as React from 'react';
+
+import type { MachineryState } from 'modules/machinery';
+
+
+type Props = {|
+    machinery: MachineryState,
+|};
+
+
+export default class MachineryCount extends React.Component<Props> {
+    render() {
+        const { machinery } = this.props;
+
+        const machineryCount = machinery.translations.length;
+
+        const preferredCount = machinery.translations.reduce((count, item) => {
+            if (item.sources.find(source => source.type === 'Translation memory')) {
+                return count + 1;
+            }
+            return count;
+        }, 0);
+
+        const remainingCount = machineryCount - preferredCount;
+
+        const preferred = (
+            !preferredCount ? null :
+            <span className='preferred'>{ preferredCount }</span>
+        );
+        const remaining = (
+            !remainingCount ? null :
+            <span>{ remainingCount }</span>
+        );
+        const plus = (
+            !remainingCount || !preferredCount ? null :
+            <span>{ '+' }</span>
+        );
+
+        return <span className='count'>
+            { preferred }
+            { plus }
+            { remaining }
+        </span>;
+    }
+}

--- a/frontend/src/modules/entitydetails/components/MachineryCount.test.js
+++ b/frontend/src/modules/entitydetails/components/MachineryCount.test.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import MachineryCount from './MachineryCount';
+
+
+describe('<MachineryCount>', () => {
+    it('shows the correct number of preferred translations', () => {
+        const machinery = {
+            translations: [
+                { sources: [{ type: 'Translation memory' }] },
+                { sources: [{ type: 'Translation memory' }] },
+            ],
+        };
+        const wrapper = shallow(<MachineryCount machinery={ machinery } />);
+
+        // There are only preferred results.
+        expect(wrapper.find('.count > span')).toHaveLength(1);
+
+        // And there are two of them.
+        expect(wrapper.find('.preferred').text()).toContain('2');
+
+        expect(wrapper.text()).not.toContain('+');
+    });
+
+    it('shows the correct number of remaining translations', () => {
+        const machinery = {
+            translations: [
+                { sources: [{ type: 'Microsoft' }] },
+                { sources: [{ type: 'Transvision' }] },
+                { sources: [{ type: 'Transvision' }] },
+            ],
+        };
+        const wrapper = shallow(<MachineryCount machinery={ machinery } />);
+
+        // There are only remaining results.
+        expect(wrapper.find('.count > span')).toHaveLength(1);
+        expect(wrapper.find('.preferred')).toHaveLength(0);
+
+        // And there are three of them.
+        expect(wrapper.find('.count > span').text()).toContain('3');
+
+        expect(wrapper.text()).not.toContain('+');
+    });
+
+    it('shows the correct numbers of preferred and remaining translations', () => {
+        const machinery = {
+            translations: [
+                { sources: [{ type: 'Translation memory' }] },
+                { sources: [{ type: 'Translation memory' }] },
+                { sources: [{ type: 'Microsoft' }] },
+                { sources: [{ type: 'Transvision' }] },
+                { sources: [{ type: 'Transvision' }] },
+            ],
+        };
+        const wrapper = shallow(<MachineryCount machinery={ machinery } />);
+
+        // There are both preferred and remaining, and the '+' sign.
+        expect(wrapper.find('.count > span')).toHaveLength(3);
+
+        // And each count is correct.
+        expect(wrapper.find('.preferred').text()).toContain('2');
+        expect(wrapper.find('.count > span').last().text()).toContain('3');
+        expect(wrapper.find('.preferred').text()).toContain('2');
+
+        // And the final display is correct as well.
+        expect(wrapper.text()).toEqual('2+3');
+    });
+});

--- a/frontend/src/modules/entitydetails/components/Tools.css
+++ b/frontend/src/modules/entitydetails/components/Tools.css
@@ -71,6 +71,10 @@
     background: #4D5967;
 }
 
+.react-tabs span.count .preferred {
+    color: #7BC876;
+}
+
 .react-tabs__tab,
 .react-tabs__tab-panel {
     height: calc(100% - 37px);

--- a/frontend/src/modules/entitydetails/components/Tools.js
+++ b/frontend/src/modules/entitydetails/components/Tools.js
@@ -6,6 +6,7 @@ import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
 import './Tools.css';
 
 import { History } from 'modules/history';
+import { Machinery } from 'modules/machinery';
 import { Locales } from 'modules/otherlocales';
 
 
@@ -37,6 +38,9 @@ export default class Tools extends React.Component<Props> {
                     }
                 </Tab>
                 <Tab>
+                    Machinery
+                </Tab>
+                <Tab>
                     Locales
                     { !otherlocalesCount ? null :
                     <span className={ 'count' }>{ otherlocalesCount }</span>
@@ -46,6 +50,9 @@ export default class Tools extends React.Component<Props> {
 
             <TabPanel>
                 <History />
+            </TabPanel>
+            <TabPanel>
+                <Machinery />
             </TabPanel>
             <TabPanel>
                 <Locales otherlocales={ otherlocales } parameters={ parameters } />

--- a/frontend/src/modules/entitydetails/components/Tools.js
+++ b/frontend/src/modules/entitydetails/components/Tools.js
@@ -9,12 +9,58 @@ import { History } from 'modules/history';
 import { Machinery } from 'modules/machinery';
 import { Locales } from 'modules/otherlocales';
 
+import type { HistoryState } from 'modules/history';
+import type { MachineryState } from 'modules/machinery';
+
 
 type Props = {|
-    history: Object,
+    history: HistoryState,
+    machinery: MachineryState,
     otherlocales: Object,
     parameters: Object,
 |};
+
+
+type CountProps = {|
+    machinery: MachineryState,
+|};
+
+
+class MachineryCount extends React.Component<CountProps> {
+    render() {
+        const { machinery } = this.props;
+
+        const machineryCount = machinery.translations.length;
+
+        const preferredCount = machinery.translations.reduce((count, item) => {
+            if (item.sources.find(source => source.type === 'Translation memory')) {
+                return count + 1;
+            }
+            return count;
+        }, 0);
+
+        const remainingCount = machineryCount - preferredCount;
+
+        const preferred = (
+            !preferredCount ? null :
+            <span className='preferred'>{ preferredCount }</span>
+        );
+        const remaining = (
+            !remainingCount ? null :
+            <span>{ remainingCount }</span>
+        );
+        const plus = (
+            !remainingCount || !preferredCount ? null :
+            <span>{ '+' }</span>
+        );
+
+        return <span className='count'>
+            { preferred }
+            { plus }
+            { remaining }
+        </span>;
+    }
+};
 
 
 /**
@@ -24,7 +70,7 @@ type Props = {|
  */
 export default class Tools extends React.Component<Props> {
     render() {
-        const { history, otherlocales, parameters } = this.props;
+        const { history, machinery, otherlocales, parameters } = this.props;
 
         const historyCount = history.translations.length;
         const otherlocalesCount = otherlocales.translations.length;
@@ -39,6 +85,7 @@ export default class Tools extends React.Component<Props> {
                 </Tab>
                 <Tab>
                     Machinery
+                    <MachineryCount machinery={ machinery } />
                 </Tab>
                 <Tab>
                     Locales

--- a/frontend/src/modules/entitydetails/components/Tools.js
+++ b/frontend/src/modules/entitydetails/components/Tools.js
@@ -9,58 +9,20 @@ import { History } from 'modules/history';
 import { Machinery } from 'modules/machinery';
 import { Locales } from 'modules/otherlocales';
 
+import MachineryCount from './MachineryCount';
+
+import type { NavigationParams } from 'core/navigation';
 import type { HistoryState } from 'modules/history';
 import type { MachineryState } from 'modules/machinery';
+import type { LocalesState } from 'modules/otherlocales';
 
 
 type Props = {|
     history: HistoryState,
     machinery: MachineryState,
-    otherlocales: Object,
-    parameters: Object,
+    otherlocales: LocalesState,
+    parameters: NavigationParams,
 |};
-
-
-type CountProps = {|
-    machinery: MachineryState,
-|};
-
-
-class MachineryCount extends React.Component<CountProps> {
-    render() {
-        const { machinery } = this.props;
-
-        const machineryCount = machinery.translations.length;
-
-        const preferredCount = machinery.translations.reduce((count, item) => {
-            if (item.sources.find(source => source.type === 'Translation memory')) {
-                return count + 1;
-            }
-            return count;
-        }, 0);
-
-        const remainingCount = machineryCount - preferredCount;
-
-        const preferred = (
-            !preferredCount ? null :
-            <span className='preferred'>{ preferredCount }</span>
-        );
-        const remaining = (
-            !remainingCount ? null :
-            <span>{ remainingCount }</span>
-        );
-        const plus = (
-            !remainingCount || !preferredCount ? null :
-            <span>{ '+' }</span>
-        );
-
-        return <span className='count'>
-            { preferred }
-            { plus }
-            { remaining }
-        </span>;
-    }
-};
 
 
 /**
@@ -73,6 +35,7 @@ export default class Tools extends React.Component<Props> {
         const { history, machinery, otherlocales, parameters } = this.props;
 
         const historyCount = history.translations.length;
+        const machineryCount = machinery.translations.length;
         const otherlocalesCount = otherlocales.translations.length;
 
         return <Tabs>
@@ -85,7 +48,9 @@ export default class Tools extends React.Component<Props> {
                 </Tab>
                 <Tab>
                     Machinery
+                    { !machineryCount ? null :
                     <MachineryCount machinery={ machinery } />
+                    }
                 </Tab>
                 <Tab>
                     Locales

--- a/frontend/src/modules/machinery/actions.js
+++ b/frontend/src/modules/machinery/actions.js
@@ -1,0 +1,89 @@
+/* @flow */
+
+import api from 'core/api';
+
+import type { Locale } from 'core/locales';
+import type { DbEntity } from 'modules/entitieslist';
+
+
+export const ADD_TRANSLATIONS: 'machinery/ADD_TRANSLATIONS' = 'machinery/ADD_TRANSLATIONS';
+export const RESET: 'machinery/RESET' = 'machinery/RESET';
+
+
+/**
+ * Add a list of machine translations to the current list.
+ */
+export type AddTranslationsAction = {
+    +type: typeof ADD_TRANSLATIONS,
+    +translations: Array<api.types.MachineryTranslation>,
+};
+export function addTranslations(
+    translations: Array<api.types.MachineryTranslation>
+): AddTranslationsAction {
+    return {
+        type: ADD_TRANSLATIONS,
+        translations: translations,
+    };
+}
+
+
+/**
+ * Reset the list of machinery translations.
+ */
+export type ResetAction = {
+    +type: typeof RESET,
+};
+export function reset(): ResetAction {
+    return {
+        type: RESET,
+    };
+}
+
+
+/**
+ * Get all machinery results for a given entity.
+ *
+ * This will fetch and return data from:
+ *  - Translation Memory
+ *  - Google Translate (if supported)
+ *  - Microsoft Translator (if supported)
+ *  - Microsoft Terminology (if enabled for the locale)
+ *  - Transvision (if enabled for the locale)
+ *  - Caighdean (if enabled for the locale)
+ */
+export function get(entity: DbEntity, locale: Locale): Function {
+    return async dispatch => {
+        dispatch(reset());
+
+        const memory = await api.machinery.getTranslationMemory(entity, locale);
+        dispatch(addTranslations(memory));
+
+        const googleTranslation = await api.machinery.getGoogleTranslation(entity, locale);
+        dispatch(addTranslations(googleTranslation));
+
+        const microsoftTranslation = await api.machinery.getMicrosoftTranslation(entity, locale);
+        dispatch(addTranslations(microsoftTranslation));
+
+        if (locale.msTerminologyCode) {
+            const msTerminology = await api.machinery.getMicrosoftTerminology(entity, locale);
+            dispatch(addTranslations(msTerminology));
+        }
+
+        if (locale.transvision) {
+            const transvisionMemory = await api.machinery.getTransvisionMemory(entity, locale);
+            dispatch(addTranslations(transvisionMemory));
+        }
+
+        if (locale.code === 'ga-IE') {
+            const caighdean = await api.machinery.getCaighdeanTranslation(entity, locale);
+            dispatch(addTranslations(caighdean));
+        }
+    }
+}
+
+
+export default {
+    addTranslations,
+    get,
+    reset,
+};

--- a/frontend/src/modules/machinery/actions.js
+++ b/frontend/src/modules/machinery/actions.js
@@ -55,28 +55,28 @@ export function get(entity: DbEntity, locale: Locale): Function {
     return async dispatch => {
         dispatch(reset());
 
-        const memory = await api.machinery.getTranslationMemory(entity, locale);
-        dispatch(addTranslations(memory));
+        api.machinery.getTranslationMemory(entity, locale)
+        .then(results => dispatch(addTranslations(results)));
 
-        const googleTranslation = await api.machinery.getGoogleTranslation(entity, locale);
-        dispatch(addTranslations(googleTranslation));
+        api.machinery.getGoogleTranslation(entity, locale)
+        .then(results => dispatch(addTranslations(results)));
 
-        const microsoftTranslation = await api.machinery.getMicrosoftTranslation(entity, locale);
-        dispatch(addTranslations(microsoftTranslation));
+        api.machinery.getMicrosoftTranslation(entity, locale)
+        .then(results => dispatch(addTranslations(results)));
 
         if (locale.msTerminologyCode) {
-            const msTerminology = await api.machinery.getMicrosoftTerminology(entity, locale);
-            dispatch(addTranslations(msTerminology));
+            api.machinery.getMicrosoftTerminology(entity, locale)
+            .then(results => dispatch(addTranslations(results)));
         }
 
         if (locale.transvision) {
-            const transvisionMemory = await api.machinery.getTransvisionMemory(entity, locale);
-            dispatch(addTranslations(transvisionMemory));
+            api.machinery.getTransvisionMemory(entity, locale)
+            .then(results => dispatch(addTranslations(results)));
         }
 
         if (locale.code === 'ga-IE') {
-            const caighdean = await api.machinery.getCaighdeanTranslation(entity, locale);
-            dispatch(addTranslations(caighdean));
+            api.machinery.getCaighdeanTranslation(entity, locale)
+            .then(results => dispatch(addTranslations(results)));
         }
     }
 }

--- a/frontend/src/modules/machinery/components/Machinery.css
+++ b/frontend/src/modules/machinery/components/Machinery.css
@@ -1,0 +1,20 @@
+.machinery {
+    line-height: 22px;
+}
+
+.machinery ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.machinery p {
+    min-height: 22px;
+}
+
+.machinery > p {
+    border-bottom: 1px solid #5E6475;
+    color: #aaa;
+    font-style: italic;
+    padding: 5px 10px 20px 10px;
+}

--- a/frontend/src/modules/machinery/components/Machinery.css
+++ b/frontend/src/modules/machinery/components/Machinery.css
@@ -18,3 +18,35 @@
     font-style: italic;
     padding: 5px 10px 20px 10px;
 }
+
+.machinery > .search-wrapper {
+    border-bottom: 1px solid #5E6475;
+    margin: 0 10px 10px;
+    position: relative;
+}
+
+.machinery > .search-wrapper .icon {
+    color: #AAAAAA;
+    font-size: 19px;
+    left: 2px;
+    position: absolute;
+    right: auto;
+    top: 12px;
+}
+
+.machinery > .search-wrapper input[type=search] {
+    background: transparent;
+    border: none;
+    color: #FFFFFF;
+    font-size: 16px;
+    font-weight: 300;
+    line-height: 23px;
+    padding: 10px 10px 5px 25px;
+    width: 100%;
+
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+
+    /* Remove extra padding in Chrome search input */
+    -webkit-appearance: textfield;
+}

--- a/frontend/src/modules/machinery/components/Machinery.js
+++ b/frontend/src/modules/machinery/components/Machinery.js
@@ -1,0 +1,66 @@
+/* @flow */
+
+import React from 'react';
+import { connect } from 'react-redux';
+// import { Localized } from 'fluent-react';
+
+import './Machinery.css';
+
+import * as locales from 'core/locales';
+
+import { NAME } from '..';
+import Translation from './Translation';
+
+import type { Locale } from 'core/locales';
+import type { MachineryState } from '../reducer';
+
+
+type Props = {|
+    locale: ?Locale,
+    machinery: MachineryState,
+|};
+
+type InternalProps = {|
+    ...Props,
+    dispatch: Function,
+|};
+
+
+/**
+ *
+ */
+export class MachineryBase extends React.Component<InternalProps> {
+    render() {
+        const { locale, machinery } = this.props;
+
+        if (!locale) {
+            return null;
+        }
+
+        return <section className="machinery">
+            <div className="search-wrapper clearfix">
+                <div className="icon fa fa-search"></div>
+                <input type="search" autoComplete="off" placeholder="Type to search machinery" />
+            </div>
+            <ul>
+                { machinery.translations.map((item, i) => {
+                    return <Translation
+                        translation={ item }
+                        locale={ locale }
+                        key={ i }
+                    />;
+                }) }
+            </ul>
+        </section>;
+    }
+}
+
+
+const mapStateToProps = (state: Object): Props => {
+    return {
+        locale: locales.selectors.getCurrentLocaleData(state),
+        machinery: state[NAME],
+    };
+};
+
+export default connect(mapStateToProps)(MachineryBase);

--- a/frontend/src/modules/machinery/components/Machinery.js
+++ b/frontend/src/modules/machinery/components/Machinery.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-// import { Localized } from 'fluent-react';
+import { Localized } from 'fluent-react';
 
 import './Machinery.css';
 
@@ -40,7 +40,9 @@ export class MachineryBase extends React.Component<InternalProps> {
         return <section className="machinery">
             <div className="search-wrapper clearfix">
                 <div className="icon fa fa-search"></div>
-                <input type="search" autoComplete="off" placeholder="Type to search machinery" />
+                <Localized id="machinery-machinery-search-placeholder" attrs={{ placeholder: true }}>
+                    <input type="search" autoComplete="off" placeholder="Type to search machinery" />
+                </Localized>
             </div>
             <ul>
                 { machinery.translations.map((item, i) => {

--- a/frontend/src/modules/machinery/components/Machinery.js
+++ b/frontend/src/modules/machinery/components/Machinery.js
@@ -12,7 +12,7 @@ import { NAME } from '..';
 import Translation from './Translation';
 
 import type { Locale } from 'core/locales';
-import type { MachineryState } from '../reducer';
+import type { MachineryState } from '..';
 
 
 type Props = {|
@@ -27,7 +27,11 @@ type InternalProps = {|
 
 
 /**
+ * Show translations from machines.
  *
+ * Shows a sorted list of translations for the same original string, or similar
+ * strings, coming from various sources like Translation Memory or
+ * third-party Machine Translation.
  */
 export class MachineryBase extends React.Component<InternalProps> {
     render() {

--- a/frontend/src/modules/machinery/components/Machinery.test.js
+++ b/frontend/src/modules/machinery/components/Machinery.test.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { MachineryBase } from './Machinery';
+
+
+describe('<Machinery>', () => {
+    const LOCALE = {
+        code: 'kg',
+    };
+
+    it('shows a search form', () => {
+        const machinery = {
+            translations: [],
+        };
+        const wrapper = shallow(<MachineryBase machinery={ machinery } locale={ LOCALE } />);
+
+        expect(wrapper.find('.search-wrapper')).toHaveLength(1);
+        expect(wrapper.find('#machinery-machinery-search-placeholder')).toHaveLength(1);
+    });
+
+    it('shows the correct number of translations', () => {
+        const machinery = {
+            translations: [
+                { original: '1' },
+                { original: '2' },
+                { original: '3' },
+            ],
+        };
+        const wrapper = shallow(<MachineryBase machinery={ machinery } locale={ LOCALE } />);
+
+        expect(wrapper.find('Translation')).toHaveLength(3);
+    });
+
+    it('returns null if there is no locale', () => {
+        const wrapper = shallow(<MachineryBase locale={ null } />);
+        expect(wrapper.type()).toBeNull();
+    });
+});

--- a/frontend/src/modules/machinery/components/Translation.css
+++ b/frontend/src/modules/machinery/components/Translation.css
@@ -1,0 +1,27 @@
+.translation > header {
+    color: #AAAAAA;
+    display: block;
+    font-size: 11px;
+    font-weight: 300;
+    padding: 1px 0 5px;
+    text-align: right;
+    text-transform: uppercase;
+}
+
+.translation > header ul {
+    display: inline-block;
+}
+
+.translation > header ul li {
+    padding-left: 3px;
+}
+
+.translation > header ul li::before {
+    content: "•";
+    padding-right: 3px;
+}
+
+.translation > header .stress,
+.translation > header sup {
+    color: #7BC876;
+}

--- a/frontend/src/modules/machinery/components/Translation.css
+++ b/frontend/src/modules/machinery/components/Translation.css
@@ -13,6 +13,7 @@
 }
 
 .translation > header ul li {
+    display: inline-block;
     padding-left: 3px;
 }
 

--- a/frontend/src/modules/machinery/components/Translation.css
+++ b/frontend/src/modules/machinery/components/Translation.css
@@ -25,3 +25,7 @@
 .translation > header sup {
     color: #7BC876;
 }
+
+.translation p.original {
+    color: #AAAAAA;
+}

--- a/frontend/src/modules/machinery/components/Translation.js
+++ b/frontend/src/modules/machinery/components/Translation.js
@@ -17,7 +17,11 @@ type Props = {|
 
 
 /**
+ * Render a Translation in the Machinery tab.
  *
+ * Shows the original string and the translation, as well as a list of sources.
+ * Similar translations (same original and translation) are shown only once
+ * and their sources are merged.
  */
  export default class Translation extends React.Component<Props> {
      render() {
@@ -30,26 +34,24 @@ type Props = {|
                      <span className="stress">{ translation.quality + '%' }</span>
                      }
                      <ul className="sources">
-                         { translation.sources.map((source, i) => {
-                             return  <li key={ i }>
-                                 <a
-                                    className="translation-source"
-                                    href={ source.url }
-                                    title={ source.title }
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                 >
-                                     <span>{ source.type }</span>
-                                     { !source.count ? null :
-                                     <Localized id="machinery-translation-number-occurrences" attrs={{ title: true }}>
-                                         <sup title="Number of translation occurrences">
-                                            { source.count }
-                                        </sup>
-                                    </Localized>
-                                     }
-                                 </a>
-                             </li>;
-                         }) }
+                        { translation.sources.map((source, i) => <li key={ i }>
+                             <a
+                                className="translation-source"
+                                href={ source.url }
+                                title={ source.title }
+                                target="_blank"
+                                rel="noopener noreferrer"
+                             >
+                                 <span>{ source.type }</span>
+                                 { !source.count ? null :
+                                 <Localized id="machinery-translation-number-occurrences" attrs={{ title: true }}>
+                                     <sup title="Number of translation occurrences">
+                                        { source.count }
+                                    </sup>
+                                </Localized>
+                                 }
+                             </a>
+                         </li>) }
                      </ul>
                  </header>
                  <p className="original">

--- a/frontend/src/modules/machinery/components/Translation.js
+++ b/frontend/src/modules/machinery/components/Translation.js
@@ -27,27 +27,29 @@ type Props = {|
              <li className="translation" title="Copy Into Translation (Tab)">
                  <header>
                      { !translation.quality ? null :
-                     <span className="stress">{ translation.quality }</span>
+                     <span className="stress">{ translation.quality + '%' }</span>
                      }
                      <ul className="sources">
-                         <li>
-                             <a
-                                className="translation-source"
-                                href={ translation.url }
-                                title={ translation.title }
-                                target="_blank"
-                                rel="noopener noreferrer"
-                             >
-                                 <span>{ translation.source }</span>
-                                 { !translation.count ? null :
-                                 <Localized id="machinery-translation-number-occurrences" attrs={{ title: true }}>
-                                     <sup title="Number of translation occurrences">
-                                        { translation.count }
-                                    </sup>
-                                </Localized>
-                                 }
-                             </a>
-                         </li>
+                         { translation.sources.map((source, i) => {
+                             return  <li key={ i }>
+                                 <a
+                                    className="translation-source"
+                                    href={ source.url }
+                                    title={ source.title }
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                 >
+                                     <span>{ source.type }</span>
+                                     { !source.count ? null :
+                                     <Localized id="machinery-translation-number-occurrences" attrs={{ title: true }}>
+                                         <sup title="Number of translation occurrences">
+                                            { source.count }
+                                        </sup>
+                                    </Localized>
+                                     }
+                                 </a>
+                             </li>;
+                         }) }
                      </ul>
                  </header>
                  <p className="original">

--- a/frontend/src/modules/machinery/components/Translation.js
+++ b/frontend/src/modules/machinery/components/Translation.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 import React from 'react';
-// import { Localized } from 'fluent-react';
+import { Localized } from 'fluent-react';
 
 import './Translation.css';
 
@@ -23,41 +23,45 @@ type Props = {|
      render() {
          const { translation, locale } = this.props;
 
-         return <li className="translation" title="Copy Into Translation (Tab)">
-             <header>
-                 { !translation.quality ? null :
-                 <span className="stress">{ translation.quality }</span>
-                 }
-                 <ul className="sources">
-                     <li>
-                         <a
-                            className="translation-source"
-                            href={ translation.url }
-                            title={ translation.title }
-                            target="_blank"
-                            rel="noopener noreferrer"
-                         >
-                             <span>{ translation.source }</span>
-                             { !translation.count ? null :
-                             <sup title="Number of translation occurrences">
-                                { translation.count }
-                            </sup>
-                             }
-                         </a>
-                     </li>
-                 </ul>
-             </header>
-             <p className="original">
-                 { translation.original }
-             </p>
-             <p
-                className="suggestion"
-                dir={ locale.direction }
-                data-script={ locale.script }
-                lang={ locale.code }
-             >
-                 { translation.translation }
-             </p>
-         </li>;
+         return <Localized id="machinery-translation-copy" attrs={{ title: true }}>
+             <li className="translation" title="Copy Into Translation (Tab)">
+                 <header>
+                     { !translation.quality ? null :
+                     <span className="stress">{ translation.quality }</span>
+                     }
+                     <ul className="sources">
+                         <li>
+                             <a
+                                className="translation-source"
+                                href={ translation.url }
+                                title={ translation.title }
+                                target="_blank"
+                                rel="noopener noreferrer"
+                             >
+                                 <span>{ translation.source }</span>
+                                 { !translation.count ? null :
+                                 <Localized id="machinery-translation-number-occurrences" attrs={{ title: true }}>
+                                     <sup title="Number of translation occurrences">
+                                        { translation.count }
+                                    </sup>
+                                </Localized>
+                                 }
+                             </a>
+                         </li>
+                     </ul>
+                 </header>
+                 <p className="original">
+                     { translation.original }
+                 </p>
+                 <p
+                    className="suggestion"
+                    dir={ locale.direction }
+                    data-script={ locale.script }
+                    lang={ locale.code }
+                 >
+                     { translation.translation }
+                 </p>
+             </li>
+         </Localized>;
      }
  }

--- a/frontend/src/modules/machinery/components/Translation.js
+++ b/frontend/src/modules/machinery/components/Translation.js
@@ -1,0 +1,61 @@
+/* @flow */
+
+import React from 'react';
+// import { Localized } from 'fluent-react';
+
+import api from 'core/api';
+
+import type { Locale } from 'core/locales';
+
+
+type Props = {|
+    locale: Locale,
+    translation: api.types.MachineryTranslation,
+|};
+
+
+/**
+ *
+ */
+ export default class Translation extends React.Component<Props> {
+     render() {
+         const { translation, locale } = this.props;
+
+         return <li className="translation" title="Copy Into Translation (Tab)">
+             <header>
+                 { !translation.quality ? null :
+                 <span className="stress">{ translation.quality }</span>
+                 }
+                 <ul className="sources">
+                     <li>
+                         <a
+                            className="translation-source"
+                            href={ translation.url }
+                            title={ translation.title }
+                            target="_blank"
+                            rel="noopener noreferrer"
+                         >
+                             <span>{ translation.source }</span>
+                             { !translation.count ? null :
+                             <sup title="Number of translation occurrences">
+                                { translation.count }
+                            </sup>
+                             }
+                         </a>
+                     </li>
+                 </ul>
+             </header>
+             <p className="original">
+                 { translation.original }
+             </p>
+             <p
+                className="translation"
+                dir={ locale.direction }
+                data-script={ locale.script }
+                lang={ locale.code }
+             >
+                 { translation.translation }
+             </p>
+         </li>;
+     }
+ }

--- a/frontend/src/modules/machinery/components/Translation.js
+++ b/frontend/src/modules/machinery/components/Translation.js
@@ -3,6 +3,8 @@
 import React from 'react';
 // import { Localized } from 'fluent-react';
 
+import './Translation.css';
+
 import api from 'core/api';
 
 import type { Locale } from 'core/locales';
@@ -49,7 +51,7 @@ type Props = {|
                  { translation.original }
              </p>
              <p
-                className="translation"
+                className="suggestion"
                 dir={ locale.direction }
                 data-script={ locale.script }
                 lang={ locale.code }

--- a/frontend/src/modules/machinery/components/Translation.test.js
+++ b/frontend/src/modules/machinery/components/Translation.test.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import Translation from './Translation';
+
+
+describe('<Translation>', () => {
+    const DEFAULT_TRANSLATION = {
+        sources: [
+            {
+                type: 'Translation memory',
+                url: 'http://pontoon.mozilla.org',
+                title: 'Pontoon',
+            },
+        ],
+        original: 'A horse, a horse! My kingdom for a horse!',
+        translation: 'Un cheval, un cheval ! Mon royaume pour un cheval !',
+    };
+
+    const DEFAULT_LOCALE = {
+        direction: 'ltr',
+        code: 'kg',
+        script: 'Latin',
+    };
+
+    it('renders a translation correctly', () => {
+        const wrapper = shallow(<Translation
+            translation={ DEFAULT_TRANSLATION }
+            locale={ DEFAULT_LOCALE }
+        />);
+
+        expect(wrapper.find('.original').text()).toContain('A horse, a horse!');
+        expect(wrapper.find('.suggestion').text()).toContain('Un cheval, un cheval !');
+
+        expect(wrapper.find('ul li')).toHaveLength(1);
+        expect(wrapper.find('ul li a').text()).toEqual('Translation memory');
+
+        // No count.
+        expect(wrapper.find('ul li sup')).toHaveLength(0);
+        // No quality.
+        expect(wrapper.find('.stress')).toHaveLength(0);
+    });
+
+    it('shows quality when possible', () => {
+        const translation = {
+            ...DEFAULT_TRANSLATION,
+            quality: 100,
+        };
+        const wrapper = shallow(<Translation
+            translation={ translation }
+            locale={ DEFAULT_LOCALE }
+        />);
+
+        expect(wrapper.find('.stress')).toHaveLength(1);
+        expect(wrapper.find('.stress').text()).toEqual('100%');
+    });
+
+    it('shows several sources', () => {
+        const translation = {
+            ...DEFAULT_TRANSLATION,
+            sources: [
+                ...DEFAULT_TRANSLATION.sources,
+                {
+                    type: 'Transvision',
+                    url: '',
+                    title: 'Transvision memory',
+                    count: 24,
+                },
+            ],
+        };
+        const wrapper = shallow(<Translation
+            translation={ translation }
+            locale={ DEFAULT_LOCALE }
+        />);
+
+        expect(wrapper.find('ul').text()).toContain('Translation memory');
+        expect(wrapper.find('ul').text()).toContain('Transvision');
+
+        expect(wrapper.find('ul li sup')).toHaveLength(1);
+        expect(wrapper.find('ul li sup').text()).toEqual('24');
+    });
+});

--- a/frontend/src/modules/machinery/index.js
+++ b/frontend/src/modules/machinery/index.js
@@ -1,0 +1,12 @@
+/* @flow */
+
+export { default as actions } from './actions';
+export { default as reducer } from './reducer';
+
+export { default as Machinery } from './components/Machinery';
+
+// export type { HistoryState } from './reducer';
+
+// Name of this module.
+// Used as the key to store this module's reducer.
+export const NAME: string = 'machinery';

--- a/frontend/src/modules/machinery/index.js
+++ b/frontend/src/modules/machinery/index.js
@@ -5,8 +5,6 @@ export { default as reducer } from './reducer';
 
 export { default as Machinery } from './components/Machinery';
 
-// export type { HistoryState } from './reducer';
-
 // Name of this module.
 // Used as the key to store this module's reducer.
 export const NAME: string = 'machinery';

--- a/frontend/src/modules/machinery/index.js
+++ b/frontend/src/modules/machinery/index.js
@@ -5,6 +5,9 @@ export { default as reducer } from './reducer';
 
 export { default as Machinery } from './components/Machinery';
 
+export type { MachineryState } from './reducer';
+
+
 // Name of this module.
 // Used as the key to store this module's reducer.
 export const NAME: string = 'machinery';

--- a/frontend/src/modules/machinery/reducer.js
+++ b/frontend/src/modules/machinery/reducer.js
@@ -12,9 +12,64 @@ type Action =
     | ResetAction
 ;
 
+type Translations = Array<api.types.MachineryTranslation>;
+
 export type MachineryState = {|
-    translations: Array<api.types.MachineryTranslation>,
+    translations: Translations,
 |};
+
+
+/**
+ * Return a list of translations that are deduplicated and sorted.
+ *
+ * The deduplication process works as follow:
+ * If a new translation has the same `original` and `translation` than
+ * an existing one, then add that translation's `source` to the previous one.
+ * Otherwise, add the translation to the list.
+ *
+ * Translations are sorted by descending quality (highest quality comes first).
+ */
+function dedupedTranslations(
+    oldTranslations: Translations,
+    newTranslations: Translations
+): Translations {
+    const translations = oldTranslations.map(item => ({ ...item }));
+
+    newTranslations.forEach(newT => {
+        const sameTranslation = translations.findIndex(
+            oldT => newT.original === oldT.original && newT.translation === oldT.translation
+        );
+
+        if (sameTranslation >= 0) {
+            translations[sameTranslation].sources.push(newT.sources[0]);
+
+            if (newT.quality && !translations[sameTranslation].quality) {
+                translations[sameTranslation].quality = newT.quality;
+            }
+        }
+        else {
+            translations.push({ ...newT });
+        }
+    });
+
+    return translations.sort((a, b) => {
+        if (!a.quality && b.quality) {
+            return -1;
+        }
+        if (a.quality && !b.quality) {
+            return 1;
+        }
+        if (a.quality && b.quality) {
+            if (a.quality > b.quality) {
+                return -1;
+            }
+            if (a.quality < b.quality) {
+                return 1;
+            }
+        }
+        return 0;
+    });
+}
 
 
 const initial: MachineryState = {
@@ -29,10 +84,10 @@ export default function reducer(
         case ADD_TRANSLATIONS:
             return {
                 ...state,
-                translations: [
-                    ...state.translations,
-                    ...action.translations,
-                ],
+                translations: dedupedTranslations(
+                    state.translations,
+                    action.translations,
+                ),
             };
         case RESET:
             return {

--- a/frontend/src/modules/machinery/reducer.js
+++ b/frontend/src/modules/machinery/reducer.js
@@ -1,0 +1,45 @@
+/* @flow */
+
+import api from 'core/api';
+
+import { ADD_TRANSLATIONS, RESET } from './actions';
+
+import type { AddTranslationsAction, ResetAction } from './actions';
+
+
+type Action =
+    | AddTranslationsAction
+    | ResetAction
+;
+
+export type MachineryState = {|
+    translations: Array<api.types.MachineryTranslation>,
+|};
+
+
+const initial: MachineryState = {
+    translations: [],
+};
+
+export default function reducer(
+    state: MachineryState = initial,
+    action: Action,
+): MachineryState {
+    switch (action.type) {
+        case ADD_TRANSLATIONS:
+            return {
+                ...state,
+                translations: [
+                    ...state.translations,
+                    ...action.translations,
+                ],
+            };
+        case RESET:
+            return {
+                ...state,
+                translations: [],
+            };
+        default:
+            return state;
+    }
+}

--- a/frontend/src/rootReducer.js
+++ b/frontend/src/rootReducer.js
@@ -10,18 +10,22 @@ import * as stats from 'core/stats';
 import * as user from 'core/user';
 import * as entitieslist from 'modules/entitieslist';
 import * as history from 'modules/history';
+import * as machinery from 'modules/machinery';
 import * as otherlocales from 'modules/otherlocales';
 
 
 // Combine reducers from all modules, using their NAME constant as key.
 export default combineReducers({
+    // Core modules
     [lightbox.NAME]: lightbox.reducer,
     [locales.NAME]: locales.reducer,
     [l10n.NAME]: l10n.reducer,
     [plural.NAME]: plural.reducer,
     [stats.NAME]: stats.reducer,
     [user.NAME]: user.reducer,
+    // Application modules
     [entitieslist.NAME]: entitieslist.reducer,
     [history.NAME]: history.reducer,
+    [machinery.NAME]: machinery.reducer,
     [otherlocales.NAME]: otherlocales.reducer,
 });

--- a/pontoon/api/schema.py
+++ b/pontoon/api/schema.py
@@ -74,6 +74,10 @@ class Locale(DjangoObjectType, Stats):
             'strings_with_errors',
             'strings_with_warnings',
             'unreviewed_strings',
+            'google_translate_code',
+            'ms_translator_code',
+            'ms_terminology_code',
+            'transvision',
         )
 
     localizations = graphene.List(


### PR DESCRIPTION
This adds the Machinery tab and all its features. On load, fetches translations from various sources (Machine Translation, Translation Memory) and shows it as it arrives. Also allows searching for specific terms.

@mathjazz the commits in this branch are a bit erratic, so I'm not sure there's much value reviewing this one commit at a time. That is because I've been working weirdly on this, going back and forth as I understood more about the feature.

Note that the search bar does nothing for now, as this patch is already huge. I'll do that in follow-up [bug 1524549](https://bugzilla.mozilla.org/show_bug.cgi?id=1524549). The copy on click action will be covered in [bug 1490346](https://bugzilla.mozilla.org/show_bug.cgi?id=1490346).