### PR TITLE
Fix bug 1550490: Allow activating Translate.Next for a subset of users

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -76,7 +76,7 @@ Of course, more can be added if needed. For example, modules with a high number 
 
 ### This feature is behind a Switch
 
-While this is under development, the feature is hidden behing a feature switch, and thus is not accessible by default. In order to turn it on, you have to run `./manage.py waffle_switch translate_next on --create`, then restart your web server. To turn it off, run `./manage.py waffle_switch translate_next off`.
+While this is under development, the feature is hidden behing a feature flag, and thus is not accessible by default. In order to turn it on, you have to run `./manage.py waffle_flag translate_next --everyone --create`, then restart your web server. To turn it off, run `./manage.py waffle_flag translate_next --deactivate`.
 
 ### Production
 

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -101,7 +101,7 @@
     </div>
 
     <div class="right">
-      {% if waffle.switch('translate_next') and request.user.is_authenticated %}
+      {% if waffle.flag('translate_next') and request.user.is_authenticated %}
       <!-- A link to switch between the current and next Translate apps. -->
       <a
         href="{{ url('pontoon.user.toggle_use_translate_next') }}?next={{ request.get_full_path() }}"

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -58,7 +58,7 @@ def translate(request, locale, slug, part):
     # To be removed as part of bug 1527853.
     user = request.user
     if (
-        waffle.switch_is_active('translate_next') and
+        waffle.flag_is_active(request, 'translate_next') and
         user.is_authenticated and
         user.profile.use_translate_next
     ):

--- a/pontoon/translate/tests/test_views.py
+++ b/pontoon/translate/tests/test_views.py
@@ -2,7 +2,7 @@ import pytest
 
 from django.urls import reverse
 
-from waffle.testutils import override_switch
+from waffle.testutils import override_flag
 
 from pontoon.translate.views import get_preferred_locale
 
@@ -15,13 +15,13 @@ def user_arabic(user_a):
 
 
 @pytest.mark.django_db
-def test_translate_behind_switch(client):
+def test_translate_behind_flag(client):
     url = reverse('pontoon.translate.next')
 
     response = client.get(url)
     assert response.status_code == 404
 
-    with override_switch('translate_next', active=True):
+    with override_flag('translate_next', active=True):
         response = client.get(url)
         assert response.status_code == 200
 
@@ -30,7 +30,7 @@ def test_translate_behind_switch(client):
 def test_translate_template(client):
     url = reverse('pontoon.translate.next')
 
-    with override_switch('translate_next', active=True):
+    with override_flag('translate_next', active=True):
         response = client.get(url)
         assert response.status_code == 200
         assert 'Translate.Next' in response.content

--- a/pontoon/translate/views.py
+++ b/pontoon/translate/views.py
@@ -100,7 +100,7 @@ def get_preferred_locale(request):
 
 
 def translate(request, locale=None, project=None, resource=None):
-    if not waffle.switch_is_active('translate_next'):
+    if not waffle.flag_is_active(request, 'translate_next'):
         raise Http404
 
     # Redirect the user to the old Translate page if needed.


### PR DESCRIPTION
We do that by switching (pun not intended) from `waffle.switch` to `waffle.flag`.