### PR TITLE
Add overflow:auto to .metadata

### DIFF
--- a/frontend/src/modules/entitydetails/components/Metadata.css
+++ b/frontend/src/modules/entitydetails/components/Metadata.css
@@ -6,6 +6,7 @@
     height: 20%;
     min-height: 100px;
     line-height: 22px;
+    overflow: auto;
     padding: 10px;
 }
 


### PR DESCRIPTION
If the source string is long or contains a longer description, we should allow scrolling to reveal all the information.