### PR TITLE
Fix bug 1542084 - Add Python 3 to the testing matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 sudo: false
 language: python
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,21 @@ sudo: false
 language: python
 python:
   - '2.7'
+  - '3.7'
+
+matrix:
+  allow_failures:
+  - python: '3.7'
+
 cache:
   pip: true
   npm: true
   directories:
     - node_modules
 install:
-  - pip2 install -U --force pip
-  - pip2 install --require-hashes -r requirements/default.txt
-  - pip2 install --require-hashes -r requirements/test.txt
+  - pip install -U --force pip
+  - pip install --require-hashes -r requirements/default.txt
+  - pip install --require-hashes -r requirements/test.txt
   - source $HOME/.nvm/nvm.sh
   - nvm install --lts node
   - nvm use --lts node
@@ -52,3 +58,4 @@ env:
     - SECRET_KEY=asdf
     - DATABASE_URL=postgres://postgres@localhost/pontoon
     - HMAC_KEY=asdf
+    - HGPYTHON3=1


### PR DESCRIPTION
Hey,
This patch introduces a few small changes:
* TravisCI will run all back-end tests on Python 3 in a separate job
* Failures on Python 3 are allowed, ([demo](https://travis-ci.org/jotes/pontoon/builds/552472428)).
* Enables support for Python 3 in Mercurial.

@mathjazz @adngdb  can you look at this?