### PR TITLE
Fix bug 1542617 - Prevent character disappearance in Editor.

### DIFF
--- a/frontend/src/modules/editor/actions.js
+++ b/frontend/src/modules/editor/actions.js
@@ -8,6 +8,7 @@ import { actions as entitiesActions } from 'modules/entitieslist';
 import type { DbEntity } from 'modules/entitieslist';
 
 
+export const RESET_SELECTION: 'editor/RESET_SELECTION' = 'editor/RESET_SELECTION';
 export const UPDATE: 'editor/UPDATE' = 'editor/UPDATE';
 export const UPDATE_SELECTION: 'editor/UPDATE_SELECTION' = 'editor/UPDATE_SELECTION';
 
@@ -39,6 +40,20 @@ export function updateSelection(content: string): UpdateSelectionAction {
     return {
         type: UPDATE_SELECTION,
         content,
+    };
+}
+
+
+/**
+ * Update the content that should replace the currently selected text in the
+ * active editor.
+ */
+export type ResetSelectionAction = {|
+    +type: typeof RESET_SELECTION,
+|};
+export function resetSelection(): ResetSelectionAction {
+    return {
+        type: RESET_SELECTION,
     };
 }
 
@@ -95,6 +110,7 @@ export function sendTranslation(
 
 
 export default {
+    resetSelection,
     sendTranslation,
     update,
     updateSelection,

--- a/frontend/src/modules/editor/components/Editor.test.js
+++ b/frontend/src/modules/editor/components/Editor.test.js
@@ -29,9 +29,8 @@ function createEditorBase({
 } = {}) {
     return shallow(<EditorBase
         dispatch={ () => {} }
-        activeTranslation='initial'
         editor={
-            { translation: '' }
+            { translation: 'initial' }
         }
         locale={
             { code: 'kg' }
@@ -60,16 +59,19 @@ function expectHiddenSettingsAndActions(wrapper) {
 describe('<EditorBase>', () => {
     beforeAll(() => {
         sinon.stub(editor.actions, 'sendTranslation').returns({ type: 'whatever' });
+        sinon.stub(editor.actions, 'update').returns({ type: 'whatever' });
         sinon.stub(user.actions, 'saveSetting').returns({ type: 'whatever' });
     });
 
     afterEach(() => {
         editor.actions.sendTranslation.reset();
+        editor.actions.update.reset();
         user.actions.saveSetting.reset();
     });
 
     afterAll(() => {
         editor.actions.sendTranslation.restore();
+        editor.actions.update.restore();
         user.actions.saveSetting.restore();
     });
 
@@ -80,30 +82,28 @@ describe('<EditorBase>', () => {
         expect(wrapper.find('button')).toHaveLength(3);
     });
 
-    it('has the active translation as content when created', () => {
-        const wrapper = createEditorBase();
-        expect(wrapper.state().translation).toEqual('initial');
-    });
-
     it('clears the text when the Clear button is clicked', () => {
         const wrapper = createEditorBase();
 
         wrapper.find('.action-clear').simulate('click');
-        expect(wrapper.state().translation).toEqual('');
+        expect(editor.actions.update.calledOnce).toBeTruthy();
+        expect(editor.actions.update.calledWith('')).toBeTruthy();
     });
 
     it('copies the original string in the textarea when the Copy button is clicked', () => {
         const wrapper = createEditorBase();
 
         wrapper.find('.action-copy').simulate('click');
-        expect(wrapper.state().translation).toEqual(SELECTED_ENTITY.original);
+        expect(editor.actions.update.calledOnce).toBeTruthy();
+        expect(editor.actions.update.calledWith(SELECTED_ENTITY.original)).toBeTruthy();
     });
 
     it('copies the plural original string in the textarea when the Copy button is clicked', () => {
         const wrapper = createEditorBase({ pluralForm: 5 });
 
         wrapper.find('.action-copy').simulate('click');
-        expect(wrapper.state().translation).toEqual(SELECTED_ENTITY.original_plural);
+        expect(editor.actions.update.calledOnce).toBeTruthy();
+        expect(editor.actions.update.calledWith(SELECTED_ENTITY.original_plural)).toBeTruthy();
     });
 
     it('calls the sendTranslation action when the Suggest button is clicked', () => {

--- a/frontend/src/modules/editor/components/EditorProxy.js
+++ b/frontend/src/modules/editor/components/EditorProxy.js
@@ -34,7 +34,6 @@ export default class EditorProxy extends React.Component<EditorProxyProps> {
             return <FluentEditor
                 isReadOnlyEditor={ this.props.isReadOnlyEditor }
                 editor={ this.props.editor }
-                translation={ this.props.translation }
                 locale={ this.props.locale }
                 copyOriginalIntoEditor={ this.props.copyOriginalIntoEditor }
                 resetSelectionContent={ this.props.resetSelectionContent }
@@ -46,7 +45,6 @@ export default class EditorProxy extends React.Component<EditorProxyProps> {
         return <GenericEditor
             isReadOnlyEditor={ this.props.isReadOnlyEditor }
             editor={ this.props.editor }
-            translation={ this.props.translation }
             locale={ this.props.locale }
             copyOriginalIntoEditor={ this.props.copyOriginalIntoEditor }
             resetSelectionContent={ this.props.resetSelectionContent }

--- a/frontend/src/modules/editor/components/FluentEditor.js
+++ b/frontend/src/modules/editor/components/FluentEditor.js
@@ -93,8 +93,8 @@ export default class FluentEditor extends React.Component<EditorProps> {
             width='100%'
             wrapEnabled={ true }
             setOptions={ options }
-            value={ this.props.translation }
-            annotations={ annotate(this.props.translation) }
+            value={ this.props.editor.translation }
+            annotations={ annotate(this.props.editor.translation) }
             onChange={ this.props.updateTranslation }
             debounceChangePeriod={200}
         />;

--- a/frontend/src/modules/editor/components/FluentEditor.test.js
+++ b/frontend/src/modules/editor/components/FluentEditor.test.js
@@ -6,8 +6,12 @@ import FluentEditor from './FluentEditor';
 
 
 describe('<FluentEditor>', () => {
+    const EDITOR = {
+        translation: 'hello',
+    };
+
     it('renders a textarea with some content', () => {
-        const wrapper = shallow(<FluentEditor translation='hello' />);
+        const wrapper = shallow(<FluentEditor editor={ EDITOR } />);
 
         expect(wrapper.find('ReactAce')).toHaveLength(1);
     });
@@ -17,12 +21,17 @@ describe('<FluentEditor>', () => {
         const updateMock = sinon.stub();
 
         const wrapper = mount(<FluentEditor
-            translation='hello'
+            editor={ EDITOR }
             resetSelectionContent={ resetMock }
             updateTranslation={ updateMock }
         />);
 
-        wrapper.setProps({ editor: { selectionReplacementContent: ' world' } });
+        wrapper.setProps({
+            editor: {
+                ...EDITOR,
+                selectionReplacementContent: ' world'
+            }
+        });
 
         expect(updateMock.calledOnce).toBeTruthy();
         expect(updateMock.calledWith('hello world')).toBeTruthy();

--- a/frontend/src/modules/editor/components/GenericEditor.js
+++ b/frontend/src/modules/editor/components/GenericEditor.js
@@ -9,7 +9,6 @@ import type { EditorState } from '..';
 export type EditorProps = {|
     isReadOnlyEditor: boolean,
     editor: EditorState,
-    translation: string,
     locale: Locale,
     copyOriginalIntoEditor: () => void,
     resetSelectionContent: () => void,
@@ -36,8 +35,8 @@ export default class GenericEditor extends React.Component<EditorProps> {
 
         // After mounting, put the cursor at the end of the content.
         this.textarea.current.setSelectionRange(
-            this.props.translation.length,
-            this.props.translation.length,
+            this.props.editor.translation.length,
+            this.props.editor.translation.length,
         );
     }
 
@@ -115,7 +114,7 @@ export default class GenericEditor extends React.Component<EditorProps> {
         return <textarea
             readOnly={ this.props.isReadOnlyEditor }
             ref={ this.textarea }
-            value={ this.props.translation }
+            value={ this.props.editor.translation }
             onKeyDown={ this.handleShortcuts }
             onChange={ this.handleChange }
             dir={ this.props.locale.direction }

--- a/frontend/src/modules/editor/components/GenericEditor.test.js
+++ b/frontend/src/modules/editor/components/GenericEditor.test.js
@@ -11,11 +11,15 @@ const DEFAULT_LOCALE = {
     script: 'Latin',
 };
 
+const EDITOR = {
+    translation: 'hello',
+};
+
 
 describe('<GenericEditor>', () => {
     it('renders a textarea with some content', () => {
         const wrapper = shallow(<GenericEditor
-            translation='hello'
+            editor={ EDITOR }
             locale={ DEFAULT_LOCALE }
         />);
 
@@ -26,7 +30,7 @@ describe('<GenericEditor>', () => {
     it('calls the updateTranslation function on change', () => {
         const mockUpdate = sinon.spy();
         const wrapper = shallow(<GenericEditor
-            translation='hello'
+            editor={ EDITOR }
             locale={ DEFAULT_LOCALE }
             updateTranslation={ mockUpdate }
         />);
@@ -41,7 +45,7 @@ describe('<GenericEditor>', () => {
         const updateMock = sinon.stub();
 
         const wrapper = mount(<GenericEditor
-            translation='hello'
+            editor={ EDITOR }
             locale={ DEFAULT_LOCALE }
             resetSelectionContent={ resetMock }
             updateTranslation={ updateMock }
@@ -57,7 +61,7 @@ describe('<GenericEditor>', () => {
     it('sends the translation on Enter', () => {
         const mockSend = sinon.spy();
         const wrapper = shallow(<GenericEditor
-            translation='hello'
+            editor={ EDITOR }
             locale={ DEFAULT_LOCALE }
             sendTranslation={ mockSend }
         />);
@@ -78,7 +82,7 @@ describe('<GenericEditor>', () => {
     it('copies the original into the Editor on Ctrl + Shift + C', () => {
         const mockCopy = sinon.spy();
         const wrapper = shallow(<GenericEditor
-            translation='hello'
+            editor={ EDITOR }
             locale={ DEFAULT_LOCALE }
             copyOriginalIntoEditor={ mockCopy }
         />);
@@ -99,7 +103,7 @@ describe('<GenericEditor>', () => {
     it('clears the translation on Ctrl + Shift + Backspace', () => {
         const mockUpdate = sinon.spy();
         const wrapper = shallow(<GenericEditor
-            translation='hello'
+            editor={ EDITOR }
             locale={ DEFAULT_LOCALE }
             updateTranslation={ mockUpdate }
         />);

--- a/frontend/src/modules/editor/reducer.js
+++ b/frontend/src/modules/editor/reducer.js
@@ -1,11 +1,16 @@
 /* @flow */
 
-import { UPDATE, UPDATE_SELECTION } from './actions';
+import { RESET_SELECTION, UPDATE, UPDATE_SELECTION } from './actions';
 
-import type { UpdateAction, UpdateSelectionAction } from './actions';
+import type {
+    ResetSelectionAction,
+    UpdateAction,
+    UpdateSelectionAction,
+} from './actions';
 
 
 type Action =
+    | ResetSelectionAction
     | UpdateAction
     | UpdateSelectionAction
 ;
@@ -35,6 +40,11 @@ export default function reducer(
             return {
                 ...state,
                 selectionReplacementContent: action.content,
+            };
+        case RESET_SELECTION:
+            return {
+                ...state,
+                selectionReplacementContent: '',
             };
         default:
             return state;


### PR DESCRIPTION
This removes the state buffer for the content of the various Editors. It was causing bugs when users were typing fast, because of our usage of debounce. It also turns out that not having that debounce is fine in terms of performance. Premature optimization it was! Bad developer!