### PR TITLE
Fix bug 1536897: Make homepage content generic

### DIFF
--- a/pontoon/homepage/templates/homepage_content.html
+++ b/pontoon/homepage/templates/homepage_content.html
@@ -4,12 +4,12 @@
   <!-- Section-1: Introduction -->
   <section id="section-1" class="section">
     <div class="container">
-      <h1>Localize Mozilla</h1>
+      <h1>Welcome to Pontoon</h1>
       <p>
-        If you want to make Firefox available in your language,
-        join a global community of localizers from all over the world,
-        track progress of various Mozilla localization projects, and more,
-        Pontoon is there for you.
+        Pontoon is a translation management system used and developed by
+        the Mozilla localization community. It specializes in open source localization
+        that is driven by the community and uses version-control systems
+        for storing translations.
       </p>
       <div class="flex">
         <a class="button primary" href="{{ start_url }}">Start Localizing Now</a>
@@ -22,24 +22,7 @@
     </div>
   </section>
 
-  <!-- Section-2: Why Mozilla? -->
-  <section id="section-2" class="section">
-    <div class="container">
-      <div class="content-wrapper flex-col-2 flex-direction-col">
-        <h2>Here's why localizing Mozilla matters.</h2>
-        <p>
-          We are committed to an internet that includes all the peoples of the earth —
-          where a person’s demographic characteristics do not determine
-          their online access, opportunities, or quality of experience.
-          <br /><br />
-          The Mozilla Localization effort represents a commitment to advancing these aspirations.
-          We work together with people everywhere who share the goal
-          to make the internet an even better place for everyone.
-        </p>
-      </div>
-      <div class="flex-col-2 flex-direction-col"></div>
-    </div>
-  </section>
+  <!-- Section-2: Add custom content here -->
 
   <!-- Section-3: Path to contribution -->
   <section id="section-3" class="section">
@@ -156,7 +139,7 @@
           <a href="https://github.com/mozilla/pontoon/">Hack it on Github</a>
         </div>
         <div class="flex-col-3 contact">
-          <a href="mailto:pontoon-team@mozilla.com">Get in touch</a>
+          <a href="mailto:">Get in touch</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Now that the homepage content can be customized, we should make the default content generic and override it on pontoon.mozilla.org.