### PR TITLE
Fix bug 1553649: Rename Approved filter to Translated

### DIFF
--- a/frontend/src/modules/search/components/SearchBox.css
+++ b/frontend/src/modules/search/components/SearchBox.css
@@ -59,7 +59,7 @@
     font-size: 18px;
 }
 
-.search-box .approved .status:before {
+.search-box .translated .status:before {
     color: #7BC876;
 }
 

--- a/frontend/src/modules/search/index.js
+++ b/frontend/src/modules/search/index.js
@@ -12,7 +12,7 @@ export const NAME: string = 'search';
 // This list controls the creation of the UI.
 export const FILTERS_STATUS = [
     { title: 'All', tag: 'all', stat: 'total' },
-    { title: 'Approved', tag: 'approved' },
+    { title: 'Translated', tag: 'translated', stat: 'approved' },
     { title: 'Fuzzy', tag: 'fuzzy' },
     { title: 'Warnings', tag: 'warnings' },
     { title: 'Errors', tag: 'errors' },


### PR DESCRIPTION
The current Approved filter not has a wrong name, it also doesn't filter anything.