### PR TITLE
Format numbers in resource progress and filters

### DIFF
--- a/frontend/src/core/utils/asLocaleString.js
+++ b/frontend/src/core/utils/asLocaleString.js
@@ -1,0 +1,12 @@
+/* @flow */
+
+/**
+ * Format number as a language-sensitive representation.
+ * TODO: De-hardcode en-GB locale. See bug 1554940 for details.
+ *
+ * @param {number} number The number to be formatted.
+ * @returns {string} A language-sensitive representation of the number.
+ */
+export default function asLocaleString(number: number): string {
+    return Number(number).toLocaleString('en-GB');
+}

--- a/frontend/src/core/utils/index.js
+++ b/frontend/src/core/utils/index.js
@@ -5,6 +5,7 @@ export { default as fluent } from './fluent';
 
 // Functions
 export { default as getOptimizedContent } from './getOptimizedContent';
+export { default as asLocaleString } from './asLocaleString';
 
 // Components and HOC
 export { default as withActionsDisabled } from './components/withActionsDisabled';

--- a/frontend/src/modules/resourceprogress/components/ResourceProgress.css
+++ b/frontend/src/modules/resourceprogress/components/ResourceProgress.css
@@ -73,7 +73,7 @@
 .progress-chart .menu header h2 .value {
     color: #FFFFFF;
     font-size: 28px;
-    padding: 0 2px;
+    padding: 0 5px;
 }
 
 .progress-chart .menu header h2.small .value {

--- a/frontend/src/modules/resourceprogress/components/ResourceProgress.js
+++ b/frontend/src/modules/resourceprogress/components/ResourceProgress.js
@@ -52,6 +52,10 @@ export class ResourceProgressBase extends React.Component<Props, State> {
         if (total) {
             percent = Math.floor(complete / total * 100);
         }
+        // Do not show resource progress until stats are available
+        else {
+            return false;
+        }
 
         return <div className="progress-chart">
             <div className="selector" onClick={ this.toggleVisibility }>

--- a/frontend/src/modules/resourceprogress/components/ResourceProgress.js
+++ b/frontend/src/modules/resourceprogress/components/ResourceProgress.js
@@ -62,8 +62,14 @@ export class ResourceProgressBase extends React.Component<Props, State> {
             <aside className="menu">
                 <div className="main">
                     <header>
-                        <h2>All strings <span className="value">{ total }</span></h2>
-                        <h2 className="small">Unreviewed <span className="value">{ unreviewed }</span></h2>
+                        <h2>
+                            All strings
+                            <span className="value">{ Number(total).toLocaleString('en-US') }</span>
+                        </h2>
+                        <h2 className="small">
+                            Unreviewed
+                            <span className="value">{ Number(unreviewed).toLocaleString('en-US') }</span>
+                        </h2>
                     </header>
                     <ProgressChart stats={ this.props.stats } size={ 220 } />
                     <span className="percent">{ percent }</span>
@@ -71,23 +77,23 @@ export class ResourceProgressBase extends React.Component<Props, State> {
                 <div className="details">
                     <div className="approved">
                         <span className="title">Translated</span>
-                        <p className="value">{ approved }</p>
+                        <p className="value">{ Number(approved).toLocaleString('en-US') }</p>
                     </div>
                     <div className="fuzzy">
                         <span className="title">Fuzzy</span>
-                        <p className="value">{ fuzzy }</p>
+                        <p className="value">{ Number(fuzzy).toLocaleString('en-US') }</p>
                     </div>
                     <div className="warnings">
                         <span className="title">Warnings</span>
-                        <p className="value">{ warnings }</p>
+                        <p className="value">{ Number(warnings).toLocaleString('en-US') }</p>
                     </div>
                     <div className="errors">
                         <span className="title">Errors</span>
-                        <p className="value">{ errors }</p>
+                        <p className="value">{ Number(errors).toLocaleString('en-US') }</p>
                     </div>
                     <div className="missing">
                         <span className="title">Missing</span>
-                        <p className="value">{ missing }</p>
+                        <p className="value">{ Number(missing).toLocaleString('en-US') }</p>
                     </div>
                 </div>
             </aside>

--- a/frontend/src/modules/resourceprogress/components/ResourceProgress.js
+++ b/frontend/src/modules/resourceprogress/components/ResourceProgress.js
@@ -7,6 +7,8 @@ import './ResourceProgress.css';
 
 import ProgressChart from './ProgressChart';
 
+import { asLocaleString } from 'core/utils';
+
 import type { Stats } from 'core/stats';
 
 
@@ -54,7 +56,7 @@ export class ResourceProgressBase extends React.Component<Props, State> {
         }
         // Do not show resource progress until stats are available
         else {
-            return false;
+            return null;
         }
 
         return <div className="progress-chart">
@@ -68,11 +70,11 @@ export class ResourceProgressBase extends React.Component<Props, State> {
                     <header>
                         <h2>
                             All strings
-                            <span className="value">{ Number(total).toLocaleString('en-US') }</span>
+                            <span className="value">{ asLocaleString(total) }</span>
                         </h2>
                         <h2 className="small">
                             Unreviewed
-                            <span className="value">{ Number(unreviewed).toLocaleString('en-US') }</span>
+                            <span className="value">{ asLocaleString(unreviewed) }</span>
                         </h2>
                     </header>
                     <ProgressChart stats={ this.props.stats } size={ 220 } />
@@ -81,23 +83,23 @@ export class ResourceProgressBase extends React.Component<Props, State> {
                 <div className="details">
                     <div className="approved">
                         <span className="title">Translated</span>
-                        <p className="value">{ Number(approved).toLocaleString('en-US') }</p>
+                        <p className="value">{ asLocaleString(approved) }</p>
                     </div>
                     <div className="fuzzy">
                         <span className="title">Fuzzy</span>
-                        <p className="value">{ Number(fuzzy).toLocaleString('en-US') }</p>
+                        <p className="value">{ asLocaleString(fuzzy) }</p>
                     </div>
                     <div className="warnings">
                         <span className="title">Warnings</span>
-                        <p className="value">{ Number(warnings).toLocaleString('en-US') }</p>
+                        <p className="value">{ asLocaleString(warnings) }</p>
                     </div>
                     <div className="errors">
                         <span className="title">Errors</span>
-                        <p className="value">{ Number(errors).toLocaleString('en-US') }</p>
+                        <p className="value">{ asLocaleString(errors) }</p>
                     </div>
                     <div className="missing">
                         <span className="title">Missing</span>
-                        <p className="value">{ Number(missing).toLocaleString('en-US') }</p>
+                        <p className="value">{ asLocaleString(missing) }</p>
                     </div>
                 </div>
             </aside>

--- a/frontend/src/modules/search/components/FiltersPanel.js
+++ b/frontend/src/modules/search/components/FiltersPanel.js
@@ -7,6 +7,8 @@ import './FiltersPanel.css';
 
 import { FILTERS_STATUS } from '..';
 
+import { asLocaleString } from 'core/utils';
+
 import type { Navigation } from 'core/navigation';
 import type { Stats } from 'core/stats';
 
@@ -88,7 +90,7 @@ export class FiltersPanelBase extends React.Component<Props, State> {
                             <span className="status fa"></span>
                             <span className="title">{ filter.title }</span>
                             <span className="count">
-                                { Number(count).toLocaleString('en-US') }
+                                { asLocaleString(count) }
                             </span>
                         </li>
                     }) }

--- a/frontend/src/modules/search/components/FiltersPanel.js
+++ b/frontend/src/modules/search/components/FiltersPanel.js
@@ -79,6 +79,7 @@ export class FiltersPanelBase extends React.Component<Props, State> {
                 <ul>
                     <li className="horizontal-separator">Translation Status</li>
                     { FILTERS_STATUS.map((filter, i) => {
+                        const count = filter.stat ? stats[filter.stat] : stats[filter.tag];
                         return <li
                             className={ filter.tag }
                             key={ i }
@@ -87,7 +88,7 @@ export class FiltersPanelBase extends React.Component<Props, State> {
                             <span className="status fa"></span>
                             <span className="title">{ filter.title }</span>
                             <span className="count">
-                                { filter.stat ? stats[filter.stat] : stats[filter.tag] }
+                                { Number(count).toLocaleString('en-US') }
                             </span>
                         </li>
                     }) }


### PR DESCRIPTION
I'm hardcoding `en-US` to make number formatting consistent with dashboards.