### PR TITLE
Fix bug 1519894: Add Resource menu

### DIFF
--- a/frontend/public/static/locale/en-US/translate.ftl
+++ b/frontend/public/static/locale/en-US/translate.ftl
@@ -210,8 +210,15 @@ user-UserMenu--settings = <glyph></glyph>Settings
 user-SignOut--sign-out = <glyph></glyph>Sign out
 
 
+## Resource menu
+## Used in the resource menu in the main navigation bar.
+navigation-ResourceMenu-all-resources = All Resources
+navigation-ResourceMenu-all-projects = All Projects
+
+
 ## Notification
 ## Messages shown to users after they perform actions.
+
 notification--translation-approved = Translation approved
 notification--translation-unaproved = Translation unaproved
 notification--translation-rejected = Translation rejected

--- a/frontend/public/static/locale/en-US/translate.ftl
+++ b/frontend/public/static/locale/en-US/translate.ftl
@@ -212,6 +212,7 @@ user-SignOut--sign-out = <glyph></glyph>Sign out
 
 ## Resource menu
 ## Used in the resource menu in the main navigation bar.
+navigation-ResourceMenu-no-results = No results
 navigation-ResourceMenu-all-resources = All Resources
 navigation-ResourceMenu-all-projects = All Projects
 

--- a/frontend/src/core/api/index.js
+++ b/frontend/src/core/api/index.js
@@ -4,6 +4,7 @@ import EntityAPI from './entity';
 import LocaleAPI from './locale';
 import L10nAPI from './l10n';
 import Machinery from './machinery';
+import ResourceAPI from './resource';
 import TranslationAPI from './translation';
 import UserAPI from './user';
 
