### PR TITLE
fix(webpack.config.js): No such file or directory: 'frontend/build/static'

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
   output: {
     // This copies each source entry into the extension dist folder named
     // after its entry config key.
-      path: path.resolve(__dirname, 'assets/webpack_bundles/'),
+      path: path.resolve(__dirname, 'frontend/build/static/'),
       filename: '[name].entry.chunk.js',
       chunkFilename: '[name].[chunkhash].js',
       publicPath: '/static/webpack_bundles/'


### PR DESCRIPTION
looks like the files are expected to be at **frontend/build/static**:
```
Request Method: 	GET
Request URL: 	http://localhost:8000/
Django Version: 	1.11.18
Exception Type: 	OSError
Exception Value: 	

[Errno 2] No such file or directory: '/opt/pontoon/frontend/build/static'

Exception Location: 	/usr/local/lib/python2.7/dist-packages/django/core/files/storage.py in listdir, line 397
Python Executable: 	/usr/bin/python
Python Version: 	2.7.15
Python Path: 	

['/opt/pontoon',
 '/usr/lib/python2.7',
 '/usr/lib/python2.7/plat-x86_64-linux-gnu',
 '/usr/lib/python2.7/lib-tk',
 '/usr/lib/python2.7/lib-old',
 '/usr/lib/python2.7/lib-dynload',
 '/usr/local/lib/python2.7/dist-packages',
 '/usr/lib/python2.7/dist-packages',
 '/opt/pontoon']
```