### PR TITLE
Fix bug 1543162 - Cancel previously running requests when changing entity.

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "abortcontroller-polyfill": "^1.3.0",
     "brace": "0.11.1",
     "connected-react-router": "4.5.0",
     "diff-match-patch": "1.0.4",

--- a/frontend/src/core/api/base.js
+++ b/frontend/src/core/api/base.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import 'abortcontroller-polyfill/dist/abortcontroller-polyfill-only';
+
 
 export default class APIBase {
     abortController: AbortController;

--- a/frontend/src/core/api/base.js
+++ b/frontend/src/core/api/base.js
@@ -2,6 +2,24 @@
 
 
 export default class APIBase {
+    abortController: AbortController;
+    signal: ?AbortSignal;
+
+    constructor() {
+        // Create a controller to abort fetch requests.
+        this.abortController = new AbortController();
+        this.signal = this.abortController.signal;
+    }
+
+    abort() {
+        // Abort the previously started requests.
+        this.abortController.abort();
+
+        // Now create a new controller for the next round of requests.
+        this.abortController = new AbortController();
+        this.signal = this.abortController.signal;
+    }
+
     getCSRFToken(): string {
         let csrfToken = '';
         const rootElt = document.getElementById('root');
@@ -28,6 +46,9 @@ export default class APIBase {
         requestParams.credentials = 'same-origin';
         requestParams.headers = headers;
 
+        // This signal is used to cancel requests with the `abort()` method.
+        requestParams.signal = this.signal;
+
         if (payload !== null) {
             if (method === 'POST') {
                 requestParams.body = payload;
@@ -37,10 +58,20 @@ export default class APIBase {
             }
         }
 
-        const response = await fetch(
-            fullUrl,
-            requestParams
-        );
+        let response;
+        try {
+            response = await fetch(
+                fullUrl,
+                requestParams
+            );
+        }
+        catch (e) {
+            // Swallow Abort errors because we trigger them ourselves.
+            if (e.name === 'AbortError') {
+                return {};
+            }
+            throw e;
+        }
 
         try {
             return await response.json();

--- a/frontend/src/core/api/entity.js
+++ b/frontend/src/core/api/entity.js
@@ -81,6 +81,10 @@ export default class EntityAPI extends APIBase {
 
         const results = await this.fetch('/other-locales/', 'GET', payload, headers);
 
+        if (!Array.isArray(results)) {
+            return [];
+        }
+
         return results.map(entry => {
             return {
                 code: entry.locale__code,

--- a/frontend/src/core/api/machinery.js
+++ b/frontend/src/core/api/machinery.js
@@ -35,6 +35,10 @@ export default class MachineryAPI extends APIBase {
 
         const results = await this._get(url, params);
 
+        if (!Array.isArray(results)) {
+            return [];
+        }
+
         return results.map(item => {
             return {
                 sources: [{

--- a/frontend/src/modules/history/actions.js
+++ b/frontend/src/modules/history/actions.js
@@ -65,6 +65,10 @@ export function reset(): ResetAction {
 export function get(entity: number, locale: string, pluralForm: number): Function {
     return async dispatch => {
         dispatch(request());
+
+        // Abort all previously running requests.
+        await api.entity.abort();
+
         const content = await api.entity.getHistory(entity, locale, pluralForm);
         dispatch(receive(content));
     }

--- a/frontend/src/modules/machinery/actions.js
+++ b/frontend/src/modules/machinery/actions.js
@@ -58,6 +58,9 @@ export function get(source: string, locale: Locale, pk: ?number): Function {
     return async dispatch => {
         dispatch(reset(source));
 
+        // Abort all previously running requests.
+        await api.machinery.abort();
+
         api.machinery.getTranslationMemory(source, locale, pk)
         .then(results => dispatch(addTranslations(results)));
 

--- a/frontend/src/modules/otherlocales/actions.js
+++ b/frontend/src/modules/otherlocales/actions.js
@@ -39,6 +39,9 @@ export function get(entity: number, locale: string): Function {
     return async dispatch => {
         dispatch(request(entity));
 
+        // Abort all previously running requests.
+        await api.entity.abort();
+
         const content = await api.entity.getOtherLocales(entity, locale);
 
         dispatch(receive(entity, content));

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1276,6 +1276,11 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
+abortcontroller-polyfill@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.3.0.tgz#de69af32ae926c210b7efbcc29bf644ee4838b00"
+  integrity sha512-lbWQgf+eRvku3va8poBlDBO12FigTQr9Zb7NIjXrePrhxWVKdCP2wbDl1tLDaYa18PWTom3UEWwdH13S46I+yA==
+
 accepts@~1.3.4, accepts@~1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.5.tgz#eb777df6011723a3b14e8a72c0805c8e86746bd2"


### PR DESCRIPTION
Whenever we fetch new content for the History, Machinery or Locales tabs, this cancels all previously running requests before starting new ones. This will reduce the load on the server and avoid mixed data issues in our tabs.