### PR TITLE
fix(webpack-cli): Cannot read property 'properties' of undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "sync-exec": "^0.6.2",
     "webpack": "^4.16.5",
     "webpack-bundle-tracker": "^0.3.0",
-    "webpack-cli": "^2.1.5",
+    "webpack-cli": "^3.1.1",
     "yuglify": "^2.0.0"
   }
 }


### PR DESCRIPTION
encountered the following error on **webpack-cli v2.1.5**:
```
webpack -p
/opt/pontoon/node_modules/webpack-cli/bin/config-yargs.js:89
				describe: optionsSchema.definitions.output.properties.path.description,
				                                           ^

TypeError: Cannot read property 'properties' of undefined
    at module.exports (/opt/pontoon/node_modules/webpack-cli/bin/config-yargs.js:89:48)
    at /opt/pontoon/node_modules/webpack-cli/bin/webpack.js:60:27
    at Object.<anonymous> (/opt/pontoon/node_modules/webpack-cli/bin/webpack.js:515:3)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Module.require (module.js:596:17)
    at require (internal/module.js:11:18)
```
looks almost identical to closed webpack-cli issue:
https://github.com/webpack/webpack-cli/issues/607

changing to version 3.1.1 solved the issue for me