### PR TITLE
Switch back to upstream caighdean

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -16,6 +16,25 @@
 webencodings==0.5.1 \
     --hash=sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78
 
+# caighdean
+sacremoses==0.0.19 \
+    --hash=sha256:4220bf1474b2d735b6d7e2b27e839ac110cf0f9b4fc244fd649707dd738e3430 \
+
+# sacremoses
+click==7.0 \
+    --hash=sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13 \
+    --hash=sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7
+
+# sacremoses
+joblib==0.13.2 \
+    --hash=sha256:21e0c34a69ad7fde4f2b1f3402290e9ec46f545f15f1541c582edfe05d87b63a \
+    --hash=sha256:315d6b19643ec4afd4c41c671f9f2d65ea9d787da093487a81ead7b0bac94524
+
+# sacremoses
+tqdm==4.31.1 \
+    --hash=sha256:d385c95361699e5cf7622485d9b9eae2d4864b21cd5a2374a9c381ffed701021 \
+    --hash=sha256:e22977e3ebe961f72362f6ddfb9197cc531c9737aaf5f607ef09740c849ecd05
+
 # >=3.3.0.20,<3.4 celery
 billiard==3.3.0.20 \
     --hash=sha256:688f9466b1c3ae14106381e6dbd328115e75c5260c542eb48e6c46931f6928cc

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -27,6 +27,8 @@ backports.csv==1.0.5 \
 bleach==3.0.2 \
     --hash=sha256:48d39675b80a75f6d1c3bdbffec791cf0bbbab665cf01e20da701c77de278718 \
     --hash=sha256:73d26f018af5d5adcdabf5c1c974add4361a9c76af215fe32fdec8a6fc5fb9b9
+caighdean==0.0.4 \
+    --hash=sha256:a0a05b39f8e185a3698a4fb67dd2b388e7fb01b28f7f53c041e0857680655d4e
 celery==3.1.18 \
     --hash=sha256:dbf59618d5a9eff172d25021f36614be5af0501e4527975ca504b95863f14fed \
     --hash=sha256:0924f94070c6fc57d408b169848c5b38832668fffe060e48b4803fb23e0e3eaf
@@ -143,6 +145,3 @@ https://github.com/mathjazz/silme/archive/v0.10.0.zip#egg=silme==0.10.0 \
 
 https://github.com/mathjazz/translate/archive/2.2.5.zip#egg=translate-toolkit==2.2.5 \
     --hash=sha256:9a23bda0f3ec07f36b6b662bf2a25492b6a354709500c736213229e94f462443
-
-https://github.com/mathjazz/python-caighdean/archive/v0.0.4.zip#egg=caighdean==0.0.4 \
-    --hash=sha256:c0225c877b94c069d393ffc520fa7f81e6d6a627c49c63eabf91d2f8ceb02aee


### PR DESCRIPTION
We switched to our own caighdean fork as part of bug 1542575. Since the
patch has been merged, we can now switch back to upstream caighdean.

@jotes One more r?