### PR TITLE
Fix bug 1556947: Do not use indent in wrapped lines

### DIFF
--- a/frontend/src/modules/editor/components/FluentEditor.js
+++ b/frontend/src/modules/editor/components/FluentEditor.js
@@ -91,6 +91,7 @@ export default class FluentEditor extends React.Component<EditorProps> {
             fontSize: 14,
             highlightActiveLine: false,
             highlightSelectedWord: false,
+            indentedSoftWrap: false,
             printMargin: false,
             printMarginColumn: false,
             readOnly: this.props.isReadOnlyEditor,

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -711,6 +711,10 @@ CSP_FONT_SRC = ("'self'",)
 CSP_IMG_SRC = (
     "'self'",
     "https:",
+
+    # Needed for ACE editor images
+    "data:",
+
     "https://*.wp.com/pontoon.mozilla.org/",
     "https://www.google-analytics.com",
     "https://www.gravatar.com/avatar/",


### PR DESCRIPTION
Without this patch, wrapped lines in the following string will appear indented:
```
update-setting-write-failure-message =
{-brand-short-name} encontró un error y no guardó este cambio. Tenga en cuenta que la configuración de esta preferencia de actualización requiere permiso para escribir en el archivo a continuación. Es posible que usted o un administrador del sistema puedan resolver el error otorgando al grupo de Usuarios el control total de este archivo.
```

Also: Show ACE editor icons by loosing CSP policy (it doesn't affect our [Observatory](https://observatory.mozilla.org/) score).