### PR TITLE
Fix bug 1529895: Set Strict-Transport-Security header only once

### DIFF
--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -673,9 +673,9 @@ X_FRAME_OPTIONS = 'DENY'
 # Use correct header for detecting HTTPS on Heroku.
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
-# Strict-Transport-Security: max-age=63072000
-# Ensures users only visit the site over HTTPS
-SECURE_HSTS_SECONDS = 63072000
+# Do not set SECURE_HSTS_SECONDS.
+# HSTS is being taken care of in pontoon/wsgi.py.
+# SECURE_HSTS_SECONDS = 63072000
 
 # X-Content-Type-Options: nosniff
 # Disables browser MIME type sniffing

--- a/pontoon/wsgi.py
+++ b/pontoon/wsgi.py
@@ -15,4 +15,6 @@ from wsgi_sslify import sslify
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'pontoon.settings')
 from whitenoise.django import DjangoWhiteNoise  # noqa
 
+# sslify sets a Strict-Transport-Security header,
+# which instructs browsers to always use HTTPS.
 application = sslify(DjangoWhiteNoise(get_wsgi_application()))


### PR DESCRIPTION
It turns out `sslify` takes care of `HSTS` for all requests, so we don't need to (and shouldn't) set it via the `SECURE_HSTS_SECONDS` setting. This patch addresses that.

It's deployed to stage:
https://mozilla-pontoon-staging.herokuapp.com/sl/firefox/

@psiinon r?