### PR TITLE
Fix bug 1519931: Show string length and countdown

### DIFF
--- a/frontend/src/modules/editor/components/Editor.js
+++ b/frontend/src/modules/editor/components/Editor.js
@@ -65,7 +65,7 @@ export class EditorBase extends React.Component<InternalProps> {
     copyOriginalIntoEditor = () => {
         const { selectedEntity, pluralForm } = this.props;
         if (selectedEntity) {
-            if (pluralForm === -1 || pluralForm === 1) {
+            if (pluralForm === -1 || pluralForm === 0) {
                 this.updateTranslation(selectedEntity.original, true);
             }
             else {
@@ -187,6 +187,7 @@ export class EditorBase extends React.Component<InternalProps> {
                         <KeyboardShortcuts />
                         <TranslationLength
                             entity={ this.props.selectedEntity }
+                            pluralForm={ this.props.pluralForm }
                             translation={ this.props.editor.translation }
                         />
                         <div className="actions">

--- a/frontend/src/modules/editor/components/Editor.js
+++ b/frontend/src/modules/editor/components/Editor.js
@@ -19,6 +19,7 @@ import FailedChecks from './FailedChecks';
 import EditorProxy from './EditorProxy';
 import EditorSettings from './EditorSettings';
 import KeyboardShortcuts from './KeyboardShortcuts';
+import TranslationLength from './TranslationLength';
 
 import type { Locale } from 'core/locales';
 import type { NavigationParams } from 'core/navigation';
@@ -184,6 +185,10 @@ export class EditorBase extends React.Component<InternalProps> {
                             updateSetting={ this.updateSetting }
                         />
                         <KeyboardShortcuts />
+                        <TranslationLength
+                            entity={ this.props.selectedEntity }
+                            translation={ this.props.editor.translation }
+                        />
                         <div className="actions">
                             <Localized id="editor-editor-button-copy">
                                 <button

--- a/frontend/src/modules/editor/components/TranslationLength.css
+++ b/frontend/src/modules/editor/components/TranslationLength.css
@@ -1,0 +1,10 @@
+.translation-length {
+    color: #AAAAAA;
+    float: left;
+    line-height: 22px;
+    padding: 9px 5px;
+}
+
+.translation-length .countdown .overflow {
+    color: #F36;
+}

--- a/frontend/src/modules/editor/components/TranslationLength.js
+++ b/frontend/src/modules/editor/components/TranslationLength.js
@@ -9,6 +9,7 @@ import type { DbEntity } from 'modules/entitieslist';
 
 type Props = {|
     entity: ?DbEntity,
+    pluralForm: number,
     translation: string,
 |};
 
@@ -60,7 +61,7 @@ export default class TranslationLength extends React.Component<Props> {
     }
 
     render() {
-        const { entity, translation } = this.props;
+        const { entity, pluralForm, translation } = this.props;
 
         if (!entity) {
             return null;
@@ -69,6 +70,8 @@ export default class TranslationLength extends React.Component<Props> {
         const limit = this.getLimit();
         const translationLength = this.stripHTML(translation).length;
         const countdown = limit !== null ? limit - translationLength : null;
+        const original = (pluralForm === -1 || pluralForm === 0) ?
+            entity.original : entity.original_plural;
 
         return <div className="translation-length">
             { countdown !== null ?
@@ -79,7 +82,7 @@ export default class TranslationLength extends React.Component<Props> {
                 </div>
             :
                 <div className="translation-vs-original">
-                    <span>{ translation.length }</span>|<span>{ entity.original.length }</span>
+                    <span>{ translation.length }</span>|<span>{ original.length }</span>
                 </div>
             }
         </div>;

--- a/frontend/src/modules/editor/components/TranslationLength.js
+++ b/frontend/src/modules/editor/components/TranslationLength.js
@@ -16,24 +16,24 @@ type Props = {|
 /*
  * Shows translation length vs. original string length, or countdown.
  * 
- * Countdown is current only supported for LANG strings, which use special
+ * Countdown is currently only supported for LANG strings, which use special
  * syntax in the comment to define maximum translation length. MAX_LENGTH
  * is provided for strings without HTML tags, so they need to be stripped.
  */
-export default class TranslationLengthBase extends React.Component<Props> {
+export default class TranslationLength extends React.Component<Props> {
     getLimit() {
         const entity = this.props.entity;
 
-        if (!entity) {
+        if (!entity || entity.format !== 'lang') {
             return null;
         }
 
-        const split = entity.comment.split('\n');
+        const parts = entity.comment.split('\n');
 
-        if (entity.format === 'lang' && split[0].startsWith('MAX_LENGTH')) {
+        if (parts[0].startsWith('MAX_LENGTH')) {
             try {
                 return parseInt(
-                    split[0].split('MAX_LENGTH: ')[1].split(' ')[0],
+                    parts[0].split('MAX_LENGTH: ')[1].split(' ')[0],
                     10,
                 );
             } catch (e) {

--- a/frontend/src/modules/editor/components/TranslationLength.test.js
+++ b/frontend/src/modules/editor/components/TranslationLength.test.js
@@ -1,23 +1,23 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import TranslationLengthBase from './TranslationLength';
+import TranslationLength from './TranslationLength';
 
 
-describe('<TranslationLengthBase>', () => {
+describe('<TranslationLength>', () => {
     const LENGTH_ENTITY = {
         comment: '',
         original: '12345',
     };
 
     const COUNTDOWN_ENTITY = {
-        comment: 'MAX_LENGTH: 5',
+        comment: 'MAX_LENGTH: 5\nThis is an actual comment.',
         format: 'lang',
         original: '12345',
     };
 
     it('shows translation length and original string length', () => {
-        const wrapper = shallow(<TranslationLengthBase
+        const wrapper = shallow(<TranslationLength
             translation='1234567'
             entity={ LENGTH_ENTITY }
         />);
@@ -29,7 +29,7 @@ describe('<TranslationLengthBase>', () => {
     });
 
     it('shows countdown if MAX_LENGTH provided in LANG entity comment', () => {
-        const wrapper = shallow(<TranslationLengthBase
+        const wrapper = shallow(<TranslationLength
             translation='123'
             entity={ COUNTDOWN_ENTITY }
         />);
@@ -40,7 +40,7 @@ describe('<TranslationLengthBase>', () => {
     });
 
     it('marks countdown overflow', () => {
-        const wrapper = shallow(<TranslationLengthBase
+        const wrapper = shallow(<TranslationLength
             translation='123456'
             entity={ COUNTDOWN_ENTITY }
         />);
@@ -49,7 +49,7 @@ describe('<TranslationLengthBase>', () => {
     });
 
     it('strips html from translation when calculating countdown', () => {
-        const wrapper = shallow(<TranslationLengthBase
+        const wrapper = shallow(<TranslationLength
             translation='12<span>34</span>56'
             entity={ COUNTDOWN_ENTITY }
         />);
@@ -58,7 +58,7 @@ describe('<TranslationLengthBase>', () => {
     });
 
     it('does not strips html from translation when calculating length', () => {
-        const wrapper = shallow(<TranslationLengthBase
+        const wrapper = shallow(<TranslationLength
             translation='12<span>34</span>56'
             entity={ LENGTH_ENTITY }
         />);

--- a/frontend/src/modules/editor/components/TranslationLength.test.js
+++ b/frontend/src/modules/editor/components/TranslationLength.test.js
@@ -8,6 +8,7 @@ describe('<TranslationLength>', () => {
     const LENGTH_ENTITY = {
         comment: '',
         original: '12345',
+        original_plural: '123456',
     };
 
     const COUNTDOWN_ENTITY = {
@@ -19,6 +20,7 @@ describe('<TranslationLength>', () => {
     it('shows translation length and original string length', () => {
         const wrapper = shallow(<TranslationLength
             translation='1234567'
+            pluralForm={ -1 }
             entity={ LENGTH_ENTITY }
         />);
 
@@ -26,6 +28,16 @@ describe('<TranslationLength>', () => {
         expect(wrapper.find('.translation-vs-original').childAt(0).text()).toEqual('7');
         expect(wrapper.find('.translation-vs-original').childAt(1).text()).toEqual('|');
         expect(wrapper.find('.translation-vs-original').childAt(2).text()).toEqual('5');
+    });
+
+    it('shows translation length and plural original string length', () => {
+        const wrapper = shallow(<TranslationLength
+            translation='1234567'
+            pluralForm={ 1 }
+            entity={ LENGTH_ENTITY }
+        />);
+
+        expect(wrapper.find('.translation-vs-original').childAt(2).text()).toEqual('6');
     });
 
     it('shows countdown if MAX_LENGTH provided in LANG entity comment', () => {

--- a/frontend/src/modules/editor/components/TranslationLength.test.js
+++ b/frontend/src/modules/editor/components/TranslationLength.test.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import TranslationLengthBase from './TranslationLength';
+
+
+describe('<TranslationLengthBase>', () => {
+    const LENGTH_ENTITY = {
+        comment: '',
+        original: '12345',
+    };
+
+    const COUNTDOWN_ENTITY = {
+        comment: 'MAX_LENGTH: 5',
+        format: 'lang',
+        original: '12345',
+    };
+
+    it('shows translation length and original string length', () => {
+        const wrapper = shallow(<TranslationLengthBase
+            translation='1234567'
+            entity={ LENGTH_ENTITY }
+        />);
+
+        expect(wrapper.find('.countdown')).toHaveLength(0);
+        expect(wrapper.find('.translation-vs-original').childAt(0).text()).toEqual('7');
+        expect(wrapper.find('.translation-vs-original').childAt(1).text()).toEqual('|');
+        expect(wrapper.find('.translation-vs-original').childAt(2).text()).toEqual('5');
+    });
+
+    it('shows countdown if MAX_LENGTH provided in LANG entity comment', () => {
+        const wrapper = shallow(<TranslationLengthBase
+            translation='123'
+            entity={ COUNTDOWN_ENTITY }
+        />);
+
+        expect(wrapper.find('.translation-vs-original')).toHaveLength(0);
+        expect(wrapper.find('.countdown span').text()).toEqual('2');
+        expect(wrapper.find('.countdown span.overflow')).toHaveLength(0);
+    });
+
+    it('marks countdown overflow', () => {
+        const wrapper = shallow(<TranslationLengthBase
+            translation='123456'
+            entity={ COUNTDOWN_ENTITY }
+        />);
+
+        expect(wrapper.find('.countdown span.overflow')).toHaveLength(1);
+    });
+
+    it('strips html from translation when calculating countdown', () => {
+        const wrapper = shallow(<TranslationLengthBase
+            translation='12<span>34</span>56'
+            entity={ COUNTDOWN_ENTITY }
+        />);
+
+        expect(wrapper.find('.countdown span').text()).toEqual('-1');
+    });
+
+    it('does not strips html from translation when calculating length', () => {
+        const wrapper = shallow(<TranslationLengthBase
+            translation='12<span>34</span>56'
+            entity={ LENGTH_ENTITY }
+        />);
+
+        expect(wrapper.find('.translation-vs-original').childAt(0).text()).toEqual('19');
+    });
+});


### PR DESCRIPTION
This patch adds support for translation length information. For `LANG` strings with `MAX_LENGTH` provided in their comment, it shows countdown instead.