### PR TITLE
Fix bug 1543158: Prevent multiple review/delete requests

### DIFF
--- a/frontend/src/core/utils/components/withActionsDisabled.js
+++ b/frontend/src/core/utils/components/withActionsDisabled.js
@@ -16,7 +16,7 @@ type State = {|
 export default function withActionsDisabled<Config: {}>(
     WrappedComponent: React.AbstractComponent<Config>
 ): React.AbstractComponent<$Diff<Config, Props>> {
-    return class extends React.Component<$Diff<Config, Props>, State> {
+    class WithActionsDisabled extends React.Component<$Diff<Config, Props>, State> {
         constructor(props: $Diff<Config, Props>) {
             super(props);
 
@@ -42,5 +42,12 @@ export default function withActionsDisabled<Config: {}>(
                 disableAction={ this.disableAction }
             />;
         }
-    };
+    }
+
+    WithActionsDisabled.displayName = `WithSubscription(${
+        WrappedComponent.displayName ||
+        WrappedComponent.name ||
+        'Component'
+    })`;
+    return WithActionsDisabled;
 }

--- a/frontend/src/core/utils/components/withActionsDisabled.js
+++ b/frontend/src/core/utils/components/withActionsDisabled.js
@@ -44,7 +44,7 @@ export default function withActionsDisabled<Config: {}>(
         }
     }
 
-    WithActionsDisabled.displayName = `WithSubscription(${
+    WithActionsDisabled.displayName = `WithActionsDisabled(${
         WrappedComponent.displayName ||
         WrappedComponent.name ||
         'Component'

--- a/frontend/src/modules/editor/components/Editor.js
+++ b/frontend/src/modules/editor/components/Editor.js
@@ -161,6 +161,8 @@ export class EditorBase extends React.Component<InternalProps, State> {
             return null;
         }
 
+        const FailedChecksWithActionsDisabled = entitydetails.withActionsDisabled(FailedChecks);
+
         return <div className="editor">
             <plural.PluralSelector />
             <EditorProxy
@@ -176,7 +178,7 @@ export class EditorBase extends React.Component<InternalProps, State> {
                 updateTranslationStatus={ this.updateTranslationStatus }
             />
             <menu>
-                <FailedChecks
+                <FailedChecksWithActionsDisabled
                     source={ this.props.editor.source }
                     user={ this.props.user }
                     errors={ this.props.editor.errors }
@@ -184,6 +186,8 @@ export class EditorBase extends React.Component<InternalProps, State> {
                     resetFailedChecks={ this.resetFailedChecks }
                     sendTranslation={ this.sendTranslation }
                     updateTranslationStatus={ this.updateTranslationStatus }
+                    isActionDisabled={ self.isActionDisabled }
+                    restoreAction={ self.restoreAction }
                 />
                 { !this.props.user.isAuthenticated ?
                     <Localized

--- a/frontend/src/modules/editor/components/Editor.js
+++ b/frontend/src/modules/editor/components/Editor.js
@@ -24,6 +24,7 @@ import TranslationLength from './TranslationLength';
 import type { Locale } from 'core/locales';
 import type { NavigationParams } from 'core/navigation';
 import type { UserState } from 'core/user';
+import { withActionsDisabled } from 'core/utils';
 import type { ChangeOperation } from 'modules/history';
 import type { DbEntity } from 'modules/entitieslist';
 import type { EditorState } from '../reducer';
@@ -44,10 +45,8 @@ type Props = {|
 type InternalProps = {|
     ...Props,
     dispatch: Function,
-|};
-
-type State = {|
-    isSendTranslationDisabled: boolean,
+    isActionDisabled: boolean,
+    disableAction: () => void,
 |};
 
 
@@ -57,21 +56,7 @@ type State = {|
  * Will present a different editor depending on the file format of the string,
  * see `EditorProxy` for more information.
  */
-export class EditorBase extends React.Component<InternalProps, State> {
-    constructor(props: InternalProps) {
-        super(props);
-
-        this.state = {
-            isSendTranslationDisabled: false,
-        };
-    }
-
-    componentDidUpdate(prevProps: InternalProps, prevState: State) {
-        if (prevState.isSendTranslationDisabled) {
-            this.setState({ isSendTranslationDisabled: false });
-        }
-    }
-
+export class EditorBase extends React.Component<InternalProps> {
     resetSelectionContent = () => {
         this.props.dispatch(actions.resetSelection());
     }
@@ -98,10 +83,10 @@ export class EditorBase extends React.Component<InternalProps, State> {
     }
 
     sendTranslation = (ignoreWarnings: ?boolean) => {
-        if (this.state.isSendTranslationDisabled) {
+        if (this.props.isActionDisabled) {
             return;
         }
-        this.setState({ isSendTranslationDisabled: true });
+        this.props.disableAction();
 
         const state = this.props;
 
@@ -236,7 +221,7 @@ export class EditorBase extends React.Component<InternalProps, State> {
                             <Localized id="editor-editor-button-suggest">
                                 <button
                                     className="action-suggest"
-                                    disabled={ this.state.isSendTranslationDisabled }
+                                    disabled={ this.props.isActionDisabled }
                                     onClick={ this.sendTranslation }
                                 >
                                     Suggest
@@ -247,7 +232,7 @@ export class EditorBase extends React.Component<InternalProps, State> {
                             <Localized id="editor-editor-button-save">
                                 <button
                                     className="action-save"
-                                    disabled={ this.state.isSendTranslationDisabled }
+                                    disabled={ this.props.isActionDisabled }
                                     onClick={ this.sendTranslation }
                                 >
                                     Save
@@ -278,4 +263,4 @@ const mapStateToProps = (state: Object): Props => {
     };
 };
 
-export default connect(mapStateToProps)(EditorBase);
+export default withActionsDisabled(connect(mapStateToProps)(EditorBase));

--- a/frontend/src/modules/editor/components/Editor.js
+++ b/frontend/src/modules/editor/components/Editor.js
@@ -46,6 +46,10 @@ type InternalProps = {|
     dispatch: Function,
 |};
 
+type State = {|
+    isSendTranslationDisabled: boolean,
+|};
+
 
 /**
  * Editor for translation strings.
@@ -53,7 +57,21 @@ type InternalProps = {|
  * Will present a different editor depending on the file format of the string,
  * see `EditorProxy` for more information.
  */
-export class EditorBase extends React.Component<InternalProps> {
+export class EditorBase extends React.Component<InternalProps, State> {
+    constructor(props: InternalProps) {
+        super(props);
+
+        this.state = {
+            isSendTranslationDisabled: false,
+        };
+    }
+
+    componentDidUpdate(prevProps: InternalProps, prevState: State) {
+        if (prevState.isSendTranslationDisabled) {
+            this.setState({ isSendTranslationDisabled: false });
+        }
+    }
+
     resetSelectionContent = () => {
         this.props.dispatch(actions.resetSelection());
     }
@@ -80,6 +98,11 @@ export class EditorBase extends React.Component<InternalProps> {
     }
 
     sendTranslation = (ignoreWarnings: ?boolean) => {
+        if (this.state.isSendTranslationDisabled) {
+            return;
+        }
+        this.setState({ isSendTranslationDisabled: true });
+
         const state = this.props;
 
         if (!state.selectedEntity || !state.locale) {
@@ -213,6 +236,7 @@ export class EditorBase extends React.Component<InternalProps> {
                             <Localized id="editor-editor-button-suggest">
                                 <button
                                     className="action-suggest"
+                                    disabled={ this.state.isSendTranslationDisabled }
                                     onClick={ this.sendTranslation }
                                 >
                                     Suggest
@@ -223,6 +247,7 @@ export class EditorBase extends React.Component<InternalProps> {
                             <Localized id="editor-editor-button-save">
                                 <button
                                     className="action-save"
+                                    disabled={ this.state.isSendTranslationDisabled }
                                     onClick={ this.sendTranslation }
                                 >
                                     Save

--- a/frontend/src/modules/editor/components/Editor.test.js
+++ b/frontend/src/modules/editor/components/Editor.test.js
@@ -46,6 +46,7 @@ function createEditorBase({
                 forceSuggestions,
             },
         } }
+        disableAction={ sinon.spy() }
     />);
 }
 
@@ -134,15 +135,6 @@ describe('<EditorBase>', () => {
             editor.actions.sendTranslation
             .calledWith(SELECTED_ENTITY.pk, 'initial', LOCALE, SELECTED_ENTITY.original)
         ).toBeTruthy();
-    });
-
-    it('prevents multiple Save button clicks to trigger simultaneous sendTranslation calls', () => {
-        const wrapper = createEditorBase({ forceSuggestions: false });
-
-        wrapper.find('.action-save').simulate('click');
-        wrapper.find('.action-save').simulate('click');
-        wrapper.find('.action-save').simulate('click');
-        expect(editor.actions.sendTranslation.calledOnce).toBeTruthy();
     });
 
     it('hides the settings and actions when the user is logged out', () => {

--- a/frontend/src/modules/editor/components/Editor.test.js
+++ b/frontend/src/modules/editor/components/Editor.test.js
@@ -136,6 +136,15 @@ describe('<EditorBase>', () => {
         ).toBeTruthy();
     });
 
+    it('prevents multiple Save button clicks to trigger simultaneous sendTranslation calls', () => {
+        const wrapper = createEditorBase({ forceSuggestions: false });
+
+        wrapper.find('.action-save').simulate('click');
+        wrapper.find('.action-save').simulate('click');
+        wrapper.find('.action-save').simulate('click');
+        expect(editor.actions.sendTranslation.calledOnce).toBeTruthy();
+    });
+
     it('hides the settings and actions when the user is logged out', () => {
         const wrapper = createEditorBase({ isAuthenticated: false });
 

--- a/frontend/src/modules/editor/components/FailedChecks.js
+++ b/frontend/src/modules/editor/components/FailedChecks.js
@@ -23,16 +23,39 @@ type Props = {|
     ) => void,
 |};
 
+type State = {|
+    isConfirmationButtonDisabled: boolean,
+|};
+
 
 /*
  * Renders the failed checks popup.
  */
-export default class FailedChecks extends React.Component<Props> {
+export default class FailedChecks extends React.Component<Props, State> {
+    constructor(props: Props) {
+        super(props);
+
+        this.state = {
+            isConfirmationButtonDisabled: false,
+        };
+    }
+
+    componentDidUpdate(prevProps: Props, prevState: State) {
+        if (prevState.isConfirmationButtonDisabled) {
+            this.setState({ isConfirmationButtonDisabled: false });
+        }
+    }
+
     closeFailedChecks = () => {
         this.props.resetFailedChecks();
     }
 
     approveAnyway = () => {
+        if (this.state.isConfirmationButtonDisabled) {
+            return;
+        }
+        this.setState({ isConfirmationButtonDisabled: true });
+
         const translationId = this.props.source;
         if (typeof(translationId) === 'number') {
             this.props.updateTranslationStatus(translationId, 'approve', true);
@@ -40,6 +63,11 @@ export default class FailedChecks extends React.Component<Props> {
     }
 
     submitAnyway = () => {
+        if (this.state.isConfirmationButtonDisabled) {
+            return;
+        }
+        this.setState({ isConfirmationButtonDisabled: true });
+
         this.props.sendTranslation(true);
     }
 
@@ -87,6 +115,7 @@ export default class FailedChecks extends React.Component<Props> {
                 <Localized id="editor-FailedChecks--approve-anyway">
                     <button
                         className="approve anyway"
+                        disabled={ this.state.isConfirmationButtonDisabled }
                         onClick={ this.approveAnyway }
                     >
                         Approve anyway
@@ -96,6 +125,7 @@ export default class FailedChecks extends React.Component<Props> {
                 <Localized id="editor-FailedChecks--suggest-anyway">
                     <button
                         className="suggest anyway"
+                        disabled={ this.state.isConfirmationButtonDisabled }
                         onClick={ this.submitAnyway }
                     >
                         Suggest anyway
@@ -105,6 +135,7 @@ export default class FailedChecks extends React.Component<Props> {
                 <Localized id="editor-FailedChecks--save-anyway">
                     <button
                         className="save anyway"
+                        disabled={ this.state.isConfirmationButtonDisabled }
                         onClick={ this.submitAnyway }
                     >
                         Save anyway

--- a/frontend/src/modules/editor/components/FailedChecks.js
+++ b/frontend/src/modules/editor/components/FailedChecks.js
@@ -21,40 +21,24 @@ type Props = {|
         change: ChangeOperation,
         ignoreWarnings: ?boolean,
     ) => void,
-|};
-
-type State = {|
-    isConfirmationButtonDisabled: boolean,
+    isActionDisabled: boolean,
+    restoreAction: () => void,
 |};
 
 
 /*
  * Renders the failed checks popup.
  */
-export default class FailedChecks extends React.Component<Props, State> {
-    constructor(props: Props) {
-        super(props);
-
-        this.state = {
-            isConfirmationButtonDisabled: false,
-        };
-    }
-
-    componentDidUpdate(prevProps: Props, prevState: State) {
-        if (prevState.isConfirmationButtonDisabled) {
-            this.setState({ isConfirmationButtonDisabled: false });
-        }
-    }
-
+export default class FailedChecks extends React.Component<Props> {
     closeFailedChecks = () => {
         this.props.resetFailedChecks();
     }
 
     approveAnyway = () => {
-        if (this.state.isConfirmationButtonDisabled) {
+        if (this.props.isActionDisabled) {
             return;
         }
-        this.setState({ isConfirmationButtonDisabled: true });
+        this.props.restoreAction();
 
         const translationId = this.props.source;
         if (typeof(translationId) === 'number') {
@@ -63,10 +47,10 @@ export default class FailedChecks extends React.Component<Props, State> {
     }
 
     submitAnyway = () => {
-        if (this.state.isConfirmationButtonDisabled) {
+        if (this.props.isActionDisabled) {
             return;
         }
-        this.setState({ isConfirmationButtonDisabled: true });
+        this.props.restoreAction();
 
         this.props.sendTranslation(true);
     }
@@ -115,7 +99,7 @@ export default class FailedChecks extends React.Component<Props, State> {
                 <Localized id="editor-FailedChecks--approve-anyway">
                     <button
                         className="approve anyway"
-                        disabled={ this.state.isConfirmationButtonDisabled }
+                        disabled={ this.props.isActionDisabled }
                         onClick={ this.approveAnyway }
                     >
                         Approve anyway
@@ -125,7 +109,7 @@ export default class FailedChecks extends React.Component<Props, State> {
                 <Localized id="editor-FailedChecks--suggest-anyway">
                     <button
                         className="suggest anyway"
-                        disabled={ this.state.isConfirmationButtonDisabled }
+                        disabled={ this.props.isActionDisabled }
                         onClick={ this.submitAnyway }
                     >
                         Suggest anyway
@@ -135,7 +119,7 @@ export default class FailedChecks extends React.Component<Props, State> {
                 <Localized id="editor-FailedChecks--save-anyway">
                     <button
                         className="save anyway"
-                        disabled={ this.state.isConfirmationButtonDisabled }
+                        disabled={ this.props.isActionDisabled }
                         onClick={ this.submitAnyway }
                     >
                         Save anyway

--- a/frontend/src/modules/editor/components/FailedChecks.test.js
+++ b/frontend/src/modules/editor/components/FailedChecks.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import sinon from 'sinon';
 
 import FailedChecks from './FailedChecks';
 
@@ -69,5 +70,26 @@ describe('<FailedChecks>', () => {
         />);
 
         expect(wrapper.find('.approve.anyway')).toHaveLength(1);
+    });
+
+    it('prevents multiple save anyway button clicks to trigger simultaneous sendTranslation calls', () => {
+        const mockUpdate = sinon.spy();
+        const wrapper = shallow(<FailedChecks
+            source={ 'submitted' }
+            errors={ [] }
+            warnings={ ['Warning1'] }
+            user={ {
+                settings: {
+                    forceSuggestions: false,
+                },
+            } }
+            sendTranslation={ mockUpdate }
+        />);
+
+        expect(mockUpdate.called).toBeFalsy();
+        wrapper.find('.save.anyway').simulate('click');
+        wrapper.find('.save.anyway').simulate('click');
+        wrapper.find('.save.anyway').simulate('click');
+        expect(mockUpdate.calledOnce).toBeTruthy();
     });
 });

--- a/frontend/src/modules/editor/components/GenericEditor.js
+++ b/frontend/src/modules/editor/components/GenericEditor.js
@@ -23,15 +23,23 @@ export type EditorProps = {|
     ) => void,
 |};
 
+type State = {|
+    isEnterShortcutDisabled: boolean,
+|};
+
 
 /*
  * Render a simple textarea to edit a translation.
  */
-export default class GenericEditor extends React.Component<EditorProps> {
+export default class GenericEditor extends React.Component<EditorProps, State> {
     textarea: { current: any };
 
     constructor(props: EditorProps) {
         super(props);
+
+        this.state = {
+            isEnterShortcutDisabled: false,
+        };
         this.textarea = React.createRef();
     }
 
@@ -45,7 +53,7 @@ export default class GenericEditor extends React.Component<EditorProps> {
         this.textarea.current.setSelectionRange(0, 0);
     }
 
-    componentDidUpdate() {
+    componentDidUpdate(prevProps: EditorProps, prevState: State) {
         // If there is content to add to the editor, do so, then remove
         // the content so it isn't added again.
         // This is an abuse of the redux store, because we want to update
@@ -59,10 +67,16 @@ export default class GenericEditor extends React.Component<EditorProps> {
             this.props.resetSelectionContent();
         }
 
-        this.textarea.current.focus();
+        if (this.textarea.current) {
+            this.textarea.current.focus();
+        }
 
         if (this.props.editor.changeSource === 'external') {
             this.textarea.current.setSelectionRange(0, 0);
+        }
+
+        if (prevState.isEnterShortcutDisabled) {
+            this.setState({ isEnterShortcutDisabled: false });
         }
     }
 
@@ -97,6 +111,12 @@ export default class GenericEditor extends React.Component<EditorProps> {
 
         // On Enter, send the current translation.
         if (key === 13 && !event.ctrlKey && !event.shiftKey && !event.altKey) {
+            if (this.state.isEnterShortcutDisabled) {
+                event.preventDefault();
+                return;
+            }
+            this.setState({ isEnterShortcutDisabled: true });
+
             handledEvent = true;
 
             const errors = this.props.editor.errors;

--- a/frontend/src/modules/editor/components/GenericEditor.test.js
+++ b/frontend/src/modules/editor/components/GenericEditor.test.js
@@ -81,6 +81,30 @@ describe('<GenericEditor>', () => {
         expect(mockSend.calledOnce).toBeTruthy();
     });
 
+    it('prevents multiple simultaneous sendTranslation calls on Enter', () => {
+        const mockSend = sinon.spy();
+
+        const wrapper = shallow(<GenericEditor
+            editor={ EDITOR }
+            locale={ DEFAULT_LOCALE }
+            sendTranslation={ mockSend }
+        />);
+
+        const event = {
+            preventDefault: sinon.spy(),
+            keyCode: 13,  // Enter
+            altKey: false,
+            ctrlKey: false,
+            shiftKey: false,
+        };
+
+        expect(mockSend.calledOnce).toBeFalsy();
+        wrapper.find('textarea').simulate('keydown', event);
+        wrapper.find('textarea').simulate('keydown', event);
+        wrapper.find('textarea').simulate('keydown', event);
+        expect(mockSend.calledOnce).toBeTruthy();
+    });
+
     it('approves the translation on Enter if failed checks triggered by approval', () => {
         const mockSend = sinon.spy();
 

--- a/frontend/src/modules/entitydetails/components/EntityDetails.test.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.test.js
@@ -119,8 +119,10 @@ describe('<EntityDetailsBase>', () => {
     it('loads the correct list of components', () => {
         const wrapper = createShallowEntityDetails();
 
+        expect(wrapper.text()).toContain('EntityNavigation');
         expect(wrapper.text()).toContain('Metadata');
-        expect(wrapper.text()).toContain('Editor');
+        //expect(wrapper.text()).toContain('Editor');
+        expect(wrapper.text()).toContain('Helpers');
     });
 
     it('shows failed checks for approved (or fuzzy) translations with errors or warnings', () => {

--- a/frontend/src/modules/entitydetails/components/EntityDetails.test.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.test.js
@@ -121,7 +121,7 @@ describe('<EntityDetailsBase>', () => {
 
         expect(wrapper.text()).toContain('EntityNavigation');
         expect(wrapper.text()).toContain('Metadata');
-        //expect(wrapper.text()).toContain('Editor');
+        expect(wrapper.text()).toContain('Editor');
         expect(wrapper.text()).toContain('Helpers');
     });
 

--- a/frontend/src/modules/entitydetails/index.js
+++ b/frontend/src/modules/entitydetails/index.js
@@ -4,6 +4,8 @@ export { default as selectors } from './selectors';
 
 export { default as EntityDetails } from './components/EntityDetails';
 
+export { default as withActionsDisabled } from './withActionsDisabled';
+
 
 // Name of this module.
 // Used as the key to store this module's reducer.

--- a/frontend/src/modules/entitydetails/withActionsDisabled.js
+++ b/frontend/src/modules/entitydetails/withActionsDisabled.js
@@ -1,0 +1,43 @@
+/* @flow */
+
+import * as React from 'react';
+
+
+type Props = Object;
+
+type State = {|
+    isActionDisabled: boolean,
+|};
+
+
+export default function withActionsDisabled<Config: Object>(
+    WrappedComponent: React.AbstractComponent<Config>
+): React.AbstractComponent<Config> {
+    return class extends React.Component<Props, State> {
+        constructor(props: Props) {
+            super(props);
+
+            this.state = {
+                isActionDisabled: false,
+            };
+        }
+
+        componentDidUpdate(prevProps: Props, prevState: State) {
+            if (prevState.isActionDisabled) {
+                this.setState({ isActionDisabled: false });
+            }
+        }
+
+        restoreAction() {
+            this.setState({ isActionDisabled: true });
+        }
+
+        render() {
+            return <WrappedComponent
+                isActionDisabled={ this.state.isActionDisabled }
+                restoreAction={ this.restoreAction }
+                { ...this.props }
+            />;
+        }
+    };
+}

--- a/frontend/src/modules/history/components/Translation.js
+++ b/frontend/src/modules/history/components/Translation.js
@@ -30,7 +30,9 @@ type Props = {|
 
 
 type State = {|
+    isDeleteDisabled: boolean,
     isDiffVisible: boolean,
+    isStatusChangeDisabled: boolean,
 |};
 
 
@@ -47,18 +49,40 @@ export default class Translation extends React.Component<Props, State> {
     constructor() {
         super();
         this.state = {
+            isDeleteDisabled: false,
             isDiffVisible: false,
+            isStatusChangeDisabled: false,
         };
     }
 
+    componentDidUpdate(prevProps: Props, prevState: State) {
+        if (prevState.isDeleteDisabled) {
+            this.setState({ isDeleteDisabled: false });
+        }
+        if (prevState.isStatusChangeDisabled) {
+            this.setState({ isStatusChangeDisabled: false });
+        }
+    }
+
     handleStatusChange = (event: SyntheticMouseEvent<HTMLButtonElement>) => {
+        if (this.state.isStatusChangeDisabled) {
+            return;
+        }
+        this.setState({ isStatusChangeDisabled: true });
+
         event.stopPropagation();
         // $FLOW_IGNORE: Flow and the DOM… >_<
         const action = event.target.name;
+
         this.props.updateTranslationStatus(this.props.translation.pk, action);
     }
 
     delete = (event: SyntheticMouseEvent<HTMLButtonElement>) => {
+        if (this.state.isDeleteDisabled) {
+            return;
+        }
+        this.setState({ isDeleteDisabled: true });
+
         event.stopPropagation();
         this.props.deleteTranslation(this.props.translation.pk);
     }
@@ -223,6 +247,7 @@ export default class Translation extends React.Component<Props, State> {
                                 className='delete far'
                                 title='Delete'
                                 onClick={ this.delete }
+                                disabled={ this.state.isDeleteDisabled }
                             />
                         </Localized>
                     }
@@ -237,6 +262,7 @@ export default class Translation extends React.Component<Props, State> {
                                 title='Unapprove'
                                 name='unapprove'
                                 onClick={ this.handleStatusChange }
+                                disabled={ this.state.isStatusChangeDisabled }
                             />
                         </Localized>
                         :
@@ -250,6 +276,7 @@ export default class Translation extends React.Component<Props, State> {
                                 title='Approve'
                                 name='approve'
                                 onClick={ this.handleStatusChange }
+                                disabled={ this.state.isStatusChangeDisabled }
                             />
                         </Localized>
                     }
@@ -264,6 +291,7 @@ export default class Translation extends React.Component<Props, State> {
                                 title='Unreject'
                                 name='unreject'
                                 onClick={ this.handleStatusChange }
+                                disabled={ this.state.isStatusChangeDisabled }
                             />
                         </Localized>
                         :
@@ -277,6 +305,7 @@ export default class Translation extends React.Component<Props, State> {
                                 title='Reject'
                                 name='reject'
                                 onClick={ this.handleStatusChange }
+                                disabled={ this.state.isStatusChangeDisabled }
                             />
                         </Localized>
                     }

--- a/frontend/src/modules/history/components/Translation.js
+++ b/frontend/src/modules/history/components/Translation.js
@@ -46,8 +46,9 @@ type State = {|
  * change said status.
  */
 export default class Translation extends React.Component<Props, State> {
-    constructor() {
-        super();
+    constructor(props: Props) {
+        super(props);
+
         this.state = {
             isDeleteDisabled: false,
             isDiffVisible: false,

--- a/frontend/src/modules/history/components/Translation.test.js
+++ b/frontend/src/modules/history/components/Translation.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import sinon from 'sinon';
 
 import Translation from './Translation';
 
@@ -320,6 +321,47 @@ describe('<Translation>', () => {
 
             expect(wrapper.find('.toggle-diff.show')).toHaveLength(0);
             expect(wrapper.find('.toggle-diff.hide')).toHaveLength(1);
+        });
+    });
+
+    describe('multiple requests', () => {
+        it('prevents multiple simultaneous status change requests', () => {
+            const mockUpdate = sinon.spy();
+            const wrapper = shallow(<Translation
+                translation={ DEFAULT_TRANSLATION }
+                locale={ DEFAULT_LOCALE }
+                updateTranslationStatus={ mockUpdate }
+            />);
+            const event = {
+                stopPropagation: sinon.spy(),
+                target: 'approve',
+            };
+
+            expect(mockUpdate.called).toBeFalsy();
+            wrapper.find('.approve').simulate('click', event);
+            wrapper.find('.approve').simulate('click', event);
+            wrapper.find('.approve').simulate('click', event);
+            expect(mockUpdate.calledOnce).toBeTruthy();
+        });
+
+        it('prevents multiple simultaneous delete requests', () => {
+            const mockDelete = sinon.spy();
+            const translation = { ...DEFAULT_TRANSLATION, rejected: true };
+            const wrapper = shallow(<Translation
+                translation={ translation }
+                locale={ DEFAULT_LOCALE }
+                canReview={ true }
+                deleteTranslation={ mockDelete }
+            />);
+            const event = {
+                stopPropagation: sinon.spy(),
+            };
+
+            expect(mockDelete.called).toBeFalsy();
+            wrapper.find('.delete').simulate('click', event);
+            wrapper.find('.delete').simulate('click', event);
+            wrapper.find('.delete').simulate('click', event);
+            expect(mockDelete.calledOnce).toBeTruthy();
         });
     });
 });


### PR DESCRIPTION
This solution is inspired by: https://stackoverflow.com/a/49642037. I tried to avoid using `ref`.

I wonder if there's a better approach for preventing multiple in React world. If not, I'll add a similar solution for saving translations/suggestions.