### PR TITLE
Unify Meta Description across templates

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -4,6 +4,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#000000">
+    <meta name="description" content="Mozilla’s Localization Platform">
+    <meta name="author" content="Mozilla">
     <!--
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/

--- a/pontoon/base/templates/500.html
+++ b/pontoon/base/templates/500.html
@@ -7,7 +7,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
  
     <title>Server Error</title>
-    <meta name="description" content="Live web localization tool">
+    <meta name="description" content="Mozilla’s Localization Platform">
     <meta name="author" content="Mozilla">
 
     <style>

--- a/pontoon/base/templates/base.html
+++ b/pontoon/base/templates/base.html
@@ -7,7 +7,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 
     <title>{% block title %}Pontoon{% endblock %}</title>
-    <meta name="description" content="Live web localization tool">
+    <meta name="description" content="Mozilla’s Localization Platform">
     <meta name="author" content="Mozilla">
 
     <!-- Defining a type is a workaround for bug 1422289. -->

--- a/pontoon/base/templates/django/base.html
+++ b/pontoon/base/templates/django/base.html
@@ -10,7 +10,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 
     <title>{% block title %}Pontoon{% endblock %}</title>
-    <meta name="description" content="Live web localization tool">
+    <meta name="description" content="Mozilla’s Localization Platform">
     <meta name="author" content="Mozilla">
     <link rel="stylesheet" href="{% static 'css/fontawesome-all.css' %}" title="" type="text/css" />
     <link rel="stylesheet" href="{% static 'css/nprogress.css' %}" title="" type="text/css" />


### PR DESCRIPTION
Let's use the same wording we use throughout the docs, GitHub, README, etc.

Let's also add Meta Description to Translate.Next.

It should improve our SEO.