### PR TITLE
Fix bug 1529895: Serve static files with HSTS header

### DIFF
--- a/pontoon/wsgi.py
+++ b/pontoon/wsgi.py
@@ -7,6 +7,7 @@ https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
 import os
 
 from django.core.wsgi import get_wsgi_application
+from wsgi_sslify import sslify
 
 
 # Set settings env var before importing whitenoise as it depends on
@@ -14,4 +15,4 @@ from django.core.wsgi import get_wsgi_application
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'pontoon.settings')
 from whitenoise.django import DjangoWhiteNoise  # noqa
 
-application = DjangoWhiteNoise(get_wsgi_application())
+application = sslify(DjangoWhiteNoise(get_wsgi_application()))

--- a/requirements.txt
+++ b/requirements.txt
@@ -339,3 +339,11 @@ python-binary-memcached==0.28.0 \
     --hash=sha256:8cc4e71c20a2d9e75c30669c4bef35ee407bbfc72a631fc7ad130a2957bd1ed1
 uhashring==1.1 \
     --hash=sha256:7bedeef34a0e1df21f7d4396c6657f9a2a0cfb0ce9f77bc18e06df7e28eecebe
+
+# ----------------------------------------------------------------------------------
+wsgi-sslify==1.0.1 \
+    --hash=sha256:cde368fda0fb9958dd58bc2cb955d0bf3df1b79c132d97cee90be5fda34a5089
+
+# Required by wsgi-sslify
+werkzeug==0.10.1 \
+    --hash=sha256:9cf783990b1a99173e707a5768610800aa87775e9d86e211d17180d5b6c245ab


### PR DESCRIPTION
Thanks to @adngdb for the hint! ([source](https://github.com/evansd/whitenoise/issues/53))

The patch is [deployed on stage for testing](https://mozilla-pontoon-staging.herokuapp.com/sl/firefox/browser/branding/official/brand.ftl/?string=175817).