@@ -15,6 +16,7 @@ export default {
     locale: new LocaleAPI(),
     l10n: new L10nAPI(),
     machinery: new Machinery(),
+    resource: new ResourceAPI(),
     translation: new TranslationAPI(),
     user: new UserAPI(),
     types,

--- a/frontend/src/core/api/resource.js
+++ b/frontend/src/core/api/resource.js
@@ -5,7 +5,7 @@ import APIBase from './base';
 
 export default class ResourceAPI extends APIBase {
     async getAll(locale: string, project: string) {
-        const url = '/' + locale + '/' + project + '/parts/';
+        const url = `/${locale}/${project}/parts/`;
 
         const headers = new Headers();
         headers.append('X-Requested-With', 'XMLHttpRequest');

--- a/frontend/src/core/api/resource.js
+++ b/frontend/src/core/api/resource.js
@@ -1,0 +1,15 @@
+/* @flow */
+
+import APIBase from './base';
+
+
+export default class ResourceAPI extends APIBase {
+    async getAll(locale: string, project: string) {
+        const url = '/' + locale + '/' + project + '/parts/';
+
+        const headers = new Headers();
+        headers.append('X-Requested-With', 'XMLHttpRequest');
+
+        return await this.fetch(url, 'GET', null, headers);
+    }
+}

--- a/frontend/src/core/api/translation.js
+++ b/frontend/src/core/api/translation.js
@@ -17,6 +17,7 @@ export default class TranslationAPI extends APIBase {
         pluralForm: number,
         original: string,
         forceSuggestions: boolean,
+        resource: string,
         ignoreWarnings: ?boolean,
     ) {
         const csrfToken = this.getCSRFToken();
@@ -28,6 +29,10 @@ export default class TranslationAPI extends APIBase {
         payload.append('plural_form', pluralForm.toString());
         payload.append('original', original);
         payload.append('force_suggestions', forceSuggestions.toString());
+
+        if (resource !== 'all-resources') {
+            payload.append('paths[]', resource);
+        }
 
         if (ignoreWarnings) {
             payload.append('ignore_warnings', ignoreWarnings.toString());

--- a/frontend/src/core/navigation/components/Navigation.css
+++ b/frontend/src/core/navigation/components/Navigation.css
@@ -3,11 +3,11 @@
     line-height: 60px;
 }
 
-.navigation ul li {
-    display: inline-block;
+.navigation > ul > li {
+    float: left;
 }
 
-.navigation ul li + li::before {
+.navigation > ul > li + li::before {
     color: #4D5967;
     content: '/';
     font-size: 28px;
@@ -15,22 +15,22 @@
     vertical-align: bottom;
 }
 
-.navigation img {
-    margin-top: -2px;
-    vertical-align: middle;
-}
-
-.navigation a {
+.navigation > ul > li > a {
     color: #EBEBEB;
     font-weight: 300;
     padding: 0 12px;
 }
 
-.navigation a:hover {
+.navigation > ul > li > a:hover {
     color: #7BC876;
+}
+
+.navigation img {
+    margin-top: -2px;
+    vertical-align: middle;
 }
 
 .navigation .locale-code {
     color: #7BC876;
-    padding-left: 8px;
+    padding-left: 7px;
 }

--- a/frontend/src/core/navigation/components/Navigation.js
+++ b/frontend/src/core/navigation/components/Navigation.js
@@ -66,7 +66,7 @@ export class NavigationBase extends React.Component<InternalProps> {
     }
 
     render() {
-        const { locales, parameters } = this.props;
+        const { locales, parameters, resources } = this.props;
 
         if (isEmpty(locales.locales)) {
             return null;
@@ -104,8 +104,8 @@ export class NavigationBase extends React.Component<InternalProps> {
                 </li>
                 <resource.ResourceMenu
                     navigateToPath={ this.navigateToPath }
-                    parameters={ this.props.parameters }
-                    resources={ this.props.resources }
+                    parameters={ parameters }
+                    resources={ resources }
                 />
             </ul>
         </nav>;

--- a/frontend/src/core/resource/actions.js
+++ b/frontend/src/core/resource/actions.js
@@ -9,28 +9,28 @@ export const UPDATE: 'resource/UPDATE' = 'resource/UPDATE';
 
 export type Resource = {|
     +path: string,
-    +approved_strings: number,
-    +strings_with_warnings: number,
-    +total_strings: number,
+    +approvedStrings: number,
+    +stringsWithWarnings: number,
+    +totalStrings: number,
 |};
 
 
 export type UpdateAction = {|
     type: typeof UPDATE,
-    resource_path: string,
-    approved_strings: number,
-    strings_with_warnings: number,
+    resourcePath: string,
+    approvedStrings: number,
+    stringsWithWarnings: number,
 |};
 export function update(
-    resource_path: string,
-    approved_strings: number,
-    strings_with_warnings: number,
+    resourcePath: string,
+    approvedStrings: number,
+    stringsWithWarnings: number,
 ): UpdateAction {
     return {
         type: UPDATE,
-        resource_path,
-        approved_strings,
-        strings_with_warnings,
+        resourcePath,
+        approvedStrings,
+        stringsWithWarnings,
     };
 }
 
@@ -54,9 +54,9 @@ export function get(locale: string, project: string): Function {
         const resources = results.map(resource => {
             return {
                 path: resource.resource__path,
-                approved_strings: resource.approved_strings,
-                strings_with_warnings: resource.strings_with_warnings,
-                total_strings: resource.resource__total_strings,
+                approvedStrings: resource.approved_strings,
+                stringsWithWarnings: resource.strings_with_warnings,
+                totalStrings: resource.resource__total_strings,
             };
         });
 

--- a/frontend/src/core/resource/actions.js
+++ b/frontend/src/core/resource/actions.js
@@ -10,6 +10,7 @@ export const UPDATE: 'resource/UPDATE' = 'resource/UPDATE';
 export type Resource = {|
     +path: string,
     +approved_strings: number,
+    +strings_with_warnings: number,
     +total_strings: number,
 |};
 
@@ -18,15 +19,18 @@ export type UpdateAction = {|
     type: typeof UPDATE,
     resource_path: string,
     approved_strings: number,
+    strings_with_warnings: number,
 |};
 export function update(
     resource_path: string,
     approved_strings: number,
+    strings_with_warnings: number,
 ): UpdateAction {
     return {
         type: UPDATE,
         resource_path,
         approved_strings,
+        strings_with_warnings,
     };
 }
 
@@ -51,6 +55,7 @@ export function get(locale: string, project: string): Function {
             return {
                 path: resource.resource__path,
                 approved_strings: resource.approved_strings,
+                strings_with_warnings: resource.strings_with_warnings,
                 total_strings: resource.resource__total_strings,
             };
         });

--- a/frontend/src/core/resource/actions.js
+++ b/frontend/src/core/resource/actions.js
@@ -1,0 +1,60 @@
+/* @flow */
+
+import api from 'core/api';
+
+
+export const RECEIVE: 'resource/RECEIVE' = 'resource/RECEIVE';
+export const REQUEST: 'resource/REQUEST' = 'resource/REQUEST';
+
+
+export type Resource = {|
+    +path: string,
+    +approved_strings: number,
+    +total_strings: number,
+|};
+
+
+export type RequestAction = {|
+    type: typeof REQUEST,
+|};
+export function request() {
+    return {
+        type: REQUEST,
+    };
+}
+
+
+export type ReceiveAction = {|
+    type: typeof RECEIVE,
+    resources: Array<Resource>,
+|};
+export function receive(resources: Array<Resource>) {
+    return {
+        type: RECEIVE,
+        resources,
+    };
+}
+
+
+export function get(locale: string, project: string): Function {
+    return async dispatch => {
+        dispatch(request());
+
+        const results = await api.resource.getAll(locale, project);
+
+        const resources = [];
+        results.forEach(resource => {
+            resources.push({
+                path: resource.resource__path,
+                approved_strings: resource.approved_strings,
+                total_strings: resource.resource__total_strings,
+            });
+        });
+
+        dispatch(receive(resources));
+    }
+}
+
+export default {
+    get,
+};

--- a/frontend/src/core/resource/actions.js
+++ b/frontend/src/core/resource/actions.js
@@ -42,13 +42,12 @@ export function get(locale: string, project: string): Function {
 
         const results = await api.resource.getAll(locale, project);
 
-        const resources = [];
-        results.forEach(resource => {
-            resources.push({
+        const resources = results.map(resource => {
+            return {
                 path: resource.resource__path,
                 approved_strings: resource.approved_strings,
                 total_strings: resource.resource__total_strings,
-            });
+            };
         });
 
         dispatch(receive(resources));

--- a/frontend/src/core/resource/actions.js
+++ b/frontend/src/core/resource/actions.js
@@ -4,7 +4,7 @@ import api from 'core/api';
 
 
 export const RECEIVE: 'resource/RECEIVE' = 'resource/RECEIVE';
-export const REQUEST: 'resource/REQUEST' = 'resource/REQUEST';
+export const UPDATE: 'resource/UPDATE' = 'resource/UPDATE';
 
 
 export type Resource = {|
@@ -14,12 +14,14 @@ export type Resource = {|
 |};
 
 
-export type RequestAction = {|
-    type: typeof REQUEST,
+export type UpdateAction = {|
+    type: typeof UPDATE,
+    resource: Resource,
 |};
-export function request() {
+export function update(resource: Resource): UpdateAction {
     return {
-        type: REQUEST,
+        type: UPDATE,
+        resource,
     };
 }
 
@@ -28,7 +30,7 @@ export type ReceiveAction = {|
     type: typeof RECEIVE,
     resources: Array<Resource>,
 |};
-export function receive(resources: Array<Resource>) {
+export function receive(resources: Array<Resource>): ReceiveAction {
     return {
         type: RECEIVE,
         resources,
@@ -38,8 +40,6 @@ export function receive(resources: Array<Resource>) {
 
 export function get(locale: string, project: string): Function {
     return async dispatch => {
-        dispatch(request());
-
         const results = await api.resource.getAll(locale, project);
 
         const resources = results.map(resource => {
@@ -56,4 +56,5 @@ export function get(locale: string, project: string): Function {
 
 export default {
     get,
+    update,
 };

--- a/frontend/src/core/resource/actions.js
+++ b/frontend/src/core/resource/actions.js
@@ -38,11 +38,16 @@ export function update(
 export type ReceiveAction = {|
     type: typeof RECEIVE,
     resources: Array<Resource>,
+    allResources: Resource,
 |};
-export function receive(resources: Array<Resource>): ReceiveAction {
+export function receive(
+    resources: Array<Resource>,
+    allResources: Resource,
+): ReceiveAction {
     return {
         type: RECEIVE,
         resources,
+        allResources,
     };
 }
 
@@ -53,14 +58,16 @@ export function get(locale: string, project: string): Function {
 
         const resources = results.map(resource => {
             return {
-                path: resource.resource__path,
+                path: resource.title,
                 approvedStrings: resource.approved_strings,
                 stringsWithWarnings: resource.strings_with_warnings,
                 totalStrings: resource.resource__total_strings,
             };
         });
 
-        dispatch(receive(resources));
+        const allResources = resources.pop();
+
+        dispatch(receive(resources, allResources));
     }
 }
 

--- a/frontend/src/core/resource/actions.js
+++ b/frontend/src/core/resource/actions.js
@@ -16,12 +16,17 @@ export type Resource = {|
 
 export type UpdateAction = {|
     type: typeof UPDATE,
-    resource: Resource,
+    resource_path: string,
+    approved_strings: number,
 |};
-export function update(resource: Resource): UpdateAction {
+export function update(
+    resource_path: string,
+    approved_strings: number,
+): UpdateAction {
     return {
         type: UPDATE,
-        resource,
+        resource_path,
+        approved_strings,
     };
 }
 

--- a/frontend/src/core/resource/components/ResourceItem.css
+++ b/frontend/src/core/resource/components/ResourceItem.css
@@ -1,3 +1,4 @@
+.resource-menu .menu li.no-results,
 .resource-menu .menu li a {
     display: block;
     padding: 2px 4px;

--- a/frontend/src/core/resource/components/ResourceItem.css
+++ b/frontend/src/core/resource/components/ResourceItem.css
@@ -1,0 +1,9 @@
+.resource-menu .menu li a {
+    display: block;
+    padding: 2px 4px;
+}
+
+.resource-menu .menu li a:hover {
+    background: #3F4752;
+    color: #fff;
+}

--- a/frontend/src/core/resource/components/ResourceItem.js
+++ b/frontend/src/core/resource/components/ResourceItem.js
@@ -13,7 +13,7 @@ import type { Resource } from '..';
 type Props = {|
     parameters: NavigationParams,
     resource: Resource,
-    navigateToPath: (SyntheticMouseEvent<>) => void,
+    navigateToPath: (SyntheticMouseEvent<HTMLAnchorElement>) => void,
 |};
 
 

--- a/frontend/src/core/resource/components/ResourceItem.js
+++ b/frontend/src/core/resource/components/ResourceItem.js
@@ -1,0 +1,37 @@
+/* @flow */
+
+import * as React from 'react';
+
+import './ResourceItem.css';
+
+import { ResourcePercent } from '..';
+
+import type { NavigationParams } from 'core/navigation';
+import type { Resource } from '..';
+
+
+type Props = {|
+    index: number,
+    parameters: NavigationParams,
+    resource: Resource,
+    navigateToPath: (SyntheticMouseEvent<>) => void,
+|};
+
+
+/**
+ * Render a resource menu item.
+ */
+export default function ResourceItem(props: Props) {
+    const { index, parameters, resource, navigateToPath } = props;
+    const className = parameters.resource === resource.path ? 'current' : null;
+
+    return <li className={ className } key={ index }>
+        <a
+            href={ `/${parameters.locale}/${parameters.project}/${resource.path}/` }
+            onClick={ navigateToPath }
+        >
+            <span>{ resource.path }</span>
+            <ResourcePercent resource={ resource } />
+        </a>
+    </li>;
+}

--- a/frontend/src/core/resource/components/ResourceItem.js
+++ b/frontend/src/core/resource/components/ResourceItem.js
@@ -4,7 +4,7 @@ import * as React from 'react';
 
 import './ResourceItem.css';
 
-import { ResourcePercent } from '..';
+import ResourcePercent from './ResourcePercent.js';
 
 import type { NavigationParams } from 'core/navigation';
 import type { Resource } from '..';

--- a/frontend/src/core/resource/components/ResourceItem.js
+++ b/frontend/src/core/resource/components/ResourceItem.js
@@ -11,7 +11,6 @@ import type { Resource } from '..';
 
 
 type Props = {|
-    index: number,
     parameters: NavigationParams,
     resource: Resource,
     navigateToPath: (SyntheticMouseEvent<>) => void,
@@ -22,10 +21,10 @@ type Props = {|
  * Render a resource menu item.
  */
 export default function ResourceItem(props: Props) {
-    const { index, parameters, resource, navigateToPath } = props;
+    const { parameters, resource, navigateToPath } = props;
     const className = parameters.resource === resource.path ? 'current' : null;
 
-    return <li className={ className } key={ index }>
+    return <li className={ className }>
         <a
             href={ `/${parameters.locale}/${parameters.project}/${resource.path}/` }
             onClick={ navigateToPath }

--- a/frontend/src/core/resource/components/ResourceItem.test.js
+++ b/frontend/src/core/resource/components/ResourceItem.test.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import ResourceItem from './ResourceItem';
+import ResourcePercent from './ResourcePercent';
+
+
+function createShallowResourceItem({
+    path = 'path',
+} = {}) {
+    return shallow(
+        <ResourceItem
+            parameters={
+                {
+                    locale: 'locale',
+                    project: 'project',
+                    resource: 'resource',
+                }
+            }
+            resource={
+                {
+                    path: path,
+                }
+            }
+        />
+    );
+}
+
+
+describe('<ResourceItem>', () => {
+    it('renders correctly', () => {
+        const wrapper = createShallowResourceItem();
+        expect(wrapper.find('li')).toHaveLength(1);
+        expect(wrapper.find('a')).toHaveLength(1);
+        expect(wrapper.find('span')).toHaveLength(1);
+        expect(wrapper.find(ResourcePercent)).toHaveLength(1);
+        expect(wrapper.find('a').prop('href')).toEqual('/locale/project/path/');
+    });
+
+    it('sets the className correctly', () => {
+        let wrapper = createShallowResourceItem();
+        expect(wrapper.find('li.current')).toHaveLength(0);
+
+        wrapper = createShallowResourceItem({ path: 'resource' });
+        expect(wrapper.find('li.current')).toHaveLength(1);
+    });
+});

--- a/frontend/src/core/resource/components/ResourceMenu.css
+++ b/frontend/src/core/resource/components/ResourceMenu.css
@@ -1,14 +1,13 @@
 .resource-menu {
-    float: right;
     font-weight: 100;
-    padding: 4px 6px;
 }
 
 .resource-menu .selector {
     border-radius: 2px;
     cursor: pointer;
     line-height: 24px;
-    margin: 10px 0;
+    margin: 14px 6px;
+    float: right;
     padding: 4px 6px;
 }
 

--- a/frontend/src/core/resource/components/ResourceMenu.css
+++ b/frontend/src/core/resource/components/ResourceMenu.css
@@ -75,20 +75,6 @@
     overflow: auto;
 }
 
-.resource-menu .menu li.no-results,
-.resource-menu .menu li a,
-.resource-menu .menu .static-links a {
-    display: block;
-    padding: 2px 4px;
-}
-
-.resource-menu .menu li.no-results:hover,
-.resource-menu .menu li a:hover,
-.resource-menu .menu .static-links a:hover {
-    background: #3F4752;
-    color: #fff;
-}
-
 .resource-menu .menu .static-links {
     border-top: 1px solid #5E6475;
     margin-top: 5px;
@@ -97,9 +83,4 @@
 
 .resource-menu .menu .current a {
     color: #7BC876;
-}
-
-.resource-menu .menu .percent {
-    color: #7BC876;
-    float: right;
 }

--- a/frontend/src/core/resource/components/ResourceMenu.css
+++ b/frontend/src/core/resource/components/ResourceMenu.css
@@ -1,0 +1,105 @@
+.resource-menu {
+    float: right;
+    font-weight: 100;
+    padding: 4px 6px;
+}
+
+.resource-menu .selector {
+    border-radius: 2px;
+    cursor: pointer;
+    line-height: 24px;
+    margin: 10px 0;
+    padding: 4px 6px;
+}
+
+.resource-menu .selector.unselectable {
+    -moz-user-select: -moz-none;
+    -khtml-user-select: none;
+    -webkit-user-select: none;
+    -o-user-select: none;
+    user-select: none;
+}
+
+.resource-menu.closed .selector:hover {
+    background: #333941;
+}
+
+.resource-menu .selector .icon {
+    color: #7BC876;
+    padding-left: 7px;
+}
+
+.resource-menu .menu {
+    background-color: #272A2F;
+    border: 1px solid #333941;
+    border-top: none;
+    color: #AAAAAA;
+    line-height: 1.231em;
+    list-style: none;
+    padding: 10px 12px;
+    position: absolute;
+    top: 59px;
+    width: 600px;
+    z-index: 20;
+}
+
+.resource-menu .menu .search-wrapper {
+    border-bottom: 1px solid #5E6475;
+    margin-bottom: 5px;
+    position: relative;
+}
+
+.resource-menu .menu .search-wrapper .icon {
+    font-size: 1.2em;
+    position: absolute;
+    left: 3px;
+    top: 5px;
+}
+
+.resource-menu .menu .search-wrapper input[type="search"] {
+    background: transparent;
+    border: none;
+    color: #FFFFFF;
+    font-weight: 300;
+    padding: 4px 0 3px 25px;
+    width: 100%;
+}
+
+.resource-menu .menu .search-wrapper input[type="search"]::-webkit-search-decoration,
+.resource-menu .menu .search-wrapper input[type="search"]::-webkit-search-cancel-button {
+    display: none;
+}
+
+.resource-menu .menu ul {
+    max-height: 318px;
+    overflow: auto;
+}
+
+.resource-menu .menu li.no-results,
+.resource-menu .menu li a,
+.resource-menu .menu .static-links a {
+    display: block;
+    padding: 2px 4px;
+}
+
+.resource-menu .menu li.no-results:hover,
+.resource-menu .menu li a:hover,
+.resource-menu .menu .static-links a:hover {
+    background: #3F4752;
+    color: #fff;
+}
+
+.resource-menu .menu .static-links {
+    border-top: 1px solid #5E6475;
+    margin-top: 5px;
+    padding-top: 5px;
+}
+
+.resource-menu .menu .current a {
+    color: #7BC876;
+}
+
+.resource-menu .menu .percent {
+    color: #7BC876;
+    float: right;
+}

--- a/frontend/src/core/resource/components/ResourceMenu.js
+++ b/frontend/src/core/resource/components/ResourceMenu.js
@@ -6,7 +6,8 @@ import onClickOutside from 'react-onclickoutside';
 
 import './ResourceMenu.css';
 
-import { ResourceItem, ResourcePercent } from '..';
+import ResourceItem from './ResourceItem.js';
+import ResourcePercent from './ResourcePercent.js';
 
 import type { NavigationParams } from 'core/navigation';
 import type { ResourcesState } from '..';

--- a/frontend/src/core/resource/components/ResourceMenu.js
+++ b/frontend/src/core/resource/components/ResourceMenu.js
@@ -84,7 +84,7 @@ export class ResourceMenuBase extends React.Component<Props, State> {
         }
 
         let resourceName = parameters.resource.split('/').slice(-1)[0];
-        if (resourceName === 'all-resources') {
+        if (parameters.resource === 'all-resources') {
             resourceName = 'All Resources';
         }
 

--- a/frontend/src/core/resource/components/ResourceMenu.js
+++ b/frontend/src/core/resource/components/ResourceMenu.js
@@ -132,7 +132,6 @@ export class ResourceMenuBase extends React.Component<Props, State> {
                                     parameters={ parameters }
                                     resource={ resource }
                                     navigateToPath={ this.navigateToPath }
-                                    index={ index }
                                     key={ index }
                                 />;
                             })

--- a/frontend/src/core/resource/components/ResourceMenu.js
+++ b/frontend/src/core/resource/components/ResourceMenu.js
@@ -87,13 +87,9 @@ export class ResourceMenuBase extends React.Component<Props, State> {
             resourceName = 'All Resources';
         }
 
-        // Extract All Resources entry for more exposed presentation
-        const allResources = resources.resources.slice(-1)[0];
-
         // Search resources
         const search = this.state.search;
         const resourceElements = resources.resources.filter(resource =>
-            typeof resource.path === 'string' &&  // Exclude All Resources
             resource.path.toLowerCase().indexOf(search.toLowerCase()) > -1
         );
 
@@ -147,7 +143,7 @@ export class ResourceMenuBase extends React.Component<Props, State> {
                             <Localized id='navigation-ResourceMenu-all-resources'>
                                 <span>All Resources</span>
                             </Localized>
-                            <ResourcePercent resource={ allResources } />
+                            <ResourcePercent resource={ resources.allResources } />
                         </a>
                     </li>
                     <li>

--- a/frontend/src/core/resource/components/ResourceMenu.js
+++ b/frontend/src/core/resource/components/ResourceMenu.js
@@ -123,11 +123,6 @@ export class ResourceMenuBase extends React.Component<Props, State> {
                     <ul>
                         { resourceElements.length ?
                             resourceElements.map((resource, index) => {
-                                // Skip All Resources entry for more exposed presentation below
-                                if (index === resourceElements.length - 1) {
-                                    return null;
-                                }
-
                                 return <ResourceItem
                                     parameters={ parameters }
                                     resource={ resource }

--- a/frontend/src/core/resource/components/ResourceMenu.js
+++ b/frontend/src/core/resource/components/ResourceMenu.js
@@ -53,10 +53,9 @@ export class ResourceMenuBase extends React.Component<Props, State> {
         });
     }
 
-    navigateToPath = (event: SyntheticMouseEvent<>) => {
+    navigateToPath = (event: SyntheticMouseEvent<HTMLAnchorElement>) => {
         event.preventDefault();
 
-        // $FLOW_IGNORE
         const path = event.currentTarget.pathname;
         this.props.navigateToPath(path);
 

--- a/frontend/src/core/resource/components/ResourceMenu.js
+++ b/frontend/src/core/resource/components/ResourceMenu.js
@@ -92,8 +92,9 @@ export class ResourceMenuBase extends React.Component<Props, State> {
 
         // Search resources
         const search = this.state.search;
-        const resourceElements = resources.resources.filter(
-            resource => resource.path.indexOf(search) > -1
+        const resourceElements = resources.resources.filter(resource =>
+            typeof resource.path === 'string' &&  // Exclude All Resources
+            resource.path.toLowerCase().indexOf(search.toLowerCase()) > -1
         );
 
         return <li>

--- a/frontend/src/core/resource/components/ResourceMenu.js
+++ b/frontend/src/core/resource/components/ResourceMenu.js
@@ -98,74 +98,72 @@ export class ResourceMenuBase extends React.Component<Props, State> {
             resource.path.toLowerCase().indexOf(search.toLowerCase()) > -1
         );
 
-        return <li>
-            <div className={ className }>
-                <div
-                    className="selector unselectable"
-                    onClick={ this.toggleVisibility }
-                    title={ parameters.resource }
-                >
-                    <span>{ resourceName }</span>
-                    <span className="icon fa fa-caret-down"></span>
-                </div>
-
-                { !this.state.visible ? null :
-                <div className="menu">
-                    <div className="search-wrapper">
-                        <div className="icon fa fa-search"></div>
-                        <input
-                            type="search"
-                            autoComplete="off"
-                            autoFocus
-                            value={ this.state.search }
-                            onChange={ this.updateResourceList }
-                        />
-                    </div>
-
-                    <ul>
-                        { resourceElements.length ?
-                            resourceElements.map((resource, index) => {
-                                return <ResourceItem
-                                    parameters={ parameters }
-                                    resource={ resource }
-                                    navigateToPath={ this.navigateToPath }
-                                    key={ index }
-                                />;
-                            })
-                            :
-                            // No resources found
-                            <Localized id='navigation-ResourceMenu-no-results'>
-                                <li className="no-results">No results</li>
-                            </Localized>
-                        }
-                    </ul>
-
-                    <ul className="static-links">
-                        <li className={ parameters.resource === 'all-resources' ? 'current' : null }>
-                            <a
-                                href={ `/${parameters.locale}/${parameters.project}/all-resources/` }
-                                onClick={ this.navigateToPath }
-                            >
-                                <Localized id='navigation-ResourceMenu-all-resources'>
-                                    <span>All Resources</span>
-                                </Localized>
-                                <ResourcePercent resource={ allResources } />
-                            </a>
-                        </li>
-                        <li>
-                            <a
-                                href={ `/${parameters.locale}/all-projects/all-resources/` }
-                                onClick={ this.navigateToPath }
-                            >
-                                <Localized id='navigation-ResourceMenu-all-projects'>
-                                    <span>All Projects</span>
-                                </Localized>
-                            </a>
-                        </li>
-                    </ul>
-                </div>
-                }
+        return <li className={ className }>
+            <div
+                className="selector unselectable"
+                onClick={ this.toggleVisibility }
+                title={ parameters.resource }
+            >
+                <span>{ resourceName }</span>
+                <span className="icon fa fa-caret-down"></span>
             </div>
+
+            { !this.state.visible ? null :
+            <div className="menu">
+                <div className="search-wrapper">
+                    <div className="icon fa fa-search"></div>
+                    <input
+                        type="search"
+                        autoComplete="off"
+                        autoFocus
+                        value={ this.state.search }
+                        onChange={ this.updateResourceList }
+                    />
+                </div>
+
+                <ul>
+                    { resourceElements.length ?
+                        resourceElements.map((resource, index) => {
+                            return <ResourceItem
+                                parameters={ parameters }
+                                resource={ resource }
+                                navigateToPath={ this.navigateToPath }
+                                key={ index }
+                            />;
+                        })
+                        :
+                        // No resources found
+                        <Localized id='navigation-ResourceMenu-no-results'>
+                            <li className="no-results">No results</li>
+                        </Localized>
+                    }
+                </ul>
+
+                <ul className="static-links">
+                    <li className={ parameters.resource === 'all-resources' ? 'current' : null }>
+                        <a
+                            href={ `/${parameters.locale}/${parameters.project}/all-resources/` }
+                            onClick={ this.navigateToPath }
+                        >
+                            <Localized id='navigation-ResourceMenu-all-resources'>
+                                <span>All Resources</span>
+                            </Localized>
+                            <ResourcePercent resource={ allResources } />
+                        </a>
+                    </li>
+                    <li>
+                        <a
+                            href={ `/${parameters.locale}/all-projects/all-resources/` }
+                            onClick={ this.navigateToPath }
+                        >
+                            <Localized id='navigation-ResourceMenu-all-projects'>
+                                <span>All Projects</span>
+                            </Localized>
+                        </a>
+                    </li>
+                </ul>
+            </div>
+            }
         </li>;
     }
 }

--- a/frontend/src/core/resource/components/ResourceMenu.js
+++ b/frontend/src/core/resource/components/ResourceMenu.js
@@ -19,6 +19,7 @@ type Props = {|
 |};
 
 type State = {|
+    search: string,
     visible: boolean,
 |};
 
@@ -32,6 +33,7 @@ export class ResourceMenuBase extends React.Component<Props, State> {
     constructor(props: Props) {
         super(props);
         this.state = {
+            search: '',
             visible: false,
         };
     }
@@ -62,6 +64,12 @@ export class ResourceMenuBase extends React.Component<Props, State> {
         });
     }
 
+    updateResourceList = (event: SyntheticInputEvent<HTMLInputElement>) => {
+        this.setState({
+            search: event.currentTarget.value,
+        });
+    }
+
     render() {
         const { parameters, resources } = this.props;
 
@@ -82,6 +90,12 @@ export class ResourceMenuBase extends React.Component<Props, State> {
         // Extract All Resources entry for more exposed presentation
         const allResources = resources.resources.slice(-1)[0];
 
+        // Search resources
+        const search = this.state.search;
+        const resourceElements = resources.resources.filter(
+            resource => resource.path.indexOf(search) > -1
+        );
+
         return <li>
             <div className={ className }>
                 <div
@@ -97,24 +111,37 @@ export class ResourceMenuBase extends React.Component<Props, State> {
                 <div className="menu">
                     <div className="search-wrapper">
                         <div className="icon fa fa-search"></div>
-                        <input type="search" autoComplete="off" autoFocus />
+                        <input
+                            type="search"
+                            autoComplete="off"
+                            autoFocus
+                            value={ this.state.search }
+                            onChange={ this.updateResourceList }
+                        />
                     </div>
 
                     <ul>
-                        { resources.resources.map((resource, index) => {
-                            // Skip All Resources entry for more exposed presentation below
-                            if (index === resources.resources.length - 1) {
-                                return null;
-                            }
+                        { resourceElements.length ?
+                            resourceElements.map((resource, index) => {
+                                // Skip All Resources entry for more exposed presentation below
+                                if (index === resourceElements.length - 1) {
+                                    return null;
+                                }
 
-                            return <ResourceItem
-                                parameters={ parameters }
-                                resource={ resource }
-                                navigateToPath={ this.navigateToPath }
-                                index={ index }
-                                key={ index }
-                            />;
-                        }) }
+                                return <ResourceItem
+                                    parameters={ parameters }
+                                    resource={ resource }
+                                    navigateToPath={ this.navigateToPath }
+                                    index={ index }
+                                    key={ index }
+                                />;
+                            })
+                            :
+                            // No resources found
+                            <Localized id='navigation-ResourceMenu-no-results'>
+                                <li className="no-results">No results</li>
+                            </Localized>
+                        }
                     </ul>
 
                     <ul className="static-links">

--- a/frontend/src/core/resource/components/ResourceMenu.js
+++ b/frontend/src/core/resource/components/ResourceMenu.js
@@ -6,8 +6,10 @@ import onClickOutside from 'react-onclickoutside';
 
 import './ResourceMenu.css';
 
+import { ResourceItem, ResourcePercent } from '..';
+
 import type { NavigationParams } from 'core/navigation';
-import type { Resource, ResourcesState } from '..';
+import type { ResourcesState } from '..';
 
 
 type Props = {|
@@ -60,27 +62,6 @@ export class ResourceMenuBase extends React.Component<Props, State> {
         });
     }
 
-    renderPercent = (resource: Resource) => {
-        return Math.floor(resource.approved_strings / resource.total_strings * 100) + '%';
-    }
-
-    renderResource = (resource: Resource, i: number) => {
-        const { parameters } = this.props;
-
-        return <li
-            className={ parameters.resource === resource.path ? 'current' : null }
-            key={ i }
-        >
-            <a
-                href={ `/${parameters.locale}/${parameters.project}/${resource.path}/` }
-                onClick={ this.navigateToPath }
-            >
-                <span>{ resource.path }</span>
-                <span className="percent">{ this.renderPercent(resource) }</span>
-            </a>
-        </li>;
-    }
-
     render() {
         const { parameters, resources } = this.props;
 
@@ -120,13 +101,19 @@ export class ResourceMenuBase extends React.Component<Props, State> {
                     </div>
 
                     <ul>
-                        { resources.resources.map((resource, i) => {
+                        { resources.resources.map((resource, index) => {
                             // Skip All Resources entry for more exposed presentation below
-                            if (i === resources.resources.length - 1) {
+                            if (index === resources.resources.length - 1) {
                                 return null;
                             }
 
-                            return this.renderResource(resource, i);
+                            return <ResourceItem
+                                parameters={ parameters }
+                                resource={ resource }
+                                navigateToPath={ this.navigateToPath }
+                                index={ index }
+                                key={ index }
+                            />;
                         }) }
                     </ul>
 
@@ -139,7 +126,7 @@ export class ResourceMenuBase extends React.Component<Props, State> {
                                 <Localized id='navigation-ResourceMenu-all-resources'>
                                     <span>All Resources</span>
                                 </Localized>
-                                <span className="percent">{ this.renderPercent(allResources) }</span>
+                                <ResourcePercent resource={ allResources } />
                             </a>
                         </li>
                         <li>
@@ -150,7 +137,6 @@ export class ResourceMenuBase extends React.Component<Props, State> {
                                 <Localized id='navigation-ResourceMenu-all-projects'>
                                     <span>All Projects</span>
                                 </Localized>
-                                <span className="percent"></span>
                             </a>
                         </li>
                     </ul>

--- a/frontend/src/core/resource/components/ResourceMenu.test.js
+++ b/frontend/src/core/resource/components/ResourceMenu.test.js
@@ -74,7 +74,7 @@ describe('<ResourceMenuBase>', () => {
         expect(wrapper.find('.resource-menu .menu #navigation-ResourceMenu-all-projects')).toHaveLength(1);
     });
 
-    it('renders resource menu correctly', () => {
+    it('searches resource items correctly', () => {
         const SEARCH = 'bc';
         const wrapper = createShallowResourceMenu();
         wrapper.instance().setState({

--- a/frontend/src/core/resource/components/ResourceMenu.test.js
+++ b/frontend/src/core/resource/components/ResourceMenu.test.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import ResourceItem from './ResourceItem';
+import ResourceItem from './ResourceItem.js';
+
 import { ResourceMenuBase } from './ResourceMenu';
 
 

--- a/frontend/src/core/resource/components/ResourceMenu.test.js
+++ b/frontend/src/core/resource/components/ResourceMenu.test.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import ResourceItem from './ResourceItem';
+import { ResourceMenuBase } from './ResourceMenu';
+
+
+function createShallowResourceMenu({
+    project = 'project',
+    resource = 'path/to.file',
+} = {}) {
+    return shallow(
+        <ResourceMenuBase
+            parameters={
+                {
+                    locale: 'locale',
+                    project: project,
+                    resource: resource,
+                }
+            }
+            resources={
+                {
+                    resources: [
+                        {
+                            path: 'resourceAbc',
+                        },
+                        {
+                            path: 'resourceBcd',
+                        },
+                        {
+                            path: 'resourceCde',
+                        },
+                    ],
+                }
+            }
+        />
+    );
+}
+
+
+describe('<ResourceMenuBase>', () => {
+    it('hides resource selector for all-projects', () => {
+        const wrapper = createShallowResourceMenu({ project: 'all-projects' });
+
+        expect(wrapper.find('.resource-menu .selector')).toHaveLength(0);
+    });
+
+    it('renders resource selector correctly', () => {
+        const wrapper = createShallowResourceMenu();
+
+        expect(wrapper.find('.resource-menu .selector')).toHaveLength(1);
+        expect(wrapper.find('.resource-menu .selector').prop('title')).toEqual('path/to.file');
+        expect(wrapper.find('.resource-menu .selector span:first-child').text()).toEqual('to.file');
+        expect(wrapper.find('.resource-menu .selector .icon')).toHaveLength(1);
+    });
+
+    it('sets resource name correctly for all-resources', () => {
+        const wrapper = createShallowResourceMenu({ resource: 'all-resources' });
+
+        expect(wrapper.find('.resource-menu .selector span:first-child').text()).toEqual('All Resources');
+    });
+
+    it('renders resource menu correctly', () => {
+        const wrapper = createShallowResourceMenu();
+        wrapper.instance().setState({visible: true});
+
+        expect(wrapper.find('.resource-menu .menu')).toHaveLength(1);
+        expect(wrapper.find('.resource-menu .menu .search-wrapper')).toHaveLength(1);
+        expect(wrapper.find('.resource-menu .menu > ul')).toHaveLength(2);
+        expect(wrapper.find('.resource-menu .menu > ul').find(ResourceItem)).toHaveLength(3);
+        expect(wrapper.find('.resource-menu .menu .static-links')).toHaveLength(1);
+        expect(wrapper.find('.resource-menu .menu #navigation-ResourceMenu-all-resources')).toHaveLength(1);
+        expect(wrapper.find('.resource-menu .menu #navigation-ResourceMenu-all-projects')).toHaveLength(1);
+    });
+
+    it('renders resource menu correctly', () => {
+        const SEARCH = 'bc';
+        const wrapper = createShallowResourceMenu();
+        wrapper.instance().setState({
+            search: SEARCH,
+            visible: true,
+        });
+
+        expect(wrapper.find('.resource-menu .menu .search-wrapper input').prop('value')).toEqual(SEARCH);
+        expect(wrapper.find('.resource-menu .menu > ul').find(ResourceItem)).toHaveLength(2);
+    });
+});

--- a/frontend/src/core/resource/components/ResourcePercent.css
+++ b/frontend/src/core/resource/components/ResourcePercent.css
@@ -1,0 +1,4 @@
+.resource-menu .menu .percent {
+    color: #7BC876;
+    float: right;
+}

--- a/frontend/src/core/resource/components/ResourcePercent.js
+++ b/frontend/src/core/resource/components/ResourcePercent.js
@@ -1,0 +1,23 @@
+/* @flow */
+
+import * as React from 'react';
+
+import './ResourcePercent.css';
+
+import type { Resource } from '..';
+
+
+type Props = {|
+    resource: Resource,
+|};
+
+
+/**
+ * Render a resource item percentage.
+ */
+export default function ResourcePercent(props: Props) {
+    const { resource } = props;
+    const percent = Math.floor(resource.approved_strings / resource.total_strings * 100) + '%';
+
+    return <span className="percent">{ percent }</span>;
+}

--- a/frontend/src/core/resource/components/ResourcePercent.js
+++ b/frontend/src/core/resource/components/ResourcePercent.js
@@ -16,8 +16,10 @@ type Props = {|
  * Render a resource item percentage.
  */
 export default function ResourcePercent(props: Props) {
-    const { resource } = props;
-    const percent = Math.floor(resource.approved_strings / resource.total_strings * 100) + '%';
+    const { approved_strings, strings_with_warnings, total_strings }  = props.resource;
+    const complete_strings = approved_strings + strings_with_warnings;
+
+    const percent = Math.floor(complete_strings / total_strings * 100) + '%';
 
     return <span className="percent">{ percent }</span>;
 }

--- a/frontend/src/core/resource/components/ResourcePercent.js
+++ b/frontend/src/core/resource/components/ResourcePercent.js
@@ -16,10 +16,10 @@ type Props = {|
  * Render a resource item percentage.
  */
 export default function ResourcePercent(props: Props) {
-    const { approved_strings, strings_with_warnings, total_strings }  = props.resource;
-    const complete_strings = approved_strings + strings_with_warnings;
+    const { approvedStrings, stringsWithWarnings, totalStrings } = props.resource;
+    const completeStrings = approvedStrings + stringsWithWarnings;
 
-    const percent = Math.floor(complete_strings / total_strings * 100) + '%';
+    const percent = Math.floor(completeStrings / totalStrings * 100) + '%';
 
     return <span className="percent">{ percent }</span>;
 }

--- a/frontend/src/core/resource/components/ResourcePercent.test.js
+++ b/frontend/src/core/resource/components/ResourcePercent.test.js
@@ -6,9 +6,9 @@ import ResourcePercent from './ResourcePercent';
 
 describe('<ResourcePercent>', () => {
     const RESOURCE = {
-        approved_strings: 2,
-        strings_with_warnings: 3,
-        total_strings: 10,
+        approvedStrings: 2,
+        stringsWithWarnings: 3,
+        totalStrings: 10,
     };
 
     it('renders correctly', () => {

--- a/frontend/src/core/resource/components/ResourcePercent.test.js
+++ b/frontend/src/core/resource/components/ResourcePercent.test.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import ResourcePercent from './ResourcePercent';
+
+
+describe('<ResourcePercent>', () => {
+    const RESOURCE = {
+        approved_strings: 2,
+        strings_with_warnings: 3,
+        total_strings: 10,
+    };
+
+    it('renders correctly', () => {
+        const wrapper = shallow(<ResourcePercent resource={ RESOURCE } />);
+        expect(wrapper.find('.percent').text()).toEqual('50%');
+    });
+});

--- a/frontend/src/core/resource/index.js
+++ b/frontend/src/core/resource/index.js
@@ -3,9 +3,7 @@
 export { default as actions } from './actions';
 export { default as reducer } from './reducer';
 
-export { default as ResourceItem } from './components/ResourceItem';
 export { default as ResourceMenu } from './components/ResourceMenu';
-export { default as ResourcePercent } from './components/ResourcePercent';
 
 export type { Resource } from './actions';
 export type { ResourcesState } from './reducer';

--- a/frontend/src/core/resource/index.js
+++ b/frontend/src/core/resource/index.js
@@ -3,7 +3,9 @@
 export { default as actions } from './actions';
 export { default as reducer } from './reducer';
 
+export { default as ResourceItem } from './components/ResourceItem';
 export { default as ResourceMenu } from './components/ResourceMenu';
+export { default as ResourcePercent } from './components/ResourcePercent';
 
 export type { Resource } from './actions';
 export type { ResourcesState } from './reducer';

--- a/frontend/src/core/resource/index.js
+++ b/frontend/src/core/resource/index.js
@@ -1,0 +1,14 @@
+/* @flow */
+
+export { default as actions } from './actions';
+export { default as reducer } from './reducer';
+
+export { default as ResourceMenu } from './components/ResourceMenu';
+
+export type { Resource } from './actions';
+export type { ResourcesState } from './reducer';
+
+
+// Name of this module.
+// Used as the key to store this module's reducer.
+export const NAME: string = 'resource';

--- a/frontend/src/core/resource/reducer.js
+++ b/frontend/src/core/resource/reducer.js
@@ -19,14 +19,19 @@ function updateResource(
     state: Object,
     resource_path: string,
     approved_strings: number,
+    strings_with_warnings: number,
 ): Array<Resource> {
     return state.resources.map(item => {
         if (item.path === resource_path) {
             const allResources = state.resources.slice(-1)[0];
-            const diff = approved_strings - item.approved_strings;
 
-            item.approved_strings += diff;
-            allResources.approved_strings += diff;
+            const diff_approved = approved_strings - item.approved_strings;
+            item.approved_strings += diff_approved;
+            allResources.approved_strings += diff_approved;
+
+            const diff_warnings = strings_with_warnings - item.strings_with_warnings;
+            item.strings_with_warnings += diff_warnings;
+            allResources.strings_with_warnings += diff_warnings;
         }
 
         return item;
@@ -55,6 +60,7 @@ export default function reducer(
                     state,
                     action.resource_path,
                     action.approved_strings,
+                    action.strings_with_warnings,
                 ),
             };
         default:

--- a/frontend/src/core/resource/reducer.js
+++ b/frontend/src/core/resource/reducer.js
@@ -1,23 +1,36 @@
 /* @flow */
 
-import { RECEIVE, REQUEST } from './actions';
+import { RECEIVE, UPDATE } from './actions';
 
-import type { Resource, ReceiveAction, RequestAction } from './actions';
+import type { Resource, ReceiveAction, UpdateAction } from './actions';
 
 
 type Action =
     | ReceiveAction
-    | RequestAction
+    | UpdateAction
 ;
 
 export type ResourcesState = {|
-    +fetching: boolean,
     +resources: Array<Resource>,
 |};
 
 
+function updateResource(
+    state: Object,
+    resource: Resource,
+): Array<Resource> {
+    return state.resources.map(item => {
+        if (item.path === resource.path) {
+            return resource;
+        }
+        else {
+            return item;
+        }
+    });
+}
+
+
 const initial: ResourcesState = {
-    fetching: false,
     resources: [],
 };
 
@@ -29,13 +42,15 @@ export default function reducer(
         case RECEIVE:
             return {
                 ...state,
-                fetching: false,
                 resources: action.resources,
             };
-        case REQUEST:
+        case UPDATE:
             return {
                 ...state,
-                fetching: true,
+                resources: updateResource(
+                    state,
+                    action.resource,
+                ),
             };
         default:
             return state;

--- a/frontend/src/core/resource/reducer.js
+++ b/frontend/src/core/resource/reducer.js
@@ -1,0 +1,43 @@
+/* @flow */
+
+import { RECEIVE, REQUEST } from './actions';
+
+import type { Resource, ReceiveAction, RequestAction } from './actions';
+
+
+type Action =
+    | ReceiveAction
+    | RequestAction
+;
+
+export type ResourcesState = {|
+    +fetching: boolean,
+    +resources: Array<Resource>,
+|};
+
+
+const initial: ResourcesState = {
+    fetching: false,
+    resources: [],
+};
+
+export default function reducer(
+    state: ResourcesState = initial,
+    action: Action,
+): ResourcesState {
+    switch (action.type) {
+        case RECEIVE:
+            return {
+                ...state,
+                fetching: false,
+                resources: action.resources,
+            };
+        case REQUEST:
+            return {
+                ...state,
+                fetching: true,
+            };
+        default:
+            return state;
+    }
+}

--- a/frontend/src/core/resource/reducer.js
+++ b/frontend/src/core/resource/reducer.js
@@ -17,21 +17,21 @@ export type ResourcesState = {|
 
 function updateResource(
     state: Object,
-    resource_path: string,
-    approved_strings: number,
-    strings_with_warnings: number,
+    resourcePath: string,
+    approvedStrings: number,
+    stringsWithWarnings: number,
 ): Array<Resource> {
     return state.resources.map(item => {
-        if (item.path === resource_path) {
+        if (item.path === resourcePath) {
             const allResources = state.resources.slice(-1)[0];
 
-            const diff_approved = approved_strings - item.approved_strings;
-            item.approved_strings += diff_approved;
-            allResources.approved_strings += diff_approved;
+            const diffApproved = approvedStrings - item.approvedStrings;
+            item.approvedStrings += diffApproved;
+            allResources.approvedStrings += diffApproved;
 
-            const diff_warnings = strings_with_warnings - item.strings_with_warnings;
-            item.strings_with_warnings += diff_warnings;
-            allResources.strings_with_warnings += diff_warnings;
+            const diffWarnings = stringsWithWarnings - item.stringsWithWarnings;
+            item.stringsWithWarnings += diffWarnings;
+            allResources.stringsWithWarnings += diffWarnings;
         }
 
         return item;
@@ -58,9 +58,9 @@ export default function reducer(
                 ...state,
                 resources: updateResource(
                     state,
-                    action.resource_path,
-                    action.approved_strings,
-                    action.strings_with_warnings,
+                    action.resourcePath,
+                    action.approvedStrings,
+                    action.stringsWithWarnings,
                 ),
             };
         default:

--- a/frontend/src/core/resource/reducer.js
+++ b/frontend/src/core/resource/reducer.js
@@ -17,15 +17,19 @@ export type ResourcesState = {|
 
 function updateResource(
     state: Object,
-    resource: Resource,
+    resource_path: string,
+    approved_strings: number,
 ): Array<Resource> {
     return state.resources.map(item => {
-        if (item.path === resource.path) {
-            return resource;
+        if (item.path === resource_path) {
+            const allResources = state.resources.slice(-1)[0];
+            const diff = approved_strings - item.approved_strings;
+
+            item.approved_strings += diff;
+            allResources.approved_strings += diff;
         }
-        else {
-            return item;
-        }
+
+        return item;
     });
 }
 
@@ -49,7 +53,8 @@ export default function reducer(
                 ...state,
                 resources: updateResource(
                     state,
-                    action.resource,
+                    action.resource_path,
+                    action.approved_strings,
                 ),
             };
         default:

--- a/frontend/src/core/resource/reducer.test.js
+++ b/frontend/src/core/resource/reducer.test.js
@@ -5,14 +5,14 @@ import { RECEIVE, UPDATE } from './actions';
 describe('reducer', () => {
     const RESOURCES = [{
         path: 'path/to.file',
-        approved_strings: 1,
-        strings_with_warnings: 1,
-        total_strings: 2,
+        approvedStrings: 1,
+        stringsWithWarnings: 1,
+        totalStrings: 2,
     }, {
         path: [],
-        approved_strings: 1,
-        strings_with_warnings: 1,
-        total_strings: 2,
+        approvedStrings: 1,
+        stringsWithWarnings: 1,
+        totalStrings: 2,
     }];
 
     it('returns the initial state', () => {
@@ -44,14 +44,14 @@ describe('reducer', () => {
     it('handles the UPDATE action', () => {
         const UPDATED_RESOURCES = [{
             path: 'path/to.file',
-            approved_strings: 2,
-            strings_with_warnings: 0,
-            total_strings: 2,
+            approvedStrings: 2,
+            stringsWithWarnings: 0,
+            totalStrings: 2,
         }, {
             path: [],
-            approved_strings: 2,
-            strings_with_warnings: 0,
-            total_strings: 2,
+            approvedStrings: 2,
+            stringsWithWarnings: 0,
+            totalStrings: 2,
         }];
 
         const res = reducer(
@@ -60,9 +60,9 @@ describe('reducer', () => {
             },
             {
                 type: UPDATE,
-                resource_path: 'path/to.file',
-                approved_strings: 2,
-                strings_with_warnings: 0,
+                resourcePath: 'path/to.file',
+                approvedStrings: 2,
+                stringsWithWarnings: 0,
             }
         );
 

--- a/frontend/src/core/resource/reducer.test.js
+++ b/frontend/src/core/resource/reducer.test.js
@@ -1,0 +1,75 @@
+import reducer from './reducer';
+import { RECEIVE, UPDATE } from './actions';
+
+
+describe('reducer', () => {
+    const RESOURCES = [{
+        path: 'path/to.file',
+        approved_strings: 1,
+        strings_with_warnings: 1,
+        total_strings: 2,
+    }, {
+        path: [],
+        approved_strings: 1,
+        strings_with_warnings: 1,
+        total_strings: 2,
+    }];
+
+    it('returns the initial state', () => {
+        const res = reducer(undefined, {});
+
+        const expected = {
+            resources: [],
+        }
+
+        expect(res).toEqual(expected);
+    });
+
+    it('handles the RECEIVE action', () => {
+        const res = reducer(
+            {},
+            {
+                type: RECEIVE,
+                resources: RESOURCES,
+            }
+        );
+
+        const expected = {
+            resources: RESOURCES,
+        };
+
+        expect(res).toEqual(expected);
+    });
+
+    it('handles the UPDATE action', () => {
+        const UPDATED_RESOURCES = [{
+            path: 'path/to.file',
+            approved_strings: 2,
+            strings_with_warnings: 0,
+            total_strings: 2,
+        }, {
+            path: [],
+            approved_strings: 2,
+            strings_with_warnings: 0,
+            total_strings: 2,
+        }];
+
+        const res = reducer(
+            {
+                resources: RESOURCES,
+            },
+            {
+                type: UPDATE,
+                resource_path: 'path/to.file',
+                approved_strings: 2,
+                strings_with_warnings: 0,
+            }
+        );
+
+        const expected = {
+            resources: UPDATED_RESOURCES,
+        };
+
+        expect(res).toEqual(expected);
+    });
+});

--- a/frontend/src/core/resource/reducer.test.js
+++ b/frontend/src/core/resource/reducer.test.js
@@ -8,18 +8,25 @@ describe('reducer', () => {
         approvedStrings: 1,
         stringsWithWarnings: 1,
         totalStrings: 2,
-    }, {
+    }];
+    const ALL_RESOURCES = {
         path: [],
         approvedStrings: 1,
         stringsWithWarnings: 1,
         totalStrings: 2,
-    }];
+    };
 
     it('returns the initial state', () => {
         const res = reducer(undefined, {});
 
         const expected = {
             resources: [],
+            allResources: {
+                path: 'all-resources',
+                approvedStrings: 0,
+                stringsWithWarnings: 0,
+                totalStrings: 0,
+            },
         }
 
         expect(res).toEqual(expected);
@@ -31,11 +38,13 @@ describe('reducer', () => {
             {
                 type: RECEIVE,
                 resources: RESOURCES,
+                allResources: ALL_RESOURCES,
             }
         );
 
         const expected = {
             resources: RESOURCES,
+            allResources: ALL_RESOURCES,
         };
 
         expect(res).toEqual(expected);
@@ -47,16 +56,18 @@ describe('reducer', () => {
             approvedStrings: 2,
             stringsWithWarnings: 0,
             totalStrings: 2,
-        }, {
+        }];
+        const UPDATED_ALL_RESOURCES = {
             path: [],
             approvedStrings: 2,
             stringsWithWarnings: 0,
             totalStrings: 2,
-        }];
+        }
 
         const res = reducer(
             {
                 resources: RESOURCES,
+                allResources: ALL_RESOURCES,
             },
             {
                 type: UPDATE,
@@ -68,6 +79,7 @@ describe('reducer', () => {
 
         const expected = {
             resources: UPDATED_RESOURCES,
+            allResources: UPDATED_ALL_RESOURCES,
         };
 
         expect(res).toEqual(expected);

--- a/frontend/src/modules/editor/actions.js
+++ b/frontend/src/modules/editor/actions.js
@@ -4,6 +4,7 @@ import api from 'core/api';
 
 import * as notification from 'core/notification';
 import { actions as pluralActions } from 'core/plural';
+import { actions as statsActions } from 'core/stats';
 import { actions as entitiesActions } from 'modules/entitieslist';
 
 import type { DbEntity } from 'modules/entitieslist';
@@ -170,6 +171,12 @@ export function sendTranslation(
                     content.translation
                 )
             );
+
+            // Update stats for the search panel if possible.
+            if (content.stats) {
+                dispatch(statsActions.update(content.stats));
+            }
+
             if (nextEntity) {
                 // The change did work, we want to move on to the next Entity or pluralForm.
                 pluralActions.moveToNextTranslation(

--- a/frontend/src/modules/editor/actions.js
+++ b/frontend/src/modules/editor/actions.js
@@ -130,6 +130,7 @@ export function sendTranslation(
     forceSuggestions: boolean,
     nextEntity: ?DbEntity,
     router: Object,
+    resource: string,
     ignoreWarnings: ?boolean,
 ): Function {
     return async dispatch => {
@@ -140,6 +141,7 @@ export function sendTranslation(
             pluralForm,
             original,
             forceSuggestions,
+            resource,
             ignoreWarnings,
         );
 

--- a/frontend/src/modules/editor/actions.js
+++ b/frontend/src/modules/editor/actions.js
@@ -4,6 +4,7 @@ import api from 'core/api';
 
 import * as notification from 'core/notification';
 import { actions as pluralActions } from 'core/plural';
+import { actions as resourceActions } from 'core/resource';
 import { actions as statsActions } from 'core/stats';
 import { actions as entitiesActions } from 'modules/entitieslist';
 
@@ -174,9 +175,10 @@ export function sendTranslation(
                 )
             );
 
-            // Update stats for the search panel if possible.
+            // Update stats in the filter panel and resource menu if possible.
             if (content.stats) {
                 dispatch(statsActions.update(content.stats));
+                dispatch(resourceActions.update(resource, content.stats.approved));
             }
 
             if (nextEntity) {

--- a/frontend/src/modules/editor/actions.js
+++ b/frontend/src/modules/editor/actions.js
@@ -178,7 +178,13 @@ export function sendTranslation(
             // Update stats in the filter panel and resource menu if possible.
             if (content.stats) {
                 dispatch(statsActions.update(content.stats));
-                dispatch(resourceActions.update(resource, content.stats.approved));
+                dispatch(
+                    resourceActions.update(
+                        resource,
+                        content.stats.approved,
+                        content.stats.warnings,
+                    )
+                );
             }
 
             if (nextEntity) {

--- a/frontend/src/modules/editor/components/Editor.js
+++ b/frontend/src/modules/editor/components/Editor.js
@@ -120,6 +120,7 @@ export class EditorBase extends React.Component<InternalProps> {
             state.user.settings.forceSuggestions,
             state.nextEntity,
             state.router,
+            state.parameters.resource,
             ignoreWarnings,
         ));
     }

--- a/frontend/src/modules/editor/components/Editor.test.js
+++ b/frontend/src/modules/editor/components/Editor.test.js
@@ -37,6 +37,9 @@ function createEditorBase({
             { translation: 'initial' }
         }
         locale={ LOCALE }
+        parameters={
+            { resource: 'resource' }
+        }
         pluralForm={ pluralForm }
         selectedEntity={ selectedEntity }
         user={ {

--- a/frontend/src/modules/entitieslist/reducer.js
+++ b/frontend/src/modules/entitieslist/reducer.js
@@ -69,7 +69,7 @@ function updateEntityTranslation(
             ...item,
             translation: translations,
         };
-    })
+    });
 }
 
 

--- a/frontend/src/modules/entitydetails/components/EntityDetails.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.js
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { connect } from 'react-redux';
+import { push } from 'connected-react-router';
 
 import './EntityDetails.css';
 
@@ -187,6 +188,17 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
         );
     }
 
+    navigateToPath = (path: string) => {
+        const { dispatch } = this.props;
+
+        dispatch(
+            unsavedchanges.actions.check(
+                this.props.unsavedchanges,
+                () => { dispatch(push(path)); }
+            )
+        );
+    }
+
     openLightbox = (image: string) => {
         this.props.dispatch(lightbox.actions.open(image));
     }
@@ -251,6 +263,7 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
                 pluralForm={ state.pluralForm }
                 openLightbox={ this.openLightbox }
                 addTextToEditorTranslation={ this.addTextToEditorTranslation }
+                navigateToPath={ this.navigateToPath }
             />
             <editor.Editor />
             <Helpers

--- a/frontend/src/modules/entitydetails/components/Metadata.js
+++ b/frontend/src/modules/entitydetails/components/Metadata.js
@@ -202,10 +202,9 @@ export default class Metadata extends React.Component<Props> {
         return this.renderSourceObject(entity.source);
     }
 
-    navigateToPath = (event: SyntheticMouseEvent<>) => {
+    navigateToPath = (event: SyntheticMouseEvent<HTMLAnchorElement>) => {
         event.preventDefault();
 
-        // $FLOW_IGNORE
         const path = event.currentTarget.pathname;
         this.props.navigateToPath(path);
     }

--- a/frontend/src/modules/entitydetails/components/Metadata.js
+++ b/frontend/src/modules/entitydetails/components/Metadata.js
@@ -1,7 +1,6 @@
 /* @flow */
 
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 import Linkify from 'react-linkify';
 import { Localized } from 'fluent-react';
 
@@ -45,6 +44,7 @@ type Props = {|
     +pluralForm: number,
     +openLightbox: (string) => void,
     +addTextToEditorTranslation: (string) => void,
+    +navigateToPath: (string) => void,
 |};
 
 
@@ -202,6 +202,14 @@ export default class Metadata extends React.Component<Props> {
         return this.renderSourceObject(entity.source);
     }
 
+    navigateToPath = (event: SyntheticMouseEvent<>) => {
+        event.preventDefault();
+
+        // $FLOW_IGNORE
+        const path = event.currentTarget.pathname;
+        this.props.navigateToPath(path);
+    }
+
     render(): React.Node {
         const { entity, locale, openLightbox } = this.props;
 
@@ -217,9 +225,12 @@ export default class Metadata extends React.Component<Props> {
             { this.renderSources(entity) }
             <Localized id='entitydetails-metadata-resource' attrs={ { title: true } }>
                 <Property title='Resource' className='resource'>
-                    <Link to={ `/${locale.code}/${entity.project.slug}/${entity.path}/` }>
+                    <a
+                        href={ `/${locale.code}/${entity.project.slug}/${entity.path}/` }
+                        onClick={ this.navigateToPath }
+                    >
                         { entity.path }
-                    </Link>
+                    </a>
                 </Property>
             </Localized>
             <Localized id='entitydetails-metadata-project' attrs={ { title: true } }>

--- a/frontend/src/modules/entitydetails/components/Metadata.test.js
+++ b/frontend/src/modules/entitydetails/components/Metadata.test.js
@@ -50,7 +50,7 @@ describe('<Metadata>', () => {
         const content = wrapper.find('Linkify').map(item => item.props().children);
         expect(content).toContain(ENTITY.comment);
 
-        expect(wrapper.find('Link').props().to).toContain(ENTITY.path);
+        expect(wrapper.find('#entitydetails-metadata-resource a').text()).toContain(ENTITY.path);
     });
 
     it('renders the selected plural form as original string', () => {

--- a/frontend/src/modules/history/actions.js
+++ b/frontend/src/modules/history/actions.js
@@ -170,7 +170,13 @@ export function updateStatus(
         // Update stats in the filter panel and resource menu if possible.
         if (results.stats) {
             dispatch(statsActions.update(results.stats));
-            dispatch(resourceActions.update(resource, results.stats.approved));
+            dispatch(
+                resourceActions.update(
+                    resource,
+                    results.stats.approved,
+                    results.stats.warnings,
+                )
+            );
         }
 
         // Refresh the data now that it has changed on the server.

--- a/frontend/src/modules/history/actions.js
+++ b/frontend/src/modules/history/actions.js
@@ -4,6 +4,7 @@ import api from 'core/api';
 
 import * as notification from 'core/notification';
 import { actions as pluralActions } from 'core/plural';
+import { actions as resourceActions } from 'core/resource';
 import { actions as statsActions } from 'core/stats';
 import { actions as editorActions } from 'modules/editor';
 import { actions as listActions } from 'modules/entitieslist';
@@ -166,9 +167,10 @@ export function updateStatus(
             dispatch(get(entity, locale.code, pluralForm));
         }
 
-        // Update stats for the search panel if possible.
+        // Update stats in the filter panel and resource menu if possible.
         if (results.stats) {
             dispatch(statsActions.update(results.stats));
+            dispatch(resourceActions.update(resource, results.stats.approved));
         }
 
         // Refresh the data now that it has changed on the server.

--- a/frontend/src/rootReducer.js
+++ b/frontend/src/rootReducer.js
@@ -7,6 +7,7 @@ import * as locales from 'core/locales';
 import * as l10n from 'core/l10n';
 import * as notification from 'core/notification';
 import * as plural from 'core/plural';
+import * as resource from 'core/resource';
 import * as stats from 'core/stats';
 import * as user from 'core/user';
 import * as editor from 'modules/editor';
@@ -25,6 +26,7 @@ export default combineReducers({
     [l10n.NAME]: l10n.reducer,
     [notification.NAME]: notification.reducer,
     [plural.NAME]: plural.reducer,
+    [resource.NAME]: resource.reducer,
     [stats.NAME]: stats.reducer,
     [user.NAME]: user.reducer,
     // Application modules

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -157,13 +157,29 @@ def locale_stats(request, locale):
 @utils.require_AJAX
 def locale_project_parts(request, locale, slug):
     """Get locale-project pages/paths with stats."""
-    locale = get_object_or_404(Locale, code=locale)
-    project = get_object_or_404(Project, slug=slug)
+    try:
+        locale = Locale.objects.get(code=locale)
+    except Locale.DoesNotExist as e:
+        return JsonResponse({
+            'status': False,
+            'message': 'Not Found: {error}'.format(error=e),
+        }, status=404)
+
+    try:
+        project = Project.objects.get(slug=slug)
+    except Project.DoesNotExist as e:
+        return JsonResponse({
+            'status': False,
+            'message': 'Not Found: {error}'.format(error=e),
+        }, status=404)
 
     try:
         return JsonResponse(locale.parts_stats(project), safe=False)
     except ProjectLocale.DoesNotExist:
-        raise Http404('Locale not enabled for selected project.')
+        return JsonResponse({
+            'status': False,
+            'message': 'Locale not enabled for selected project.',
+        }, status=400)
 
 
 @utils.require_AJAX


### PR DESCRIPTION
This patch exposes the name of the resource currently localized in the main navigation, and lists the entire batch of project resources with their completion percentages in the corresponding menu.

Selecting a resource in the menu hot-reloads the translate view. Before loading we check for any unsaved changes in the editor, which we now also do upon clicking on the resource path in the Metadata section.

--

I still need to implement search and write some tests, and then I believe navigation will be in a good enough state for Stage 2 testing. We'll still need to figure out what to do with "All Projects" afterwards, because right now that view hides the resource menu and makes it hard to switch to the regular locale - project - resource view.

@adngdb I'd appreciate your help with the "Can't load specified string" message that appears when switching resources. For some reason `connected-react-router`'s `push()` method preserves the `entity` param and I haven't yet figured out how to reset it.

Also, a quick high-level review would be nice. :)