### PR TITLE
Align team page heading details position with other dashboards

### DIFF
--- a/pontoon/base/static/css/heading_info.css
+++ b/pontoon/base/static/css/heading_info.css
@@ -41,7 +41,13 @@ ul {
 #heading .details .title {
   color: #AAAAAA;
   padding-right: 5px;
+  position: relative;
   text-transform: uppercase;
+}
+
+#heading .details .title sup {
+  position: absolute;
+  top: -5px;
 }
 
 #heading .details .value {


### PR DESCRIPTION
Darn `vertical-align: super`.