### PR TITLE
Fix bug 1490346 - Copy translations into the Editor on click.

### DIFF
--- a/frontend/public/static/locale/en-US/translate.ftl
+++ b/frontend/public/static/locale/en-US/translate.ftl
@@ -28,6 +28,9 @@ editor-settings-change-all = Change All Settings
 machinery-machinery-search-placeholder =
     .placeholder = Type to search machinery
 
+## Machinery Translation
+## Shows a specific translation from machinery
+
 machinery-translation-copy =
     .title = Copy Into Translation (Tab)
 
@@ -66,8 +69,12 @@ history-history-no-translations = No translations available.
 ## History Translation
 ## Shows a specific translation for an entity, and actions around it
 
+history-translation-copy =
+    .title = Copy Into Translation (Tab)
+
 history-translation-button-delete =
     .title = Delete
+
 history-translation-button-approve =
     .title = Approve
 
@@ -79,3 +86,10 @@ history-translation-button-reject =
 
 history-translation-button-unreject =
     .title = Unreject
+
+
+## OtherLocales Translation
+## Shows a specific translation from a different locale
+
+otherlocales-translation-copy =
+    .title = Copy Into Translation (Tab)

--- a/frontend/public/static/locale/fr/translate.ftl
+++ b/frontend/public/static/locale/fr/translate.ftl
@@ -28,6 +28,9 @@ editor-settings-change-all = Changer tous les paramètres
 machinery-machinery-search-placeholder =
     .placeholder = Saisir pour rechercher la machinerie
 
+## Machinery Translation
+## Shows a specific translation from machinery
+
 machinery-translation-copy =
     .title = Copier la traduction (Tab)
 
@@ -66,8 +69,12 @@ history-history-no-translations = Pas de traduction disponible.
 ## History Translation
 ## Shows a specific translation for an entity, and actions around it
 
+history-translation-copy =
+    .title = Copier la traduction (Tab)
+
 history-translation-button-delete =
     .title = Supprimer
+
 history-translation-button-approve =
     .title = Approuver
 
@@ -79,3 +86,10 @@ history-translation-button-reject =
 
 history-translation-button-unreject =
     .title = Dérejeter
+
+
+## OtherLocales Translation
+## Shows a specific translation from a different locale
+
+otherlocales-translation-copy =
+    .title = Copier la traduction (Tab)

