### PR TITLE
Fix bug 1553621: Don't show review action notifications on failed checks

### DIFF
--- a/frontend/src/modules/history/actions.js
+++ b/frontend/src/modules/history/actions.js
@@ -142,28 +142,30 @@ export function updateStatus(
             change, translation, resource, ignoreWarnings
         );
 
-        // Show a notification to explain what happened.
-        const notif = _getOperationNotif(change, !!results.translation);
-        dispatch(notification.actions.add(notif));
-
         // Update the UI based on the response.
         if (results.failedChecks) {
             dispatch(editorActions.update(results.string, 'external'));
             dispatch(editorActions.updateFailedChecks(results.failedChecks, translation));
         }
-        else if (results.translation && change === 'approve' && nextEntity) {
-            // The change did work, we want to move on to the next Entity or pluralForm.
-            pluralActions.moveToNextTranslation(
-                dispatch,
-                router,
-                entity,
-                nextEntity.pk,
-                pluralForm,
-                locale,
-            );
-        }
         else {
-            dispatch(get(entity, locale.code, pluralForm));
+            // Show a notification to explain what happened.
+            const notif = _getOperationNotif(change, !!results.translation);
+            dispatch(notification.actions.add(notif));
+
+            if (results.translation && change === 'approve' && nextEntity) {
+                // The change did work, we want to move on to the next Entity or pluralForm.
+                pluralActions.moveToNextTranslation(
+                    dispatch,
+                    router,
+                    entity,
+                    nextEntity.pk,
+                    pluralForm,
+                    locale,
+                );
+            }
+            else {
+                dispatch(get(entity, locale.code, pluralForm));
+            }
         }
 
         // Update stats for the search panel if possible.


### PR DESCRIPTION
If approving a translation results in a failed check, we shouldn't display the notification on top of the page.

It doesn't add value and distracts the user from the actual focus, which should be in the failed checks popup.