### PR TITLE
Fix bug 1545450: Fix entity status icons

### DIFF
--- a/frontend/src/modules/entitieslist/components/Entity.css
+++ b/frontend/src/modules/entitieslist/components/Entity.css
@@ -10,6 +10,7 @@
     outline: 0;
     font-size: 100%;
 }
+
 .entity.selected,
 .entity:hover {
     background-color: #4d5967;
@@ -31,11 +32,13 @@
     white-space: nowrap;
     width: 49%;
 }
+
 .entity .translation-string {
     color: #AAAAAA;
     padding-left: 2%;
     text-align: start;
 }
+
 .entity .translation-string[data-script="Latin"],
 .entity .translation-string[data-script="Greek"],
 .entity .translation-string[data-script="Cyrillic"],
@@ -63,34 +66,31 @@
     top: 13px;
     position: absolute;
 }
+
 .entity .status:before {
     color: #4D5967;
     content: "";
 }
-.entity.fuzzy .status:before {
-    color: #FED271;
-}
+
 .entity.approved .status:before {
     color: #7BC876;
 }
-.entity.untranslated .status:before {
-    color: #AAAAAA;
-    content: "";
+
+.entity.fuzzy .status:before {
+    color: #FED271;
 }
-.entity.unreviewed .status:before {
-    color: #4FC4F6;
-    content: "";
+
+.entity.errors .status:before {
+    color: #F36;
 }
-.entity.rejected .status:before {
-    color: #AAAAAA;
-    content: "";
-}
-.entity.time-range .status:before {
-    color: #AAAAAA;
-    content: "";
+
+.entity.warnings .status:before {
+    color: #FFA10F;
 }
 
 .entity.missing.selected .status:before,
-.entity.missing:hover .status:before {
+.entity.missing:hover .status:before,
+.entity.partial.selected .status:before,
+.entity.partial:hover .status:before {
     color: #3F4752;
 }

--- a/frontend/src/modules/entitieslist/components/Entity.js
+++ b/frontend/src/modules/entitieslist/components/Entity.js
@@ -64,19 +64,19 @@ export default class Entity extends React.Component<Props> {
             }
         });
 
-        if (errors > 0) {
+        if (errors) {
             return 'errors';
         }
-        else if (warnings > 0) {
+        if (warnings) {
             return 'warnings';
         }
-        else if (approved === translations.length) {
+        if (approved === translations.length) {
             return 'approved';
         }
-        else if (fuzzy === translations.length) {
+        if (fuzzy === translations.length) {
             return 'fuzzy';
         }
-        else if (approved > 0 || fuzzy > 0) {
+        if (approved > 0 || fuzzy > 0) {
             return 'partial';
         }
         return 'missing';

--- a/frontend/src/modules/entitieslist/components/Entity.test.js
+++ b/frontend/src/modules/entitieslist/components/Entity.test.js
@@ -12,6 +12,8 @@ describe('<Entity>', () => {
             {
                 string: 'chaine a',
                 approved: true,
+                errors: [],
+                warnings: [],
             },
         ],
     };
@@ -22,6 +24,8 @@ describe('<Entity>', () => {
             {
                 string: 'chaine b',
                 fuzzy: true,
+                errors: [],
+                warnings: [],
             },
         ],
     };
@@ -31,6 +35,50 @@ describe('<Entity>', () => {
         translation: [
             {
                 string: 'chaine c',
+                errors: [],
+                warnings: [],
+            },
+        ],
+    };
+
+    const ENTITY_D = {
+        original: 'string d',
+        translation: [
+            {
+                string: 'chaine d',
+                approved: true,
+                errors: ['error'],
+                warnings: [],
+            },
+        ],
+    };
+
+    const ENTITY_E = {
+        original: 'string e',
+        translation: [
+            {
+                string: 'chaine e',
+                fuzzy: true,
+                errors: [],
+                warnings: ['warning'],
+            },
+        ],
+    };
+
+    const ENTITY_F = {
+        original: 'string f',
+        translation: [
+            {
+                string: 'chaine f1',
+                approved: true,
+                errors: [],
+                warnings: [],
+            },
+            {
+                string: 'chaine f2',
+                fuzzy: true,
+                errors: [],
+                warnings: [],
             },
         ],
     };
@@ -70,6 +118,24 @@ describe('<Entity>', () => {
             locale={ DEFAULT_LOCALE }
         />);
         expect(wrapper.instance().status).toEqual('missing');
+
+        wrapper = shallow(<Entity
+            entity={ ENTITY_D }
+            locale={ DEFAULT_LOCALE }
+        />);
+        expect(wrapper.instance().status).toEqual('errors');
+
+        wrapper = shallow(<Entity
+            entity={ ENTITY_E }
+            locale={ DEFAULT_LOCALE }
+        />);
+        expect(wrapper.instance().status).toEqual('warnings');
+
+        wrapper = shallow(<Entity
+            entity={ ENTITY_F }
+            locale={ DEFAULT_LOCALE }
+        />);
+        expect(wrapper.instance().status).toEqual('partial');
     });
 
     it('calls the selectEntity function on click', () => {

--- a/frontend/src/modules/entitieslist/reducer.js
+++ b/frontend/src/modules/entitieslist/reducer.js
@@ -17,6 +17,8 @@ export type Translation = {
     +approved: boolean,
     +fuzzy: boolean,
     +rejected: boolean,
+    +errors: Array<string>,
+    +warnings: Array<string>,
 };
 
 export type DbEntity = {


### PR DESCRIPTION
This fixes two things:

1. It takes into account all plural forms when determining entity status, not just the first one.

2. It adds support for `errors`, `warnings` and `partial` stati.