### PR TITLE
Caighdean: Use approved translation of the right plural form as source

### DIFF
--- a/pontoon/machinery/tests/test_views.py
+++ b/pontoon/machinery/tests/test_views.py
@@ -149,7 +149,11 @@ def test_view_caighdean(client, entity_a):
     assert json.loads(response.content) == {}
 
     translation = TranslationFactory.create(
-        entity=entity_a, locale=gd, string='GD translation'
+        entity=entity_a,
+        locale=gd,
+        string='GD translation',
+        plural_form=None,
+        approved=True,
     )
     entity_a.translation_set.add(translation)
 
@@ -213,7 +217,11 @@ def test_view_caighdean_bad(client, entity_a):
 
     translator = caighdean.Translator()
     translation = TranslationFactory.create(
-        entity=entity_a, locale=gd, string='foo'
+        entity=entity_a,
+        locale=gd,
+        string='foo',
+        plural_form=None,
+        approved=True,
     )
     entity_a.translation_set.add(translation)
 

--- a/pontoon/machinery/views.py
+++ b/pontoon/machinery/views.py
@@ -236,7 +236,16 @@ def caighdean(request):
         }, status=404)
 
     try:
-        text = entity.translation_set.get(locale__code='gd').string
+        text = (
+            entity
+            .translation_set
+            .get(
+                locale__code='gd',
+                plural_form=None if entity.string_plural == '' else 0,
+                approved=True
+            )
+            .string
+        )
     except Translation.DoesNotExist:
         return JsonResponse({})
 


### PR DESCRIPTION
Caighdean MT takes `gd` translations as source and returns machine translation suggestions for `ga-IE`. We need to be more specific in determining the source string in order to prevent errors like this:

```
Message: str: get() returned more than one Translation -- it returned 2!

Traceback:

File "/app/.heroku/python/lib/python2.7/site-packages/django/core/handlers/base.py", line 185, in _get_response
                  response = wrapped_callback(request, *callback_args, **callback_kwargs)

File "/app/.heroku/python/lib/python2.7/site-packages/newrelic/hooks/framework_django.py", line 544, in wrapper
                  return wrapped(*args, **kwargs)

File "/app/pontoon/machinery/views.py", line 239, in caighdean
          text = entity.translation_set.get(locale__code='gd').string

File "/app/.heroku/python/lib/python2.7/site-packages/django/db/models/manager.py", line 85, in manager_method
                  return getattr(self.get_queryset(), name)(*args, **kwargs)

File "/app/.heroku/python/lib/python2.7/site-packages/django/db/models/query.py", line 384, in get
              (self.model._meta.object_name, num)
```