### PR TITLE
Fix bug 1527864: Prevent entity list scrollbar flashing

### DIFF
--- a/frontend/src/core/loaders/components/CircleLoader.css
+++ b/frontend/src/core/loaders/components/CircleLoader.css
@@ -1,6 +1,7 @@
 .entities .loading {
     color: #7BC876;
     font-size: 128px;
+    height: 190px;
     padding: 40px 0 10px;
     text-align: center;
 }


### PR DESCRIPTION
The loader at the end of the string list is always visible and spinning, which changes its height and the height of the entity list. In effect, that flashes the scrollbar.

By making the loader height fixed, scrollbar flashing stops.