### PR TITLE
Fix bug 1542575: Update Caighdean endpoint by using fork

### DIFF
--- a/frontend/src/modules/machinery/components/Translation.js
+++ b/frontend/src/modules/machinery/components/Translation.js
@@ -41,6 +41,9 @@ export default class Translation extends React.Component<Props> {
         const { locale, sourceString, translation } = this.props;
 
         const TranslationPlaceablesDiff = withDiff(WithPlaceablesNoLeadingSpace);
+        const types = translation.sources.map(function(source) {
+            return source.type;
+        });
 
         return <Localized id="machinery-translation-copy" attrs={{ title: true }}>
             <li
@@ -78,11 +81,15 @@ export default class Translation extends React.Component<Props> {
                     </ul>
                 </header>
                 <p className="original">
-                    <TranslationPlaceablesDiff
-                        diffTarget={ translation.original }
-                    >
-                        { sourceString }
-                    </TranslationPlaceablesDiff>
+                    { types.indexOf('Caighdean') === -1 ?
+                        <TranslationPlaceablesDiff
+                            diffTarget={ translation.original }
+                        >
+                            { sourceString }
+                        </TranslationPlaceablesDiff>
+                    :
+                        sourceString
+                    }
                 </p>
                 <p
                     className="suggestion"

--- a/frontend/src/modules/machinery/components/Translation.js
+++ b/frontend/src/modules/machinery/components/Translation.js
@@ -41,9 +41,7 @@ export default class Translation extends React.Component<Props> {
         const { locale, sourceString, translation } = this.props;
 
         const TranslationPlaceablesDiff = withDiff(WithPlaceablesNoLeadingSpace);
-        const types = translation.sources.map(function(source) {
-            return source.type;
-        });
+        const types = translation.sources.map(source => source.type);
 
         return <Localized id="machinery-translation-copy" attrs={{ title: true }}>
             <li
@@ -88,7 +86,13 @@ export default class Translation extends React.Component<Props> {
                             { sourceString }
                         </TranslationPlaceablesDiff>
                     :
-                        sourceString
+                        /*
+                         * Caighdean takes `gd` translations as input, so we shouldn't
+                         * diff it against the `en-US` source string.
+                         */
+                        <WithPlaceables>
+                            { translation.original }
+                        </WithPlaceables>
                     }
                 </p>
                 <p

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -30,8 +30,6 @@ bleach==3.0.2 \
 celery==3.1.18 \
     --hash=sha256:dbf59618d5a9eff172d25021f36614be5af0501e4527975ca504b95863f14fed \
     --hash=sha256:0924f94070c6fc57d408b169848c5b38832668fffe060e48b4803fb23e0e3eaf
-caighdean==0.0.3 \
-    --hash=sha256:5d527a66a7e0a755f5fa87c63e365da05f18a2f37897bef21c5c02cb10867a92
 compare-locales==6.0.0 \
     --hash=sha256:fb155a0675f092b4cfc337019162f95e3a0422c2c61c639fb25d6c08f3cf1c68 \
     --hash=sha256:09ecc275a39df70adda8ff11d2550c40f93b24d1b9aaa4e13b749807925bf7d0
@@ -147,3 +145,6 @@ https://github.com/mathjazz/silme/archive/v0.9.4.zip#egg=silme==0.9.4 \
 
 https://github.com/mathjazz/translate/archive/2.2.5.zip#egg=translate-toolkit==2.2.5 \
     --hash=sha256:9a23bda0f3ec07f36b6b662bf2a25492b6a354709500c736213229e94f462443
+
+https://github.com/mathjazz/python-caighdean/archive/v0.0.4.zip#egg=caighdean==0.0.4 \
+    --hash=sha256:c0225c877b94c069d393ffc520fa7f81e6d6a627c49c63eabf91d2f8ceb02aee


### PR DESCRIPTION
Caighdean API endpoint [has moved](https://github.com/translate/python-caighdean/pull/2). Since the PR hasn't been merged upstream yet, we need to switch to a fork, which fixes the endpoint.

The patch is deployed to stage:
https://mozilla-pontoon-staging.herokuapp.com/ga-IE/firefox/browser/branding/official/brand.dtd/?string=74131