### PR TITLE
Fix bug 1537613: Move Mercurial to a separate requirements file

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -6,5 +6,9 @@ requirements:
       update: security
   - requirements/dev.txt:
       update: security
+  - requirements/python2.txt:
+      update: security
+  - requirements/test.txt:
+      update: security
   - docs/requirements.txt:
       update: security

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,10 @@ before_install:
   # caches may need to be cleared from time to time https://docs.travis-ci.com/user/caching#Clearing-Caches
   - cp -a $HOME/virtualenv/python2.7.14/lib/python2.7/site-packages/ $HOME/py-workaround/
 install:
-  - pip install -U --force pip
-  - pip install --require-hashes -r requirements/default.txt
-  - pip install --require-hashes -r requirements/test.txt
+  - pip2 install -U --force pip
+  - pip2 install --require-hashes -r requirements/default.txt
+  - pip2 install --require-hashes -r requirements/test.txt
+  - pip2 install --require-hashes -r requirements/python2.txt
   - source $HOME/.nvm/nvm.sh
   - nvm install --lts node
   - nvm use --lts node

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -163,7 +163,7 @@ Then open ``requirements/default.txt`` and move the added dependencies to:
 * the ``requirements/constraints.txt`` if they are sub-dependencies, and add all their dependencies there as well.
 
 That format is documented more extensively inside the ``requirements/default.txt`` file.
-If a depedency has to be installed explicitly on Python2, add it to ``requirements/python2.txt`` and follow the same
+If a dependency has to be installed explicitly on Python2, add it to ``requirements/python2.txt`` and follow the same
 rules as for ``requirements/default.txt``.
 
 Once you are done adding or updating requirements, rebuild your docker environment:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -163,6 +163,8 @@ Then open ``requirements/default.txt`` and move the added dependencies to:
 * the ``requirements/constraints.txt`` if they are sub-dependencies, and add all their dependencies there as well.
 
 That format is documented more extensively inside the ``requirements/default.txt`` file.
+If a depedency has to be installed explicitly on Python2, add it to ``requirements/python2.txt`` and follow the same
+rules as for ``requirements/default.txt``.
 
 Once you are done adding or updating requirements, rebuild your docker environment:
 
@@ -291,7 +293,8 @@ steps, as they don't affect your setup if nothing has changed:
    git pull origin master
 
    # Install new dependencies or update existing ones.
-   pip install -U --force --require-hashes -r requirements/default.txt
+   pip2 install -U --force --require-hashes -r requirements/default.txt
+   pip2 install -U --force --require-hashes -r requirements/python2.txt
 
    # Run database migrations.
    python manage.py migrate

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,9 +11,10 @@ RUN useradd --shell /bin/bash -c "" -m app
 
 # Install Pontoon Python requirements
 COPY requirements/* /app/requirements/
-RUN pip install -U 'pip>=8' && \
-    pip install --no-cache-dir --require-hashes -r requirements/dev.txt && \
-    pip install --no-cache-dir --require-hashes -r requirements/test.txt
+RUN pip2 install -U 'pip>=8' && \
+    pip2 install --no-cache-dir --require-hashes -r requirements/dev.txt && \
+    pip2 install --no-cache-dir --require-hashes -r requirements/python2.txt && \
+    pip2 install --no-cache-dir --require-hashes -r requirements/test.txt
 
 # Install nodejs and npm from Nodesource's 10.x branch, as well as yarn
 RUN curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@
 #
 # Source: https://devcenter.heroku.com/articles/python-pip
 -r requirements/default.txt
+
+# All dependencies which support Python 2 only.
+-r requirements/python2.txt

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -97,8 +97,6 @@ jsonschema==2.6.0 \
     --hash=sha256:000e68abd33c972a5248544925a0cae7d1125f9bf6c58280d37546b946769a08
 lxml==3.4.4 \
     --hash=sha256:b3d362bac471172747cda3513238f115cbd6c5f8b8e6319bf6a97a7892724099
-mercurial==4.7.2 \
-    --hash=sha256:97f0594216f2348a2e37b2ad8a56eade044e741153fee8c584487e9934ca09fb
 mock==1.3.0 \
     --hash=sha256:3f573a18be94de886d1191f27c168427ef693e8dcfcecf95b170577b2eb69cbb
 newrelic==2.106.1.88 \
@@ -140,8 +138,8 @@ wsgi-sslify==1.0.1 \
 
 
 # Dependencies loaded from outside pypi.
-https://github.com/mathjazz/silme/archive/v0.9.4.zip#egg=silme==0.9.4 \
-    --hash=sha256:473c20e2d955359e69e84db8904db1a49fc10ecd2f8864c005404d070bd67b0c
+https://github.com/mathjazz/silme/archive/python3.zip#egg=silme==0.10.0 \
+    --hash=sha256:6cc76700ba3f37515849c7d8c859d2951bde3c3a1cdfea6833b79c9935e020f4
 
 https://github.com/mathjazz/translate/archive/2.2.5.zip#egg=translate-toolkit==2.2.5 \
     --hash=sha256:9a23bda0f3ec07f36b6b662bf2a25492b6a354709500c736213229e94f462443

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -138,8 +138,8 @@ wsgi-sslify==1.0.1 \
 
 
 # Dependencies loaded from outside pypi.
-https://github.com/mathjazz/silme/archive/python3.zip#egg=silme==0.10.0 \
-    --hash=sha256:6cc76700ba3f37515849c7d8c859d2951bde3c3a1cdfea6833b79c9935e020f4
+https://github.com/mathjazz/silme/archive/v0.10.0.zip#egg=silme==0.10.0 \
+    --hash=sha256:6227f6cb9b2e3a5898ce6761e339dad9ee6166a449d895202045c92815dc995d
 
 https://github.com/mathjazz/translate/archive/2.2.5.zip#egg=translate-toolkit==2.2.5 \
     --hash=sha256:9a23bda0f3ec07f36b6b662bf2a25492b6a354709500c736213229e94f462443

--- a/requirements/python2.txt
+++ b/requirements/python2.txt
@@ -1,0 +1,7 @@
+# All dependencies which should be installed in the Python 2 environment.
+# ----------------------------------------------------------------------------------
+
+# Mercurial 4.7.2 runs only on Python 2.7.* . The support for Python 3 is in the works.
+# https://www.mercurial-scm.org/wiki/Python3
+mercurial==4.7.2 \
+    --hash=sha256:97f0594216f2348a2e37b2ad8a56eade044e741153fee8c584487e9934ca09fb


### PR DESCRIPTION
I moved `mercurial` to a separate requirements file and updated the version of `silme`.
However, it's still WIP.

TODO:
* [x] fix tests for Silme/fix Silme
* [x] Merge https://github.com/mathjazz/silme/pull/2 and update reqs to https://github.com/mathjazz/silme/tree/master.