### PR TITLE
Fix bug 1555083: Prevent duplicate helpers requests

### DIFF
--- a/frontend/src/modules/entitydetails/components/EntityDetails.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.js
@@ -81,8 +81,8 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
     componentDidUpdate(prevProps: InternalProps) {
         const { parameters, pluralForm, selectedEntity, activeTranslation } = this.props;
 
+        // We should not use parameters.entity here, because it's already set from the URL
         if (
-            parameters.entity !== prevProps.parameters.entity ||
             pluralForm !== prevProps.pluralForm ||
             selectedEntity !== prevProps.selectedEntity
         ) {

--- a/frontend/src/modules/entitydetails/components/EntityDetails.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.js
@@ -79,9 +79,8 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
     }
 
     componentDidUpdate(prevProps: InternalProps) {
-        const { parameters, pluralForm, selectedEntity, activeTranslation } = this.props;
+        const { pluralForm, selectedEntity, activeTranslation } = this.props;
 
-        // We should not use parameters.entity here, because it's already set from the URL
         if (
             pluralForm !== prevProps.pluralForm ||
             selectedEntity !== prevProps.selectedEntity

--- a/frontend/src/modules/entitydetails/components/EntityDetails.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.js
@@ -93,7 +93,8 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
     }
 
     /*
-     * Only fetch helpers data if the entity has changed.
+     * Only fetch helpers data if the entity changes.
+     * Also fetch history data if the pluralForm changes.
      */
     fetchHelpersData() {
         const { dispatch, locale, parameters, pluralForm, selectedEntity } = this.props;
@@ -102,7 +103,10 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
             return;
         }
 
-        if (selectedEntity.pk !== this.props.history.entity) {
+        if (
+            selectedEntity.pk !== this.props.history.entity ||
+            pluralForm !== this.props.history.pluralForm
+        ) {
             dispatch(history.actions.get(parameters.entity, parameters.locale, pluralForm));
         }
 

--- a/frontend/src/modules/entitydetails/components/EntityDetails.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.js
@@ -92,6 +92,9 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
         }
     }
 
+    /*
+     * Only fetch helpers data if the entity has changed.
+     */
     fetchHelpersData() {
         const { dispatch, locale, parameters, pluralForm, selectedEntity } = this.props;
 
@@ -99,11 +102,18 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
             return;
         }
 
-        dispatch(history.actions.get(parameters.entity, parameters.locale, pluralForm));
-        dispatch(otherlocales.actions.get(parameters.entity, parameters.locale));
+        if (selectedEntity.pk !== this.props.history.entity) {
+            dispatch(history.actions.get(parameters.entity, parameters.locale, pluralForm));
+        }
 
-        const source = utils.getOptimizedContent(selectedEntity.original, selectedEntity.format);
-        dispatch(machinery.actions.get(source, locale, selectedEntity.pk));
+        if (selectedEntity.pk !== this.props.otherlocales.entity) {
+            dispatch(otherlocales.actions.get(parameters.entity, parameters.locale));
+        }
+
+        if (selectedEntity.pk !== this.props.machinery.entity) {
+            const source = utils.getOptimizedContent(selectedEntity.original, selectedEntity.format);
+            dispatch(machinery.actions.get(source, locale, selectedEntity.pk));
+        }
     }
 
     updateFailedChecks() {

--- a/frontend/src/modules/history/actions.js
+++ b/frontend/src/modules/history/actions.js
@@ -15,7 +15,6 @@ import type { Locale } from 'core/locales';
 
 export const RECEIVE: 'history/RECEIVE' = 'history/RECEIVE';
 export const REQUEST: 'history/REQUEST' = 'history/REQUEST';
-export const RESET: 'history/RESET' = 'history/RESET';
 export const UPDATE: 'history/UPDATE' = 'history/UPDATE';
 
 
@@ -54,16 +53,6 @@ export type RequestAction = {|
 export function request(): RequestAction {
     return {
         type: REQUEST,
-    };
-}
-
-
-export type ResetAction = {|
-    +type: typeof RESET,
-|};
-export function reset(): ResetAction {
-    return {
-        type: RESET,
     };
 }
 
@@ -220,7 +209,6 @@ export default {
     get,
     receive,
     request,
-    reset,
     updateStatus,
     deleteTranslation,
 };

--- a/frontend/src/modules/history/actions.js
+++ b/frontend/src/modules/history/actions.js
@@ -21,15 +21,18 @@ export const UPDATE: 'history/UPDATE' = 'history/UPDATE';
 export type ReceiveAction = {|
     +type: typeof RECEIVE,
     +entity: number,
+    +pluralForm: number,
     +translations: Array<Object>,
 |};
 export function receive(
     entity: number,
+    pluralForm: number,
     translations: Array<Object>,
 ): ReceiveAction {
     return {
         type: RECEIVE,
         entity,
+        pluralForm,
         translations,
     };
 }
@@ -65,7 +68,7 @@ export function get(entity: number, locale: string, pluralForm: number): Functio
         await api.entity.abort();
 
         const content = await api.entity.getHistory(entity, locale, pluralForm);
-        dispatch(receive(entity, content));
+        dispatch(receive(entity, pluralForm, content));
     }
 }
 

