### PR TITLE
Fix bug 1528273: Properly support read-only projects

### DIFF
--- a/frontend/public/static/locale/en-US/translate.ftl
+++ b/frontend/public/static/locale/en-US/translate.ftl
@@ -5,6 +5,7 @@
 ## Allows contributors to modify or propose a translation
 
 editor-editor-sign-in-to-translate = <a>Sign in</a> to translate.
+editor-editor-read-only-localization = This is a read-only localization.
 editor-editor-button-copy = Copy
 editor-editor-button-clear = Clear
 editor-editor-button-save = Save

--- a/frontend/src/modules/editor/components/Editor.js
+++ b/frontend/src/modules/editor/components/Editor.js
@@ -175,6 +175,12 @@ export class EditorBase extends React.Component<InternalProps, State> {
                         { '<a>Sign in</a> to translate.' }
                     </p>
                 </Localized>
+            : this.props.selectedEntity.readonly ?
+                <Localized
+                    id="editor-editor-read-only-localization"
+                >
+                    <p className='banner'>This is a read-only localization.</p>
+                </Localized>
             :
             <React.Fragment>
                 <EditorSettings

--- a/frontend/src/modules/editor/components/Editor.js
+++ b/frontend/src/modules/editor/components/Editor.js
@@ -135,6 +135,16 @@ export class EditorBase extends React.Component<InternalProps, State> {
         ));
     }
 
