### PR TITLE
No bug - use --batch option to verify gosu gpg signature.

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
 RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
 RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
     && curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.10/gosu-$(dpkg --print-architecture | awk -F- '{ print $NF }').asc" \
-    && gpg --verify /usr/local/bin/gosu.asc \
+    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
     && rm /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu
 


### PR DESCRIPTION
While investigating a potential issue with our Dockerfile, I read that gosu's instruction for verifying the GPG key has changed a bit, so I took the time to update our build process.

See https://github.com/tianon/gosu/commit/74d8730b0bab611cbf204fd4419ef21ecb6df017 for reference.

Also, I guess we actually weren't verifying anything with that command of ours, for it missing the second argument of the `gpg` command... :disappointed: 