### PR TITLE
Bug 1525984 - Add basic keyboard shortcuts for the Editor.

### DIFF
--- a/frontend/src/modules/editor/components/Editor.js
+++ b/frontend/src/modules/editor/components/Editor.js
@@ -147,7 +147,9 @@ export class EditorBase extends React.Component<InternalProps, State> {
                 editor={ this.props.editor }
                 translation={ this.state.translation }
                 locale={ this.props.locale }
+                copyOriginalIntoEditor={ this.copyOriginalIntoEditor }
                 resetSelectionContent={ this.resetSelectionContent }
+                sendTranslation={ this.sendTranslation }
                 updateTranslation={ this.updateTranslation }
             />
             <menu>

--- a/frontend/src/modules/editor/components/EditorProxy.js
+++ b/frontend/src/modules/editor/components/EditorProxy.js
@@ -24,7 +24,7 @@ type EditorProxyProps = {|
  */
 export default class EditorProxy extends React.Component<EditorProxyProps> {
     render() {
-        const { editor, entity, translation, locale, updateTranslation, resetSelectionContent } = this.props;
+        const { entity } = this.props;
 
         if (!entity) {
             return null;
@@ -32,20 +32,24 @@ export default class EditorProxy extends React.Component<EditorProxyProps> {
 
         if (entity.format === 'ftl') {
             return <FluentEditor
-                editor={ editor }
-                translation={ translation }
-                locale={ locale }
-                resetSelectionContent={ resetSelectionContent }
-                updateTranslation={ updateTranslation }
+                editor={ this.props.editor }
+                translation={ this.props.translation }
+                locale={ this.props.locale }
+                copyOriginalIntoEditor={ this.props.copyOriginalIntoEditor }
+                resetSelectionContent={ this.props.resetSelectionContent }
+                sendTranslation={ this.props.sendTranslation }
+                updateTranslation={ this.props.updateTranslation }
             />;
         }
 
         return <GenericEditor
-            editor={ editor }
-            translation={ translation }
-            locale={ locale }
-            resetSelectionContent={ resetSelectionContent }
-            updateTranslation={ updateTranslation }
+            editor={ this.props.editor }
+            translation={ this.props.translation }
+            locale={ this.props.locale }
+            copyOriginalIntoEditor={ this.props.copyOriginalIntoEditor }
+            resetSelectionContent={ this.props.resetSelectionContent }
+            sendTranslation={ this.props.sendTranslation }
+            updateTranslation={ this.props.updateTranslation }
         />;
     }
 }

--- a/frontend/src/modules/editor/components/GenericEditor.js
+++ b/frontend/src/modules/editor/components/GenericEditor.js
@@ -10,7 +10,9 @@ export type EditorProps = {|
     editor: EditorState,
     translation: string,
     locale: Locale,
+    copyOriginalIntoEditor: () => void,
     resetSelectionContent: () => void,
+    sendTranslation: () => void,
     updateTranslation: (string) => void,
 |};
 
@@ -77,10 +79,42 @@ export default class GenericEditor extends React.Component<EditorProps> {
         this.props.updateTranslation(event.currentTarget.value);
     }
 
+    handleShortcuts = (event: SyntheticKeyboardEvent<HTMLTextAreaElement>) => {
+        const key = event.keyCode;
+
+        let handledEvent = false;
+
+        // On Enter, send the current translation.
+        if (key === 13 && !event.ctrlKey && !event.shiftKey && !event.altKey) {
+            handledEvent = true;
+            this.props.sendTranslation();
+        }
+
+        // On Ctrl + Shift + C, copy the original translation.
+        if (key === 67 && event.ctrlKey && event.shiftKey && !event.altKey) {
+            handledEvent = true;
+            this.props.copyOriginalIntoEditor();
+        }
+
+        // On Ctrl + Shift + Backspace, clear the content.
+        if (key === 8 && event.ctrlKey && event.shiftKey && !event.altKey) {
+            handledEvent = true;
+            this.props.updateTranslation('');
+        }
+
+        // On Tab, walk through current helper tab content and copy it.
+        // TODO
+
+        if (handledEvent) {
+            event.preventDefault();
+        }
+    }
+
     render() {
         return <textarea
             ref={ this.textarea }
             value={ this.props.translation }
+            onKeyDown={ this.handleShortcuts }
             onChange={ this.handleChange }
             dir={ this.props.locale.direction }
             lang={ this.props.locale.code }

--- a/frontend/src/modules/editor/components/GenericEditor.test.js
+++ b/frontend/src/modules/editor/components/GenericEditor.test.js
@@ -53,4 +53,68 @@ describe('<GenericEditor>', () => {
         expect(updateMock.calledWith('hello world')).toBeTruthy();
         expect(resetMock.calledOnce).toBeTruthy();
     });
+
+    it('sends the translation on Enter', () => {
+        const mockSend = sinon.spy();
+        const wrapper = shallow(<GenericEditor
+            translation='hello'
+            locale={ DEFAULT_LOCALE }
+            sendTranslation={ mockSend }
+        />);
+
+        const event = {
+            preventDefault: sinon.spy(),
+            keyCode: 13,  // Enter
+            altKey: false,
+            ctrlKey: false,
+            shiftKey: false,
+        };
+
+        expect(mockSend.calledOnce).toBeFalsy();
+        wrapper.find('textarea').simulate('keydown', event);
+        expect(mockSend.calledOnce).toBeTruthy();
+    });
+
+    it('copies the original into the Editor on Ctrl + Shift + C', () => {
+        const mockCopy = sinon.spy();
+        const wrapper = shallow(<GenericEditor
+            translation='hello'
+            locale={ DEFAULT_LOCALE }
+            copyOriginalIntoEditor={ mockCopy }
+        />);
+
+        const event = {
+            preventDefault: sinon.spy(),
+            keyCode: 67,  // C
+            altKey: false,
+            ctrlKey: true,
+            shiftKey: true,
+        };
+
+        expect(mockCopy.calledOnce).toBeFalsy();
+        wrapper.find('textarea').simulate('keydown', event);
+        expect(mockCopy.calledOnce).toBeTruthy();
+    });
+
+    it('clears the translation on Ctrl + Shift + Backspace', () => {
+        const mockUpdate = sinon.spy();
+        const wrapper = shallow(<GenericEditor
+            translation='hello'
+            locale={ DEFAULT_LOCALE }
+            updateTranslation={ mockUpdate }
+        />);
+
+        const event = {
+            preventDefault: sinon.spy(),
+            keyCode: 8,  // Backspace
+            altKey: false,
+            ctrlKey: true,
+            shiftKey: true,
+        };
+
+        expect(mockUpdate.calledOnce).toBeFalsy();
+        wrapper.find('textarea').simulate('keydown', event);
+        expect(mockUpdate.calledOnce).toBeTruthy();
+        expect(mockUpdate.calledWith('')).toBeTruthy();
+    });
 });


### PR DESCRIPTION
This is part one of bug 1525984. It adds three shortcuts for the Editor: send translation on Enter, copy original on Ctrl + Shift + C and clear on Ctrl + Shift + Backspace.

@mathjazz, I'm going to do this in parts, because it will make it easier for you to review, and also those shortcuts aren't really tied to each others.