+    // Return true if editor must be read-only, which happens when:
+    //   - the user is not authenticated or
+    //   - the entity is read-only
+    isReadOnlyEditor = () => {
+        if (!this.props.user.isAuthenticated || this.props.selectedEntity.readonly) {
+            return true;
+        }
+        return false;
+    }
+
     render() {
         if (!this.props.locale) {
             return null;
@@ -143,6 +153,7 @@ export class EditorBase extends React.Component<InternalProps, State> {
         return <div className="editor">
             <plural.PluralSelector />
             <EditorProxy
+                readOnly={ this.isReadOnlyEditor() }
                 entity={ this.props.selectedEntity }
                 editor={ this.props.editor }
                 translation={ this.state.translation }

--- a/frontend/src/modules/editor/components/Editor.js
+++ b/frontend/src/modules/editor/components/Editor.js
@@ -27,6 +27,7 @@ import type { EditorState } from '../reducer';
 type Props = {|
     activeTranslation: string,
     editor: EditorState,
+    isReadOnlyEditor: boolean,
     locale: ?Locale,
     nextEntity: DbEntity,
     pluralForm: number,
@@ -135,16 +136,6 @@ export class EditorBase extends React.Component<InternalProps, State> {
         ));
     }
 
-    // Return true if editor must be read-only, which happens when:
-    //   - the user is not authenticated or
-    //   - the entity is read-only
-    isReadOnlyEditor = () => {
-        if (!this.props.user.isAuthenticated || this.props.selectedEntity.readonly) {
-            return true;
-        }
-        return false;
-    }
-
     render() {
         if (!this.props.locale) {
             return null;
@@ -153,7 +144,7 @@ export class EditorBase extends React.Component<InternalProps, State> {
         return <div className="editor">
             <plural.PluralSelector />
             <EditorProxy
-                readOnly={ this.isReadOnlyEditor() }
+                isReadOnlyEditor={ this.props.isReadOnlyEditor }
                 entity={ this.props.selectedEntity }
                 editor={ this.props.editor }
                 translation={ this.state.translation }
@@ -175,7 +166,7 @@ export class EditorBase extends React.Component<InternalProps, State> {
                         { '<a>Sign in</a> to translate.' }
                     </p>
                 </Localized>
-            : this.props.selectedEntity.readonly ?
+            : (this.props.selectedEntity && this.props.selectedEntity.readonly) ?
                 <Localized
                     id="editor-editor-read-only-localization"
                 >
@@ -240,6 +231,7 @@ const mapStateToProps = (state: Object): Props => {
     return {
         activeTranslation: entitydetails.selectors.getTranslationForSelectedEntity(state),
         editor: state[NAME],
+        isReadOnlyEditor: entitydetails.selectors.isReadOnlyEditor(state),
         locale: locales.selectors.getCurrentLocaleData(state),
         nextEntity: entitieslist.selectors.getNextEntity(state),
         pluralForm: plural.selectors.getPluralForm(state),

--- a/frontend/src/modules/editor/components/Editor.test.js
+++ b/frontend/src/modules/editor/components/Editor.test.js
@@ -56,6 +56,7 @@ function expectHiddenSettingsAndActions(wrapper) {
     expect(wrapper.find('#editor-editor-button-copy')).toHaveLength(0);
 }
 
+
 describe('<EditorBase>', () => {
     beforeAll(() => {
         sinon.stub(editor.actions, 'sendTranslation').returns({ type: 'whatever' });
@@ -146,7 +147,7 @@ describe('<EditorBase>', () => {
             ...SELECTED_ENTITY,
             readonly: true,
         }
-        const wrapper = createEditorBase({ selectedEntity: selectedEntity });
+        const wrapper = createEditorBase({ selectedEntity });
 
         expectHiddenSettingsAndActions(wrapper);
 

--- a/frontend/src/modules/editor/components/Editor.test.js
+++ b/frontend/src/modules/editor/components/Editor.test.js
@@ -25,6 +25,7 @@ function createEditorBase({
     pluralForm = -1,
     forceSuggestions = true,
     isAuthenticated = true,
+    selectedEntity = SELECTED_ENTITY,
 } = {}) {
     return shallow(<EditorBase
         dispatch={ () => {} }
@@ -36,7 +37,7 @@ function createEditorBase({
             { code: 'kg' }
         }
         pluralForm={ pluralForm }
-        selectedEntity={ SELECTED_ENTITY }
+        selectedEntity={ selectedEntity }
         user={ {
             isAuthenticated,
             username: 'Sarevok',
@@ -47,6 +48,13 @@ function createEditorBase({
     />);
 }
 
+
+function expectHiddenSettingsAndActions(wrapper) {
+    expect(wrapper.find('button')).toHaveLength(0);
+    expect(wrapper.find(EditorSettings)).toHaveLength(0);
+    expect(wrapper.find(KeyboardShortcuts)).toHaveLength(0);
+    expect(wrapper.find('#editor-editor-button-copy')).toHaveLength(0);
+}
 
 describe('<EditorBase>', () => {
     beforeAll(() => {
@@ -128,12 +136,21 @@ describe('<EditorBase>', () => {
     it('hides the settings and actions when the user is logged out', () => {
         const wrapper = createEditorBase({ isAuthenticated: false });
 
-        expect(wrapper.find('button')).toHaveLength(0);
-        expect(wrapper.find(EditorSettings)).toHaveLength(0);
-        expect(wrapper.find(KeyboardShortcuts)).toHaveLength(0);
-        expect(wrapper.find('#editor-editor-button-copy')).toHaveLength(0);
+        expectHiddenSettingsAndActions(wrapper);
 
         expect(wrapper.find('#editor-editor-sign-in-to-translate')).toHaveLength(1);
+    });
+
+    it('hides the settings and actions when the entity is read-only', () => {
+        const selectedEntity = {
+            ...SELECTED_ENTITY,
+            readonly: true,
+        }
+        const wrapper = createEditorBase({ selectedEntity: selectedEntity });
+
+        expectHiddenSettingsAndActions(wrapper);
+
+        expect(wrapper.find('#editor-editor-read-only-localization')).toHaveLength(1);
     });
 
     it('dispatches the saveSetting action when updateSetting is called', () => {

--- a/frontend/src/modules/editor/components/EditorProxy.js
+++ b/frontend/src/modules/editor/components/EditorProxy.js
@@ -32,7 +32,7 @@ export default class EditorProxy extends React.Component<EditorProxyProps> {
 
         if (entity.format === 'ftl') {
             return <FluentEditor
-                readOnly={ this.props.readOnly }
+                isReadOnlyEditor={ this.props.isReadOnlyEditor }
                 editor={ this.props.editor }
                 translation={ this.props.translation }
                 locale={ this.props.locale }
@@ -44,7 +44,7 @@ export default class EditorProxy extends React.Component<EditorProxyProps> {
         }
 
         return <GenericEditor
-            readOnly={ this.props.readOnly }
+            isReadOnlyEditor={ this.props.isReadOnlyEditor }
             editor={ this.props.editor }
             translation={ this.props.translation }
             locale={ this.props.locale }

--- a/frontend/src/modules/editor/components/EditorProxy.js
+++ b/frontend/src/modules/editor/components/EditorProxy.js
@@ -32,6 +32,7 @@ export default class EditorProxy extends React.Component<EditorProxyProps> {
 
         if (entity.format === 'ftl') {
             return <FluentEditor
+                readOnly={ this.props.readOnly }
                 editor={ this.props.editor }
                 translation={ this.props.translation }
                 locale={ this.props.locale }
@@ -43,6 +44,7 @@ export default class EditorProxy extends React.Component<EditorProxyProps> {
         }
 
         return <GenericEditor
+            readOnly={ this.props.readOnly }
             editor={ this.props.editor }
             translation={ this.props.translation }
             locale={ this.props.locale }

--- a/frontend/src/modules/editor/components/FluentEditor.js
+++ b/frontend/src/modules/editor/components/FluentEditor.js
@@ -78,7 +78,7 @@ export default class FluentEditor extends React.Component<EditorProps> {
             highlightSelectedWord: false,
             printMargin: false,
             printMarginColumn: false,
-            readOnly: this.props.readOnly,
+            readOnly: this.props.isReadOnlyEditor,
             scrollPastEnd: false,
             showInvisibles: false,
             showFoldWidgets: false,

--- a/frontend/src/modules/editor/components/FluentEditor.js
+++ b/frontend/src/modules/editor/components/FluentEditor.js
@@ -78,6 +78,7 @@ export default class FluentEditor extends React.Component<EditorProps> {
             highlightSelectedWord: false,
             printMargin: false,
             printMarginColumn: false,
+            readOnly: this.props.readOnly,
             scrollPastEnd: false,
             showInvisibles: false,
             showFoldWidgets: false,

--- a/frontend/src/modules/editor/components/GenericEditor.js
+++ b/frontend/src/modules/editor/components/GenericEditor.js
@@ -7,7 +7,7 @@ import type { EditorState } from '..';
 
 
 export type EditorProps = {|
-    readOnly: boolean,
+    isReadOnlyEditor: boolean,
     editor: EditorState,
     translation: string,
     locale: Locale,
@@ -113,7 +113,7 @@ export default class GenericEditor extends React.Component<EditorProps> {
 
     render() {
         return <textarea
-            readOnly={ this.props.readOnly }
+            readOnly={ this.props.isReadOnlyEditor }
             ref={ this.textarea }
             value={ this.props.translation }
             onKeyDown={ this.handleShortcuts }

--- a/frontend/src/modules/editor/components/GenericEditor.js
+++ b/frontend/src/modules/editor/components/GenericEditor.js
@@ -7,6 +7,7 @@ import type { EditorState } from '..';
 
 
 export type EditorProps = {|
+    readOnly: boolean,
     editor: EditorState,
     translation: string,
     locale: Locale,
@@ -112,6 +113,7 @@ export default class GenericEditor extends React.Component<EditorProps> {
 
     render() {
         return <textarea
+            readOnly={ this.props.readOnly }
             ref={ this.textarea }
             value={ this.props.translation }
             onKeyDown={ this.handleShortcuts }

--- a/frontend/src/modules/entitydetails/components/EntityDetails.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.js
@@ -173,6 +173,7 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
             />
             <Metadata
                 entity={ state.selectedEntity }
+                isReadOnlyEditor={ state.isReadOnlyEditor }
                 locale={ state.locale }
                 pluralForm={ state.pluralForm }
                 openLightbox={ this.openLightbox }

--- a/frontend/src/modules/entitydetails/components/EntityDetails.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.js
@@ -36,6 +36,7 @@ type Props = {|
     activeTranslation: string,
     editor: EditorState,
     history: HistoryState,
+    isReadOnlyEditor: boolean,
     isTranslator: boolean,
     locale: ?Locale,
     machinery: MachineryState,
@@ -181,6 +182,7 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
             <Tools
                 entity={ state.selectedEntity }
                 history={ state.history }
+                isReadOnlyEditor={ state.isReadOnlyEditor }
                 isTranslator={ state.isTranslator }
                 locale={ state.locale }
                 machinery={ state.machinery }
@@ -203,6 +205,7 @@ const mapStateToProps = (state: Object): Props => {
         activeTranslation: selectors.getTranslationForSelectedEntity(state),
         editor: state[editor.NAME],
         history: state[history.NAME],
+        isReadOnlyEditor: selectors.isReadOnlyEditor(state),
         isTranslator: user.selectors.isTranslator(state),
         locale: locales.selectors.getCurrentLocaleData(state),
         machinery: state[machinery.NAME],

--- a/frontend/src/modules/entitydetails/components/Metadata.js
+++ b/frontend/src/modules/entitydetails/components/Metadata.js
@@ -40,6 +40,7 @@ class Property extends React.Component<PropertyProps> {
 
 type Props = {|
     +entity: DbEntity,
+    +isReadOnlyEditor: boolean,
     +locale: Locale,
     +pluralForm: number,
     +openLightbox: (string) => void,
@@ -60,6 +61,9 @@ type Props = {|
  */
 export default class Metadata extends React.Component<Props> {
     handleClickOnPlaceable = (e: SyntheticMouseEvent<HTMLParagraphElement>) => {
+        if (this.props.isReadOnlyEditor) {
+            return;
+        }
         // Flow requires that we use `e.currentTarget` instead of `e.target`.
         // However in this case, we do want to use that, so I'm ignoring all
         // errors Flow throws there.

--- a/frontend/src/modules/entitydetails/components/Tools.js
+++ b/frontend/src/modules/entitydetails/components/Tools.js
@@ -91,6 +91,7 @@ export default class Tools extends React.Component<Props> {
 
             <TabPanel>
                 <History
+                    entity={ entity }
                     history={ history }
                     isTranslator={ isTranslator }
                     locale={ locale }

--- a/frontend/src/modules/entitydetails/components/Tools.js
+++ b/frontend/src/modules/entitydetails/components/Tools.js
@@ -93,7 +93,6 @@ export default class Tools extends React.Component<Props> {
 
             <TabPanel>
                 <History
-                    entity={ entity }
                     history={ history }
                     isReadOnlyEditor={ isReadOnlyEditor }
                     isTranslator={ isTranslator }

--- a/frontend/src/modules/entitydetails/components/Tools.js
+++ b/frontend/src/modules/entitydetails/components/Tools.js
@@ -23,6 +23,7 @@ import type { LocalesState } from 'modules/otherlocales';
 type Props = {|
     entity: DbEntity,
     history: HistoryState,
+    isReadOnlyEditor: boolean,
     isTranslator: boolean,
     locale: Locale,
     machinery: MachineryState,
@@ -47,6 +48,7 @@ export default class Tools extends React.Component<Props> {
         const {
             entity,
             history,
+            isReadOnlyEditor,
             isTranslator,
             locale,
             machinery,
@@ -93,6 +95,7 @@ export default class Tools extends React.Component<Props> {
                 <History
                     entity={ entity }
                     history={ history }
+                    isReadOnlyEditor={ isReadOnlyEditor }
                     isTranslator={ isTranslator }
                     locale={ locale }
                     user={ user }
@@ -104,6 +107,7 @@ export default class Tools extends React.Component<Props> {
             <TabPanel>
                 <Machinery
                     entity={ entity }
+                    isReadOnlyEditor={ isReadOnlyEditor }
                     locale={ locale }
                     machinery={ machinery }
                     updateEditorTranslation={ updateEditorTranslation }
@@ -111,6 +115,7 @@ export default class Tools extends React.Component<Props> {
             </TabPanel>
             <TabPanel>
                 <OtherLocales
+                    isReadOnlyEditor={ isReadOnlyEditor }
                     otherlocales={ otherlocales }
                     orderedOtherLocales= { orderedOtherLocales }
                     preferredLocalesCount={ preferredLocalesCount }

--- a/frontend/src/modules/entitydetails/selectors.js
+++ b/frontend/src/modules/entitydetails/selectors.js
@@ -5,12 +5,15 @@ import { createSelector } from 'reselect';
 import * as navigation from 'core/navigation';
 import * as plural from 'core/plural';
 import * as entitieslist from 'modules/entitieslist';
+import * as user from 'core/user';
 
+import type { DbEntity, Entities } from 'modules/entitieslist';
 import type { NavigationParams } from 'core/navigation';
-import type { Entities } from 'modules/entitieslist';
+import type { UserState } from 'core/user';
 
 
 const entitiesSelector = (state): string => state[entitieslist.NAME].entities;
+const userSelector = (state): UserState => state[user.NAME];
 
 
 export function _getTranslationForSelectedEntity(
@@ -51,6 +54,34 @@ export const getTranslationForSelectedEntity: Function = createSelector(
 );
 
 
+export function _isReadOnlyEditor(
+    entities: Entities,
+    params: NavigationParams,
+    user: UserState,
+): boolean {
+    const selectedEntity = entities.find(element => element.pk === params.entity);
+
+    return (
+        (selectedEntity && selectedEntity.readonly) ||
+        !user.isAuthenticated
+    );
+}
+
+
+/**
+ * Return true if editor must be read-only, which happens when:
+ *   - the entity is read-only OR
+ *   - the user is not authenticated
+ */
+export const isReadOnlyEditor: Function = createSelector(
+    entitiesSelector,
+    navigation.selectors.getNavigationParams,
+    userSelector,
+    _isReadOnlyEditor
+);
+
+
 export default {
     getTranslationForSelectedEntity,
+    isReadOnlyEditor,
 };

--- a/frontend/src/modules/entitydetails/selectors.js
+++ b/frontend/src/modules/entitydetails/selectors.js
@@ -2,28 +2,21 @@
 
 import { createSelector } from 'reselect';
 
-import * as navigation from 'core/navigation';
 import * as plural from 'core/plural';
 import * as entitieslist from 'modules/entitieslist';
 import * as user from 'core/user';
 
-import type { NavigationParams } from 'core/navigation';
 import type { UserState } from 'core/user';
-import type { DbEntity, Entities } from 'modules/entitieslist';
+import type { DbEntity } from 'modules/entitieslist';
 
 
-const entitiesSelector = (state): string => state[entitieslist.NAME].entities;
 const userSelector = (state): UserState => state[user.NAME];
 
 
 export function _getTranslationForSelectedEntity(
-    entities: Entities,
-    params: NavigationParams,
+    entity: DbEntity,
     pluralForm: number,
 ): string {
-    const entityId = params.entity;
-    const entity = entities.find(element => element.pk === entityId);
-
     if (pluralForm === -1) {
         pluralForm = 0;
     }
@@ -47,8 +40,7 @@ export function _getTranslationForSelectedEntity(
  * most recent non-rejected one.
  */
 export const getTranslationForSelectedEntity: Function = createSelector(
-    entitiesSelector,
-    navigation.selectors.getNavigationParams,
+    entitieslist.selectors.getSelectedEntity,
     plural.selectors.getPluralForm,
     _getTranslationForSelectedEntity
 );

--- a/frontend/src/modules/entitydetails/selectors.js
+++ b/frontend/src/modules/entitydetails/selectors.js
@@ -9,7 +9,7 @@ import * as user from 'core/user';
 
 import type { NavigationParams } from 'core/navigation';
 import type { UserState } from 'core/user';
-import type { Entities } from 'modules/entitieslist';
+import type { DbEntity, Entities } from 'modules/entitieslist';
 
 
 const entitiesSelector = (state): string => state[entitieslist.NAME].entities;
@@ -55,14 +55,11 @@ export const getTranslationForSelectedEntity: Function = createSelector(
 
 
 export function _isReadOnlyEditor(
-    entities: Entities,
-    params: NavigationParams,
+    entity: DbEntity,
     user: UserState,
 ): boolean {
-    const selectedEntity = entities.find(element => element.pk === params.entity);
-
     return (
-        (selectedEntity && selectedEntity.readonly) ||
+        (entity && entity.readonly) ||
         !user.isAuthenticated
     );
 }
@@ -74,8 +71,7 @@ export function _isReadOnlyEditor(
  *   - the user is not authenticated
  */
 export const isReadOnlyEditor: Function = createSelector(
-    entitiesSelector,
-    navigation.selectors.getNavigationParams,
+    entitieslist.selectors.getSelectedEntity,
     userSelector,
     _isReadOnlyEditor
 );

--- a/frontend/src/modules/entitydetails/selectors.js
+++ b/frontend/src/modules/entitydetails/selectors.js
@@ -7,9 +7,9 @@ import * as plural from 'core/plural';
 import * as entitieslist from 'modules/entitieslist';
 import * as user from 'core/user';
 
-import type { DbEntity, Entities } from 'modules/entitieslist';
 import type { NavigationParams } from 'core/navigation';
 import type { UserState } from 'core/user';
+import type { Entities } from 'modules/entitieslist';
 
 
 const entitiesSelector = (state): string => state[entitieslist.NAME].entities;

--- a/frontend/src/modules/entitydetails/selectors.test.js
+++ b/frontend/src/modules/entitydetails/selectors.test.js
@@ -5,38 +5,35 @@ import {
 
 
 describe('selectors', () => {
-    const entities = [
-        {
-            pk: 1,
-            readonly: false,
-            translation: [
-                {
-                    string: 'hello',
-                },
-            ],
-        },
-        {
-            pk: 2,
-            readonly: true,
-            translation: [
-                {
-                    string: 'world',
-                },
-            ],
-        },
-        {
-            pk: 3,
-            readonly: false,
-            translation: [
-                {
-                    string: 'wat',
-                    rejected: true,
-                },
-            ],
-        },
-    ];
-
     describe('getTranslationForSelectedEntity', () => {
+        const entities = [
+            {
+                pk: 1,
+                translation: [
+                    {
+                        string: 'hello',
+                    },
+                ],
+            },
+            {
+                pk: 2,
+                translation: [
+                    {
+                        string: 'world',
+                    },
+                ],
+            },
+            {
+                pk: 3,
+                translation: [
+                    {
+                        string: 'wat',
+                        rejected: true,
+                    },
+                ],
+            },
+        ];
+
         it('returns the correct string', () => {
             const navigation = {
                 entity: 2,
@@ -58,37 +55,37 @@ describe('selectors', () => {
 
     describe('isReadOnlyEditor', () => {
         it('returns true if user not authenticated', () => {
-            const navigation = {
-                entity: 1,
+            const entity = {
+                readonly: false,
             };
             const user = {
                 isAuthenticated: false,
             };
-            const res = _isReadOnlyEditor(entities, navigation, user);
+            const res = _isReadOnlyEditor(entity, user);
 
             expect(res).toBeTruthy();
         });
 
         it('returns true if entity read-only', () => {
-            const navigation = {
-                entity: 2,
+            const entity = {
+                readonly: true,
             };
             const user = {
                 isAuthenticated: true,
             };
-            const res = _isReadOnlyEditor(entities, navigation, user);
+            const res = _isReadOnlyEditor(entity, user);
 
             expect(res).toBeTruthy();
         });
 
         it('returns false if entity not read-only and user authenticated', () => {
-            const navigation = {
-                entity: 1,
+            const entity = {
+                readonly: false,
             };
             const user = {
                 isAuthenticated: true,
             };
-            const res = _isReadOnlyEditor(entities, navigation, user);
+            const res = _isReadOnlyEditor(entity, user);
 
             expect(res).toBeFalsy();
         });

--- a/frontend/src/modules/entitydetails/selectors.test.js
+++ b/frontend/src/modules/entitydetails/selectors.test.js
@@ -8,15 +8,6 @@ describe('selectors', () => {
     describe('getTranslationForSelectedEntity', () => {
         const entities = [
             {
-                pk: 1,
-                translation: [
-                    {
-                        string: 'hello',
-                    },
-                ],
-            },
-            {
-                pk: 2,
                 translation: [
                     {
                         string: 'world',
@@ -24,7 +15,6 @@ describe('selectors', () => {
                 ],
             },
             {
-                pk: 3,
                 translation: [
                     {
                         string: 'wat',
@@ -35,19 +25,15 @@ describe('selectors', () => {
         ];
 
         it('returns the correct string', () => {
-            const navigation = {
-                entity: 2,
-            };
-            const res = _getTranslationForSelectedEntity(entities, navigation, -1);
+            const entity = entities[0];
+            const res = _getTranslationForSelectedEntity(entity, -1);
 
             expect(res).toEqual('world');
         });
 
         it('does not return rejected translations', () => {
-            const navigation = {
-                entity: 3,
-            };
-            const res = _getTranslationForSelectedEntity(entities, navigation, -1);
+            const entity = entities[1];
+            const res = _getTranslationForSelectedEntity(entity, -1);
 
             expect(res).toEqual('');
         });

--- a/frontend/src/modules/entitydetails/selectors.test.js
+++ b/frontend/src/modules/entitydetails/selectors.test.js
@@ -1,39 +1,42 @@
 import {
     _getTranslationForSelectedEntity,
+    _isReadOnlyEditor,
 } from './selectors';
 
 
 describe('selectors', () => {
+    const entities = [
+        {
+            pk: 1,
+            readonly: false,
+            translation: [
+                {
+                    string: 'hello',
+                },
+            ],
+        },
+        {
+            pk: 2,
+            readonly: true,
+            translation: [
+                {
+                    string: 'world',
+                },
+            ],
+        },
+        {
+            pk: 3,
+            readonly: false,
+            translation: [
+                {
+                    string: 'wat',
+                    rejected: true,
+                },
+            ],
+        },
+    ];
+
     describe('getTranslationForSelectedEntity', () => {
-
-        const entities = [
-            {
-                pk: 1,
-                translation: [
-                    {
-                        string: 'hello',
-                    },
-                ],
-            },
-            {
-                pk: 2,
-                translation: [
-                    {
-                        string: 'world',
-                    },
-                ],
-            },
-            {
-                pk: 3,
-                translation: [
-                    {
-                        string: 'wat',
-                        rejected: true,
-                    },
-                ],
-            },
-        ];
-
         it('returns the correct string', () => {
             const navigation = {
                 entity: 2,
@@ -50,6 +53,44 @@ describe('selectors', () => {
             const res = _getTranslationForSelectedEntity(entities, navigation, -1);
 
             expect(res).toEqual('');
+        });
+    });
+
+    describe('isReadOnlyEditor', () => {
+        it('returns true if user not authenticated', () => {
+            const navigation = {
+                entity: 1,
+            };
+            const user = {
+                isAuthenticated: false,
+            };
+            const res = _isReadOnlyEditor(entities, navigation, user);
+
+            expect(res).toBeTruthy();
+        });
+
+        it('returns true if entity read-only', () => {
+            const navigation = {
+                entity: 2,
+            };
+            const user = {
+                isAuthenticated: true,
+            };
+            const res = _isReadOnlyEditor(entities, navigation, user);
+
+            expect(res).toBeTruthy();
+        });
+
+        it('returns false if entity not read-only and user authenticated', () => {
+            const navigation = {
+                entity: 1,
+            };
+            const user = {
+                isAuthenticated: true,
+            };
+            const res = _isReadOnlyEditor(entities, navigation, user);
+
+            expect(res).toBeFalsy();
         });
     });
 });

--- a/frontend/src/modules/history/components/History.js
+++ b/frontend/src/modules/history/components/History.js
@@ -7,12 +7,14 @@ import './History.css';
 
 import Translation from './Translation';
 
+import type { DbEntity } from 'modules/entitieslist';
 import type { Locale } from 'core/locales';
 import type { UserState } from 'core/user';
 import type { HistoryState } from '..';
 
 
 type Props = {|
+    entity: DbEntity,
     history: HistoryState,
     isTranslator: boolean,
     locale: Locale,
@@ -39,6 +41,7 @@ export default class History extends React.Component<Props> {
 
     render() {
         const {
+            entity,
             history,
             isTranslator,
             locale,
@@ -60,6 +63,7 @@ export default class History extends React.Component<Props> {
             <ul>
                 { history.translations.map((translation, index) => {
                     return <Translation
+                        entity={ entity }
                         translation={ translation }
                         activeTranslation={ history.translations[0] }
                         canReview={ isTranslator }

--- a/frontend/src/modules/history/components/History.js
+++ b/frontend/src/modules/history/components/History.js
@@ -7,14 +7,12 @@ import './History.css';
 
 import Translation from './Translation';
 
-import type { DbEntity } from 'modules/entitieslist';
 import type { Locale } from 'core/locales';
 import type { UserState } from 'core/user';
 import type { HistoryState } from '..';
 
 
 type Props = {|
-    entity: DbEntity,
     history: HistoryState,
     isReadOnlyEditor: boolean,
     isTranslator: boolean,
@@ -42,7 +40,6 @@ export default class History extends React.Component<Props> {
 
     render() {
         const {
-            entity,
             history,
             isReadOnlyEditor,
             isTranslator,
@@ -65,7 +62,6 @@ export default class History extends React.Component<Props> {
             <ul>
                 { history.translations.map((translation, index) => {
                     return <Translation
-                        entity={ entity }
                         translation={ translation }
                         activeTranslation={ history.translations[0] }
                         isReadOnlyEditor={ isReadOnlyEditor }

--- a/frontend/src/modules/history/components/History.js
+++ b/frontend/src/modules/history/components/History.js
@@ -16,6 +16,7 @@ import type { HistoryState } from '..';
 type Props = {|
     entity: DbEntity,
     history: HistoryState,
+    isReadOnlyEditor: boolean,
     isTranslator: boolean,
     locale: Locale,
     user: UserState,
@@ -43,6 +44,7 @@ export default class History extends React.Component<Props> {
         const {
             entity,
             history,
+            isReadOnlyEditor,
             isTranslator,
             locale,
             user,
@@ -66,6 +68,7 @@ export default class History extends React.Component<Props> {
                         entity={ entity }
                         translation={ translation }
                         activeTranslation={ history.translations[0] }
+                        isReadOnlyEditor={ isReadOnlyEditor }
                         canReview={ isTranslator }
                         locale={ locale }
                         user={ user }

--- a/frontend/src/modules/history/components/Translation.js
+++ b/frontend/src/modules/history/components/Translation.js
@@ -9,14 +9,12 @@ import './Translation.css';
 import { withDiff } from 'core/diff';
 import { WithPlaceables, WithPlaceablesNoLeadingSpace } from 'core/placeable';
 
-import type { DbEntity } from 'modules/entitieslist';
 import type { Locale } from 'core/locales';
 import type { UserState } from 'core/user';
 import type { DBTranslation } from '../reducer';
 
 
 type Props = {|
-    entity: DbEntity,
     isReadOnlyEditor: boolean,
     canReview: boolean,
     translation: DBTranslation,
@@ -171,8 +169,8 @@ export default class Translation extends React.Component<Props, State> {
 
     render() {
         const {
-            entity,
             canReview,
+            isReadOnlyEditor,
             translation,
             locale,
             user,
@@ -185,21 +183,19 @@ export default class Translation extends React.Component<Props, State> {
             user.username === translation.username
         );
 
-        const notReadOnly = entity && !entity.readonly;
-
         let className = 'translation ' + this.getStatus();
-        if (canReview && notReadOnly) {
+        if (canReview && !isReadOnlyEditor) {
             // This user is a translator for the current locale, they can
             // perform all review actions.
             className += ' can-approve can-reject';
         }
-        else if (ownTranslation && !translation.approved && notReadOnly) {
+        else if (ownTranslation && !translation.approved && !isReadOnlyEditor) {
             // This user owns the translation and it's not approved, they
             // can only reject or unreject it.
             className += ' can-reject';
         }
 
-        let canDelete = (canReview || ownTranslation) && notReadOnly;
+        let canDelete = (canReview || ownTranslation) && !isReadOnlyEditor;
 
         const TranslationPlaceablesDiff = withDiff(WithPlaceablesNoLeadingSpace);
 

--- a/frontend/src/modules/history/components/Translation.js
+++ b/frontend/src/modules/history/components/Translation.js
@@ -9,12 +9,14 @@ import './Translation.css';
 import { withDiff } from 'core/diff';
 import { WithPlaceables, WithPlaceablesNoLeadingSpace } from 'core/placeable';
 
+import type { DbEntity } from 'modules/entitieslist';
 import type { Locale } from 'core/locales';
 import type { UserState } from 'core/user';
 import type { DBTranslation } from '../reducer';
 
 
 type Props = {|
+    entity: DbEntity,
     canReview: boolean,
     translation: DBTranslation,
     activeTranslation: DBTranslation,
@@ -165,6 +167,7 @@ export default class Translation extends React.Component<Props, State> {
 
     render() {
         const {
+            entity,
             canReview,
             translation,
             locale,
@@ -179,18 +182,18 @@ export default class Translation extends React.Component<Props, State> {
         );
 
         let className = 'translation ' + this.getStatus();
-        if (canReview) {
+        if (canReview && !entity.readonly) {
             // This user is a translator for the current locale, they can
             // perform all review actions.
             className += ' can-approve can-reject';
         }
-        else if (ownTranslation && !translation.approved) {
+        else if (ownTranslation && !translation.approved && !entity.readonly) {
             // This user owns the translation and it's not approved, they
             // can only reject or unreject it.
             className += ' can-reject';
         }
 
-        let canDelete = canReview || ownTranslation;
+        let canDelete = (canReview || ownTranslation) && !entity.readonly;
 
         const TranslationPlaceablesDiff = withDiff(WithPlaceablesNoLeadingSpace);
 

--- a/frontend/src/modules/history/components/Translation.js
+++ b/frontend/src/modules/history/components/Translation.js
@@ -17,6 +17,7 @@ import type { DBTranslation } from '../reducer';
 
 type Props = {|
     entity: DbEntity,
+    isReadOnlyEditor: boolean,
     canReview: boolean,
     translation: DBTranslation,
     activeTranslation: DBTranslation,
@@ -72,6 +73,9 @@ export default class Translation extends React.Component<Props, State> {
     }
 
     copyTranslationIntoEditor = () => {
+        if (this.props.isReadOnlyEditor) {
+            return;
+        }
         this.props.updateEditorTranslation(this.props.translation.string);
     }
 
@@ -181,19 +185,21 @@ export default class Translation extends React.Component<Props, State> {
             user.username === translation.username
         );
 
+        const notReadOnly = entity && !entity.readonly;
+
         let className = 'translation ' + this.getStatus();
-        if (canReview && !entity.readonly) {
+        if (canReview && notReadOnly) {
             // This user is a translator for the current locale, they can
             // perform all review actions.
             className += ' can-approve can-reject';
         }
-        else if (ownTranslation && !translation.approved && !entity.readonly) {
+        else if (ownTranslation && !translation.approved && notReadOnly) {
             // This user owns the translation and it's not approved, they
             // can only reject or unreject it.
             className += ' can-reject';
         }
 
-        let canDelete = (canReview || ownTranslation) && !entity.readonly;
+        let canDelete = (canReview || ownTranslation) && notReadOnly;
 
         const TranslationPlaceablesDiff = withDiff(WithPlaceablesNoLeadingSpace);
 

--- a/frontend/src/modules/history/components/Translation.test.js
+++ b/frontend/src/modules/history/components/Translation.test.js
@@ -191,13 +191,8 @@ describe('<Translation>', () => {
     });
 
     describe('permissions', () => {
-        const DEFAULT_ENTITY = {
-            readonly: false,
-        };
-
         it('allows the user to reject their own unapproved translation', () => {
             const wrapper = shallow(<Translation
-                entity={ DEFAULT_ENTITY }
                 translation={ DEFAULT_TRANSLATION }
                 locale={ DEFAULT_LOCALE }
                 user={ DEFAULT_USER }
@@ -210,7 +205,6 @@ describe('<Translation>', () => {
         it('forbids the user to reject their own approved translation', () => {
             const translation = { ...DEFAULT_TRANSLATION, approved: true };
             const wrapper = shallow(<Translation
-                entity={ DEFAULT_ENTITY }
                 translation={ translation }
                 locale={ DEFAULT_LOCALE }
                 user={ DEFAULT_USER }
@@ -222,7 +216,6 @@ describe('<Translation>', () => {
 
         it('allows translators to review the translation', () => {
             const wrapper = shallow(<Translation
-                entity={ DEFAULT_ENTITY }
                 translation={ DEFAULT_TRANSLATION }
                 locale={ DEFAULT_LOCALE }
                 canReview={ true }
@@ -235,7 +228,6 @@ describe('<Translation>', () => {
         it('allows translators to delete the rejected translation', () => {
             const translation = { ...DEFAULT_TRANSLATION, rejected: true };
             const wrapper = shallow(<Translation
-                entity={ DEFAULT_ENTITY }
                 translation={ translation }
                 locale={ DEFAULT_LOCALE }
                 canReview={ true }
@@ -247,7 +239,6 @@ describe('<Translation>', () => {
         it('forbids translators to delete non-rejected translation', () => {
             const translation = { ...DEFAULT_TRANSLATION, rejected: false };
             const wrapper = shallow(<Translation
-                entity={ DEFAULT_ENTITY }
                 translation={ translation }
                 locale={ DEFAULT_LOCALE }
                 canReview={ true }
@@ -259,7 +250,6 @@ describe('<Translation>', () => {
         it('allows the user to delete their own rejected translation', () => {
             const translation = { ...DEFAULT_TRANSLATION, rejected: true };
             const wrapper = shallow(<Translation
-                entity={ DEFAULT_ENTITY }
                 translation={ translation }
                 locale={ DEFAULT_LOCALE }
                 user={ DEFAULT_USER }
@@ -271,7 +261,6 @@ describe('<Translation>', () => {
         it('forbids the user to delete rejected translation of another user', () => {
             const translation = { ...DEFAULT_TRANSLATION, rejected: true };
             const wrapper = shallow(<Translation
-                entity={ DEFAULT_ENTITY }
                 translation={ translation }
                 locale={ DEFAULT_LOCALE }
             />);

--- a/frontend/src/modules/history/components/Translation.test.js
+++ b/frontend/src/modules/history/components/Translation.test.js
@@ -191,8 +191,13 @@ describe('<Translation>', () => {
     });
 
     describe('permissions', () => {
+        const DEFAULT_ENTITY = {
+            readonly: false,
+        };
+
         it('allows the user to reject their own unapproved translation', () => {
             const wrapper = shallow(<Translation
+                entity={ DEFAULT_ENTITY }
                 translation={ DEFAULT_TRANSLATION }
                 locale={ DEFAULT_LOCALE }
                 user={ DEFAULT_USER }
@@ -205,6 +210,7 @@ describe('<Translation>', () => {
         it('forbids the user to reject their own approved translation', () => {
             const translation = { ...DEFAULT_TRANSLATION, approved: true };
             const wrapper = shallow(<Translation
+                entity={ DEFAULT_ENTITY }
                 translation={ translation }
                 locale={ DEFAULT_LOCALE }
                 user={ DEFAULT_USER }
@@ -216,6 +222,7 @@ describe('<Translation>', () => {
 
         it('allows translators to review the translation', () => {
             const wrapper = shallow(<Translation
+                entity={ DEFAULT_ENTITY }
                 translation={ DEFAULT_TRANSLATION }
                 locale={ DEFAULT_LOCALE }
                 canReview={ true }
@@ -228,6 +235,7 @@ describe('<Translation>', () => {
         it('allows translators to delete the rejected translation', () => {
             const translation = { ...DEFAULT_TRANSLATION, rejected: true };
             const wrapper = shallow(<Translation
+                entity={ DEFAULT_ENTITY }
                 translation={ translation }
                 locale={ DEFAULT_LOCALE }
                 canReview={ true }
@@ -239,6 +247,7 @@ describe('<Translation>', () => {
         it('forbids translators to delete non-rejected translation', () => {
             const translation = { ...DEFAULT_TRANSLATION, rejected: false };
             const wrapper = shallow(<Translation
+                entity={ DEFAULT_ENTITY }
                 translation={ translation }
                 locale={ DEFAULT_LOCALE }
                 canReview={ true }
@@ -250,6 +259,7 @@ describe('<Translation>', () => {
         it('allows the user to delete their own rejected translation', () => {
             const translation = { ...DEFAULT_TRANSLATION, rejected: true };
             const wrapper = shallow(<Translation
+                entity={ DEFAULT_ENTITY }
                 translation={ translation }
                 locale={ DEFAULT_LOCALE }
                 user={ DEFAULT_USER }
@@ -261,6 +271,7 @@ describe('<Translation>', () => {
         it('forbids the user to delete rejected translation of another user', () => {
             const translation = { ...DEFAULT_TRANSLATION, rejected: true };
             const wrapper = shallow(<Translation
+                entity={ DEFAULT_ENTITY }
                 translation={ translation }
                 locale={ DEFAULT_LOCALE }
             />);

--- a/frontend/src/modules/machinery/components/Machinery.js
+++ b/frontend/src/modules/machinery/components/Machinery.js
@@ -14,6 +14,7 @@ import type { MachineryState } from '..';
 
 type Props = {|
     entity: DbEntity,
+    isReadOnlyEditor: boolean,
     locale: ?Locale,
     machinery: MachineryState,
     updateEditorTranslation: (string) => void,
@@ -29,7 +30,13 @@ type Props = {|
  */
 export default class Machinery extends React.Component<Props> {
     render() {
-        const { entity, locale, machinery, updateEditorTranslation } = this.props;
+        const {
+            entity,
+            isReadOnlyEditor,
+            locale,
+            machinery,
+            updateEditorTranslation,
+        } = this.props;
 
         if (!locale) {
             return null;
@@ -46,6 +53,7 @@ export default class Machinery extends React.Component<Props> {
                 { machinery.translations.map((translation, index) => {
                     return <Translation
                         entity={ entity }
+                        isReadOnlyEditor={ isReadOnlyEditor }
                         locale={ locale }
                         translation={ translation }
                         updateEditorTranslation={ updateEditorTranslation }

--- a/frontend/src/modules/machinery/components/Translation.js
+++ b/frontend/src/modules/machinery/components/Translation.js
@@ -16,6 +16,7 @@ import type { Locale } from 'core/locales';
 
 type Props = {|
     entity: DbEntity,
+    isReadOnlyEditor: boolean,
     locale: Locale,
     translation: api.types.MachineryTranslation,
     updateEditorTranslation: (string) => void,
@@ -31,6 +32,9 @@ type Props = {|
  */
 export default class Translation extends React.Component<Props> {
     copyTranslationIntoEditor = () => {
+        if (this.props.isReadOnlyEditor) {
+            return;
+        }
         this.props.updateEditorTranslation(this.props.translation.translation);
     }
 

--- a/frontend/src/modules/otherlocales/components/OtherLocales.js
+++ b/frontend/src/modules/otherlocales/components/OtherLocales.js
@@ -14,6 +14,7 @@ import type { UserState } from 'core/user';
 
 
 type Props = {|
+    isReadOnlyEditor: boolean,
     orderedOtherLocales: Array<api.types.OtherLocaleTranslation>,
     preferredLocalesCount: number,
     otherlocales: LocalesState,
@@ -37,6 +38,7 @@ export default class OtherLocales extends React.Component<Props> {
 
     render() {
         const {
+            isReadOnlyEditor,
             orderedOtherLocales,
             preferredLocalesCount,
             otherlocales,
@@ -58,6 +60,7 @@ export default class OtherLocales extends React.Component<Props> {
                     let lastPreferred = (index === preferredLocalesCount - 1);
 
                     return <Translation
+                        isReadOnlyEditor={ isReadOnlyEditor }
                         translation={ translation }
                         parameters={ parameters }
                         updateEditorTranslation={ updateEditorTranslation }

--- a/frontend/src/modules/otherlocales/components/Translation.js
+++ b/frontend/src/modules/otherlocales/components/Translation.js
@@ -25,45 +25,45 @@ type Props = {|
  * Show the translation of a given entity in a different locale, as well as the
  * locale and its code.
  */
- export default class Translation extends React.Component<Props> {
-     copyTranslationIntoEditor = () => {
-         if (this.props.isReadOnlyEditor) {
-             return;
-         }
-         this.props.updateEditorTranslation(this.props.translation.translation);
-     }
+export default class Translation extends React.Component<Props> {
+    copyTranslationIntoEditor = () => {
+        if (this.props.isReadOnlyEditor) {
+            return;
+        }
+        this.props.updateEditorTranslation(this.props.translation.translation);
+    }
 
-     render() {
-         const { translation, parameters, lastPreferred } = this.props;
+    render() {
+        const { translation, parameters, lastPreferred } = this.props;
 
-         const className = lastPreferred ? 'translation last-preferred' : 'translation';
+        const className = lastPreferred ? 'translation last-preferred' : 'translation';
 
-         return <Localized id='otherlocales-translation-copy' attrs={{ title: true }}>
-             <li
-                className={ className }
-                title='Copy Into Translation (Tab)'
-                onClick={ this.copyTranslationIntoEditor }
-             >
-                 <header>
-                     <a
-                         href={ `/translate/${translation.code}/${parameters.project}/${parameters.resource}/?string=${parameters.entity}` }
-                         target="_blank"
-                         rel="noopener noreferrer"
-                     >
-                         { translation.locale }
-                         <span>{ translation.code }</span>
-                     </a>
-                 </header>
-                 <p
-                     lang={ translation.code }
-                     dir={ translation.direction }
-                     script={ translation.script }
-                 >
-                     <WithPlaceables>
-                         { translation.translation }
-                     </WithPlaceables>
-                 </p>
-             </li>
-         </Localized>;
-     }
- }
+        return <Localized id='otherlocales-translation-copy' attrs={{ title: true }}>
+            <li
+            className={ className }
+            title='Copy Into Translation (Tab)'
+            onClick={ this.copyTranslationIntoEditor }
+            >
+                <header>
+                    <a
+                        href={ `/translate/${translation.code}/${parameters.project}/${parameters.resource}/?string=${parameters.entity}` }
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        { translation.locale }
+                        <span>{ translation.code }</span>
+                    </a>
+                </header>
+                <p
+                    lang={ translation.code }
+                    dir={ translation.direction }
+                    script={ translation.script }
+                >
+                    <WithPlaceables>
+                        { translation.translation }
+                    </WithPlaceables>
+                </p>
+            </li>
+        </Localized>;
+    }
+}

--- a/frontend/src/modules/otherlocales/components/Translation.js
+++ b/frontend/src/modules/otherlocales/components/Translation.js
@@ -11,6 +11,7 @@ import type { Navigation } from 'core/navigation';
 
 
 type Props = {|
+    isReadOnlyEditor: boolean,
     translation: Object,
     parameters: Navigation,
     updateEditorTranslation: (string) => void,
@@ -26,6 +27,9 @@ type Props = {|
  */
  export default class Translation extends React.Component<Props> {
      copyTranslationIntoEditor = () => {
+         if (this.props.isReadOnlyEditor) {
+             return;
+         }
          this.props.updateEditorTranslation(this.props.translation.translation);
      }
 

--- a/frontend/src/modules/otherlocales/components/Translation.js
+++ b/frontend/src/modules/otherlocales/components/Translation.js
@@ -40,9 +40,9 @@ export default class Translation extends React.Component<Props> {
 
         return <Localized id='otherlocales-translation-copy' attrs={{ title: true }}>
             <li
-            className={ className }
-            title='Copy Into Translation (Tab)'
-            onClick={ this.copyTranslationIntoEditor }
+                className={ className }
+                title='Copy Into Translation (Tab)'
+                onClick={ this.copyTranslationIntoEditor }
             >
                 <header>
                     <a


### PR DESCRIPTION
In addition to supporting [read-only projects](https://bugzilla.mozilla.org/show_bug.cgi?id=1528273) as expected, this bug also extends support for [non-authenticated mode](https://bugzilla.mozilla.org/show_bug.cgi?id=1524602), by:
* making editor read-only
* disabling copying from helpers (tools)
* disabling copying from placeables