### PR TITLE
Fix bug 1528293: Convert read-only AJAX responses to JSON

### DIFF
--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -387,9 +387,10 @@ def approve_translation(request):
 
     # Read-only translations cannot be approved
     if utils.readonly_exists(project, locale):
-        return HttpResponseForbidden(
-            "Forbidden: This translation is in read-only mode"
-        )
+        return JsonResponse({
+            'status': False,
+            'message': 'Forbidden: This string is in read-only mode',
+        }, status=403)
 
     if translation.approved:
         return HttpResponseForbidden(
@@ -441,9 +442,10 @@ def unapprove_translation(request):
 
     # Read-only translations cannot be un-approved
     if utils.readonly_exists(project, locale):
-        return HttpResponseForbidden(
-            "Forbidden: This string is in read-only mode"
-        )
+        return JsonResponse({
+            'status': False,
+            'message': 'Forbidden: This string is in read-only mode',
+        }, status=403)
 
     # Only privileged users or authors can un-approve translations
     if not (
@@ -485,9 +487,10 @@ def reject_translation(request):
 
     # Read-only translations cannot be rejected
     if utils.readonly_exists(project, locale):
-        return HttpResponseForbidden(
-            "Forbidden: This string is in read-only mode"
-        )
+        return JsonResponse({
+            'status': False,
+            'message': 'Forbidden: This string is in read-only mode',
+        }, status=403)
 
     # Non-privileged users can only reject own unapproved translations
     if not request.user.can_translate(locale, project):
@@ -531,9 +534,10 @@ def unreject_translation(request):
 
     # Read-only translations cannot be un-rejected
     if utils.readonly_exists(project, locale):
-        return HttpResponseForbidden(
-            "Forbidden: This string is in read-only mode"
-        )
+        return JsonResponse({
+            'status': False,
+            'message': 'Forbidden: This string is in read-only mode',
+        }, status=403)
 
     # Only privileged users or authors can un-reject translations
     if not (
@@ -574,9 +578,10 @@ def delete_translation(request):
 
     # Read-only translations cannot be deleted
     if utils.readonly_exists(project, locale):
-        return HttpResponseForbidden(
-            "Forbidden: This string is in read-only mode"
-        )
+        return JsonResponse({
+            'status': False,
+            'message': 'Forbidden: This string is in read-only mode',
+        }, status=403)
 
     # Only privileged users or authors can delete translations
     if not translation.rejected or not (
@@ -679,9 +684,10 @@ def update_translation(request):
 
     # Read-only translations cannot saved
     if utils.readonly_exists(project, locale):
-        return HttpResponseForbidden(
-            "Forbidden: This string is in read-only mode"
-        )
+        return JsonResponse({
+            'status': False,
+            'message': 'Forbidden: This string is in read-only mode',
+        }, status=403)
 
     try:
         use_ttk_checks = UserProfile.objects.get(user=user).quality_checks

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -389,28 +389,31 @@ def approve_translation(request):
     if utils.readonly_exists(project, locale):
         return JsonResponse({
             'status': False,
-            'message': 'Forbidden: This string is in read-only mode',
+            'message': 'Forbidden: This string is in read-only mode.',
         }, status=403)
 
     if translation.approved:
-        return HttpResponseForbidden(
-            "Forbidden: This translation is already approved"
-        )
+        return JsonResponse({
+            'status': False,
+            'message': 'Forbidden: This translation is already approved.',
+        }, status=403)
 
     # Only privileged users can approve translations
     if not user.can_translate(locale, project):
-        return HttpResponseForbidden(
-            "Forbidden: You don't have permission to approve this translation."
-        )
+        return JsonResponse({
+            'status': False,
+            'message': "Forbidden: You don't have permission to approve this translation.",
+        }, status=403)
 
     # Check for errors.
     # Checks are disabled for the tutorial.
     use_checks = project.slug != 'tutorial'
 
     if use_checks and translation.errors.exists():
-        return HttpResponseForbidden(
-            "Forbidden: There are errors with this translation."
-        )
+        return JsonResponse({
+            'status': False,
+            'message': 'Forbidden: This translation has errors.',
+        }, status=403)
 
     translation.approve(user)
 
@@ -444,7 +447,7 @@ def unapprove_translation(request):
     if utils.readonly_exists(project, locale):
         return JsonResponse({
             'status': False,
-            'message': 'Forbidden: This string is in read-only mode',
+            'message': 'Forbidden: This string is in read-only mode.',
         }, status=403)
 
     # Only privileged users or authors can un-approve translations
@@ -453,9 +456,10 @@ def unapprove_translation(request):
         request.user == translation.user or
         translation.approved
     ):
-        return HttpResponseForbidden(
-            "Forbidden: You can't unapprove this translation."
-        )
+        return JsonResponse({
+            'status': False,
+            'message': "Forbidden: You can't unapprove this translation.",
+        }, status=403)
 
     translation.unapprove(request.user)
 
@@ -489,20 +493,22 @@ def reject_translation(request):
     if utils.readonly_exists(project, locale):
         return JsonResponse({
             'status': False,
-            'message': 'Forbidden: This string is in read-only mode',
+            'message': 'Forbidden: This string is in read-only mode.',
         }, status=403)
 
     # Non-privileged users can only reject own unapproved translations
     if not request.user.can_translate(locale, project):
         if translation.user == request.user:
             if translation.approved is True:
-                return HttpResponseForbidden(
-                    "Forbidden: Can't reject approved translations"
-                )
+                return JsonResponse({
+                    'status': False,
+                    'message': "Forbidden: You can't reject approved translations.",
+                }, status=403)
         else:
-            return HttpResponseForbidden(
-                "Forbidden: Can't reject translations from other users"
-            )
+            return JsonResponse({
+                'status': False,
+                'message': "Forbidden: You can't reject translations from other users.",
+            }, status=403)
 
     translation.reject(request.user)
 
@@ -536,7 +542,7 @@ def unreject_translation(request):
     if utils.readonly_exists(project, locale):
         return JsonResponse({
             'status': False,
-            'message': 'Forbidden: This string is in read-only mode',
+            'message': 'Forbidden: This string is in read-only mode.',
         }, status=403)
 
     # Only privileged users or authors can un-reject translations
@@ -545,9 +551,10 @@ def unreject_translation(request):
         request.user == translation.user or
         translation.approved
     ):
-        return HttpResponseForbidden(
-            "Forbidden: You can't unreject this translation."
-        )
+        return JsonResponse({
+            'status': False,
+            'message': "Forbidden: You can't unreject this translation.",
+        }, status=403)
 
     translation.unreject(request.user)
 
@@ -580,7 +587,7 @@ def delete_translation(request):
     if utils.readonly_exists(project, locale):
         return JsonResponse({
             'status': False,
-            'message': 'Forbidden: This string is in read-only mode',
+            'message': 'Forbidden: This string is in read-only mode.',
         }, status=403)
 
     # Only privileged users or authors can delete translations
@@ -589,9 +596,10 @@ def delete_translation(request):
         request.user == translation.user or
         translation.approved
     ):
-        return HttpResponseForbidden(
-            "Forbidden: You can't delete this translation."
-        )
+        return JsonResponse({
+            'status': False,
+            'message': "Forbidden: You can't delete this translation.",
+        }, status=403)
 
     translation.delete()
 
@@ -686,7 +694,7 @@ def update_translation(request):
     if utils.readonly_exists(project, locale):
         return JsonResponse({
             'status': False,
-            'message': 'Forbidden: This string is in read-only mode',
+            'message': 'Forbidden: This string is in read-only mode.',
         }, status=403)
 
     try:
@@ -857,7 +865,7 @@ def upload(request):
         not request.user.can_translate(project=project, locale=locale)
         or utils.readonly_exists(project, locale)
     ):
