### PR TITLE
Bug 1541252 - Fix deployment on Heroku

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -6,8 +6,6 @@ requirements:
       update: security
   - requirements/dev.txt:
       update: security
-  - requirements/python2.txt:
-      update: security
   - requirements/test.txt:
       update: security
   - docs/requirements.txt:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -178,8 +178,6 @@ Then open ``requirements/default.txt`` and move the added dependencies to:
 * the ``requirements/constraints.txt`` if they are sub-dependencies, and add all their dependencies there as well.
 
 That format is documented more extensively inside the ``requirements/default.txt`` file.
-If a dependency has to be installed explicitly on Python2, add it to ``requirements/python2.txt`` and follow the same
-rules as for ``requirements/default.txt``.
 
 Once you are done adding or updating requirements, rebuild your docker environment:
 
@@ -309,7 +307,6 @@ steps, as they don't affect your setup if nothing has changed:
 
    # Install new dependencies or update existing ones.
    pip2 install -U --force --require-hashes -r requirements/default.txt
-   pip2 install -U --force --require-hashes -r requirements/python2.txt
 
    # Run database migrations.
    python manage.py migrate

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,3 @@
 #
 # Source: https://devcenter.heroku.com/articles/python-pip
 -r requirements/default.txt
-
-# All dependencies which support Python 2 only.
--r requirements/python2.txt


### PR DESCRIPTION
Hey,

The integration with Heroku isn't so thoroughly, and #1288 broke the requirements dedicated for Heroku.
This PR removes all remains of `requirements/python2.txt`.

@mathjazz @adngdb Could you look at this?