### PR TITLE
Fix bug 1518820: Add errors and warnings

### DIFF
--- a/frontend/public/static/locale/en-US/translate.ftl
+++ b/frontend/public/static/locale/en-US/translate.ftl
@@ -18,6 +18,9 @@ editor-editor-button-suggest = Suggest
 editor-settings-toolkit-checks = ×
     .aria-label = Close failed checks popup
 editor-FailedChecks--title = The following checks have failed
+editor-FailedChecks--save-anyway = Save anyway
+editor-FailedChecks--suggest-anyway = Suggest anyway
+editor-FailedChecks--approve-anyway = Approve anyway
 
 
 ## EditorSettings

--- a/frontend/public/static/locale/en-US/translate.ftl
+++ b/frontend/public/static/locale/en-US/translate.ftl
@@ -12,6 +12,14 @@ editor-editor-button-save = Save
 editor-editor-button-suggest = Suggest
 
 
+## Failed Checks
+## Renders the failed checks popup
+
+editor-settings-toolkit-checks = ×
+    .aria-label = Close failed checks popup
+editor-FailedChecks--title = The following checks have failed
+
+
 ## EditorSettings
 ## Shows options to update user settings regarding the editor.
 

--- a/frontend/src/core/api/translation.js
+++ b/frontend/src/core/api/translation.js
@@ -17,6 +17,7 @@ export default class TranslationAPI extends APIBase {
         pluralForm: number,
         original: string,
         forceSuggestions: boolean,
+        ignoreWarnings: ?boolean,
     ) {
         const csrfToken = this.getCSRFToken();
 
@@ -27,6 +28,11 @@ export default class TranslationAPI extends APIBase {
         payload.append('plural_form', pluralForm.toString());
         payload.append('original', original);
         payload.append('force_suggestions', forceSuggestions.toString());
+
+        if (ignoreWarnings) {
+            payload.append('ignore_warnings', ignoreWarnings.toString());
+        }
+
         payload.append('csrfmiddlewaretoken', csrfToken);
 
         const headers = new Headers();

--- a/frontend/src/core/api/translation.js
+++ b/frontend/src/core/api/translation.js
@@ -43,7 +43,7 @@ export default class TranslationAPI extends APIBase {
         return this.fetch('/update/', 'POST', payload, headers);
     }
 
-    _changeStatus(url: string, id: number, resource: string) {
+    _changeStatus(url: string, id: number, resource: string, ignoreWarnings: ?boolean) {
         const csrfToken = this.getCSRFToken();
 
         const payload = new URLSearchParams();
@@ -53,6 +53,10 @@ export default class TranslationAPI extends APIBase {
             payload.append('paths[]', resource);
         }
 
+        if (ignoreWarnings) {
+            payload.append('ignore_warnings', ignoreWarnings.toString());
+        }
+
         const headers = new Headers();
         headers.append('X-Requested-With', 'XMLHttpRequest');
         headers.append('X-CSRFToken', csrfToken);
@@ -60,8 +64,8 @@ export default class TranslationAPI extends APIBase {
         return this.fetch(url, 'POST', payload, headers);
     }
 
-    approve(id: number, resource: string) {
-        return this._changeStatus('/approve-translation/', id, resource);
+    approve(id: number, resource: string, ignoreWarnings: ?boolean) {
+        return this._changeStatus('/approve-translation/', id, resource, ignoreWarnings);
     }
 
     unapprove(id: number, resource: string) {

--- a/frontend/src/modules/editor/actions.js
+++ b/frontend/src/modules/editor/actions.js
@@ -61,13 +61,16 @@ export type FailedChecks = {|
 export type UpdateFailedChecksAction = {|
     +type: typeof UPDATE_FAILED_CHECKS,
     +failedChecks: FailedChecks,
+    +source: '' | 'stored' | 'submitted' | 'approved',
 |};
 export function updateFailedChecks(
     failedChecks: FailedChecks,
+    source: '' | 'stored' | 'submitted' | 'approved',
 ): UpdateFailedChecksAction {
     return {
         type: UPDATE_FAILED_CHECKS,
         failedChecks,
+        source,
     };
 }
 
@@ -122,7 +125,7 @@ export function sendTranslation(
         );
 
         if (content.failedChecks) {
-            dispatch(updateFailedChecks(content.failedChecks));
+            dispatch(updateFailedChecks(content.failedChecks, 'submitted'));
         }
         else if (content.same) {
             // The translation that was provided is the same as an existing

--- a/frontend/src/modules/editor/actions.js
+++ b/frontend/src/modules/editor/actions.js
@@ -61,11 +61,11 @@ export type FailedChecks = {|
 export type UpdateFailedChecksAction = {|
     +type: typeof UPDATE_FAILED_CHECKS,
     +failedChecks: FailedChecks,
-    +source: '' | 'stored' | 'submitted' | 'approved',
+    +source: '' | 'stored' | 'submitted' | number,
 |};
 export function updateFailedChecks(
     failedChecks: FailedChecks,
-    source: '' | 'stored' | 'submitted' | 'approved',
+    source: '' | 'stored' | 'submitted' | number,
 ): UpdateFailedChecksAction {
     return {
         type: UPDATE_FAILED_CHECKS,

--- a/frontend/src/modules/editor/actions.js
+++ b/frontend/src/modules/editor/actions.js
@@ -10,6 +10,7 @@ import type { DbEntity } from 'modules/entitieslist';
 
 export const RESET_SELECTION: 'editor/RESET_SELECTION' = 'editor/RESET_SELECTION';
 export const UPDATE: 'editor/UPDATE' = 'editor/UPDATE';
+export const UPDATE_FAILED_CHECKS: 'editor/UPDATE_FAILED_CHECKS' = 'editor/UPDATE_FAILED_CHECKS';
 export const UPDATE_SELECTION: 'editor/UPDATE_SELECTION' = 'editor/UPDATE_SELECTION';
 
 
@@ -42,6 +43,30 @@ export function updateSelection(content: string): UpdateSelectionAction {
     return {
         type: UPDATE_SELECTION,
         content,
+    };
+}
+
+
+/**
+ * Update failed checks in the active editor.
+ */
+export type FailedChecks = {|
+    +clErrors: Array<string>,
+    +pErrors: Array<string>,
+    +clWarnings: Array<string>,
+    +pndbWarnings: Array<string>,
+    +ttWarnings: Array<string>,
+|};
+export type UpdateFailedChecksAction = {|
+    +type: typeof UPDATE_FAILED_CHECKS,
+    +failedChecks: FailedChecks,
+|};
+export function updateFailedChecks(
+    failedChecks: FailedChecks,
+): UpdateFailedChecksAction {
+    return {
+        type: UPDATE_FAILED_CHECKS,
+        failedChecks: failedChecks,
     };
 }
 
@@ -83,7 +108,10 @@ export function sendTranslation(
             forceSuggestions,
         );
 
-        if (content.same) {
+        if (content.failedChecks) {
+            dispatch(updateFailedChecks(content.failedChecks));
+        }
+        else if (content.same) {
             // The translation that was provided is the same as an existing
             // translation for that entity.
             // Show an error.
@@ -115,5 +143,6 @@ export default {
     resetSelection,
     sendTranslation,
     update,
+    updateFailedChecks,
     updateSelection,
 };

--- a/frontend/src/modules/editor/actions.js
+++ b/frontend/src/modules/editor/actions.js
@@ -8,6 +8,7 @@ import { actions as entitiesActions } from 'modules/entitieslist';
 import type { DbEntity } from 'modules/entitieslist';
 
 
+export const RESET_FAILED_CHECKS: 'editor/RESET_FAILED_CHECKS' = 'editor/RESET_FAILED_CHECKS';
 export const RESET_SELECTION: 'editor/RESET_SELECTION' = 'editor/RESET_SELECTION';
 export const UPDATE: 'editor/UPDATE' = 'editor/UPDATE';
 export const UPDATE_FAILED_CHECKS: 'editor/UPDATE_FAILED_CHECKS' = 'editor/UPDATE_FAILED_CHECKS';
@@ -72,8 +73,7 @@ export function updateFailedChecks(
 
 
 /**
- * Update the content that should replace the currently selected text in the
- * active editor.
+ * Reset content to default value.
  */
 export type ResetSelectionAction = {|
     +type: typeof RESET_SELECTION,
@@ -81,6 +81,19 @@ export type ResetSelectionAction = {|
 export function resetSelection(): ResetSelectionAction {
     return {
         type: RESET_SELECTION,
+    };
+}
+
+
+/**
+ * Reset failed checks to default value.
+ */
+export type ResetFailedChecksAction = {|
+    +type: typeof RESET_FAILED_CHECKS,
+|};
+export function resetFailedChecks(): ResetFailedChecksAction {
+    return {
+        type: RESET_FAILED_CHECKS,
     };
 }
 
@@ -140,6 +153,7 @@ export function sendTranslation(
 
 
 export default {
+    resetFailedChecks,
     resetSelection,
     sendTranslation,
     update,

--- a/frontend/src/modules/editor/actions.js
+++ b/frontend/src/modules/editor/actions.js
@@ -66,7 +66,7 @@ export function updateFailedChecks(
 ): UpdateFailedChecksAction {
     return {
         type: UPDATE_FAILED_CHECKS,
-        failedChecks: failedChecks,
+        failedChecks,
     };
 }
 

--- a/frontend/src/modules/editor/actions.js
+++ b/frontend/src/modules/editor/actions.js
@@ -113,6 +113,7 @@ export function sendTranslation(
     forceSuggestions: boolean,
     nextEntity: ?DbEntity,
     router: Object,
+    ignoreWarnings: ?boolean,
 ): Function {
     return async dispatch => {
         const content = await api.translation.updateTranslation(
@@ -122,6 +123,7 @@ export function sendTranslation(
             pluralForm,
             original,
             forceSuggestions,
+            ignoreWarnings,
         );
 
         if (content.failedChecks) {

--- a/frontend/src/modules/editor/components/Editor.js
+++ b/frontend/src/modules/editor/components/Editor.js
@@ -102,7 +102,7 @@ export class EditorBase extends React.Component<InternalProps> {
         );
     }
 
-    getFailedChecksOfType = (type: string) => {
+    getFailedChecksOfType = (type: 'errors' | 'warnings') => {
         const { editor, pluralForm, selectedEntity } = this.props;
 
         if (!selectedEntity) {
@@ -116,6 +116,8 @@ export class EditorBase extends React.Component<InternalProps> {
         const plural = pluralForm === -1 ? 0 : pluralForm;
         const translation = selectedEntity.translation[plural];
 
+        // Only show failed checks popup for active translations that are approved or fuzzy,
+        // in which case their status icon is also colored as error/warning in string list
         if (!translation || (!translation.approved && !translation.fuzzy)) {
             return [];
         }
@@ -144,7 +146,7 @@ export class EditorBase extends React.Component<InternalProps> {
                 <FailedChecks
                     errors={ this.getFailedChecksOfType('errors') }
                     warnings={ this.getFailedChecksOfType('warnings') }
-                    />
+                />
                 { !this.props.user.isAuthenticated ?
                     <Localized
                         id="editor-editor-sign-in-to-translate"

--- a/frontend/src/modules/editor/components/Editor.js
+++ b/frontend/src/modules/editor/components/Editor.js
@@ -148,6 +148,7 @@ export class EditorBase extends React.Component<InternalProps> {
                 editor={ this.props.editor }
                 locale={ this.props.locale }
                 copyOriginalIntoEditor={ this.copyOriginalIntoEditor }
+                resetFailedChecks={ this.resetFailedChecks }
                 resetSelectionContent={ this.resetSelectionContent }
                 sendTranslation={ this.sendTranslation }
                 updateTranslation={ this.updateTranslation }

--- a/frontend/src/modules/editor/components/Editor.js
+++ b/frontend/src/modules/editor/components/Editor.js
@@ -119,72 +119,72 @@ export class EditorBase extends React.Component<InternalProps> {
                 updateTranslation={ this.updateTranslation }
             />
             <menu>
-            { !this.props.user.isAuthenticated ?
-                <Localized
-                    id="editor-editor-sign-in-to-translate"
-                    a={
-                        <user.SignInLink url={ this.props.user.signInURL }></user.SignInLink>
-                    }
-                >
-                    <p className='banner'>
-                        { '<a>Sign in</a> to translate.' }
-                    </p>
-                </Localized>
-            : (this.props.selectedEntity && this.props.selectedEntity.readonly) ?
-                <Localized
-                    id="editor-editor-read-only-localization"
-                >
-                    <p className='banner'>This is a read-only localization.</p>
-                </Localized>
-            :
-            <React.Fragment>
-                <EditorSettings
-                    settings={ this.props.user.settings }
-                    updateSetting={ this.updateSetting }
-                />
-                <KeyboardShortcuts />
-                <div className="actions">
-                    <Localized id="editor-editor-button-copy">
-                        <button
-                            className="action-copy"
-                            onClick={ this.copyOriginalIntoEditor }
-                        >
-                            Copy
-                        </button>
+                { !this.props.user.isAuthenticated ?
+                    <Localized
+                        id="editor-editor-sign-in-to-translate"
+                        a={
+                            <user.SignInLink url={ this.props.user.signInURL }></user.SignInLink>
+                        }
+                    >
+                        <p className='banner'>
+                            { '<a>Sign in</a> to translate.' }
+                        </p>
                     </Localized>
-                    <Localized id="editor-editor-button-clear">
-                        <button
-                            className="action-clear"
-                            onClick={ this.clearEditor }
-                        >
-                            Clear
-                        </button>
+                : (this.props.selectedEntity && this.props.selectedEntity.readonly) ?
+                    <Localized
+                        id="editor-editor-read-only-localization"
+                    >
+                        <p className='banner'>This is a read-only localization.</p>
                     </Localized>
-                    { this.props.user.settings.forceSuggestions ?
-                    // Suggest button, will send an unreviewed translation.
-                    <Localized id="editor-editor-button-suggest">
-                        <button
-                            className="action-suggest"
-                            onClick={ this.sendTranslation }
-                        >
-                            Suggest
-                        </button>
-                    </Localized>
-                    :
-                    // Save button, will send an approved translation.
-                    <Localized id="editor-editor-button-save">
-                        <button
-                            className="action-save"
-                            onClick={ this.sendTranslation }
-                        >
-                            Save
-                        </button>
-                    </Localized>
-                    }
-                </div>
-                <div className="clearfix" />
-            </React.Fragment>
-            }
+                :
+                    <React.Fragment>
+                        <EditorSettings
+                            settings={ this.props.user.settings }
+                            updateSetting={ this.updateSetting }
+                        />
+                        <KeyboardShortcuts />
+                        <div className="actions">
+                            <Localized id="editor-editor-button-copy">
+                                <button
+                                    className="action-copy"
+                                    onClick={ this.copyOriginalIntoEditor }
+                                >
+                                    Copy
+                                </button>
+                            </Localized>
+                            <Localized id="editor-editor-button-clear">
+                                <button
+                                    className="action-clear"
+                                    onClick={ this.clearEditor }
+                                >
+                                    Clear
+                                </button>
+                            </Localized>
+                            { this.props.user.settings.forceSuggestions ?
+                            // Suggest button, will send an unreviewed translation.
+                            <Localized id="editor-editor-button-suggest">
+                                <button
+                                    className="action-suggest"
+                                    onClick={ this.sendTranslation }
+                                >
+                                    Suggest
+                                </button>
+                            </Localized>
+                            :
+                            // Save button, will send an approved translation.
+                            <Localized id="editor-editor-button-save">
+                                <button
+                                    className="action-save"
+                                    onClick={ this.sendTranslation }
+                                >
+                                    Save
+                                </button>
+                            </Localized>
+                            }
+                        </div>
+                        <div className="clearfix" />
+                    </React.Fragment>
+                }
             </menu>
         </div>;
     }

--- a/frontend/src/modules/editor/components/Editor.js
+++ b/frontend/src/modules/editor/components/Editor.js
@@ -102,27 +102,8 @@ export class EditorBase extends React.Component<InternalProps> {
         );
     }
 
-    getFailedChecksOfType = (type: 'errors' | 'warnings') => {
-        const { editor, pluralForm, selectedEntity } = this.props;
-
-        if (!selectedEntity) {
-            return [];
-        }
-
-        if (editor[type].length) {
-            return editor[type];
-        }
-
-        const plural = pluralForm === -1 ? 0 : pluralForm;
-        const translation = selectedEntity.translation[plural];
-
-        // Only show failed checks popup for active translations that are approved or fuzzy,
-        // in which case their status icon is also colored as error/warning in string list
-        if (!translation || (!translation.approved && !translation.fuzzy)) {
-            return [];
-        }
-
-        return translation[type];
+    resetFailedChecks = () => {
+        this.props.dispatch(actions.resetFailedChecks());
     }
 
     render() {
@@ -144,8 +125,9 @@ export class EditorBase extends React.Component<InternalProps> {
             />
             <menu>
                 <FailedChecks
-                    errors={ this.getFailedChecksOfType('errors') }
-                    warnings={ this.getFailedChecksOfType('warnings') }
+                    errors={ this.props.editor.errors }
+                    warnings={ this.props.editor.warnings }
+                    resetFailedChecks={ this.resetFailedChecks }
                 />
                 { !this.props.user.isAuthenticated ?
                     <Localized

--- a/frontend/src/modules/editor/components/Editor.js
+++ b/frontend/src/modules/editor/components/Editor.js
@@ -125,6 +125,8 @@ export class EditorBase extends React.Component<InternalProps> {
             />
             <menu>
                 <FailedChecks
+                    source={ this.props.editor.source }
+                    user={ this.props.user }
                     errors={ this.props.editor.errors }
                     warnings={ this.props.editor.warnings }
                     resetFailedChecks={ this.resetFailedChecks }

--- a/frontend/src/modules/editor/components/Editor.js
+++ b/frontend/src/modules/editor/components/Editor.js
@@ -73,7 +73,7 @@ export class EditorBase extends React.Component<InternalProps> {
         this.updateTranslation('');
     }
 
-    sendTranslation = () => {
+    sendTranslation = (ignoreWarnings: ?boolean) => {
         const state = this.props;
 
         if (!state.selectedEntity || !state.locale) {
@@ -89,6 +89,7 @@ export class EditorBase extends React.Component<InternalProps> {
             state.user.settings.forceSuggestions,
             state.nextEntity,
             state.router,
+            ignoreWarnings,
         ));
     }
 
@@ -130,6 +131,7 @@ export class EditorBase extends React.Component<InternalProps> {
                     errors={ this.props.editor.errors }
                     warnings={ this.props.editor.warnings }
                     resetFailedChecks={ this.resetFailedChecks }
+                    sendTranslation={ this.sendTranslation }
                 />
                 { !this.props.user.isAuthenticated ?
                     <Localized

--- a/frontend/src/modules/editor/components/Editor.js
+++ b/frontend/src/modules/editor/components/Editor.js
@@ -13,6 +13,7 @@ import * as entitieslist from 'modules/entitieslist';
 import * as entitydetails from 'modules/entitydetails';
 
 import { actions, NAME } from '..';
+import FailedChecks from './FailedChecks';
 import EditorProxy from './EditorProxy';
 import EditorSettings from './EditorSettings';
 import KeyboardShortcuts from './KeyboardShortcuts';
@@ -101,6 +102,27 @@ export class EditorBase extends React.Component<InternalProps> {
         );
     }
 
+    getFailedChecksOfType = (type: string) => {
+        const { editor, pluralForm, selectedEntity } = this.props;
+
+        if (!selectedEntity) {
+            return [];
+        }
+
+        if (editor[type].length) {
+            return editor[type];
+        }
+
+        const plural = pluralForm === -1 ? 0 : pluralForm;
+        const translation = selectedEntity.translation[plural];
+
+        if (!translation || (!translation.approved && !translation.fuzzy)) {
+            return [];
+        }
+
+        return translation[type];
+    }
+
     render() {
         if (!this.props.locale) {
             return null;
@@ -119,6 +141,10 @@ export class EditorBase extends React.Component<InternalProps> {
                 updateTranslation={ this.updateTranslation }
             />
             <menu>
+                <FailedChecks
+                    errors={ this.getFailedChecksOfType('errors') }
+                    warnings={ this.getFailedChecksOfType('warnings') }
+                    />
                 { !this.props.user.isAuthenticated ?
                     <Localized
                         id="editor-editor-sign-in-to-translate"

--- a/frontend/src/modules/editor/components/Editor.js
+++ b/frontend/src/modules/editor/components/Editor.js
@@ -107,26 +107,22 @@ export class EditorBase extends React.Component<InternalProps> {
         );
     }
 
-    updateTranslationStatus = (
-        translationId: number,
-        change: string,
-        ignoreWarnings: ?boolean,
-    ) => {
-        const state = this.props;
-
-        if (!state.selectedEntity || !state.locale) {
-            return;
-        }
-
-        this.props.dispatch(history.actions.updateStatus(
+    /*
+     * This is a copy of EntityDetailsBase.updateTranslationStatus().
+     * When changing this function, you probably want to change both.
+     * We might want to refactor to keep the logic in one place only.
+     */
+    updateTranslationStatus = (translationId: number, change: string, ignoreWarnings: ?boolean) => {
+        const { nextEntity, parameters, pluralForm, router, dispatch } = this.props;
+        dispatch(history.actions.updateStatus(
             change,
-            state.selectedEntity.pk,
-            state.locale.code,
-            state.parameters.resource,
-            state.pluralForm,
+            parameters.entity,
+            parameters.locale,
+            parameters.resource,
+            pluralForm,
             translationId,
-            state.nextEntity,
-            state.router,
+            nextEntity,
+            router,
             ignoreWarnings,
         ));
     }

--- a/frontend/src/modules/editor/components/EditorProxy.js
+++ b/frontend/src/modules/editor/components/EditorProxy.js
@@ -40,6 +40,7 @@ export default class EditorProxy extends React.Component<EditorProxyProps> {
                 resetSelectionContent={ this.props.resetSelectionContent }
                 sendTranslation={ this.props.sendTranslation }
                 updateTranslation={ this.props.updateTranslation }
+                updateTranslationStatus={ this.props.updateTranslationStatus }
             />;
         }
 
@@ -52,6 +53,7 @@ export default class EditorProxy extends React.Component<EditorProxyProps> {
             resetSelectionContent={ this.props.resetSelectionContent }
             sendTranslation={ this.props.sendTranslation }
             updateTranslation={ this.props.updateTranslation }
+            updateTranslationStatus={ this.props.updateTranslationStatus }
         />;
     }
 }

--- a/frontend/src/modules/editor/components/EditorProxy.js
+++ b/frontend/src/modules/editor/components/EditorProxy.js
@@ -23,6 +23,22 @@ type EditorProxyProps = {|
  *   - default -> GenericEditor
  */
 export default class EditorProxy extends React.Component<EditorProxyProps> {
+    componentDidUpdate(prevProps: EditorProxyProps) {
+        // Close failed checks popup when content of the editor changes,
+        // but only if the errors and warnings did not change
+        // meaning they were already shown in the previous render
+        const prevEditor = prevProps.editor;
+        const editor = this.props.editor;
+        if (
+            prevEditor.translation !== editor.translation &&
+            prevEditor.errors === editor.errors &&
+            prevEditor.warnings === editor.warnings &&
+            (editor.errors.length || editor.warnings.length)
+        ) {
+            this.props.resetFailedChecks();
+        }
+    }
+
     render() {
         const { entity } = this.props;
 

--- a/frontend/src/modules/editor/components/EditorProxy.js
+++ b/frontend/src/modules/editor/components/EditorProxy.js
@@ -37,6 +37,7 @@ export default class EditorProxy extends React.Component<EditorProxyProps> {
                 editor={ this.props.editor }
                 locale={ this.props.locale }
                 copyOriginalIntoEditor={ this.props.copyOriginalIntoEditor }
+                resetFailedChecks={ this.props.resetFailedChecks }
                 resetSelectionContent={ this.props.resetSelectionContent }
                 sendTranslation={ this.props.sendTranslation }
                 updateTranslation={ this.props.updateTranslation }
@@ -50,6 +51,7 @@ export default class EditorProxy extends React.Component<EditorProxyProps> {
             editor={ this.props.editor }
             locale={ this.props.locale }
             copyOriginalIntoEditor={ this.props.copyOriginalIntoEditor }
+            resetFailedChecks={ this.props.resetFailedChecks }
             resetSelectionContent={ this.props.resetSelectionContent }
             sendTranslation={ this.props.sendTranslation }
             updateTranslation={ this.props.updateTranslation }

--- a/frontend/src/modules/editor/components/EditorProxy.test.js
+++ b/frontend/src/modules/editor/components/EditorProxy.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
+import sinon from 'sinon';
 
 import EditorProxy from './EditorProxy';
 import FluentEditor from './FluentEditor';
@@ -7,6 +8,12 @@ import GenericEditor from './GenericEditor';
 
 
 describe('<EditorProxy>', () => {
+    const EDITOR = {
+        translation: 'world',
+        errors: ['error1'],
+        warnings: ['warning1'],
+    };
+
     it('returns null when the entity is empty', () => {
         const wrapper = shallow(<EditorProxy entity={ null } />);
 
@@ -23,5 +30,42 @@ describe('<EditorProxy>', () => {
         const wrapper = shallow(<EditorProxy entity={ { format: 'po' } } />);
 
         expect(wrapper.type()).toEqual(GenericEditor);
+    });
+
+    it('resets failed checks when translation changes, but errors and warnings do not', () => {
+        const resetMock = sinon.stub();
+
+        const wrapper = mount(<EditorProxy
+            editor={ EDITOR }
+            resetFailedChecks={ resetMock }
+        />);
+
+        wrapper.setProps({
+            editor: {
+                ...EDITOR,
+                translation: 'hello',
+            }
+        });
+
+        expect(resetMock.calledOnce).toBeTruthy();
+    });
+
+    it('keeps failed checks when translation changes, along with errors or warnings', () => {
+        const resetMock = sinon.stub();
+
+        const wrapper = mount(<EditorProxy
+            editor={ EDITOR }
+            resetFailedChecks={ resetMock }
+        />);
+
+        wrapper.setProps({
+            editor: {
+                ...EDITOR,
+                translation: 'hello',
+                errors: [],
+            }
+        });
+
+        expect(resetMock.calledOnce).toBeFalsy();
     });
 });

--- a/frontend/src/modules/editor/components/EditorProxy.test.js
+++ b/frontend/src/modules/editor/components/EditorProxy.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { mount, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import sinon from 'sinon';
 
 import EditorProxy from './EditorProxy';
@@ -35,7 +35,7 @@ describe('<EditorProxy>', () => {
     it('resets failed checks when translation changes, but errors and warnings do not', () => {
         const resetMock = sinon.stub();
 
-        const wrapper = mount(<EditorProxy
+        const wrapper = shallow(<EditorProxy
             editor={ EDITOR }
             resetFailedChecks={ resetMock }
         />);
@@ -53,7 +53,7 @@ describe('<EditorProxy>', () => {
     it('keeps failed checks when translation changes, along with errors or warnings', () => {
         const resetMock = sinon.stub();
 
-        const wrapper = mount(<EditorProxy
+        const wrapper = shallow(<EditorProxy
             editor={ EDITOR }
             resetFailedChecks={ resetMock }
         />);

--- a/frontend/src/modules/editor/components/FailedChecks.css
+++ b/frontend/src/modules/editor/components/FailedChecks.css
@@ -8,12 +8,13 @@
     position: absolute;
     text-align: left;
     width: 100%;
+    z-index: 10;
 
     -moz-box-sizing: border-box;
     box-sizing: border-box;
 }
 
-.failed-checks .cancel {
+.failed-checks .close {
     background: none;
     border: none;
     color: #AAAAAA;
@@ -25,7 +26,7 @@
     padding: 0;
 }
 
-.failed-checks .cancel:hover {
+.failed-checks .close:hover {
     color: #FFFFFF;
 }
 
@@ -45,22 +46,26 @@
     width: calc(100% - 140px);
 }
 
-.failed-checks ul i {
+.failed-checks ul li:before {
+    content: '';
+    font-family: 'Font Awesome 5 Free';
     font-size: 18px;
+    font-style: normal;
+    font-weight: bold;
     margin: 0px 8px;
-    vertical-align: text-bottom;
+    vertical-align: sub;
 }
 
 .failed-checks .warning {
     color: #AAAAAA;
 }
 
-.failed-checks .warning i {
-    color: #4D5967;
+.failed-checks .error:before {
+    color: #F36;
 }
 
-.failed-checks .error i {
-    color: #F36;
+.failed-checks .warning:before {
+    color: #4D5967;
 }
 
 .failed-checks .save-anyway {

--- a/frontend/src/modules/editor/components/FailedChecks.css
+++ b/frontend/src/modules/editor/components/FailedChecks.css
@@ -68,8 +68,24 @@
     color: #4D5967;
 }
 
-.failed-checks .save-anyway {
+.failed-checks .anyway {
+    background: #7BC876;
+    border: none;
+    border-radius: 3px;
     bottom: 10px;
+    color: #272A2F;
+    font-weight: 600;
+    margin-left: 10px;
+    padding: 10px;
     position: absolute;
     right: 10px;
+    text-transform: uppercase;
+}
+
+.failed-checks .anyway.suggest {
+    background: #4FC4F6;
+}
+
+.failed-checks .anyway:hover {
+    color: #EBEBEB;
 }

--- a/frontend/src/modules/editor/components/FailedChecks.css
+++ b/frontend/src/modules/editor/components/FailedChecks.css
@@ -1,0 +1,70 @@
+.failed-checks {
+    background: #272A2F;
+    border-top: 1px solid #5E6475;
+    bottom: 0;
+    left: 0;
+    min-height: 90px;
+    padding: 10px;
+    position: absolute;
+    text-align: left;
+    width: 100%;
+
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+}
+
+.failed-checks .cancel {
+    background: none;
+    border: none;
+    color: #AAAAAA;
+    float: right;
+    font-size: 24px;
+    font-weight: 100;
+    line-height: 22px;
+    margin-top: -3px;
+    padding: 0;
+}
+
+.failed-checks .cancel:hover {
+    color: #FFFFFF;
+}
+
+.failed-checks .title {
+    color: #F36;
+    font-size: 14px;
+    font-weight: 300;
+    text-transform: uppercase;
+    padding-bottom: 5px;
+}
+
+.failed-checks ul {
+    font-style: italic;
+    line-height: 22px;
+    list-style: none;
+    margin: 0px;
+    width: calc(100% - 140px);
+}
+
+.failed-checks ul i {
+    font-size: 18px;
+    margin: 0px 8px;
+    vertical-align: text-bottom;
+}
+
+.failed-checks .warning {
+    color: #AAAAAA;
+}
+
+.failed-checks .warning i {
+    color: #4D5967;
+}
+
+.failed-checks .error i {
+    color: #F36;
+}
+
+.failed-checks .save-anyway {
+    bottom: 10px;
+    position: absolute;
+    right: 10px;
+}

--- a/frontend/src/modules/editor/components/FailedChecks.js
+++ b/frontend/src/modules/editor/components/FailedChecks.js
@@ -6,7 +6,12 @@ import { Localized } from 'fluent-react';
 import './FailedChecks.css';
 
 
+import type { UserState } from 'core/user';
+
+
 type Props = {|
+    source: '' | 'stored' | 'submitted' | 'approved',
+    user: UserState,
     errors: Array<string>,
     warnings: Array<string>,
     resetFailedChecks: () => void,
@@ -21,8 +26,16 @@ export default class FailedChecks extends React.Component<Props> {
         this.props.resetFailedChecks();
     }
 
+    approveAnyway = () => {
+        return null;
+    }
+
+    submitAnyway = () => {
+        return null;
+    }
+
     render() {
-        const { errors, warnings } = this.props;
+        const { source, user, errors, warnings } = this.props;
 
         if (!errors.length && !warnings.length) {
             return null;
@@ -60,6 +73,35 @@ export default class FailedChecks extends React.Component<Props> {
                     })
                 }
             </ul>
+            { (source === 'stored' || errors.length) ? null :
+                source === 'approved' ?
+                <Localized id="editor-FailedChecks--approve-anyway">
+                    <button
+                        className="approve anyway"
+                        onClick={ this.approveAnyway }
+                    >
+                        Approve anyway
+                    </button>
+                </Localized>
+                : user.settings.forceSuggestions ?
+                <Localized id="editor-FailedChecks--suggest-anyway">
+                    <button
+                        className="suggest anyway"
+                        onClick={ this.submitAnyway }
+                    >
+                        Suggest anyway
+                    </button>
+                </Localized>
+                :
+                <Localized id="editor-FailedChecks--save-anyway">
+                    <button
+                        className="save anyway"
+                        onClick={ this.submitAnyway }
+                    >
+                        Save anyway
+                    </button>
+                </Localized>
+            }
         </div>;
     }
 }

--- a/frontend/src/modules/editor/components/FailedChecks.js
+++ b/frontend/src/modules/editor/components/FailedChecks.js
@@ -10,12 +10,17 @@ import type { UserState } from 'core/user';
 
 
 type Props = {|
-    source: '' | 'stored' | 'submitted' | 'approved',
+    source: '' | 'stored' | 'submitted' | number,
     user: UserState,
     errors: Array<string>,
     warnings: Array<string>,
     resetFailedChecks: () => void,
     sendTranslation: (ignoreWarnings: ?boolean) => void,
+    updateTranslationStatus: (
+        translationId: number,
+        change: string,
+        ignoreWarnings: ?boolean,
+    ) => void,
 |};
 
 
@@ -28,7 +33,10 @@ export default class FailedChecks extends React.Component<Props> {
     }
 
     approveAnyway = () => {
-        return null;
+        const translationId = this.props.source;
+        if (typeof(translationId) === 'number') {
+            this.props.updateTranslationStatus(translationId, 'approve', true);
+        }
     }
 
     submitAnyway = () => {
@@ -75,7 +83,7 @@ export default class FailedChecks extends React.Component<Props> {
                 }
             </ul>
             { (source === 'stored' || errors.length) ? null :
-                source === 'approved' ?
+                source !== 'submitted' ?
                 <Localized id="editor-FailedChecks--approve-anyway">
                     <button
                         className="approve anyway"

--- a/frontend/src/modules/editor/components/FailedChecks.js
+++ b/frontend/src/modules/editor/components/FailedChecks.js
@@ -9,44 +9,19 @@ import './FailedChecks.css';
 type Props = {|
     errors: Array<string>,
     warnings: Array<string>,
-|};
-
-
-type State = {|
-    visible: boolean,
+    resetFailedChecks: () => void,
 |};
 
 
 /*
  * Renders the failed checks popup.
  */
-export default class FailedChecks extends React.Component<Props, State> {
-    constructor(props: Props) {
-        super(props);
-        this.state = {
-            visible: true,
-        };
-    }
-
-    componentDidUpdate(prevProps: Props, prevState: State) {
-        if (prevState.visible) {
-            this.setState(() => {
-                return { visible: false };
-            });
-        }
-    }
-
+export default class FailedChecks extends React.Component<Props> {
     closeFailedChecks = () => {
-        this.setState(() => {
-            return { visible: false };
-        });
+        this.props.resetFailedChecks();
     }
 
     render() {
-        if (!this.state.visible) {
-            return null;
-        }
-
         const { errors, warnings } = this.props;
 
         if (!errors.length && !warnings.length) {

--- a/frontend/src/modules/editor/components/FailedChecks.js
+++ b/frontend/src/modules/editor/components/FailedChecks.js
@@ -1,0 +1,85 @@
+/* @flow */
+
+import * as React from 'react';
+import { Localized } from 'fluent-react';
+
+import './FailedChecks.css';
+
+import type { DbEntity } from 'modules/entitieslist';
+
+
+type Props = {|
+    errors: Array<string>,
+    warnings: Array<string>,
+|};
+
+
+type State = {|
+    visible: boolean,
+|};
+
+
+/*
+ * Renders an appropriate Editor for an entity, based on its file format.
+ */
+export default class FailedChecks extends React.Component<Props, State> {
+    constructor() {
+        super();
+        this.state = {
+            visible: true,
+        };
+    }
+
+    componentDidUpdate(prevProps: Props, prevState: State) {
+        if (!prevState.visible) {
+            this.setState(() => {
+                return { visible: true };
+            });
+        }
+    }
+
+    closeFailedChecks = () => {
+        this.setState(() => {
+            return { visible: false };
+        });
+    }
+
+    render() {
+        if (!this.state.visible) {
+            return null;
+        }
+
+        const { errors, warnings } = this.props;
+
+        if (!errors.length && !warnings.length) {
+            return null;
+        }
+
+        return <div className="failed-checks">
+            <button className="cancel" onClick={ this.closeFailedChecks }>&times;</button>
+            <Localized
+                id="editor-FailedChecks--title"
+            >
+                <p className="title">The following checks have failed</p>
+            </Localized>
+            <ul>
+                {
+                    errors.map((error, key) => {
+                        return <li className="error" key={ key }>
+                            <i className="fa fa-times-circle"></i>
+                            { error }
+                        </li>;
+                    })
+                }
+                {
+                    warnings.map((warning, key) => {
+                        return <li className="warning" key={ key }>
+                            <i className="fa fa-times-circle"></i>
+                            { warning }
+                        </li>;
+                    })
+                }
+            </ul>
+        </div>;
+    }
+}

--- a/frontend/src/modules/editor/components/FailedChecks.js
+++ b/frontend/src/modules/editor/components/FailedChecks.js
@@ -15,6 +15,7 @@ type Props = {|
     errors: Array<string>,
     warnings: Array<string>,
     resetFailedChecks: () => void,
+    sendTranslation: (ignoreWarnings: ?boolean) => void,
 |};
 
 
@@ -31,7 +32,7 @@ export default class FailedChecks extends React.Component<Props> {
     }
 
     submitAnyway = () => {
-        return null;
+        this.props.sendTranslation(true);
     }
 
     render() {

--- a/frontend/src/modules/editor/components/FailedChecks.js
+++ b/frontend/src/modules/editor/components/FailedChecks.js
@@ -5,8 +5,6 @@ import { Localized } from 'fluent-react';
 
 import './FailedChecks.css';
 
-import type { DbEntity } from 'modules/entitieslist';
-
 
 type Props = {|
     errors: Array<string>,
@@ -20,11 +18,11 @@ type State = {|
 
 
 /*
- * Renders an appropriate Editor for an entity, based on its file format.
+ * Renders the failed checks popup.
  */
 export default class FailedChecks extends React.Component<Props, State> {
-    constructor() {
-        super();
+    constructor(props: Props) {
+        super(props);
         this.state = {
             visible: true,
         };
@@ -56,7 +54,16 @@ export default class FailedChecks extends React.Component<Props, State> {
         }
 
         return <div className="failed-checks">
-            <button className="cancel" onClick={ this.closeFailedChecks }>&times;</button>
+            <Localized
+                id="editor-FailedChecks--close"
+                attrs={{ ariaLabel: true }}
+            >
+                <button
+                    aria-label="Close failed checks popup"
+                    className="close"
+                    onClick={ this.closeFailedChecks }
+                >×</button>
+            </Localized>
             <Localized
                 id="editor-FailedChecks--title"
             >
@@ -66,7 +73,6 @@ export default class FailedChecks extends React.Component<Props, State> {
                 {
                     errors.map((error, key) => {
                         return <li className="error" key={ key }>
-                            <i className="fa fa-times-circle"></i>
                             { error }
                         </li>;
                     })
@@ -74,7 +80,6 @@ export default class FailedChecks extends React.Component<Props, State> {
                 {
                     warnings.map((warning, key) => {
                         return <li className="warning" key={ key }>
-                            <i className="fa fa-times-circle"></i>
                             { warning }
                         </li>;
                     })

--- a/frontend/src/modules/editor/components/FailedChecks.js
+++ b/frontend/src/modules/editor/components/FailedChecks.js
@@ -29,9 +29,9 @@ export default class FailedChecks extends React.Component<Props, State> {
     }
 
     componentDidUpdate(prevProps: Props, prevState: State) {
-        if (!prevState.visible) {
+        if (prevState.visible) {
             this.setState(() => {
-                return { visible: true };
+                return { visible: false };
             });
         }
     }

--- a/frontend/src/modules/editor/components/FailedChecks.js
+++ b/frontend/src/modules/editor/components/FailedChecks.js
@@ -5,7 +5,6 @@ import { Localized } from 'fluent-react';
 
 import './FailedChecks.css';
 
-
 import type { UserState } from 'core/user';
 
 

--- a/frontend/src/modules/editor/components/FailedChecks.test.js
+++ b/frontend/src/modules/editor/components/FailedChecks.test.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import FailedChecks from './FailedChecks';
+
+
+describe('<FailedChecks>', () => {
+    it('do not render if no errors or warnings present', () => {
+        const wrapper = shallow(<FailedChecks
+            errors={ [] }
+            warnings={ [] }
+        />);
+
+        expect(wrapper.find('.failed-checks')).toHaveLength(0);
+    });
+
+    it('render popup with errors and warnings', () => {
+        const wrapper = shallow(<FailedChecks
+            errors={ ['Error1'] }
+            warnings={ ['Warning1', 'Warning2'] }
+        />);
+
+        expect(wrapper.find('.failed-checks')).toHaveLength(1);
+        expect(wrapper.find('#editor-FailedChecks--close')).toHaveLength(1);
+        expect(wrapper.find('#editor-FailedChecks--title')).toHaveLength(1);
+        expect(wrapper.find('.error')).toHaveLength(1);
+        expect(wrapper.find('.warning')).toHaveLength(2);
+    });
+
+    it('render save anyway button if translation with warnings submitted', () => {
+        const wrapper = shallow(<FailedChecks
+            source={ 'submitted' }
+            errors={ [] }
+            warnings={ ['Warning1'] }
+            user={ {
+                settings: {
+                    forceSuggestions: false,
+                },
+            } }
+        />);
+
+        expect(wrapper.find('.save.anyway')).toHaveLength(1);
+    });
+
+    it('render suggest anyway button if translation with warnings suggested', () => {
+        const wrapper = shallow(<FailedChecks
+            source={ 'submitted' }
+            errors={ [] }
+            warnings={ ['Warning1'] }
+            user={ {
+                settings: {
+                    forceSuggestions: true,
+                },
+            } }
+        />);
+
+        expect(wrapper.find('.suggest.anyway')).toHaveLength(1);
+    });
+
+    it('render approve anyway button if translation with warnings approved', () => {
+        const wrapper = shallow(<FailedChecks
+            errors={ [] }
+            warnings={ ['Warning1'] }
+            user={ {
+                settings: {
+                    forceSuggestions: true,
+                },
+            } }
+        />);
+
+        expect(wrapper.find('.approve.anyway')).toHaveLength(1);
+    });
+});

--- a/frontend/src/modules/editor/components/FluentEditor.js
+++ b/frontend/src/modules/editor/components/FluentEditor.js
@@ -52,7 +52,7 @@ export default class FluentEditor extends React.Component<EditorProps> {
         this.aceEditor.current.editor.clearSelection();
     }
 
-    componentDidUpdate() {
+    componentDidUpdate(prevProps: EditorProps) {
         if (!this.aceEditor.current) {
             return;
         }
@@ -71,6 +71,20 @@ export default class FluentEditor extends React.Component<EditorProps> {
         }
 
         this.aceEditor.current.editor.focus();
+
+        // Close failed checks popup when content of the editor changes,
+        // but only if the errors and warnings did not change
+        // meaning they were already shown in the previous render
+        const prevEditor = prevProps.editor;
+        const editor = this.props.editor;
+        if (
+            prevEditor.translation !== editor.translation &&
+            prevEditor.errors === editor.errors &&
+            prevEditor.warnings === editor.warnings &&
+            (editor.errors.length || editor.warnings.length)
+        ) {
+            this.props.resetFailedChecks();
+        }
     }
 
     updateTranslationSelectionWith(content: string) {

--- a/frontend/src/modules/editor/components/FluentEditor.js
+++ b/frontend/src/modules/editor/components/FluentEditor.js
@@ -52,7 +52,7 @@ export default class FluentEditor extends React.Component<EditorProps> {
         this.aceEditor.current.editor.clearSelection();
     }
 
-    componentDidUpdate(prevProps: EditorProps) {
+    componentDidUpdate() {
         if (!this.aceEditor.current) {
             return;
         }
@@ -71,20 +71,6 @@ export default class FluentEditor extends React.Component<EditorProps> {
         }
 
         this.aceEditor.current.editor.focus();
-
-        // Close failed checks popup when content of the editor changes,
-        // but only if the errors and warnings did not change
-        // meaning they were already shown in the previous render
-        const prevEditor = prevProps.editor;
-        const editor = this.props.editor;
-        if (
-            prevEditor.translation !== editor.translation &&
-            prevEditor.errors === editor.errors &&
-            prevEditor.warnings === editor.warnings &&
-            (editor.errors.length || editor.warnings.length)
-        ) {
-            this.props.resetFailedChecks();
-        }
     }
 
     updateTranslationSelectionWith(content: string) {

--- a/frontend/src/modules/editor/components/FluentEditor.test.js
+++ b/frontend/src/modules/editor/components/FluentEditor.test.js
@@ -10,7 +10,7 @@ describe('<FluentEditor>', () => {
         translation: 'world',
     };
 
-    it('renders a textarea with some content', () => {
+    it('renders ReactAce editor with some content', () => {
         const wrapper = shallow(<FluentEditor editor={ EDITOR } />);
 
         expect(wrapper.find('ReactAce')).toHaveLength(1);

--- a/frontend/src/modules/editor/components/GenericEditor.js
+++ b/frontend/src/modules/editor/components/GenericEditor.js
@@ -11,6 +11,7 @@ export type EditorProps = {|
     editor: EditorState,
     locale: Locale,
     copyOriginalIntoEditor: () => void,
+    resetFailedChecks: () => void,
     resetSelectionContent: () => void,
     sendTranslation: (ignoreWarnings: ?boolean) => void,
     updateTranslation: (string) => void,
@@ -43,7 +44,7 @@ export default class GenericEditor extends React.Component<EditorProps> {
         this.textarea.current.setSelectionRange(0, 0);
     }
 
-    componentDidUpdate() {
+    componentDidUpdate(prevProps: EditorProps) {
         // If there is content to add to the editor, do so, then remove
         // the content so it isn't added again.
         // This is an abuse of the redux store, because we want to update
@@ -61,6 +62,20 @@ export default class GenericEditor extends React.Component<EditorProps> {
 
         if (this.props.editor.changeSource === 'external') {
             this.textarea.current.setSelectionRange(0, 0);
+        }
+
+        // Close failed checks popup when content of the editor changes,
+        // but only if the errors and warnings did not change
+        // meaning they were already shown in the previous render
+        const prevEditor = prevProps.editor;
+        const editor = this.props.editor;
+        if (
+            prevEditor.translation !== editor.translation &&
+            prevEditor.errors === editor.errors &&
+            prevEditor.warnings === editor.warnings &&
+            (editor.errors.length || editor.warnings.length)
+        ) {
+            this.props.resetFailedChecks();
         }
     }
 

--- a/frontend/src/modules/editor/components/GenericEditor.js
+++ b/frontend/src/modules/editor/components/GenericEditor.js
@@ -125,6 +125,18 @@ export default class GenericEditor extends React.Component<EditorProps> {
             }
         }
 
+        // On Esc, close failed checks popup if open.
+        if (key === 27) {
+            handledEvent = true;
+
+            const errors = this.props.editor.errors;
+            const warnings = this.props.editor.warnings;
+
+            if (errors.length || warnings.length) {
+                this.props.resetFailedChecks();
+            }
+        }
+
         // On Ctrl + Shift + C, copy the original translation.
         if (key === 67 && event.ctrlKey && event.shiftKey && !event.altKey) {
             handledEvent = true;

--- a/frontend/src/modules/editor/components/GenericEditor.js
+++ b/frontend/src/modules/editor/components/GenericEditor.js
@@ -12,7 +12,7 @@ export type EditorProps = {|
     locale: Locale,
     copyOriginalIntoEditor: () => void,
     resetSelectionContent: () => void,
-    sendTranslation: () => void,
+    sendTranslation: (ignoreWarnings: ?boolean) => void,
     updateTranslation: (string) => void,
 |};
 
@@ -91,7 +91,10 @@ export default class GenericEditor extends React.Component<EditorProps> {
         // On Enter, send the current translation.
         if (key === 13 && !event.ctrlKey && !event.shiftKey && !event.altKey) {
             handledEvent = true;
-            this.props.sendTranslation();
+            const errors = this.props.editor.errors;
+            const warnings = this.props.editor.warnings;
+            const ignoreWarnings = !!(errors.length || warnings.length);
+            this.props.sendTranslation(ignoreWarnings);
         }
 
         // On Ctrl + Shift + C, copy the original translation.

--- a/frontend/src/modules/editor/components/GenericEditor.js
+++ b/frontend/src/modules/editor/components/GenericEditor.js
@@ -14,6 +14,11 @@ export type EditorProps = {|
     resetSelectionContent: () => void,
     sendTranslation: (ignoreWarnings: ?boolean) => void,
     updateTranslation: (string) => void,
+    updateTranslationStatus: (
+        translationId: number,
+        change: string,
+        ignoreWarnings: ?boolean,
+    ) => void,
 |};
 
 
@@ -91,10 +96,18 @@ export default class GenericEditor extends React.Component<EditorProps> {
         // On Enter, send the current translation.
         if (key === 13 && !event.ctrlKey && !event.shiftKey && !event.altKey) {
             handledEvent = true;
+
             const errors = this.props.editor.errors;
             const warnings = this.props.editor.warnings;
+            const source = this.props.editor.source;
             const ignoreWarnings = !!(errors.length || warnings.length);
-            this.props.sendTranslation(ignoreWarnings);
+
+            if (typeof(source) === 'number') {
+                this.props.updateTranslationStatus(source, 'approve', ignoreWarnings);
+            }
+            else {
+                this.props.sendTranslation(ignoreWarnings);
+            }
         }
 
         // On Ctrl + Shift + C, copy the original translation.

--- a/frontend/src/modules/editor/components/GenericEditor.js
+++ b/frontend/src/modules/editor/components/GenericEditor.js
@@ -44,7 +44,7 @@ export default class GenericEditor extends React.Component<EditorProps> {
         this.textarea.current.setSelectionRange(0, 0);
     }
 
-    componentDidUpdate(prevProps: EditorProps) {
+    componentDidUpdate() {
         // If there is content to add to the editor, do so, then remove
         // the content so it isn't added again.
         // This is an abuse of the redux store, because we want to update
@@ -62,20 +62,6 @@ export default class GenericEditor extends React.Component<EditorProps> {
 
         if (this.props.editor.changeSource === 'external') {
             this.textarea.current.setSelectionRange(0, 0);
-        }
-
-        // Close failed checks popup when content of the editor changes,
-        // but only if the errors and warnings did not change
-        // meaning they were already shown in the previous render
-        const prevEditor = prevProps.editor;
-        const editor = this.props.editor;
-        if (
-            prevEditor.translation !== editor.translation &&
-            prevEditor.errors === editor.errors &&
-            prevEditor.warnings === editor.warnings &&
-            (editor.errors.length || editor.warnings.length)
-        ) {
-            this.props.resetFailedChecks();
         }
     }
 

--- a/frontend/src/modules/editor/components/GenericEditor.test.js
+++ b/frontend/src/modules/editor/components/GenericEditor.test.js
@@ -81,6 +81,60 @@ describe('<GenericEditor>', () => {
         expect(mockSend.calledOnce).toBeTruthy();
     });
 
+    it('approves the translation on Enter if failed checks triggered by approval', () => {
+        const mockSend = sinon.spy();
+
+        const editor = {
+            ...EDITOR,
+            errors: ['error1'],
+            warnings: ['warning1'],
+            source: 1,
+        }
+
+        const wrapper = shallow(<GenericEditor
+            editor={ editor }
+            locale={ DEFAULT_LOCALE }
+            updateTranslationStatus={ mockSend }
+        />);
+
+        const event = {
+            preventDefault: sinon.spy(),
+            keyCode: 13,  // Enter
+            altKey: false,
+            ctrlKey: false,
+            shiftKey: false,
+        };
+
+        expect(mockSend.calledOnce).toBeFalsy();
+        wrapper.find('textarea').simulate('keydown', event);
+        expect(mockSend.calledOnce).toBeTruthy();
+    });
+
+    it('closes failed checks popup if open on Esc', () => {
+        const mockSend = sinon.spy();
+
+        const editor = {
+            ...EDITOR,
+            errors: ['error1'],
+            warnings: ['warning1'],
+        }
+
+        const wrapper = shallow(<GenericEditor
+            editor={ editor }
+            locale={ DEFAULT_LOCALE }
+            resetFailedChecks={ mockSend }
+        />);
+
+        const event = {
+            preventDefault: sinon.spy(),
+            keyCode: 27,  // Esc
+        };
+
+        expect(mockSend.calledOnce).toBeFalsy();
+        wrapper.find('textarea').simulate('keydown', event);
+        expect(mockSend.calledOnce).toBeTruthy();
+    });
+
     it('copies the original into the Editor on Ctrl + Shift + C', () => {
         const mockCopy = sinon.spy();
         const wrapper = shallow(<GenericEditor

--- a/frontend/src/modules/editor/components/GenericEditor.test.js
+++ b/frontend/src/modules/editor/components/GenericEditor.test.js
@@ -13,6 +13,8 @@ const DEFAULT_LOCALE = {
 
 const EDITOR = {
     translation: 'world',
+    errors: [],
+    warnings: [],
 };
 
 

--- a/frontend/src/modules/editor/reducer.js
+++ b/frontend/src/modules/editor/reducer.js
@@ -33,7 +33,7 @@ export type EditorState = {|
     +errors: Array<string>,
     +warnings: Array<string>,
 
-    // A source of failed checks (erros and warnings). Possible values:
+    // A source of failed checks (errors and warnings). Possible values:
     //   - '': no failed checks are displayed (default)
     //   - 'stored': failed checks of the translation stored in the DB
     //   - 'submitted': failed checks of the submitted translation

--- a/frontend/src/modules/editor/reducer.js
+++ b/frontend/src/modules/editor/reducer.js
@@ -32,7 +32,13 @@ export type EditorState = {|
     +selectionReplacementContent: string,
     +errors: Array<string>,
     +warnings: Array<string>,
-    +source: '' | 'stored' | 'submitted' | 'approved',
+
+    // A source of failed checks (erros and warnings). Possible values:
+    //   - '': no failed checks are displayed (default)
+    //   - 'stored': failed checks of the translation stored in the DB
+    //   - 'submitted': failed checks of the submitted translation
+    //   - number (translationId): failed checks of the approved translation
+    +source: '' | 'stored' | 'submitted' | number,
 |};
 
 

--- a/frontend/src/modules/editor/reducer.js
+++ b/frontend/src/modules/editor/reducer.js
@@ -32,6 +32,7 @@ export type EditorState = {|
     +selectionReplacementContent: string,
     +errors: Array<string>,
     +warnings: Array<string>,
+    +source: '' | 'stored' | 'submitted' | 'approved',
 |};
 
 
@@ -72,6 +73,7 @@ const initial: EditorState = {
     selectionReplacementContent: '',
     errors: [],
     warnings: [],
+    source: '',
 };
 
 export default function reducer(
@@ -90,6 +92,7 @@ export default function reducer(
                 ...state,
                 errors: extractFailedChecksOfType(action.failedChecks, 'Errors'),
                 warnings: extractFailedChecksOfType(action.failedChecks, 'Warnings'),
+                source: action.source,
             };
         case UPDATE_SELECTION:
             return {

--- a/frontend/src/modules/editor/reducer.js
+++ b/frontend/src/modules/editor/reducer.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import {
+    RESET_FAILED_CHECKS,
     RESET_SELECTION,
     UPDATE,
     UPDATE_FAILED_CHECKS,
@@ -9,6 +10,7 @@ import {
 
 import type {
     FailedChecks,
+    ResetFailedChecksAction,
     ResetSelectionAction,
     UpdateAction,
     UpdateFailedChecksAction,
@@ -17,6 +19,7 @@ import type {
 
 
 type Action =
+    | ResetFailedChecksAction
     | ResetSelectionAction
     | UpdateAction
     | UpdateFailedChecksAction
@@ -93,6 +96,12 @@ export default function reducer(
                 ...state,
                 selectionReplacementContent: action.content,
                 changeSource: 'internal',
+            };
+        case RESET_FAILED_CHECKS:
+            return {
+                ...state,
+                errors: [],
+                warnings: [],
             };
         case RESET_SELECTION:
             return {

--- a/frontend/src/modules/editor/reducer.js
+++ b/frontend/src/modules/editor/reducer.js
@@ -37,7 +37,7 @@ export type EditorState = {|
  */
 function extractFailedChecksOfType(
     failedChecks: FailedChecks,
-    type: string,
+    type: 'Errors' | 'Warnings',
 ): Array<string> {
     let extractedFailedChecks = [];
     const keys = Object.keys(failedChecks);

--- a/frontend/src/modules/entitieslist/reducer.js
+++ b/frontend/src/modules/entitieslist/reducer.js
@@ -13,6 +13,7 @@ export type Action =
 ;
 
 export type Translation = {
+    +pk: number,
     +string: ?string,
     +approved: boolean,
     +fuzzy: boolean,

--- a/frontend/src/modules/entitydetails/components/EntityDetails.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.js
@@ -110,7 +110,11 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
 
         // Only show failed checks for active translations that are approved or fuzzy,
         // i.e. when their status icon is colored as error/warning in the string list
-        if (translation && (translation.approved || translation.fuzzy)) {
+        if (
+            translation &&
+            (translation.errors.length || translation.warnings.length) &&
+            (translation.approved || translation.fuzzy)
+        ) {
             const failedChecks = {
                 clErrors: translation.errors,
                 clWarnings: translation.warnings,

--- a/frontend/src/modules/entitydetails/components/EntityDetails.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.js
@@ -81,6 +81,7 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
             selectedEntity !== prevProps.selectedEntity
         ) {
             this.updateEditorTranslation(activeTranslation);
+            this.updateFailedChecks();
             this.fetchHelpersData();
         }
     }
@@ -95,6 +96,32 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
         dispatch(history.actions.get(parameters.entity, parameters.locale, pluralForm));
         dispatch(machinery.actions.get(selectedEntity.original, locale, selectedEntity.pk));
         dispatch(otherlocales.actions.get(parameters.entity, parameters.locale));
+    }
+
+    updateFailedChecks() {
+        const { dispatch, pluralForm, selectedEntity } = this.props;
+
+        if (!selectedEntity) {
+            return;
+        }
+
+        const plural = pluralForm === -1 ? 0 : pluralForm;
+        const translation = selectedEntity.translation[plural];
+
+        // Only show failed checks for active translations that are approved or fuzzy,
+        // i.e. when their status icon is colored as error/warning in the string list
+        if (translation && (translation.approved || translation.fuzzy)) {
+            const failedChecks = {
+                clErrors: translation.errors,
+                clWarnings: translation.warnings,
+                pErrors: [],
+                pndbWarnings: [],
+                ttWarnings: [],
+            };
+            dispatch(editor.actions.updateFailedChecks(failedChecks));
+        } else {
+            dispatch(editor.actions.resetFailedChecks());
+        }
     }
 
     searchMachinery = (query: string) => {

--- a/frontend/src/modules/entitydetails/components/EntityDetails.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.js
@@ -118,7 +118,7 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
                 pndbWarnings: [],
                 ttWarnings: [],
             };
-            dispatch(editor.actions.updateFailedChecks(failedChecks));
+            dispatch(editor.actions.updateFailedChecks(failedChecks, 'stored'));
         } else {
             dispatch(editor.actions.resetFailedChecks());
         }

--- a/frontend/src/modules/entitydetails/components/EntityDetails.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.js
@@ -183,6 +183,11 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
         ));
     }
 
+    /*
+     * This is a copy of EditorBase.updateTranslationStatus().
+     * When changing this function, you probably want to change both.
+     * We might want to refactor to keep the logic in one place only.
+     */
     updateTranslationStatus = (translationId: number, change: string) => {
         const { nextEntity, parameters, pluralForm, router, dispatch } = this.props;
         dispatch(history.actions.updateStatus(

--- a/frontend/src/modules/entitydetails/components/EntityDetails.test.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.test.js
@@ -96,12 +96,12 @@ function createEntityDetailsWithStore() {
 
 
 describe('<EntityDetailsBase>', () => {
-    beforeAll(() => {
+    beforeEach(() => {
         sinon.stub(editor.actions, 'updateFailedChecks').returns({ type: 'whatever'});
         sinon.stub(editor.actions, 'resetFailedChecks').returns({ type: 'whatever'});
     });
 
-    afterAll(() => {
+    afterEach(() => {
         editor.actions.updateFailedChecks.restore();
         editor.actions.resetFailedChecks.restore();
     });
@@ -156,7 +156,7 @@ describe('<EntityDetailsBase>', () => {
             },
         });
 
-        expect(editor.actions.updateFailedChecks.calledOnce).toBeTruthy();
+        expect(editor.actions.updateFailedChecks.calledOnce).toBeFalsy();
         expect(editor.actions.resetFailedChecks.calledOnce).toBeTruthy();
     });
 });

--- a/frontend/src/modules/entitydetails/components/EntityDetails.test.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.test.js
@@ -6,7 +6,7 @@ import { createReduxStore } from 'test/store';
 import { shallowUntilTarget } from 'test/utils';
 
 // import * as navigation from 'core/navigation';
-// import * as editor from 'modules/editor';
+import * as editor from 'modules/editor';
 import * as history from 'modules/history';
 
 import EntityDetails, { EntityDetailsBase } from './EntityDetails';
@@ -106,6 +106,43 @@ describe('<EntityDetailsBase>', () => {
 
         expect(wrapper.text()).toContain('Metadata');
         expect(wrapper.text()).toContain('Editor');
+    });
+
+    it('shows failed checks for approved (or fuzzy) translations with errors or warnings', () => {
+        const wrapper = createShallowEntityDetails();
+
+        wrapper.setProps({
+            selectedEntity: {
+                pk: 2,
+                original: 'something',
+                translation: [{
+                    approved: true,
+                    string: 'quelque chose',
+                    errors: ['Error1'],
+                }],
+            },
+        });
+
+        expect(editor.actions.updateFailedChecks.calledOnce.toBeTruthy());
+        expect(editor.actions.resetFailedChecks.calledOnce.toBeFalsy());
+    });
+
+    it('hides failed checks for approved (or fuzzy) translations without errors or warnings', () => {
+        const wrapper = createShallowEntityDetails();
+
+        wrapper.setProps({
+            selectedEntity: {
+                pk: 2,
+                original: 'something',
+                translation: [{
+                    approved: true,
+                    string: 'quelque chose',
+                }],
+            },
+        });
+
+        expect(editor.actions.updateFailedChecks.calledOnce.toBeFalsy());
+        expect(editor.actions.resetFailedChecks.calledOnce.toBeTruthy());
     });
 });
 

--- a/frontend/src/modules/entitydetails/components/EntityDetails.test.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.test.js
@@ -96,6 +96,16 @@ function createEntityDetailsWithStore() {
 
 
 describe('<EntityDetailsBase>', () => {
+    beforeAll(() => {
+        sinon.stub(editor.actions, 'updateFailedChecks').returns({ type: 'whatever'});
+        sinon.stub(editor.actions, 'resetFailedChecks').returns({ type: 'whatever'});
+    });
+
+    afterAll(() => {
+        editor.actions.updateFailedChecks.restore();
+        editor.actions.resetFailedChecks.restore();
+    });
+
     it('shows an empty section when no entity is selected', () => {
         const wrapper = createShallowEntityDetails(null);
         expect(wrapper.text()).toContain('');
@@ -112,6 +122,7 @@ describe('<EntityDetailsBase>', () => {
         const wrapper = createShallowEntityDetails();
 
         wrapper.setProps({
+            pluralForm: -1,
             selectedEntity: {
                 pk: 2,
                 original: 'something',
@@ -123,14 +134,15 @@ describe('<EntityDetailsBase>', () => {
             },
         });
 
-        expect(editor.actions.updateFailedChecks.calledOnce.toBeTruthy());
-        expect(editor.actions.resetFailedChecks.calledOnce.toBeFalsy());
+        expect(editor.actions.updateFailedChecks.calledOnce).toBeTruthy();
+        expect(editor.actions.resetFailedChecks.calledOnce).toBeFalsy();
     });
 
     it('hides failed checks for approved (or fuzzy) translations without errors or warnings', () => {
         const wrapper = createShallowEntityDetails();
 
         wrapper.setProps({
+            pluralForm: -1,
             selectedEntity: {
                 pk: 2,
                 original: 'something',
@@ -141,8 +153,8 @@ describe('<EntityDetailsBase>', () => {
             },
         });
 
-        expect(editor.actions.updateFailedChecks.calledOnce.toBeFalsy());
-        expect(editor.actions.resetFailedChecks.calledOnce.toBeTruthy());
+        expect(editor.actions.updateFailedChecks.calledOnce).toBeFalsy();
+        expect(editor.actions.resetFailedChecks.calledOnce).toBeTruthy();
     });
 });
 

--- a/frontend/src/modules/entitydetails/components/EntityDetails.test.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.test.js
@@ -96,12 +96,17 @@ function createEntityDetailsWithStore() {
 
 
 describe('<EntityDetailsBase>', () => {
-    beforeEach(() => {
+    beforeAll(() => {
         sinon.stub(editor.actions, 'updateFailedChecks').returns({ type: 'whatever'});
         sinon.stub(editor.actions, 'resetFailedChecks').returns({ type: 'whatever'});
     });
 
     afterEach(() => {
+        editor.actions.updateFailedChecks.reset();
+        editor.actions.resetFailedChecks.reset();
+    });
+
+    afterAll(() => {
         editor.actions.updateFailedChecks.restore();
         editor.actions.resetFailedChecks.restore();
     });

--- a/frontend/src/modules/entitydetails/components/EntityDetails.test.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.test.js
@@ -130,6 +130,7 @@ describe('<EntityDetailsBase>', () => {
                     approved: true,
                     string: 'quelque chose',
                     errors: ['Error1'],
+                    warnings: ['Warning1'],
                 }],
             },
         });
@@ -149,11 +150,13 @@ describe('<EntityDetailsBase>', () => {
                 translation: [{
                     approved: true,
                     string: 'quelque chose',
+                    errors: [],
+                    warnings: [],
                 }],
             },
         });
 
-        expect(editor.actions.updateFailedChecks.calledOnce).toBeFalsy();
+        expect(editor.actions.updateFailedChecks.calledOnce).toBeTruthy();
         expect(editor.actions.resetFailedChecks.calledOnce).toBeTruthy();
     });
 });

--- a/frontend/src/modules/history/actions.js
+++ b/frontend/src/modules/history/actions.js
@@ -72,11 +72,12 @@ export function get(entity: number, locale: string, pluralForm: number): Functio
 function updateStatusOnServer(
     change: string,
     translation: number,
-    resource: string
+    resource: string,
+    ignoreWarnings: ?boolean,
 ): Promise<Object> {
     switch (change) {
         case 'approve':
-            return api.translation.approve(translation, resource);
+            return api.translation.approve(translation, resource, ignoreWarnings);
         case 'unapprove':
             return api.translation.unapprove(translation, resource);
         case 'reject':
@@ -98,11 +99,13 @@ export function updateStatus(
     translation: number,
     nextEntity: ?DbEntity,
     router: Object,
+    ignoreWarnings: ?boolean,
 ): Function {
     return async dispatch => {
-        const results = await updateStatusOnServer(change, translation, resource);
+        const results = await updateStatusOnServer(change, translation, resource, ignoreWarnings);
         if (results.failedChecks) {
-            dispatch(editorActions.updateFailedChecks(results.failedChecks, 'approved'));
+            dispatch(editorActions.update(results.string, 'external'));
+            dispatch(editorActions.updateFailedChecks(results.failedChecks, translation));
         }
         else if (results.translation && change === 'approve' && nextEntity && nextEntity.pk !== entity) {
             // The change did work, we want to move on to the next Entity.

--- a/frontend/src/modules/history/actions.js
+++ b/frontend/src/modules/history/actions.js
@@ -4,6 +4,7 @@ import api from 'core/api';
 
 import { actions as navActions } from 'core/navigation';
 import { actions as statsActions } from 'core/stats';
+import { actions as editorActions } from 'modules/editor';
 import { actions as listActions } from 'modules/entitieslist';
 
 import type { DbEntity } from 'modules/entitieslist';
@@ -100,7 +101,10 @@ export function updateStatus(
 ): Function {
     return async dispatch => {
         const results = await updateStatusOnServer(change, translation, resource);
-        if (results.translation && change === 'approve' && nextEntity && nextEntity.pk !== entity) {
+        if (results.failedChecks) {
+            dispatch(editorActions.updateFailedChecks(results.failedChecks));
+        }
+        else if (results.translation && change === 'approve' && nextEntity && nextEntity.pk !== entity) {
             // The change did work, we want to move on to the next Entity.
             dispatch(navActions.updateEntity(router, nextEntity.pk.toString()));
         }
@@ -112,7 +116,9 @@ export function updateStatus(
             dispatch(statsActions.update(results.stats));
         }
 
-        dispatch(listActions.updateEntityTranslation(entity, pluralForm, results.translation));
+        if (results.translation) {
+            dispatch(listActions.updateEntityTranslation(entity, pluralForm, results.translation));
+        }
     }
 }
 

--- a/frontend/src/modules/history/actions.js
+++ b/frontend/src/modules/history/actions.js
@@ -102,7 +102,7 @@ export function updateStatus(
     return async dispatch => {
         const results = await updateStatusOnServer(change, translation, resource);
         if (results.failedChecks) {
-            dispatch(editorActions.updateFailedChecks(results.failedChecks));
+            dispatch(editorActions.updateFailedChecks(results.failedChecks, 'approved'));
         }
         else if (results.translation && change === 'approve' && nextEntity && nextEntity.pk !== entity) {
             // The change did work, we want to move on to the next Entity.

--- a/pontoon/base/tests/views/test_translation.py
+++ b/pontoon/base/tests/views/test_translation.py
@@ -37,6 +37,7 @@ def test_approve_translation_basic(translation_a, client_superuser):
     params = {
         'translation': translation_a.pk,
         'paths': [],
+        'ignore_warnings': 'true',
     }
     response = client_superuser.post(url, params)
     assert response.status_code == 400
@@ -63,6 +64,7 @@ def test_approve_translation_rejects_previous_approved(
     params = {
         'translation': translation_a.pk,
         'paths': [],
+        'ignore_warnings': 'true',
     }
 
     response = client_superuser.post(

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -433,6 +433,7 @@ def approve_translation(request):
 
         if are_blocking_checks(failed_checks, ignore_warnings):
             return JsonResponse({
+                'string': translation.string,
                 'failedChecks': failed_checks,
             })
 


### PR DESCRIPTION
This is a WIP, see TODO for details. Due to the indent fix, it will be easier to review on a commit-by-commit basis.

TODO:
- [x] Fix showing/hiding of failed checks popup.
- [x] Add ability to `ignore_warnings` (pass param to `update_translation` and add button).
- [x] Close failed checks popup when textarea content changes.