### PR TITLE
Fix bug 1531778 - Update package.json to accomodate for Heroku's new …

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,6 @@
   "dependencies": {
     "fluent-syntax": "^0.9.0"
   },
-  "engines": {
-    "node": "9.4.0"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/mozilla/pontoon.git"
@@ -27,7 +24,8 @@
   "scripts": {
     "test": "jest",
     "build": "webpack",
-    "build-w": "webpack -w"
+    "build-w": "webpack -w",
+    "heroku-postbuild": "echo Build is taken care of in ./bin/post_compile"
   },
   "jest": {
     "testMatch": [


### PR DESCRIPTION
…nodejs buildpact.

This also removes the set node.js engine version, to make heroku use the latest LTS version of node.js. That's what we test with for development and testing on travis, so this should be a fine move.

Documentation about Heroku's node versions: https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version