### PR TITLE
Fix bug 1514722: Highlight user preferred locales in Locales tab

### DIFF
--- a/frontend/src/core/user/reducer.js
+++ b/frontend/src/core/user/reducer.js
@@ -55,6 +55,7 @@ export type UserState = {|
     +translatorForLocales: Array<string>,
     +translatorForProjects: Array<string>,
     +settings: SettingsState,
+    +preferredLocales: Array<string>,
 |};
 
 const initial: UserState = {
@@ -67,6 +68,7 @@ const initial: UserState = {
     translatorForLocales: [],
     translatorForProjects: [],
     settings: initialSettings,
+    preferredLocales: [],
 };
 
 export default function reducer(
@@ -85,6 +87,7 @@ export default function reducer(
                 translatorForLocales: action.data.translator_for_locales,
                 translatorForProjects: action.data.translator_for_projects,
                 settings: settings(state.settings, action),
+                preferredLocales: action.data.preferred_locales,
             };
         case UPDATE_SETTINGS:
             return {

--- a/frontend/src/modules/entitydetails/components/OtherLocalesCount.js
+++ b/frontend/src/modules/entitydetails/components/OtherLocalesCount.js
@@ -1,0 +1,41 @@
+/* @flow */
+
+import * as React from 'react';
+
+import type { LocalesState } from 'modules/otherlocales';
+
+
+type Props = {|
+    otherlocales: LocalesState,
+    preferredCount: number,
+|};
+
+
+export default class OtherLocalesCount extends React.Component<Props> {
+    render() {
+        const { otherlocales, preferredCount } = this.props;
+
+        const otherlocalesCount = otherlocales.translations.length;
+
+        const remainingCount = otherlocalesCount - preferredCount;
+
+        const preferred = (
+            !preferredCount ? null :
+            <span className='preferred'>{ preferredCount }</span>
+        );
+        const remaining = (
+            !remainingCount ? null :
+            <span>{ remainingCount }</span>
+        );
+        const plus = (
+            !remainingCount || !preferredCount ? null :
+            <span>{ '+' }</span>
+        );
+
+        return <span className='count'>
+            { preferred }
+            { plus }
+            { remaining }
+        </span>;
+    }
+}

--- a/frontend/src/modules/entitydetails/components/OtherLocalesCount.test.js
+++ b/frontend/src/modules/entitydetails/components/OtherLocalesCount.test.js
@@ -1,18 +1,21 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import MachineryCount from './MachineryCount';
+import OtherLocalesCount from './OtherLocalesCount';
 
 
-describe('<MachineryCount>', () => {
+describe('<OtherLocalesCount>', () => {
     it('shows the correct number of preferred translations', () => {
-        const machinery = {
+        const otherlocales = {
             translations: [
-                { sources: [{ type: 'Translation memory' }] },
-                { sources: [{ type: 'Translation memory' }] },
+                { code: 'ab' },
+                { code: 'cd' },
             ],
         };
-        const wrapper = shallow(<MachineryCount machinery={ machinery } />);
+        const wrapper = shallow(<OtherLocalesCount
+            otherlocales={ otherlocales }
+            preferredCount={ 2 }
+        />);
 
         // There are only preferred results.
         expect(wrapper.find('.count > span')).toHaveLength(1);
@@ -24,14 +27,17 @@ describe('<MachineryCount>', () => {
     });
 
     it('shows the correct number of remaining translations', () => {
-        const machinery = {
+        const otherlocales = {
             translations: [
-                { sources: [{ type: 'Microsoft' }] },
-                { sources: [{ type: 'Transvision' }] },
-                { sources: [{ type: 'Transvision' }] },
+                { code: 'ef' },
+                { code: 'gh' },
+                { code: 'ij' },
             ],
         };
-        const wrapper = shallow(<MachineryCount machinery={ machinery } />);
+        const wrapper = shallow(<OtherLocalesCount
+            otherlocales={ otherlocales }
+            preferredCount={ 0 }
+        />);
 
         // There are only remaining results.
         expect(wrapper.find('.count > span')).toHaveLength(1);
@@ -44,16 +50,19 @@ describe('<MachineryCount>', () => {
     });
 
     it('shows the correct numbers of preferred and remaining translations', () => {
-        const machinery = {
+        const otherlocales = {
             translations: [
-                { sources: [{ type: 'Translation memory' }] },
-                { sources: [{ type: 'Translation memory' }] },
-                { sources: [{ type: 'Microsoft' }] },
-                { sources: [{ type: 'Transvision' }] },
-                { sources: [{ type: 'Transvision' }] },
+                { code: 'ab' },
+                { code: 'cd' },
+                { code: 'ef' },
+                { code: 'gh' },
+                { code: 'ij' },
             ],
         };
-        const wrapper = shallow(<MachineryCount machinery={ machinery } />);
+        const wrapper = shallow(<OtherLocalesCount
+            otherlocales={ otherlocales }
+            preferredCount={ 2 }
+        />);
 
         // There are both preferred and remaining, and the '+' sign.
         expect(wrapper.find('.count > span')).toHaveLength(3);

--- a/frontend/src/modules/entitydetails/components/Tools.js
+++ b/frontend/src/modules/entitydetails/components/Tools.js
@@ -10,6 +10,7 @@ import { Machinery } from 'modules/machinery';
 import { Locales } from 'modules/otherlocales';
 
 import MachineryCount from './MachineryCount';
+import OtherLocalesCount from './OtherLocalesCount';
 
 import type { Locale } from 'core/locales';
 import type { NavigationParams } from 'core/navigation';
@@ -38,6 +39,23 @@ type Props = {|
  * Shows the metadata of the entity and an editor for translations.
  */
 export default class Tools extends React.Component<Props> {
+    preferredCount() {
+        const { otherlocales, user } = this.props;
+
+        if (!user.isAuthenticated) {
+            return 0;
+        }
+
+        const preferred = otherlocales.translations.reduce((count, item) => {
+            if (user.preferredLocales.indexOf(item.code) > -1) {
+                return count + 1;
+            }
+            return count;
+        }, 0);
+
+        return preferred;
+    }
+
     render() {
         const {
             history,
@@ -72,7 +90,10 @@ export default class Tools extends React.Component<Props> {
                 <Tab>
                     Locales
                     { !otherlocalesCount ? null :
-                    <span className={ 'count' }>{ otherlocalesCount }</span>
+                    <OtherLocalesCount
+                        otherlocales={ otherlocales }
+                        preferredCount={ this.preferredCount() }
+                    />
                     }
                 </Tab>
             </TabList>
@@ -98,8 +119,10 @@ export default class Tools extends React.Component<Props> {
             <TabPanel>
                 <Locales
                     otherlocales={ otherlocales }
+                    user={ user }
                     parameters={ parameters }
                     updateEditorTranslation={ updateEditorTranslation }
+                    preferredCount={ this.preferredCount() }
                 />
             </TabPanel>
         </Tabs>;

--- a/frontend/src/modules/otherlocales/components/Locales.test.js
+++ b/frontend/src/modules/otherlocales/components/Locales.test.js
@@ -17,18 +17,54 @@ describe('<Locales>', () => {
             locale: 'kg',
             project: 'tmo',
         };
+        const user = {}
         const wrapper = shallow(
-            <Locales otherlocales={ otherlocales } parameters={ params } />
+            <Locales
+                otherlocales={ otherlocales }
+                parameters={ params }
+                user={ user }
+            />
         );
 
         expect(wrapper.find('Translation')).toHaveLength(3);
+    });
+
+    it('shows preferred locales first', () => {
+        const otherlocales = {
+            translations: [
+                { code: 'ar' },
+                { code: 'br' },
+                { code: 'cr' },
+            ],
+        };
+        const params = {
+            locale: 'kg',
+            project: 'tmo',
+        };
+        const user = {
+            isAuthenticated: true,
+            preferredLocales: ['ab', 'br', 'cd']
+        };
+        const wrapper = shallow(
+            <Locales
+                otherlocales={ otherlocales }
+                parameters={ params }
+                user={ user }
+            />
+        );
+
+        expect(wrapper.find('Translation:first-child .stress').text()).toContain('br');
     });
 
     it('returns null while otherlocales are loading', () => {
         const otherlocales = {
             fetching: true,
         };
-        const wrapper = shallow(<Locales otherlocales={ otherlocales } />);
+        const user = {}
+        const wrapper = shallow(<Locales
+            otherlocales={ otherlocales }
+            user={ user }
+        />);
 
         expect(wrapper.type()).toBeNull();
     });
@@ -38,7 +74,11 @@ describe('<Locales>', () => {
             fetching: false,
             translations: [],
         };
-        const wrapper = shallow(<Locales otherlocales={ otherlocales } />);
+        const user = {}
+        const wrapper = shallow(<Locales
+            otherlocales={ otherlocales }
+            user={ user }
+        />);
 
         expect(wrapper.find('#history-history-no-translations')).toHaveLength(1);
     });

--- a/frontend/src/modules/otherlocales/components/Translation.css
+++ b/frontend/src/modules/otherlocales/components/Translation.css
@@ -5,6 +5,10 @@
     transition: all 0.1s ease-out;
 }
 
+.other-locales .translation.last-preferred {
+    border-bottom-color: #7BC876;
+}
+
 .other-locales .translation:hover {
     background: #4D5967;
     border-color: #5E6475;

--- a/frontend/src/modules/otherlocales/components/Translation.js
+++ b/frontend/src/modules/otherlocales/components/Translation.js
@@ -12,6 +12,7 @@ type Props = {|
     translation: Object,
     parameters: Navigation,
     updateEditorTranslation: (string) => void,
+    lastPreferred: boolean,
 |};
 
 
@@ -27,11 +28,13 @@ type Props = {|
      }
 
      render() {
-         const { translation, parameters } = this.props;
+         const { translation, parameters, lastPreferred } = this.props;
+
+         const className = lastPreferred ? 'translation last-preferred' : 'translation';
 
          return <Localized id='otherlocales-translation-copy' attrs={{ title: true }}>
              <li
-                className='translation'
+                className={ className }
                 title='Copy Into Translation (Tab)'
                 onClick={ this.copyTranslationIntoEditor }
              >

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -931,6 +931,7 @@ def user_data(request):
             'quality_checks': user.profile.quality_checks,
             'force_suggestions': user.profile.force_suggestions,
         },
+        'preferred_locales': user.profile.sorted_locales_codes,
     })
 
 


### PR DESCRIPTION
This should work with the exception of the failing test, but I have a couple of questions:

1. Should we move `MachineryCount` and `OtherLocalesCount` components to corresponding modules (`machinery` and `otherlocales`)?

2. Should we rename `Locales` component to `OtherLocales`?