### PR TITLE
Bug 1492166 - Add a tool to mark patterns in a string.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -58,6 +58,7 @@ module.exports = {
         'react',
     ],
     rules: {
+        'react/display-name': 1,
         'react/prefer-es6-class': 1,
         'react/prefer-stateless-function': 0,
         "react/prop-types": 0,

--- a/frontend/src/lib/react-content-marker/createMarker.js
+++ b/frontend/src/lib/react-content-marker/createMarker.js
@@ -1,0 +1,48 @@
+/* @flow */
+
+import * as React from 'react';
+
+import mark from './mark';
+
+
+type Props = {
+    children: string | Array<string | React.Node>,
+};
+
+
+type Parser = {
+    rule: string | RegExp,
+    tag: (string) => React.Node,
+};
+
+
+/**
+ * Creates a React component class to mark content based on rules.
+ *
+ * The component takes its children and marks them using the rules of the
+ * parsers that are provided.
+ *
+ * @param {Array<Parser>} parsers A list of Parser systems. A Parser must
+ * define a `rule` and a `tag`. The `rule` can be either a string to match
+ * terms or a RegExp. Note that a RegExp must have parentheses surrounding
+ * your pattern, otherwise matches won't be captured. The `tag` is a function
+ * that accepts a string (the matched term or pattern) and returns a React
+ * element that will replace the match in the output.
+ *
+ * @returns {Array} An array of strings and React components, similar to the
+ * original content but where each matching pattern has been replaced by a
+ * marking component.
+ */
+export default function createMarker(parsers: Array<Parser>) {
+    return class ContentMarker extends React.Component<Props> {
+        render() {
+            let content = this.props.children;
+
+            for (let parser of parsers) {
+                content = mark(content, parser.rule, parser.tag);
+            }
+
+            return content;
+        }
+    }
+}

--- a/frontend/src/lib/react-content-marker/createMarker.test.js
+++ b/frontend/src/lib/react-content-marker/createMarker.test.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import createMarker from './createMarker';
+
+
+describe('createMarker', () => {
+    it('returns a correct component', () => {
+        const content = 'A horse, a horse, my kingdom for a horse.';
+        const parsers = [
+            { rule: 'horse', tag: x => <i>{x}</i> },
+            { rule: /(a)/gi, tag: x => <b>{x}</b> },
+            { rule: /king\w+/, tag: x => <u>{x}</u> },
+        ];
+        const ContentMarker = createMarker(parsers);
+
+        const wrapper = shallow(<ContentMarker>{ content }</ContentMarker>);
+        expect(wrapper.find('i')).toHaveLength(3);
+        expect(wrapper.find('b')).toHaveLength(3);
+        expect(wrapper.find('u')).toHaveLength(1);
+    });
+});

--- a/frontend/src/lib/react-content-marker/index.js
+++ b/frontend/src/lib/react-content-marker/index.js
@@ -1,0 +1,3 @@
+/* @flow */
+
+export { default as createMarker } from './createMarker';

--- a/frontend/src/lib/react-content-marker/mark.js
+++ b/frontend/src/lib/react-content-marker/mark.js
@@ -1,0 +1,59 @@
+/* @flow */
+
+import * as React from 'react';
+
+import markRegExp from './markRegExp';
+import markTerm from './markTerm';
+
+
+/**
+ * Replaces matching patterns in a string with markers.
+ *
+ * @param {string | Array} content The content to parse and mark.
+ *
+ * @param {string | RegExp} rule The pattern to search and replace in the
+ * content.
+ *
+ * @param {Function} tag A function that takes the match string and must return
+ * a React component or a string. The value returned by that function will
+ * replace the term in the output.
+ *
+ * @returns {Array} An array of strings and React components, similar to the
+ * original content but where each matching pattern has been replaced by a
+ * marking component.
+ */
+export default function mark(
+    content: string | Array<string | React.Node>,
+    rule: string | RegExp,
+    tag: (string) => React.Node
+): Array<string | React.Node> {
+    if (!Array.isArray(content)) {
+        content = [content];
+    }
+
+    if (!(rule instanceof RegExp || typeof rule === 'string')) {
+        throw Error('Unsupported rule type for rule `' + rule + '`.');
+    }
+
+    const output = [];
+
+    for (let part of content) {
+        if (typeof part === 'string') {
+            let marked;
+
+            if (rule instanceof RegExp) {
+                marked = markRegExp(part, rule, tag);
+            }
+            else if (typeof rule === 'string') {
+                marked = markTerm(part, rule, tag);
+            }
+
+            output.push(marked);
+        }
+        else {
+            output.push(part);
+        }
+    }
+
+    return [].concat(...output);
+}

--- a/frontend/src/lib/react-content-marker/mark.test.js
+++ b/frontend/src/lib/react-content-marker/mark.test.js
@@ -1,0 +1,77 @@
+import React from 'react';
+
+import mark from './mark';
+import markRegExp from './markRegExp';
+import markTerm from './markTerm';
+
+
+describe('mark', () => {
+    it('works correctly with a `term` rule', () => {
+        const content = 'A horse, a horse, my kingdom for a horse.';
+        const rule = 'horse';
+        const tag = x => <mark>{x}</mark>;
+
+        const res = mark(content, rule, tag);
+        const expected = markTerm(content, rule, tag);
+
+        expect(res).toEqual(expected);
+    });
+
+    it('works correctly with a `regex` rule', () => {
+        const content = 'A horse, a horse, my kingdom for a horse.';
+        const rule = /(horse)/;
+        const tag = x => <mark>{x}</mark>;
+
+        const res = mark(content, rule, tag);
+        const expected = markRegExp(content, rule, tag);
+
+        expect(res).toEqual(expected);
+    });
+
+    it('works with an array input', () => {
+        const content = [
+            'Hello, ',
+            <div />,
+            'What is your name?',
+        ];
+        const rule = 'name';
+        const tag = x => <mark>{x}</mark>;
+
+        const res = mark(content, rule, tag);
+        const expected = [
+            'Hello, ',
+            <div />,
+            'What is your ',
+            <mark>{ 'name' }</mark>,
+            '?',
+        ];
+
+        expect(res).toEqual(expected);
+    });
+
+    it('can chain marks', () => {
+        const content = 'My name is what my name is who my name is Slim Shady';
+        const tag = x => <mark>{x}</mark>;
+
+        let res = mark(content, 'name', tag);
+        res = mark(res, /(wh\w+)/, tag);
+        res = mark(res, /([A-Z]\w+ [A-Z]\w+)/, tag);
+
+        const expected = [
+            "My ",
+            <mark>name</mark>,
+            " is ",
+            <mark>what</mark>,
+            " my ",
+            <mark>name</mark>,
+            " is ",
+            <mark>who</mark>,
+            " my ",
+            <mark>name</mark>,
+            " is ",
+            <mark>Slim Shady</mark>,
+        ];
+
+        expect(res).toEqual(expected);
+    });
+});

--- a/frontend/src/lib/react-content-marker/markRegExp.js
+++ b/frontend/src/lib/react-content-marker/markRegExp.js
@@ -1,0 +1,44 @@
+/* @flow */
+
+import * as React from 'react';
+
+
+/**
+ * Replaces matching patterns in a string with markers.
+ *
+ * @param {string} content The content to parse and mark.
+ *
+ * @param {RegExp} rule The pattern to search and replace in the content.
+ *
+ * @param {Function} tag A function that takes the match string and must return
+ * a React component or a string. The value returned by that function will
+ * replace the term in the output.
+ *
+ * @returns {Array} An array of strings and React components, similar to the
+ * original content but where each matching pattern has been replaced by a
+ * marking component.
+ */
+export default function markRegExp(
+    content: string,
+    rule: RegExp,
+    tag: (string) => React.Node
+): Array<string | React.Node> {
+    const output = [];
+
+    const parts = content.split(rule);
+
+    for (let i = 0; i < parts.length; i++) {
+        if (!parts[i]) {
+            continue;
+        }
+
+        if (i % 2) {
+            output.push(tag(parts[i]));
+        }
+        else {
+            output.push(parts[i]);
+        }
+    }
+
+    return output;
+}

--- a/frontend/src/lib/react-content-marker/markRegExp.test.js
+++ b/frontend/src/lib/react-content-marker/markRegExp.test.js
@@ -1,0 +1,68 @@
+import React from 'react';
+
+import markRegExp from './markRegExp';
+
+
+describe('markRegExp', () => {
+    it('correctly marks matches of a simple pattern', () => {
+        const content = 'A horse, a horse, my kingdom for a horse.';
+
+        const res = markRegExp(content, /(horse)/, x => <mark>{x}</mark>);
+        const expected = [
+            'A ',
+            <mark>{ 'horse' }</mark>,
+            ', a ',
+            <mark>{ 'horse' }</mark>,
+            ', my kingdom for a ',
+            <mark>{ 'horse' }</mark>,
+            '.',
+        ];
+        expect(res).toEqual(expected);
+    });
+
+    it('correctly marks matches of a more complex pattern', () => {
+        const content = 'Foux du fa fa';
+
+        const res = markRegExp(content, /(f\w+)/i, x => <mark>{x}</mark>);
+        const expected = [
+            <mark>{ 'Foux' }</mark>,
+            ' du ',
+            <mark>{ 'fa' }</mark>,
+            ' ',
+            <mark>{ 'fa' }</mark>,
+        ];
+        expect(res).toEqual(expected);
+    });
+
+    it('correctly marks the entire content', () => {
+        const content = 'horse';
+
+        const res = markRegExp(content, /(horse)/, x => <mark>{x}</mark>);
+        const expected = [
+            <mark>{ 'horse' }</mark>,
+        ];
+        expect(res).toEqual(expected);
+    });
+
+    it('supports attributes in tag', () => {
+        const content = 'word';
+
+        const res = markRegExp(
+            content, /(word)/, x => <mark title='Word Finder'>{x}</mark>
+        );
+
+        const expected = [
+            <mark title='Word Finder'>{ 'word' }</mark>,
+        ];
+        expect(res).toEqual(expected);
+    });
+
+    it('returns the input as an array if there is no match', () => {
+        const content = 'A horse, a horse, my kingdom for a horse.';
+
+        const res = markRegExp(content, /(missing)/, x => <mark>{x}</mark>);
+
+        const expected = [content];
+        expect(res).toEqual(expected);
+    });
+});

--- a/frontend/src/lib/react-content-marker/markTerm.js
+++ b/frontend/src/lib/react-content-marker/markTerm.js
@@ -1,0 +1,49 @@
+/* @flow */
+
+import * as React from 'react';
+
+
+/**
+ * Replaces matching terms in a string with markers.
+ *
+ * @param {string} content The content to parse and mark.
+ *
+ * @param {string} term The term to search and replace in the content. Case
+ * sensitive.
+ *
+ * @param {Function} tag A function that takes the matched term and must return
+ * a React component or a string. The value returned by that function will
+ * replace the term in the output.
+ *
+ * @returns {Array} An array of strings and React components, similar to the
+ * original content but where each matching term has been replaced by a
+ * marking component.
+ */
+export default function markTerm(
+    content: string,
+    term: string,
+    tag: (string) => React.Node
+): Array<string | React.Node> {
+    const output = [];
+
+    const pos = content.indexOf(term);
+
+    if (pos === -1) {
+        return [content];
+    }
+
+    const parts = content.split(term);
+
+    for (let i = 0; i < parts.length - 1; i++) {
+        if (parts[i]) {
+            output.push(parts[i]);
+        }
+        output.push(tag(term));
+    }
+
+    if (parts[parts.length - 1]) {
+        output.push(parts[parts.length - 1]);
+    }
+
+    return output;
+}

--- a/frontend/src/lib/react-content-marker/markTerm.test.js
+++ b/frontend/src/lib/react-content-marker/markTerm.test.js
@@ -1,0 +1,76 @@
+import React from 'react';
+
+import markTerm from './markTerm';
+
+
+describe('markTerm', () => {
+    it('correctly marks several strings in the content', () => {
+        const content = 'A horse, a horse, my kingdom for a horse.';
+
+        const res = markTerm(content, 'horse', x => <mark>{x}</mark>);
+        const expected = [
+            'A ',
+            <mark>{ 'horse' }</mark>,
+            ', a ',
+            <mark>{ 'horse' }</mark>,
+            ', my kingdom for a ',
+            <mark>{ 'horse' }</mark>,
+            '.',
+        ];
+        expect(res).toEqual(expected);
+    });
+
+    it('correctly marks a string at the beginning of the content', () => {
+        const content = 'A horse, a horse, my kingdom for a horse.';
+
+        const res = markTerm(content, 'A', x => <mark>{x}</mark>);
+        const expected = [
+            <mark>{ 'A' }</mark>,
+            ' horse, a horse, my kingdom for a horse.',
+        ];
+        expect(res).toEqual(expected);
+    });
+
+    it('correctly marks a string at the end of the content', () => {
+        const content = 'A horse, a horse, my kingdom for a horse.';
+
+        const res = markTerm(content, 'horse.', x => <mark>{x}</mark>);
+        const expected = [
+            'A horse, a horse, my kingdom for a ',
+            <mark>{ 'horse.' }</mark>,
+        ];
+        expect(res).toEqual(expected);
+    });
+
+    it('correctly marks the entire content', () => {
+        const content = 'horse';
+
+        const res = markTerm(content, 'horse', x => <mark>{x}</mark>);
+        const expected = [
+            <mark>{ 'horse' }</mark>,
+        ];
+        expect(res).toEqual(expected);
+    });
+
+    it('supports attributes in tag', () => {
+        const content = 'word';
+
+        const res = markTerm(
+            content, content, x => <mark title='Word Finder'>{x}</mark>
+        );
+
+        const expected = [
+            <mark title='Word Finder'>{ 'word' }</mark>,
+        ];
+        expect(res).toEqual(expected);
+    });
+
+    it('returns the input as an array if there is no match', () => {
+        const content = 'A horse, a horse, my kingdom for a horse.';
+
+        const res = markTerm(content, 'missing', x => <mark>{x}</mark>);
+
+        const expected = [content];
+        expect(res).toEqual(expected);
+    });
+});


### PR DESCRIPTION
This tool can be used to generate a React component that will apply a list of parsers to a string, and replace each matching pattern or term with a special marker. It currently supports RegExp and simple string terms. The markers can be anything, allowing us to define specific tags to use for each parser.

Note that this tool is in a `lib` folder because I intend to extract it to a library in the future.

Note: I'm asking review from all of you because this is a pretty generic problem and I'd like to get some feedback on my algorithms here.