### PR TITLE
Fix ISO date format for notifications data and translation history

### DIFF
--- a/frontend/src/core/user/components/UserNotification.js
+++ b/frontend/src/core/user/components/UserNotification.js
@@ -70,7 +70,7 @@ export default class UserNotification extends React.Component<Props, State> {
 
                 <TimeAgo
                     className="timeago"
-                    date={ notification.date_iso }
+                    date={ new Date(notification.date_iso) }
                     title={ `${notification.date} UTC` }
                 />
 

--- a/frontend/src/core/user/components/UserNotificationsMenu.test.js
+++ b/frontend/src/core/user/components/UserNotificationsMenu.test.js
@@ -68,7 +68,7 @@ describe('<UserNotificationsMenuBase>', () => {
                     description: 'description',
                     verb: 'verb',
                     date: 'Jan 31, 2000 10:20',
-                    date_iso: '2019-01-31T10:20:00+00:00+0000',
+                    date_iso: '2019-01-31T10:20:00+00:00',
                     actor: {
                         anchor: 'actor_anchor',
                         url: 'actor_url',

--- a/frontend/src/modules/history/components/Translation.js
+++ b/frontend/src/modules/history/components/Translation.js
@@ -224,7 +224,7 @@ export class TranslationBase extends React.Component<InternalProps, State> {
                         { this.renderUser() }
                         <TimeAgo
                             dir='ltr'
-                            date={ translation.date_iso }
+                            date={ new Date(translation.date_iso) }
                             title={ `${translation.date} UTC` }
                         />
                     </div>

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -298,10 +298,7 @@ def serialized_notifications(self):
             'description': notification.description,
             'verb': notification.verb,
             'date': notification.timestamp.strftime('%b %d, %Y %H:%M'),
-            'date_iso': (
-                notification.timestamp.isoformat() +
-                timezone.now().strftime('%z')
-            ),
+            'date_iso': notification.timestamp.isoformat(),
             'actor': actor,
             'target': target,
         })

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -374,7 +374,6 @@ def get_translation_history(request):
     translations = translations.order_by('-active', 'rejected', '-date')
 
     payload = []
-    offset = timezone.now().strftime('%z')
 
     for t in translations:
         u = t.user
@@ -384,7 +383,7 @@ def get_translation_history(request):
             "uid": "" if u is None else u.id,
             "username": "" if u is None else u.username,
             "date": t.date.strftime('%b %d, %Y %H:%M'),
-            "date_iso": t.date.isoformat() + offset,
+            "date_iso": t.date.isoformat(),
             "approved_user": User.display_name_or_blank(t.approved_user),
             "unapproved_user": User.display_name_or_blank(t.unapproved_user),
         })


### PR DESCRIPTION
The format of `date_iso` in notifications data returned by `/user-data/` endpoint is not valid. It contains duplicated timezone offset. The same is in `/get-history/`.

This should fix it and also avoid the [parsing magic](https://github.com/nmn/react-timeago/blob/v4.4.0/src/dateParser.js) which happens in _react-timeago_ [when `date` is a string](https://github.com/nmn/react-timeago/blob/v4.4.0/src/index.js#L187). They only [test with `Date` objects](https://github.com/nmn/react-timeago/blob/v4.4.0/__tests__/index.js), so let's use them too.