### PR TITLE
Bug 1429392 - Textarea More Explicitly Locked for Non-Auth Users

### DIFF
--- a/frontend/src/modules/editor/components/Editor.css
+++ b/frontend/src/modules/editor/components/Editor.css
@@ -7,7 +7,7 @@
     min-height: 160px;
 }
 
-.editor > textarea {
+.editor textarea {
     border: none;
     box-sizing: border-box;
     display: block;
@@ -18,6 +18,14 @@
     padding: 10px;
     resize: none;
     width: 100%;
+}
+
+.editor textarea[readonly] {
+    background: #C7CACF;
+}
+
+.editor textarea[data-script="Arabic"] {
+    font-size: 15px;
 }
 
 .editor .banner {
@@ -70,8 +78,4 @@
 .editor .actions .action-save:hover,
 .editor .actions .action-suggest:hover {
     color: #EBEBEB;
-}
-
-.editor > textarea[data-script="Arabic"] {
-    font-size: 15px;
 }

--- a/frontend/src/modules/editor/components/GenericEditor.js
+++ b/frontend/src/modules/editor/components/GenericEditor.js
@@ -145,6 +145,7 @@ export default class GenericEditor extends React.Component<EditorProps> {
 
     render() {
         return <textarea
+            placeHolder={ this.props.isReadOnlyEditor ? null : 'Type translation and press Enter to save' }
             readOnly={ this.props.isReadOnlyEditor }
             ref={ this.textarea }
             value={ this.props.editor.translation }

--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -1476,7 +1476,6 @@ body > header aside p {
 
 #editor textarea[readonly] {
   background: #C7CACF;
-  height: 20%;
 }
 
 #editor #translation {

--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -1474,10 +1474,9 @@ body > header aside p {
   font-size: 15px;
 }
 
-#editor #translation-no-login {
+#editor textarea[readonly] {
   background: #C7CACF;
   height: 20%;
-  min-height: 100px;
 }
 
 #editor #translation {

--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -1474,6 +1474,12 @@ body > header aside p {
   font-size: 15px;
 }
 
+#editor #translation-no-login {
+  background: #C7CACF;
+  height: 20%;
+  min-height: 100px;
+}
+
 #editor #translation {
   height: 20%;
   min-height: 100px;

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -310,7 +310,6 @@
           placeholder="Type translation and press Enter to save"
         {% else %}
           readonly
-          placeholder="Sign in below to begin translating."
         {% endif %}
         ></textarea>
 
@@ -324,7 +323,6 @@
                   placeholder="Type translation and press Enter to save"
                 {% else %}
                   readonly
-                  placeholder="Sign in below to begin translating."
                 {% endif %}
               ></textarea>
             </li>

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -304,13 +304,29 @@
         </ul>
       </nav>
 
-      <textarea id="translation" {% if user.is_authenticated() %} placeholder="Type translation and press Enter to save" {% else %} readonly placeholder="Sign in below to begin translating."  {% endif %}></textarea>
+      <textarea
+        id="translation"
+        {% if user.is_authenticated() %}
+          placeholder="Type translation and press Enter to save"
+        {% else %}
+          readonly
+          placeholder="Sign in below to begin translating."
+        {% endif %}
+        ></textarea>
 
       <div id="ftl-area" class="ftl-area">
         <section class="main-value">
           <ul>
             <li>
-              <textarea id="translation" {% if user.is_authenticated() %} placeholder="Type translation and press Enter to save" {% else %} readonly placeholder="Sign in below to begin translating."  {% endif %}></textarea>
+              <textarea
+                id="only-value"
+                {% if user.is_authenticated() %}
+                  placeholder="Type translation and press Enter to save"
+                {% else %}
+                  readonly
+                  placeholder="Sign in below to begin translating."
+                {% endif %}
+              ></textarea>
             </li>
           </ul>
         </section>

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -304,7 +304,8 @@
         </ul>
       </nav>
 
-      <textarea {% if not user.is_authenticated() %} readonly {% endif %} id="translation" placeholder="Type translation and press Enter to save"></textarea>
+      <textarea {% if user.is_authenticated() %} id="translation" placeholder="Type translation and press Enter to save" 
+      {% else %} id="translation-no-login"  placeholder="Sign in below to begin translating."  {% endif %}></textarea>
 
       <div id="ftl-area" class="ftl-area">
         <section class="main-value">

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -304,14 +304,13 @@
         </ul>
       </nav>
 
-      <textarea {% if user.is_authenticated() %} id="translation" placeholder="Type translation and press Enter to save" 
-      {% else %} id="translation-no-login"  placeholder="Sign in below to begin translating."  {% endif %}></textarea>
+      <textarea id="translation" {% if user.is_authenticated() %} placeholder="Type translation and press Enter to save" {% else %} readonly placeholder="Sign in below to begin translating."  {% endif %}></textarea>
 
       <div id="ftl-area" class="ftl-area">
         <section class="main-value">
           <ul>
             <li>
-              <textarea {% if not user.is_authenticated() %} readonly {% endif %} id="only-value" placeholder="Type translation and press Enter to save"></textarea>
+              <textarea id="translation" {% if user.is_authenticated() %} placeholder="Type translation and press Enter to save" {% else %} readonly placeholder="Sign in below to begin translating."  {% endif %}></textarea>
             </li>
           </ul>
         </section>


### PR DESCRIPTION
Changes:
* Added different styling to textarea for non-authenticated users. (translate.css)
* Changed placeholder text to clearly state what is required next. (translate.html)

The textarea in question already was already readonly and disabled focus, this pull request just adds in the formatting changes that were also requested when the bug report was created. 

Rather than removing the placeholder text, the placeholder text now also directs the user to sign in, in case the link below was overlooked.

Testing:
Viewed and interacted with textarea both as an authenticated and non-authenticated user.