-        return HttpResponseForbidden("Forbidden: You don't have permission to upload files")
+        return HttpResponseForbidden("You don't have permission to upload files.")
 
     form = forms.UploadFileForm(request.POST, request.FILES)
 

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -672,7 +672,9 @@ def perform_checks(request):
             'failedChecks': failed_checks,
         })
     else:
-        return HttpResponse('ok')
+        return JsonResponse({
+            'status': True,
+        })
 
 
 @require_POST
@@ -706,15 +708,19 @@ def update_translation(request):
 
     try:
         e = Entity.objects.get(pk=entity)
-    except Entity.DoesNotExist as error:
-        log.error(str(error))
-        return HttpResponse("error")
+    except Entity.DoesNotExist as e:
+        return JsonResponse({
+            'status': False,
+            'message': 'Bad Request: {error}'.format(error=e),
+        }, status=400)
 
     try:
         locale = Locale.objects.get(code=locale)
-    except Locale.DoesNotExist as error:
-        log.error(str(error))
-        return HttpResponse("error")
+    except Locale.DoesNotExist as e:
+        return JsonResponse({
+            'status': False,
+            'message': 'Bad Request: {error}'.format(error=e),
+        }, status=400)
 
     if plural_form == "-1":
         plural_form = None

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from datetime import datetime
 from urlparse import urlparse
@@ -737,7 +736,7 @@ def update_translation(request):
 
     try:
         use_ttk_checks = UserProfile.objects.get(user=user).quality_checks
-    except UserProfile.DoesNotExist as error:
+    except UserProfile.DoesNotExist:
         use_ttk_checks = True
 
     # Disable checks for tutorial project.


### PR DESCRIPTION
This fixes the following error shown in the JS Console when a user tries to submit a translation to a read-only project:
```
SyntaxError: JSON.parse: unexpected character at line 1 column 1 of the JSON data
```

While the error will be harder to trigger when [bug 1528273](https://bugzilla.mozilla.org/show_bug.cgi?id=1528273) gets fixed, we should still convert all AJAX responses to JSON, because that's what our new frontend expects. So this is just a first step. I'd be happy to make the next (and the final) one in a follow-up commit.

It shouldn't be too hard to keep compatibility with Translate.Current if we keep the status codes unchanged, because that's what our old frontend expects.

@adngdb Thoughts?