### PR TITLE
Only show "Set up your first project" link to admins

### DIFF
--- a/pontoon/base/templates/no_projects.html
+++ b/pontoon/base/templates/no_projects.html
@@ -11,9 +11,11 @@
       </a>
       <p>There are no projects to localize yet.</p>
     </div>
+    {% if perms.base.can_manage_project %}
     <div id="subtitle">
       <a href={{ url('pontoon.admin.project.new') }}>Set up your first project</a>
     </div>
+    {% endif %}
   </div>
 </section>
 {% endblock %}


### PR DESCRIPTION
@VishalCR7 r?

It doesn't make much sense to show the "Set up your first project" link to all users.