### PR TITLE
Fix bug 1525863: In tour, add link to the team dashboard

### DIFF
--- a/pontoon/tour/static/js/tour.js
+++ b/pontoon/tour/static/js/tour.js
@@ -279,7 +279,7 @@ $(function () {
           "(https://mozilla-l10n.github.io/localizer-documentation/)." +
           "<br /><br />" +
           "Next, feel free to explore this tutorial project or move straight to " +
-          "translating live projects!",
+          "[translating live projects](/" + Pontoon.state.locale + "/)!",
         format: "markdown",
         listeners: {
           afterStep: function() {


### PR DESCRIPTION
This patch adds a link to the locale dashboard in the last step of the tour. The locale is the same as the one the tour has been taken in.

@MikkCZ r?