--- a/frontend/src/modules/history/actions.js
+++ b/frontend/src/modules/history/actions.js
@@ -20,19 +20,13 @@ export const UPDATE: 'history/UPDATE' = 'history/UPDATE';
 
 export type ReceiveAction = {|
     +type: typeof RECEIVE,
-    +entity: number,
-    +pluralForm: number,
     +translations: Array<Object>,
 |};
 export function receive(
-    entity: number,
-    pluralForm: number,
     translations: Array<Object>,
 ): ReceiveAction {
     return {
         type: RECEIVE,
-        entity,
-        pluralForm,
         translations,
     };
 }
@@ -52,23 +46,30 @@ export function update(translation: Object) {
 
 export type RequestAction = {|
     +type: typeof REQUEST,
+    +entity: number,
+    +pluralForm: number,
 |};
-export function request(): RequestAction {
+export function request(
+    entity: number,
+    pluralForm: number,
+): RequestAction {
     return {
         type: REQUEST,
+        entity,
+        pluralForm,
     };
 }
 
 
 export function get(entity: number, locale: string, pluralForm: number): Function {
     return async dispatch => {
-        dispatch(request());
+        dispatch(request(entity, pluralForm));
 
         // Abort all previously running requests.
         await api.entity.abort();
 
         const content = await api.entity.getHistory(entity, locale, pluralForm);
-        dispatch(receive(entity, pluralForm, content));
+        dispatch(receive(content));
     }
 }
 

--- a/frontend/src/modules/history/actions.js
+++ b/frontend/src/modules/history/actions.js
@@ -21,11 +21,16 @@ export const UPDATE: 'history/UPDATE' = 'history/UPDATE';
 
 export type ReceiveAction = {|
     +type: typeof RECEIVE,
+    +entity: number,
     +translations: Array<Object>,
 |};
-export function receive(translations: Array<Object>): ReceiveAction {
+export function receive(
+    entity: number,
+    translations: Array<Object>,
+): ReceiveAction {
     return {
         type: RECEIVE,
+        entity,
         translations,
     };
 }
@@ -71,7 +76,7 @@ export function get(entity: number, locale: string, pluralForm: number): Functio
         await api.entity.abort();
 
         const content = await api.entity.getHistory(entity, locale, pluralForm);
-        dispatch(receive(content));
+        dispatch(receive(entity, content));
     }
 }
 

--- a/frontend/src/modules/history/reducer.js
+++ b/frontend/src/modules/history/reducer.js
@@ -1,14 +1,13 @@
 /* @flow */
 
-import { RECEIVE, REQUEST, RESET, UPDATE } from './actions';
+import { RECEIVE, REQUEST, UPDATE } from './actions';
 
-import type { ReceiveAction, RequestAction, ResetAction, UpdateAction } from './actions';
+import type { ReceiveAction, RequestAction, UpdateAction } from './actions';
 
 
 type Action =
     | ReceiveAction
     | RequestAction
-    | ResetAction
     | UpdateAction
 ;
 
@@ -68,11 +67,6 @@ export default function reducer(
                 fetching: false,
                 entity: action.entity,
                 translations: action.translations,
-            };
-        case RESET:
-            return {
-                ...state,
-                translations: [],
             };
         case UPDATE:
             return {

--- a/frontend/src/modules/history/reducer.js
+++ b/frontend/src/modules/history/reducer.js
@@ -30,6 +30,7 @@ export type DBTranslation = {|
 
 export type HistoryState = {|
     +fetching: boolean,
+    +entity: ?number,
     +translations: Array<DBTranslation>,
 |};
 
@@ -46,6 +47,7 @@ function updateTranslation(translations: Array<DBTranslation>, newTranslation: D
 
 const initialState = {
     fetching: false,
+    entity: null,
     translations: [],
 };
 
@@ -58,11 +60,13 @@ export default function reducer(
             return {
                 ...state,
                 fetching: true,
+                entity: null,
             };
         case RECEIVE:
             return {
                 ...state,
                 fetching: false,
+                entity: action.entity,
                 translations: action.translations,
             };
         case RESET:

--- a/frontend/src/modules/history/reducer.js
+++ b/frontend/src/modules/history/reducer.js
@@ -61,16 +61,14 @@ export default function reducer(
             return {
                 ...state,
                 fetching: true,
-                entity: null,
-                pluralForm: null,
+                entity: action.entity,
+                pluralForm: action.pluralForm,
                 translations: [],
             };
         case RECEIVE:
             return {
                 ...state,
                 fetching: false,
-                entity: action.entity,
-                pluralForm: action.pluralForm,
                 translations: action.translations,
             };
         case UPDATE:

--- a/frontend/src/modules/history/reducer.js
+++ b/frontend/src/modules/history/reducer.js
@@ -30,6 +30,7 @@ export type DBTranslation = {|
 export type HistoryState = {|
     +fetching: boolean,
     +entity: ?number,
+    +pluralForm: ?number,
     +translations: Array<DBTranslation>,
 |};
 
@@ -47,6 +48,7 @@ function updateTranslation(translations: Array<DBTranslation>, newTranslation: D
 const initialState = {
     fetching: false,
     entity: null,
+    pluralForm: null,
     translations: [],
 };
 
@@ -60,6 +62,7 @@ export default function reducer(
                 ...state,
                 fetching: true,
                 entity: null,
+                pluralForm: null,
                 translations: [],
             };
         case RECEIVE:
@@ -67,6 +70,7 @@ export default function reducer(
                 ...state,
                 fetching: false,
                 entity: action.entity,
+                pluralForm: action.pluralForm,
                 translations: action.translations,
             };
         case UPDATE:

--- a/frontend/src/modules/history/reducer.js
+++ b/frontend/src/modules/history/reducer.js
@@ -60,6 +60,7 @@ export default function reducer(
                 ...state,
                 fetching: true,
                 entity: null,
+                translations: [],
             };
         case RECEIVE:
             return {

--- a/frontend/src/modules/machinery/actions.js
+++ b/frontend/src/modules/machinery/actions.js
@@ -32,13 +32,16 @@ export function addTranslations(
  */
 export type ResetAction = {
     +type: typeof RESET,
+    +entity: ?number,
     +sourceString: string,
 };
 export function reset(
-    sourceString: string
+    entity: ?number,
+    sourceString: string,
 ): ResetAction {
     return {
         type: RESET,
+        entity: entity,
         sourceString: sourceString,
     };
 }
@@ -57,7 +60,7 @@ export function reset(
  */
 export function get(source: string, locale: Locale, pk: ?number): Function {
     return async dispatch => {
-        dispatch(reset(source));
+        dispatch(reset(pk, source));
 
         // Abort all previously running requests.
         await api.machinery.abort();

--- a/frontend/src/modules/machinery/reducer.js
+++ b/frontend/src/modules/machinery/reducer.js
@@ -14,6 +14,7 @@ type Action =
 type Translations = Array<MachineryTranslation>;
 
 export type MachineryState = {|
+    entity: ?number,
     sourceString: string,
     translations: Translations,
 |};
@@ -73,6 +74,7 @@ function dedupedTranslations(
 
 
 const initial: MachineryState = {
+    entity: null,
     sourceString: '',
     translations: [],
 };
@@ -93,6 +95,7 @@ export default function reducer(
         case RESET:
             return {
                 ...state,
+                entity: action.entity,
                 sourceString: action.sourceString,
                 translations: [],
             };

--- a/frontend/src/modules/otherlocales/actions.js
+++ b/frontend/src/modules/otherlocales/actions.js
@@ -28,19 +28,17 @@ export function receive(
 
 export type RequestAction = {|
     +type: typeof REQUEST,
-    +entity: number,
 |};
-export function request(entity: number): RequestAction {
+export function request(): RequestAction {
     return {
         type: REQUEST,
-        entity,
     };
 }
 
 
 export function get(entity: number, locale: string): Function {
     return async dispatch => {
-        dispatch(request(entity));
+        dispatch(request());
 
         // Abort all previously running requests.
         await api.entity.abort();

--- a/frontend/src/modules/otherlocales/actions.js
+++ b/frontend/src/modules/otherlocales/actions.js
@@ -11,16 +11,13 @@ export const REQUEST: 'otherlocales/REQUEST' = 'otherlocales/REQUEST';
 
 export type ReceiveAction = {|
     +type: typeof RECEIVE,
-    +entity: number,
     +translations: Array<OtherLocaleTranslation>,
 |};
 export function receive(
-    entity: number,
     translations: Array<OtherLocaleTranslation>
 ): ReceiveAction {
     return {
         type: RECEIVE,
-        entity,
         translations,
     };
 }
@@ -28,24 +25,28 @@ export function receive(
 
 export type RequestAction = {|
     +type: typeof REQUEST,
+    +entity: number,
 |};
-export function request(): RequestAction {
+export function request(
+    entity: number,
+): RequestAction {
     return {
         type: REQUEST,
+        entity,
     };
 }
 
 
 export function get(entity: number, locale: string): Function {
     return async dispatch => {
-        dispatch(request());
+        dispatch(request(entity));
 
         // Abort all previously running requests.
         await api.entity.abort();
 
         const content = await api.entity.getOtherLocales(entity, locale);
 
-        dispatch(receive(entity, content));
+        dispatch(receive(content));
     }
 }
 

--- a/frontend/src/modules/otherlocales/reducer.js
+++ b/frontend/src/modules/otherlocales/reducer.js
@@ -34,14 +34,13 @@ export default function reducer(
             return {
                 ...state,
                 fetching: true,
-                entity: null,
+                entity: action.entity,
                 translations: [],
             };
         case RECEIVE:
             return {
                 ...state,
                 fetching: false,
-                entity: action.entity,
                 translations: action.translations,
             };
         default:

--- a/frontend/src/modules/otherlocales/reducer.js
+++ b/frontend/src/modules/otherlocales/reducer.js
@@ -14,12 +14,14 @@ type Action =
 
 export type LocalesState = {|
     +fetching: boolean,
+    +entity: ?number,
     +translations: Array<OtherLocaleTranslation>,
 |};
 
 
 const initialState = {
     fetching: false,
+    entity: null,
     translations: [],
 };
 
@@ -32,12 +34,14 @@ export default function reducer(
             return {
                 ...state,
                 fetching: true,
+                entity: null,
                 translations: [],
             };
         case RECEIVE:
             return {
                 ...state,
                 fetching: false,
+                entity: action.entity,
                 translations: action.translations,
             };
         default:


### PR DESCRIPTION
I'd like to add a comment in comment in `componentDidUpdate` to explain why do we need the `selectedEntity !== prevProps.selectedEntity` check. But I forgot the answer. :) Could you please remind me?

Note that I've found some unused code and inconsistencies, which are addressed in followup commits.