### PR TITLE
Fix bug 1539228: Load entities not on the first page

### DIFF
--- a/frontend/public/static/locale/en-US/translate.ftl
+++ b/frontend/public/static/locale/en-US/translate.ftl
@@ -219,7 +219,7 @@ notification--tt-checks-enabled = Translate Toolkit Checks enabled
 notification--tt-checks-disabled = Translate Toolkit Checks disabled
 notification--make-suggestions-enabled = Make Suggestions enabled
 notification--make-suggestions-disabled = Make Suggestions disabled
-notification--entity-not-found = Can't load specified string
+notification--entity-not-found = Can’t load specified string
 
 
 ## Placeable parsers

--- a/frontend/public/static/locale/en-US/translate.ftl
+++ b/frontend/public/static/locale/en-US/translate.ftl
@@ -219,6 +219,7 @@ notification--tt-checks-enabled = Translate Toolkit Checks enabled
 notification--tt-checks-disabled = Translate Toolkit Checks disabled
 notification--make-suggestions-enabled = Make Suggestions enabled
 notification--make-suggestions-disabled = Make Suggestions disabled
+notification--entity-not-found = Can't load specified string
 
 
 ## Placeable parsers

--- a/frontend/src/core/api/entity.js
+++ b/frontend/src/core/api/entity.js
@@ -18,6 +18,7 @@ export default class EntityAPI extends APIBase {
         project: string,
         resource: string,
         exclude: Array<number>,
+        entity: ?string,
         search: ?string,
         status: ?string,
     ): Promise<Object> {
@@ -31,6 +32,10 @@ export default class EntityAPI extends APIBase {
 
         if (exclude.length) {
             payload.append('exclude_entities', exclude.join(','));
+        }
+
+        if (entity) {
+            payload.append('entity', entity);
         }
 
         if (search) {

--- a/frontend/src/core/notification/messages.js
+++ b/frontend/src/core/notification/messages.js
@@ -105,4 +105,10 @@ export default {
         </Localized>,
         type: 'info',
     },
+    'ENTITY_NOT_FOUND': {
+        content: <Localized id='notification--entity-not-found'>
+            Can't load specified string
+        </Localized>,
+        type: 'error',
+    },
 };

--- a/frontend/src/core/notification/messages.js
+++ b/frontend/src/core/notification/messages.js
@@ -107,7 +107,7 @@ export default {
     },
     'ENTITY_NOT_FOUND': {
         content: <Localized id='notification--entity-not-found'>
-            Can't load specified string
+            Can’t load specified string
         </Localized>,
         type: 'error',
     },

--- a/frontend/src/modules/entitieslist/actions.js
+++ b/frontend/src/modules/entitieslist/actions.js
@@ -73,6 +73,7 @@ export function get(
     project: string,
     resource: string,
     exclude: Array<number>,
+    entity: ?string,
     search: ?string,
     status: ?string,
 ): Function {
@@ -84,6 +85,7 @@ export function get(
             project,
             resource,
             exclude,
+            entity,
             search,
             status,
         );

--- a/frontend/src/modules/entitieslist/components/EntitiesList.js
+++ b/frontend/src/modules/entitieslist/components/EntitiesList.js
@@ -86,7 +86,15 @@ export class EntitiesListBase extends React.Component<InternalProps> {
             this.props.dispatch(actions.reset());
         }
 
-        if (previous.entity !== current.entity) {
+        // Scroll to selected entity when entity changes
+        // and when entity list loads for the first time
+        if (
+            previous.entity !== current.entity ||
+            (
+                !prevProps.entities.entities.length &&
+                this.props.entities.entities.length
+            )
+        ) {
             this.scrollToSelectedElement();
         }
     }

--- a/frontend/src/modules/entitieslist/components/EntitiesList.js
+++ b/frontend/src/modules/entitieslist/components/EntitiesList.js
@@ -8,6 +8,7 @@ import './EntitiesList.css';
 
 import * as locales from 'core/locales';
 import * as navigation from 'core/navigation';
+import * as notification from 'core/notification';
 
 import { actions, NAME } from '..';
 import Entity from './Entity';
@@ -123,17 +124,28 @@ export class EntitiesListBase extends React.Component<InternalProps> {
         }
     }
 
+    /*
+     * If entity not provided through a URL parameter, or if provided entity
+     * cannot be found, select the first entity in the list.
+     */
     selectFirstEntityIfNoneSelected() {
-        const { entities, parameters, router } = this.props;
+        const { dispatch, entities, parameters } = this.props;
         const selectedEntity = parameters.entity;
+        const firstEntity = entities.entities[0];
 
-        if (!selectedEntity && entities.entities.length > 0) {
-            this.props.dispatch(
-                navigation.actions.updateEntity(
-                    router,
-                    entities.entities[0].pk.toString(),
-                )
-            );
+        const entityIds = entities.entities.map(entity => entity.pk);
+        const isSelectedEntityValid = entityIds.indexOf(selectedEntity) > -1;
+
+        if ((!selectedEntity || !isSelectedEntityValid) && firstEntity) {
+            this.selectEntity(firstEntity);
+
+            if (selectedEntity && !isSelectedEntityValid) {
+                dispatch(
+                    notification.actions.add(
+                        notification.messages.ENTITY_NOT_FOUND
+                    )
+                );
+            }
         }
     }
 

--- a/frontend/src/modules/entitieslist/components/EntitiesList.js
+++ b/frontend/src/modules/entitieslist/components/EntitiesList.js
@@ -137,7 +137,7 @@ export class EntitiesListBase extends React.Component<InternalProps> {
 
     getMoreEntities = () => {
         const { entities, parameters } = this.props;
-        const { locale, project, resource, search, status } = parameters;
+        const { locale, project, resource, entity, search, status } = parameters;
 
         // Temporary fix for the infinite number of requests from InfiniteScroller
         // More info at:
@@ -156,6 +156,7 @@ export class EntitiesListBase extends React.Component<InternalProps> {
                 project,
                 resource,
                 currentEntityIds,
+                entity.toString(),
                 search,
                 status,
             )

--- a/frontend/src/modules/entitydetails/components/EntityDetails.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.js
@@ -69,6 +69,8 @@ type State = {|
  */
 export class EntityDetailsBase extends React.Component<InternalProps, State> {
     componentDidMount() {
+        this.updateEditorTranslation(this.props.activeTranslation);
+        this.updateFailedChecks();
         this.fetchHelpersData();
     }
 

--- a/frontend/src/modules/entitydetails/components/EntityDetails.test.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.test.js
@@ -16,12 +16,20 @@ const ENTITIES = [
     {
         pk: 42,
         original: 'le test',
-        translation: [{string: 'test'}],
+        translation: [{
+            string: 'test',
+            errors: [],
+            warnings: [],
+        }],
     },
     {
         pk: 1,
         original: 'something',
-        translation: [{string: 'quelque chose'}],
+        translation: [{
+            string: 'quelque chose',
+            errors: [],
+            warnings: [],
+        }],
     },
 ];
 const TRANSLATION = 'test';
@@ -128,6 +136,10 @@ describe('<EntityDetailsBase>', () => {
     it('shows failed checks for approved (or fuzzy) translations with errors or warnings', () => {
         const wrapper = createShallowEntityDetails();
 
+        // componentDidMount(): reset failed checks
+        expect(editor.actions.updateFailedChecks.calledOnce).toBeFalsy();
+        expect(editor.actions.resetFailedChecks.calledOnce).toBeTruthy();
+
         wrapper.setProps({
             pluralForm: -1,
             selectedEntity: {
@@ -142,12 +154,17 @@ describe('<EntityDetailsBase>', () => {
             },
         });
 
+        // componentDidUpdate(): update failed checks
         expect(editor.actions.updateFailedChecks.calledOnce).toBeTruthy();
-        expect(editor.actions.resetFailedChecks.calledOnce).toBeFalsy();
+        expect(editor.actions.resetFailedChecks.calledOnce).toBeTruthy();
     });
 
     it('hides failed checks for approved (or fuzzy) translations without errors or warnings', () => {
         const wrapper = createShallowEntityDetails();
+
+        // componentDidMount(): reset failed checks
+        expect(editor.actions.updateFailedChecks.calledOnce).toBeFalsy();
+        expect(editor.actions.resetFailedChecks.calledOnce).toBeTruthy();
 
         wrapper.setProps({
             pluralForm: -1,
@@ -163,8 +180,9 @@ describe('<EntityDetailsBase>', () => {
             },
         });
 
+        // componentDidUpdate(): reset failed checks
         expect(editor.actions.updateFailedChecks.calledOnce).toBeFalsy();
-        expect(editor.actions.resetFailedChecks.calledOnce).toBeTruthy();
+        expect(editor.actions.resetFailedChecks.calledTwice).toBeTruthy();
     });
 });
 


### PR DESCRIPTION
This patch loads entities that are not on the first page and scrolls the string list accordingly.

Also:
* If entity isn't found, the first entity is selected and a notification is sent.
* Fixes a bug that didn't populate the editor and update checks if entity specified via URL