--- a/frontend/src/modules/editor/components/Editor.js
+++ b/frontend/src/modules/editor/components/Editor.js
@@ -21,8 +21,9 @@ type Props = {|
     locale: Locale,
     pluralForm: number,
     settings: SettingsState,
-    sendTranslation: Function,
-    updateSetting: Function,
+    sendTranslation: () => void,
+    updateEditorTranslation: (string) => void,
+    updateSetting: (string, boolean) => void,
 |};
 
 type State = {|
@@ -37,47 +38,34 @@ type State = {|
  * see `EditorProxy` for more information.
  */
 export default class Editor extends React.Component<Props, State> {
-    constructor(props: Props) {
-        super(props);
-        this.state = {
-            translation: props.translation,
-        };
-    }
-
     componentDidUpdate(prevProps: Props) {
         if (this.props.translation !== prevProps.translation) {
-            this.setState({
-                translation: this.props.translation,
-            });
+            this.updateTranslation(this.props.translation);
         }
     }
 
     updateTranslation = (translation: string) => {
-        this.setState({
-            translation,
-        });
+        this.props.updateEditorTranslation(translation);
     }
 
     copyOriginalIntoEditor = () => {
         const { entity, pluralForm } = this.props;
         if (entity) {
             if (pluralForm === -1 || pluralForm === 1) {
-                this.setState({ translation: entity.original });
+                this.updateTranslation(entity.original);
             }
             else {
-                this.setState({ translation: entity.original_plural });
+                this.updateTranslation(entity.original_plural);
             }
         }
     }
 
     clearEditor = () => {
-        this.setState({
-            translation: '',
-        });
+        this.updateTranslation('');
     }
 
     sendTranslation = () => {
-        this.props.sendTranslation(this.state.translation);
+        this.props.sendTranslation();
     }
 
     render() {
@@ -85,7 +73,7 @@ export default class Editor extends React.Component<Props, State> {
             <PluralSelector />
             <EditorProxy
                 entity={ this.props.entity }
-                translation={ this.state.translation }
+                translation={ this.props.translation }
                 locale={ this.props.locale }
                 updateTranslation={ this.updateTranslation }
             />

--- a/frontend/src/modules/editor/components/Editor.test.js
+++ b/frontend/src/modules/editor/components/Editor.test.js
@@ -18,11 +18,17 @@ const SELECTED_ENTITY = {
 };
 
 
-function createShallowEditor(suggestMock = null, pluralForm = -1, forceSuggestions = true) {
+function createShallowEditor({
+    suggestMock,
+    updateMock,
+    pluralForm = -1,
+    forceSuggestions = true
+} = {}) {
     return shallow(<Editor
         translation={ (Math.abs(pluralForm) !== 1) ? TRANSLATION_PLURAL : TRANSLATION }
         entity={ SELECTED_ENTITY }
         sendTranslation={ suggestMock }
+        updateEditorTranslation={ updateMock }
         pluralForm={ pluralForm }
         settings={ { forceSuggestions } }
     />);
@@ -38,51 +44,54 @@ describe('<Editor>', () => {
     });
 
     it('clears the text when the Clear button is clicked', () => {
-        const wrapper = createShallowEditor();
+        const updateMock = sinon.spy();
+        const wrapper = createShallowEditor({ updateMock });
 
-        expect(wrapper.state('translation')).toEqual(TRANSLATION);
         wrapper.find('.action-clear').simulate('click');
-        expect(wrapper.state('translation')).toEqual('');
+        expect(updateMock.calledOnce).toBeTruthy();
+        expect(updateMock.calledWith('')).toBeTruthy();
     });
 
     it('copies the original string in the textarea when the Copy button is clicked', () => {
-        const wrapper = createShallowEditor();
+        const updateMock = sinon.spy();
+        const wrapper = createShallowEditor({ updateMock });
 
-        expect(wrapper.state('translation')).toEqual(TRANSLATION);
         wrapper.find('.action-copy').simulate('click');
-        expect(wrapper.state('translation')).toEqual(SELECTED_ENTITY.original);
+        expect(updateMock.calledOnce).toBeTruthy();
+        expect(updateMock.calledWith(SELECTED_ENTITY.original)).toBeTruthy();
     });
 
     it('copies the plural original string in the textarea when the Copy button is clicked', () => {
-        const wrapper = createShallowEditor(null, 5);
+        const updateMock = sinon.spy();
+        const wrapper = createShallowEditor({ updateMock, pluralForm: 5 });
 
-        expect(wrapper.state('translation')).toEqual(TRANSLATION_PLURAL);
         wrapper.find('.action-copy').simulate('click');
-        expect(wrapper.state('translation')).toEqual(SELECTED_ENTITY.original_plural);
+        expect(updateMock.calledOnce).toBeTruthy();
+        expect(updateMock.calledWith(SELECTED_ENTITY.original_plural)).toBeTruthy();
     });
 
     it('calls the suggest action when the Suggest button is clicked', () => {
         const suggestMock = sinon.spy();
-        const wrapper = createShallowEditor(suggestMock);
+        const wrapper = createShallowEditor({ suggestMock });
 
         wrapper.find('.action-suggest').simulate('click');
-        expect(suggestMock.calledOnce).toBeTrue;
+        expect(suggestMock.calledOnce).toBeTruthy();
     });
 
     it('shows the Save button when forceSuggestions is off', () => {
         const suggestMock = sinon.spy();
-        const wrapper = createShallowEditor(suggestMock, -1, false);
+        const wrapper = createShallowEditor({ suggestMock, pluralForm: -1, forceSuggestions: false });
 
         expect(wrapper.find('.action-save').exists()).toBeTruthy();
         wrapper.find('.action-save').simulate('click');
-        expect(suggestMock.calledOnce).toBeTrue;
+        expect(suggestMock.calledOnce).toBeTruthy();
     });
 
     it('calls the suggest action when the Save button is clicked', () => {
         const suggestMock = sinon.spy();
-        const wrapper = createShallowEditor(suggestMock, -1, false);
+        const wrapper = createShallowEditor({ suggestMock, pluralForm: -1, forceSuggestions: false });
 
         wrapper.find('.action-save').simulate('click');
-        expect(suggestMock.calledOnce).toBeTrue;
+        expect(suggestMock.calledOnce).toBeTruthy();
     });
 });

--- a/frontend/src/modules/editor/components/GenericEditor.js
+++ b/frontend/src/modules/editor/components/GenericEditor.js
@@ -8,7 +8,7 @@ import type { Locale } from 'core/locales';
 export type EditorProps = {|
     translation: string,
     locale: Locale,
-    updateTranslation: Function,
+    updateTranslation: (string) => void,
 |};
 
 

--- a/frontend/src/modules/entitydetails/components/EntityDetails.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.js
@@ -59,18 +59,26 @@ type State = {|
  * Shows the metadata of the entity and an editor for translations.
  */
 export class EntityDetailsBase extends React.Component<InternalProps, State> {
+    constructor(props: InternalProps) {
+        super(props);
+        this.state = {
+            translation: this.props.activeTranslation,
+        };
+    }
+
     componentDidMount() {
         this.fetchHelpersData();
     }
 
     componentDidUpdate(prevProps: InternalProps) {
-        const { parameters, pluralForm, selectedEntity } = this.props;
+        const { parameters, pluralForm, selectedEntity, activeTranslation } = this.props;
 
         if (
             parameters.entity !== prevProps.parameters.entity ||
             pluralForm !== prevProps.pluralForm ||
             selectedEntity !== prevProps.selectedEntity
         ) {
+            this.updateEditorTranslation(activeTranslation);
             this.fetchHelpersData();
         }
     }
@@ -110,6 +118,36 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
         ));
     }
 
+    updateEditorTranslation = (translation: string) => {
+        this.setState({
+            translation,
+        });
+    }
+
+    deleteTranslation = (translationId: number) => {
+        const { parameters, pluralForm, dispatch } = this.props;
+        dispatch(history.actions.deleteTranslation(
+            parameters.entity,
+            parameters.locale,
+            pluralForm,
+            translationId,
+        ));
+    }
+
+    updateTranslationStatus = (translationId: number, change: string) => {
+        const { nextEntity, parameters, pluralForm, router, dispatch } = this.props;
+        dispatch(history.actions.updateStatus(
+            change,
+            parameters.entity,
+            parameters.locale,
+            parameters.resource,
+            pluralForm,
+            translationId,
+            nextEntity,
+            router,
+        ));
+    }
+
     updateSetting = (setting: string, value: boolean) => {
         this.props.dispatch(user.actions.saveSetting(setting, value, this.props.user.username));
     }
@@ -133,7 +171,7 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
                 openLightbox={ this.openLightbox }
             />
             <Editor
-                translation={ state.activeTranslation}
+                translation={ this.state.translation }
                 entity={ state.selectedEntity }
                 locale={ state.locale }
                 pluralForm= { state.pluralForm }
@@ -142,10 +180,15 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
                 updateSetting={ this.updateSetting }
             />
             <Tools
-                parameters={ state.parameters }
                 history={ state.history }
+                locale={ state.locale }
                 machinery={ state.machinery }
                 otherlocales={ state.otherlocales }
+                parameters={ state.parameters }
+                user={ state.user }
+                deleteTranslation={ this.deleteTranslation }
+                updateTranslationStatus={ this.updateTranslationStatus }
+                updateEditorTranslation={ this.updateEditorTranslation }
             />
         </section>;
     }

--- a/frontend/src/modules/entitydetails/components/EntityDetails.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.js
@@ -99,7 +99,13 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
         this.props.dispatch(lightbox.actions.open(image));
     }
 
-    sendTranslation = (translation: string) => {
+    updateEditorTranslation = (translation: string) => {
+        this.setState({
+            translation,
+        });
+    }
+
+    sendTranslation = () => {
         const state = this.props;
 
         if (!state.selectedEntity || !state.locale) {
@@ -108,7 +114,7 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
 
         this.props.dispatch(actions.sendTranslation(
             state.selectedEntity.pk,
-            translation,
+            this.state.translation,
             state.locale.code,
             state.selectedEntity.original,
             state.pluralForm,
@@ -116,12 +122,6 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
             state.nextEntity,
             state.router,
         ));
-    }
-
-    updateEditorTranslation = (translation: string) => {
-        this.setState({
-            translation,
-        });
     }
 
     deleteTranslation = (translationId: number) => {
@@ -177,6 +177,7 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
                 pluralForm= { state.pluralForm }
                 settings={ state.user.settings }
                 sendTranslation={ this.sendTranslation }
+                updateEditorTranslation={ this.updateEditorTranslation }
                 updateSetting={ this.updateSetting }
             />
             <Tools

--- a/frontend/src/modules/entitydetails/components/EntityDetails.test.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.test.js
@@ -154,7 +154,8 @@ describe('<EntityDetails>', () => {
     it('calls the sendTranslation action when the sendTranslation method is ran', () => {
         const [wrapper] = createEntityDetailsWithStore();
 
-        wrapper.instance().sendTranslation('fake translation');
+        wrapper.instance().setState({translation: 'fake translation'});
+        wrapper.instance().sendTranslation();
         expect(entityActions.sendTranslation.calledOnce).toBeTruthy();
         expect(
             entityActions.sendTranslation

--- a/frontend/src/modules/entitydetails/components/EntityDetails.test.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.test.js
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 import { createReduxStore } from 'test/store';
 import { shallowUntilTarget } from 'test/utils';
 
-import * as navigation from 'core/navigation';
+// import * as navigation from 'core/navigation';
 import * as user from 'core/user';
 import * as history from 'modules/history';
 
@@ -163,7 +163,7 @@ describe('<EntityDetails>', () => {
     });
 
     it('updates translation state when props change', () => {
-        const [wrapper, store] = createEntityDetailsWithStore();
+        const [wrapper] = createEntityDetailsWithStore();
 
         expect(wrapper.state('translation')).toEqual(TRANSLATION);
 

--- a/frontend/src/modules/entitydetails/components/Tools.js
+++ b/frontend/src/modules/entitydetails/components/Tools.js
@@ -11,7 +11,9 @@ import { Locales } from 'modules/otherlocales';
 
 import MachineryCount from './MachineryCount';
 
+import type { Locale } from 'core/locales';
 import type { NavigationParams } from 'core/navigation';
+import type { UserState } from 'core/user';
 import type { HistoryState } from 'modules/history';
 import type { MachineryState } from 'modules/machinery';
 import type { LocalesState } from 'modules/otherlocales';
@@ -19,9 +21,14 @@ import type { LocalesState } from 'modules/otherlocales';
 
 type Props = {|
     history: HistoryState,
+    locale: Locale,
     machinery: MachineryState,
     otherlocales: LocalesState,
     parameters: NavigationParams,
+    user: UserState,
+    deleteTranslation: (number) => void,
+    updateEditorTranslation: (string) => void,
+    updateTranslationStatus: (number, string) => void,
 |};
 
 
@@ -32,7 +39,17 @@ type Props = {|
  */
 export default class Tools extends React.Component<Props> {
     render() {
-        const { history, machinery, otherlocales, parameters } = this.props;
+        const {
+            history,
+            locale,
+            machinery,
+            otherlocales,
+            parameters,
+            user,
+            deleteTranslation,
+            updateEditorTranslation,
+            updateTranslationStatus,
+        } = this.props;
 
         const historyCount = history.translations.length;
         const machineryCount = machinery.translations.length;
@@ -61,13 +78,29 @@ export default class Tools extends React.Component<Props> {
             </TabList>
 
             <TabPanel>
-                <History />
+                <History
+                    history={ history }
+                    locale={ locale }
+                    parameters={ parameters }
+                    user={ user }
+                    deleteTranslation={ deleteTranslation }
+                    updateTranslationStatus={ updateTranslationStatus }
+                    updateEditorTranslation={ updateEditorTranslation }
+                />
             </TabPanel>
             <TabPanel>
-                <Machinery />
+                <Machinery
+                    machinery={ machinery }
+                    locale={ locale }
+                    updateEditorTranslation={ updateEditorTranslation }
+                />
             </TabPanel>
             <TabPanel>
-                <Locales otherlocales={ otherlocales } parameters={ parameters } />
+                <Locales
+                    otherlocales={ otherlocales }
+                    parameters={ parameters }
+                    updateEditorTranslation={ updateEditorTranslation }
+                />
             </TabPanel>
         </Tabs>;
     }

--- a/frontend/src/modules/history/components/History.test.js
+++ b/frontend/src/modules/history/components/History.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import { HistoryBase } from './History';
+import History from './History';
 
 
 describe('<History>', () => {
@@ -14,7 +14,7 @@ describe('<History>', () => {
             ],
         };
         const user = {};
-        const wrapper = shallow(<HistoryBase history={ history } user={ user } />);
+        const wrapper = shallow(<History history={ history } user={ user } />);
 
         expect(wrapper.find('Translation')).toHaveLength(3);
     });
@@ -24,7 +24,7 @@ describe('<History>', () => {
             fetching: true,
             translations: [],
         };
-        const wrapper = shallow(<HistoryBase history={ history } />);
+        const wrapper = shallow(<History history={ history } />);
 
         expect(wrapper.type()).toBeNull();
     });
@@ -34,7 +34,7 @@ describe('<History>', () => {
             fetching: false,
             translations: [],
         };
-        const wrapper = shallow(<HistoryBase history={ history } />);
+        const wrapper = shallow(<History history={ history } />);
 
         expect(wrapper.find('#history-history-no-translations')).toHaveLength(1);
     });

--- a/frontend/src/modules/history/components/Translation.css
+++ b/frontend/src/modules/history/components/Translation.css
@@ -1,15 +1,15 @@
-.translation {
+.history .translation {
     border-bottom: 1px solid #5E6475;
+    cursor: pointer;
     padding: 5px 10px 20px 10px;
     transition: all 0.1s ease-out;
 }
 
-.translation:hover {
+.history .translation:hover {
     background: #4D5967;
-    border-color: #5E6475;
 }
 
-.translation > header {
+.history .translation > header {
     color: #AAAAAA;
     display: block;
     font-size: 11px;
@@ -18,37 +18,37 @@
     text-transform: uppercase;
 }
 
-.translation > header .info {
+.history .translation > header .info {
     float: left;
 }
 
-.translation > header .toolbar {
+.history .translation > header .toolbar {
     display: block;
     float: right;
 }
 
-.translation > header + p {
+.history .translation > header + p {
     clear: both;
     text-align: start;
 }
 
-.translation > header .info time {
+.history .translation > header .info time {
     color: #7BC876;
     padding-left: 3px;
 }
-.translation > header .info a {
+.history .translation > header .info a {
     text-transform: none;
 }
 
-.translation > header .toggle-diff {
+.history .translation > header .toggle-diff {
     margin-right: 6px;
 }
 
-.translation > header .toggle-diff.active {
+.history .translation > header .toggle-diff.active {
     color: #7BC876;
 }
 
-.translation > header button {
+.history .translation > header button {
     background: no-repeat transparent;
     border: none;
     color: #AAAAAA;
@@ -63,55 +63,55 @@
     width: 22px;
 }
 
-.translation.rejected.can-reject header button.delete,
-.translation.can-approve header button.approve,
-.translation.can-approve header button.unapprove,
-.translation.can-reject header button.reject,
-.translation.can-reject header button.unreject {
+.history .translation.rejected.can-reject header button.delete,
+.history .translation.can-approve header button.approve,
+.history .translation.can-approve header button.unapprove,
+.history .translation.can-reject header button.reject,
+.history .translation.can-reject header button.unreject {
     pointer-events: auto;
     opacity: 1;
 }
 
-.translation.rejected {
+.history .translation.rejected {
     opacity: 0.4;
 }
 
-.translation.rejected:hover {
+.history .translation.rejected:hover {
     opacity: 1;
 }
 
-.translation.fuzzy > header button.approve:before {
+.history .translation.fuzzy > header button.approve:before {
     color: #FED271;
 }
 
-.translation > header button.approve:before,
-.translation > header button.unapprove:before {
+.history .translation > header button.approve:before,
+.history .translation > header button.unapprove:before {
     content: "";
 }
 
-.translation > header button.approve:hover:before,
-.translation > header button.unapprove:before {
+.history .translation > header button.approve:hover:before,
+.history .translation > header button.unapprove:before {
     color: #7BC876;
 }
 
-.translation > header button.approve:not(:hover):before,
-.translation > header button.unapprove:hover:before {
+.history .translation > header button.approve:not(:hover):before,
+.history .translation > header button.unapprove:hover:before {
     font-weight: 400;
 }
 
-.translation > header button.reject:before,
-.translation > header button.unreject:before {
+.history .translation > header button.reject:before,
+.history .translation > header button.unreject:before {
     content: "";
     margin-left: 5px;
 }
 
-.translation > header button.reject:hover:before,
-.translation > header button.unreject:before {
+.history .translation > header button.reject:hover:before,
+.history .translation > header button.unreject:before {
     color: #F36;
 }
 
-.translation > header button.reject:not(:hover):before,
-.translation > header button.unreject:hover:before {
+.history .translation > header button.reject:not(:hover):before,
+.history .translation > header button.unreject:hover:before {
     font-weight: 400;
 }
 

--- a/frontend/src/modules/history/components/Translation.js
+++ b/frontend/src/modules/history/components/Translation.js
@@ -16,8 +16,9 @@ type Props = {|
     translation: DBTranslation,
     locale: Locale,
     user: UserState,
-    updateTranslationStatus: Function,
-    deleteTranslation: Function,
+    deleteTranslation: (number) => void,
+    updateEditorTranslation: (string) => void,
+    updateTranslationStatus: (number, string) => void,
 |};
 
 /**
@@ -31,23 +32,27 @@ type Props = {|
  */
 export default class Translation extends React.Component<Props> {
     approve = () => {
-        this.props.updateTranslationStatus(this.props.translation, 'approve');
+        this.props.updateTranslationStatus(this.props.translation.pk, 'approve');
     }
 
     unapprove = () => {
-        this.props.updateTranslationStatus(this.props.translation, 'unapprove');
+        this.props.updateTranslationStatus(this.props.translation.pk, 'unapprove');
     }
 
     reject = () => {
-        this.props.updateTranslationStatus(this.props.translation, 'reject');
+        this.props.updateTranslationStatus(this.props.translation.pk, 'reject');
     }
 
     unreject = () => {
-        this.props.updateTranslationStatus(this.props.translation, 'unreject');
+        this.props.updateTranslationStatus(this.props.translation.pk, 'unreject');
+    }
+
+    copyTranslationIntoEditor = () => {
+        this.props.updateEditorTranslation(this.props.translation.string);
     }
 
     delete = () => {
-        this.props.deleteTranslation(this.props.translation);
+        this.props.deleteTranslation(this.props.translation.pk);
     }
 
     getStatus() {
@@ -87,8 +92,8 @@ export default class Translation extends React.Component<Props> {
         return <a
             href={ `/contributors/${translation.username}` }
             title={ this.getApprovalTitle() }
-            target="_blank"
-            rel="noopener noreferrer"
+            target='_blank'
+            rel='noopener noreferrer'
         >
             { translation.user }
         </a>
@@ -117,89 +122,95 @@ export default class Translation extends React.Component<Props> {
 
         let canDelete = canReview || ownTranslation;
 
-        return <li className={ className }>
-            <header className="clearfix">
-                <div className="info">
-                    { this.renderUser() }
-                    <TimeAgo
-                        dir="ltr"
-                        date={ translation.date_iso }
-                        title={ `${translation.date} UTC` }
-                    />
-                </div>
-                <menu className="toolbar">
-                { (!translation.rejected || !canDelete ) ? null :
-                    // Delete Button
-                    <Localized
-                        id="history-translation-button-delete"
-                        attrs={{ title: true }}
-                    >
-                        <button
-                            className='delete far'
-                            title='Delete'
-                            onClick={ this.delete }
-                        />
-                    </Localized>
-                }
-                { translation.approved ?
-                    // Unapprove Button
-                    <Localized
-                        id="history-translation-button-unapprove"
-                        attrs={{ title: true }}
-                    >
-                        <button
-                            className='unapprove fa'
-                            title='Unapprove'
-                            onClick={ this.unapprove }
-                        />
-                    </Localized>
-                    :
-                    // Approve Button
-                    <Localized
-                        id="history-translation-button-approve"
-                        attrs={{ title: true }}
-                    >
-                        <button
-                            className='approve fa'
-                            title='Approve'
-                            onClick={ this.approve }
-                        />
-                    </Localized>
-                }
-                { translation.rejected ?
-                    // Unreject Button
-                    <Localized
-                        id="history-translation-button-unreject"
-                        attrs={{ title: true }}
-                    >
-                        <button
-                            className='unreject fa'
-                            title='Unreject'
-                            onClick={ this.unreject }
-                        />
-                    </Localized>
-                    :
-                    // Reject Button
-                    <Localized
-                        id="history-translation-button-reject"
-                        attrs={{ title: true }}
-                    >
-                        <button
-                            className='reject fa'
-                            title='Reject'
-                            onClick={ this.reject }
-                        />
-                    </Localized>
-                }
-                </menu>
-            </header>
-            <p
-                dir={ locale.direction }
-                lang={ locale.code }
-                data-script={ locale.script }
+        return <Localized id='history-translation-copy' attrs={{ title: true }}>
+            <li
+                className={ className }
+                title='Copy Into Translation (Tab)'
+                onClick={ this.copyTranslationIntoEditor }
             >
-                { translation.string }
-            </p>
-        </li>;
+                <header className='clearfix'>
+                    <div className='info'>
+                        { this.renderUser() }
+                        <TimeAgo
+                            dir='ltr'
+                            date={ translation.date_iso }
+                            title={ `${translation.date} UTC` }
+                        />
+                    </div>
+                    <menu className='toolbar'>
+                    { (!translation.rejected || !canDelete ) ? null :
+                        // Delete Button
+                        <Localized
+                            id='history-translation-button-delete'
+                            attrs={{ title: true }}
+                        >
+                            <button
+                                className='delete far'
+                                title='Delete'
+                                onClick={ this.delete }
+                            />
+                        </Localized>
+                    }
+                    { translation.approved ?
+                        // Unapprove Button
+                        <Localized
+                            id='history-translation-button-unapprove'
+                            attrs={{ title: true }}
+                        >
+                            <button
+                                className='unapprove fa'
+                                title='Unapprove'
+                                onClick={ this.unapprove }
+                            ></button>
+                        </Localized>
+                        :
+                        // Approve Button
+                        <Localized
+                            id='history-translation-button-approve'
+                            attrs={{ title: true }}
+                        >
+                            <button
+                                className='approve fa'
+                                title='Approve'
+                                onClick={ this.approve }
+                            ></button>
+                        </Localized>
+                    }
+                    { translation.rejected ?
+                        // Unreject Button
+                        <Localized
+                            id='history-translation-button-unreject'
+                            attrs={{ title: true }}
+                        >
+                            <button
+                                className='unreject fa'
+                                title='Unreject'
+                                onClick={ this.unreject }
+                            ></button>
+                        </Localized>
+                        :
+                        // Reject Button
+                        <Localized
+                            id='history-translation-button-reject'
+                            attrs={{ title: true }}
+                        >
+                            <button
+                                className='reject fa'
+                                title='Reject'
+                                onClick={ this.reject }
+                            ></button>
+                        </Localized>
+                    }
+                    </menu>
+                </header>
+                <p
+                    dir={ locale.direction }
+                    lang={ locale.code }
+                    data-script={ locale.script }
+                >
+                    { translation.string }
+                </p>
+            </li>
+        </Localized>;
     }
 }

--- a/frontend/src/modules/history/components/Translation.js
+++ b/frontend/src/modules/history/components/Translation.js
@@ -47,12 +47,12 @@ export default class Translation extends React.Component<Props> {
         this.props.updateTranslationStatus(this.props.translation.pk, 'unreject');
     }
 
-    copyTranslationIntoEditor = () => {
-        this.props.updateEditorTranslation(this.props.translation.string);
-    }
-
     delete = () => {
         this.props.deleteTranslation(this.props.translation.pk);
+    }
+
+    copyTranslationIntoEditor = () => {
+        this.props.updateEditorTranslation(this.props.translation.string);
     }
 
     getStatus() {

--- a/frontend/src/modules/machinery/components/Machinery.js
+++ b/frontend/src/modules/machinery/components/Machinery.js
@@ -1,14 +1,10 @@
 /* @flow */
 
 import React from 'react';
-import { connect } from 'react-redux';
 import { Localized } from 'fluent-react';
 
 import './Machinery.css';
 
-import * as locales from 'core/locales';
-
-import { NAME } from '..';
 import Translation from './Translation';
 
 import type { Locale } from 'core/locales';
@@ -18,11 +14,7 @@ import type { MachineryState } from '..';
 type Props = {|
     locale: ?Locale,
     machinery: MachineryState,
-|};
-
-type InternalProps = {|
-    ...Props,
-    dispatch: Function,
+    updateEditorTranslation: (string) => void,
 |};
 
 
@@ -33,9 +25,9 @@ type InternalProps = {|
  * strings, coming from various sources like Translation Memory or
  * third-party Machine Translation.
  */
-export class MachineryBase extends React.Component<InternalProps> {
+export default class Machinery extends React.Component<Props> {
     render() {
-        const { locale, machinery } = this.props;
+        const { locale, machinery, updateEditorTranslation } = this.props;
 
         if (!locale) {
             return null;
@@ -53,6 +45,7 @@ export class MachineryBase extends React.Component<InternalProps> {
                     return <Translation
                         translation={ item }
                         locale={ locale }
+                        updateEditorTranslation={ updateEditorTranslation }
                         key={ i }
                     />;
                 }) }
@@ -60,13 +53,3 @@ export class MachineryBase extends React.Component<InternalProps> {
         </section>;
     }
 }
-
-
-const mapStateToProps = (state: Object): Props => {
-    return {
-        locale: locales.selectors.getCurrentLocaleData(state),
-        machinery: state[NAME],
-    };
-};
-
-export default connect(mapStateToProps)(MachineryBase);

--- a/frontend/src/modules/machinery/components/Machinery.test.js
+++ b/frontend/src/modules/machinery/components/Machinery.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import { MachineryBase } from './Machinery';
+import Machinery from './Machinery';
 
 
 describe('<Machinery>', () => {
@@ -13,7 +13,7 @@ describe('<Machinery>', () => {
         const machinery = {
             translations: [],
         };
-        const wrapper = shallow(<MachineryBase machinery={ machinery } locale={ LOCALE } />);
+        const wrapper = shallow(<Machinery machinery={ machinery } locale={ LOCALE } />);
 
         expect(wrapper.find('.search-wrapper')).toHaveLength(1);
         expect(wrapper.find('#machinery-machinery-search-placeholder')).toHaveLength(1);
@@ -27,13 +27,13 @@ describe('<Machinery>', () => {
                 { original: '3' },
             ],
         };
-        const wrapper = shallow(<MachineryBase machinery={ machinery } locale={ LOCALE } />);
+        const wrapper = shallow(<Machinery machinery={ machinery } locale={ LOCALE } />);
 
         expect(wrapper.find('Translation')).toHaveLength(3);
     });
 
     it('returns null if there is no locale', () => {
-        const wrapper = shallow(<MachineryBase locale={ null } />);
+        const wrapper = shallow(<Machinery locale={ null } />);
         expect(wrapper.type()).toBeNull();
     });
 });

--- a/frontend/src/modules/machinery/components/Translation.css
+++ b/frontend/src/modules/machinery/components/Translation.css
@@ -1,4 +1,15 @@
-.translation > header {
+.machinery .translation {
+    border-bottom: 1px solid #5E6475;
+    cursor: pointer;
+    padding: 5px 10px 20px 10px;
+    transition: all 0.1s ease-out;
+}
+
+.machinery .translation:hover {
+    background: #4D5967;
+}
+
+.machinery .translation > header {
     color: #AAAAAA;
     display: block;
     font-size: 11px;
@@ -8,25 +19,25 @@
     text-transform: uppercase;
 }
 
-.translation > header ul {
+.machinery .translation > header ul {
     display: inline-block;
 }
 
-.translation > header ul li {
+.machinery .translation > header ul li {
     display: inline-block;
     padding-left: 3px;
 }
 
-.translation > header ul li::before {
+.machinery .translation > header ul li::before {
     content: "•";
     padding-right: 3px;
 }
 
-.translation > header .stress,
-.translation > header sup {
+.machinery .translation > header .stress,
+.machinery .translation > header sup {
     color: #7BC876;
 }
 
-.translation p.original {
+.machinery .translation p.original {
     color: #AAAAAA;
 }

--- a/frontend/src/modules/machinery/components/Translation.js
+++ b/frontend/src/modules/machinery/components/Translation.js
@@ -13,6 +13,7 @@ import type { Locale } from 'core/locales';
 type Props = {|
     locale: Locale,
     translation: api.types.MachineryTranslation,
+    updateEditorTranslation: (string) => void,
 |};
 
 
@@ -24,11 +25,19 @@ type Props = {|
  * and their sources are merged.
  */
  export default class Translation extends React.Component<Props> {
+     copyTranslationIntoEditor = () => {
+         this.props.updateEditorTranslation(this.props.translation.translation);
+     }
+
      render() {
          const { translation, locale } = this.props;
 
          return <Localized id="machinery-translation-copy" attrs={{ title: true }}>
-             <li className="translation" title="Copy Into Translation (Tab)">
+             <li
+                className="translation"
+                title="Copy Into Translation (Tab)"
+                onClick={ this.copyTranslationIntoEditor }
+            >
                  <header>
                      { !translation.quality ? null :
                      <span className="stress">{ translation.quality + '%' }</span>

--- a/frontend/src/modules/otherlocales/components/Locales.css
+++ b/frontend/src/modules/otherlocales/components/Locales.css
@@ -7,40 +7,6 @@
     margin: 0;
 }
 
-.other-locales > ul li {
-    border-bottom: 1px solid #5E6475;
-    cursor: pointer;
-    margin: 0;
-    padding: 5px 10px 20px 10px;
-    transition: all 0.1s ease-out;
-}
-
-.other-locales > ul li:hover {
-    background: #4D5967;
-    border-color: #5E6475;
-}
-
-.other-locales > ul li > header {
-    color: #AAAAAA;
-    display: block;
-    font-size: 11px;
-    font-weight: 300;
-    padding: 1px 0 5px;
-    text-align: right;
-    text-transform: uppercase;
-}
-
-.other-locales > ul li > header span {
-    color: #7BC876;
-    padding-left: 3px;
-}
-
-.other-locales > ul li > p {
-    min-height: 22px;
-    text-align: start;
-    white-space: pre-wrap;
-}
-
 .other-locales > p {
     border-bottom: 1px solid #5E6475;
     color: #aaa;

--- a/frontend/src/modules/otherlocales/components/Locales.js
+++ b/frontend/src/modules/otherlocales/components/Locales.js
@@ -5,6 +5,8 @@ import { Localized } from 'fluent-react';
 
 import './Locales.css';
 
+import Translation from './Translation';
+
 import type { Navigation } from 'core/navigation';
 import type { LocalesState } from '..';
 
@@ -12,6 +14,7 @@ import type { LocalesState } from '..';
 type Props = {|
     otherlocales: LocalesState,
     parameters: Navigation,
+    updateEditorTranslation: (string) => void,
 |};
 
 
@@ -28,7 +31,7 @@ export default class Locales extends React.Component<Props> {
     }
 
     render() {
-        const { otherlocales, parameters } = this.props;
+        const { otherlocales, parameters, updateEditorTranslation } = this.props;
 
         if (otherlocales.fetching) {
             return null;
@@ -41,25 +44,12 @@ export default class Locales extends React.Component<Props> {
         return <section className="other-locales">
             <ul>
                 { otherlocales.translations.map((translation, key) => {
-                    return <li key={ key }>
-                        <header>
-                            <a
-                                href={ `/translate/${translation.code}/${parameters.project}/${parameters.resource}/?string=${parameters.entity}` }
-                                target="_blank"
-                                rel="noopener noreferrer"
-                            >
-                                { translation.locale }
-                                <span>{ translation.code }</span>
-                            </a>
-                        </header>
-                        <p
-                            lang={ translation.code }
-                            dir={ translation.direction }
-                            script={ translation.script }
-                        >
-                            { translation.translation }
-                        </p>
-                    </li>;
+                    return <Translation
+                        translation={ translation }
+                        parameters={ parameters }
+                        updateEditorTranslation={ updateEditorTranslation }
+                        key={ key }
+                    />;
                 }) }
             </ul>
         </section>;

--- a/frontend/src/modules/otherlocales/components/Locales.test.js
+++ b/frontend/src/modules/otherlocales/components/Locales.test.js
@@ -21,7 +21,7 @@ describe('<Locales>', () => {
             <Locales otherlocales={ otherlocales } parameters={ params } />
         );
 
-        expect(wrapper.find('li')).toHaveLength(3);
+        expect(wrapper.find('Translation')).toHaveLength(3);
     });
 
     it('returns null while otherlocales are loading', () => {

--- a/frontend/src/modules/otherlocales/components/Translation.css
+++ b/frontend/src/modules/otherlocales/components/Translation.css
@@ -1,0 +1,32 @@
+.other-locales .translation {
+    border-bottom: 1px solid #5E6475;
+    cursor: pointer;
+    padding: 5px 10px 20px 10px;
+    transition: all 0.1s ease-out;
+}
+
+.other-locales .translation:hover {
+    background: #4D5967;
+    border-color: #5E6475;
+}
+
+.other-locales .translation > header {
+    color: #AAAAAA;
+    display: block;
+    font-size: 11px;
+    font-weight: 300;
+    padding: 1px 0 5px;
+    text-align: right;
+    text-transform: uppercase;
+}
+
+.other-locales .translation > header span {
+    color: #7BC876;
+    padding-left: 3px;
+}
+
+.other-locales .translation > p {
+    min-height: 22px;
+    text-align: start;
+    white-space: pre-wrap;
+}

--- a/frontend/src/modules/otherlocales/components/Translation.js
+++ b/frontend/src/modules/otherlocales/components/Translation.js
@@ -1,0 +1,58 @@
+/* @flow */
+
+import React from 'react';
+import { Localized } from 'fluent-react';
+
+import './Translation.css';
+
+import type { Navigation } from 'core/navigation';
+
+
+type Props = {|
+    translation: Object,
+    parameters: Navigation,
+    updateEditorTranslation: (string) => void,
+|};
+
+
+/**
+ * Render a Translation in the Locales tab.
+ *
+ * Show the translation of a given entity in a different locale, as well as the
+ * locale and its code.
+ */
+ export default class Translation extends React.Component<Props> {
+     copyTranslationIntoEditor = () => {
+         this.props.updateEditorTranslation(this.props.translation.translation);
+     }
+
+     render() {
+         const { translation, parameters } = this.props;
+
+         return <Localized id='otherlocales-translation-copy' attrs={{ title: true }}>
+             <li
+                className='translation'
+                title='Copy Into Translation (Tab)'
+                onClick={ this.copyTranslationIntoEditor }
+             >
+                 <header>
+                     <a
+                         href={ `/translate/${translation.code}/${parameters.project}/${parameters.resource}/?string=${parameters.entity}` }
+                         target="_blank"
+                         rel="noopener noreferrer"
+                     >
+                         { translation.locale }
+                         <span>{ translation.code }</span>
+                     </a>
+                 </header>
+                 <p
+                     lang={ translation.code }
+                     dir={ translation.direction }
+                     script={ translation.script }
+                 >
+                     { translation.translation }
+                 </p>
+             </li>
+         </Localized>;
+     }
+ }


### PR DESCRIPTION
This enables copying a translation in one of the helper tabs (History, Machinery, Locales) into the Editor when clicked. It involves refactoring some of those components to make the data flow the right way. It might not be the best way to do this, but it works and is satisfying for now. We might want to refactor this part of the code again later.

This also separates CSS rules for the various Translation components of the tabs, so that they do not impact each other.