### PR TITLE
Use correct url for jquery

### DIFF
--- a/pontoon/base/templates/js/pontoon.js
+++ b/pontoon/base/templates/js/pontoon.js
@@ -650,7 +650,7 @@
     if (!window.jQuery) {
       if (!jqueryAppended && document.body) {
         var script = document.createElement('script');
-        script.src = '//pontoon.mozilla.org/static/js/jquery-1.11.1.min.js';
+        script.src = '//pontoon.mozilla.org/static/js/lib/jquery-1.11.1.min.js';
         document.body.appendChild(script);
 
         jqueryAppended = true;


### PR DESCRIPTION
Really we should be using `{{settings.SITE_URL}}` here, but then we'd need to strip out the scheme.