### PR TITLE
All resources update

### DIFF
--- a/frontend/src/core/plural/components/PluralSelector.css
+++ b/frontend/src/core/plural/components/PluralSelector.css
@@ -11,7 +11,6 @@
     border-left: none;
     display: table-cell;
     text-align: center;
-    text-transform: uppercase;
 }
 
 .plural-selector ul li.active,
@@ -29,7 +28,9 @@
     color: #ccc;
     cursor: pointer;
     display: block;
+    font-weight: 300;
     padding: 10px;
+    text-transform: uppercase;
     width: 100%;
 }
 

--- a/frontend/src/core/resource/reducer.js
+++ b/frontend/src/core/resource/reducer.js
@@ -45,6 +45,11 @@ function updateAllResources(
 ): Resource {
     const updatedResource = state.resources.find(item => item.path === resourcePath);
 
+    // That can happen in All Projects view
+    if (!updatedResource) {
+        return state.allResources;
+    }
+
     const diffApproved = approvedStrings - updatedResource.approvedStrings;
     const diffWarnings = stringsWithWarnings - updatedResource.stringsWithWarnings;
 

--- a/frontend/src/modules/editor/actions.js
+++ b/frontend/src/modules/editor/actions.js
@@ -123,10 +123,9 @@ function _getOperationNotif(change: 'added' | 'saved' | 'updated') {
  * Save the current translation.
  */
 export function sendTranslation(
-    entity: number,
+    entity: DbEntity,
     translation: string,
     locale: Locale,
-    original: string,
     pluralForm: number,
     forceSuggestions: boolean,
     nextEntity: ?DbEntity,
@@ -136,11 +135,11 @@ export function sendTranslation(
 ): Function {
     return async dispatch => {
         const content = await api.translation.updateTranslation(
-            entity,
+            entity.pk,
             translation,
             locale.code,
             pluralForm,
-            original,
+            entity.original,
             forceSuggestions,
             resource,
             ignoreWarnings,
@@ -169,7 +168,7 @@ export function sendTranslation(
 
             dispatch(
                 entitiesActions.updateEntityTranslation(
-                    entity,
+                    entity.pk,
                     pluralForm,
                     content.translation
                 )
@@ -180,7 +179,7 @@ export function sendTranslation(
                 dispatch(statsActions.update(content.stats));
                 dispatch(
                     resourceActions.update(
-                        resource,
+                        entity.path,
                         content.stats.approved,
                         content.stats.warnings,
                     )
@@ -192,7 +191,7 @@ export function sendTranslation(
                 pluralActions.moveToNextTranslation(
                     dispatch,
                     router,
-                    entity,
+                    entity.pk,
                     nextEntity.pk,
                     pluralForm,
                     locale,

--- a/frontend/src/modules/editor/components/Editor.js
+++ b/frontend/src/modules/editor/components/Editor.js
@@ -41,7 +41,7 @@ type Props = {|
     parameters: NavigationParams,
     pluralForm: number,
     router: Object,
-    selectedEntity: ?DbEntity,
+    selectedEntity: DbEntity,
     unsavedchanges: UnsavedChangesState,
     user: UserState,
 |};
@@ -112,10 +112,9 @@ export class EditorBase extends React.Component<InternalProps> {
         }
 
         this.props.dispatch(actions.sendTranslation(
-            state.selectedEntity.pk,
+            state.selectedEntity,
             state.editor.translation,
             state.locale,
-            state.selectedEntity.original,
             state.pluralForm,
             state.user.settings.forceSuggestions,
             state.nextEntity,
@@ -141,10 +140,10 @@ export class EditorBase extends React.Component<InternalProps> {
      * We might want to refactor to keep the logic in one place only.
      */
     updateTranslationStatus = (translationId: number, change: ChangeOperation, ignoreWarnings: ?boolean) => {
-        const { locale, nextEntity, parameters, pluralForm, router, dispatch } = this.props;
+        const { locale, nextEntity, parameters, pluralForm, router, selectedEntity, dispatch } = this.props;
         dispatch(history.actions.updateStatus(
             change,
-            parameters.entity,
+            selectedEntity,
             locale,
             parameters.resource,
             pluralForm,

--- a/frontend/src/modules/editor/components/Editor.test.js
+++ b/frontend/src/modules/editor/components/Editor.test.js
@@ -119,7 +119,7 @@ describe('<EditorBase>', () => {
         expect(editor.actions.sendTranslation.calledOnce).toBeTruthy();
         expect(
             editor.actions.sendTranslation
-            .calledWith(SELECTED_ENTITY.pk, 'initial', LOCALE, SELECTED_ENTITY.original)
+            .calledWith(SELECTED_ENTITY, 'initial', LOCALE)
         ).toBeTruthy();
     });
 
@@ -136,7 +136,7 @@ describe('<EditorBase>', () => {
         expect(editor.actions.sendTranslation.calledOnce).toBeTruthy();
         expect(
             editor.actions.sendTranslation
-            .calledWith(SELECTED_ENTITY.pk, 'initial', LOCALE, SELECTED_ENTITY.original)
+            .calledWith(SELECTED_ENTITY, 'initial', LOCALE)
         ).toBeTruthy();
     });
 

--- a/frontend/src/modules/entitydetails/components/EntityDetails.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.js
@@ -52,7 +52,7 @@ type Props = {|
     parameters: NavigationParams,
     pluralForm: number,
     router: Object,
-    selectedEntity: ?DbEntity,
+    selectedEntity: DbEntity,
     unsavedchanges: UnsavedChangesState,
     user: UserState,
 |};
@@ -227,10 +227,10 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
      * We might want to refactor to keep the logic in one place only.
      */
     updateTranslationStatus = (translationId: number, change: ChangeOperation) => {
-        const { locale, nextEntity, parameters, pluralForm, router, dispatch } = this.props;
+        const { locale, nextEntity, parameters, pluralForm, router, selectedEntity, dispatch } = this.props;
         dispatch(history.actions.updateStatus(
             change,
-            parameters.entity,
+            selectedEntity,
             locale,
             parameters.resource,
             pluralForm,

--- a/frontend/src/modules/history/actions.js
+++ b/frontend/src/modules/history/actions.js
@@ -133,7 +133,7 @@ function _getOperationNotif(change: ChangeOperation, success: boolean) {
 
 export function updateStatus(
     change: ChangeOperation,
-    entity: number,
+    entity: DbEntity,
     locale: Locale,
     resource: string,
     pluralForm: number,
@@ -162,14 +162,14 @@ export function updateStatus(
                 pluralActions.moveToNextTranslation(
                     dispatch,
                     router,
-                    entity,
+                    entity.pk,
                     nextEntity.pk,
                     pluralForm,
                     locale,
                 );
             }
             else {
-                dispatch(get(entity, locale.code, pluralForm));
+                dispatch(get(entity.pk, locale.code, pluralForm));
             }
         }
 
@@ -178,7 +178,7 @@ export function updateStatus(
             dispatch(statsActions.update(results.stats));
             dispatch(
                 resourceActions.update(
-                    resource,
+                    entity.path,
                     results.stats.approved,
                     results.stats.warnings,
                 )
@@ -188,7 +188,7 @@ export function updateStatus(
         // Refresh the data now that it has changed on the server.
         if (results.translation) {
             dispatch(
-                listActions.updateEntityTranslation(entity, pluralForm, results.translation)
+                listActions.updateEntityTranslation(entity.pk, pluralForm, results.translation)
             );
         }
     }


### PR DESCRIPTION
Pass entity path, not resource parameter for updating stats in Resource menu. Without this fix, an error occurs in All Resources view every time you send or approve a translation.

A regression from https://bugzilla.mozilla.org/show_bug.cgi?id=1519894.