### PR TITLE
Fix bug 1563677: Escape selectors in data-expression attributes

### DIFF
--- a/pontoon/base/static/js/fluent_interface.js
+++ b/pontoon/base/static/js/fluent_interface.js
@@ -263,7 +263,7 @@ var Pontoon = (function (my) {
         if (element.expression.selector) {
           expression = FluentSyntax.serializeExpression(element.expression.selector);
         }
-        content += '<li data-expression="' + expression + '"><ul>';
+        content += '<li data-expression="' + escape(expression) + '"><ul>';
 
         element.expression.variants.forEach(function (item) {
           content += renderOriginalElement(FluentSyntax.serializeVariantKey(item.key), item.value.elements);
@@ -306,7 +306,7 @@ var Pontoon = (function (my) {
         if (element.expression.selector) {
           expression = FluentSyntax.serializeExpression(element.expression.selector);
         }
-        content += '<li data-expression="' + expression + '"><ul>';
+        content += '<li data-expression="' + escape(expression) + '"><ul>';
 
         if (isPluralElement(element) && !isTranslated) {
           getPluralForms(element).forEach(function (pluralName) {
@@ -349,7 +349,7 @@ var Pontoon = (function (my) {
       // SelectExpression
       else {
         var expression = $(node).data('expression');
-        var nodeValue = expression ? ' ' + expression + ' ->' : '';
+        var nodeValue = expression ? ' ' + unescape(expression) + ' ->' : '';
         var variants = $(node).find('ul li');
         var hasTranslatedVariants = false;
         var defaultMarker = '';


### PR DESCRIPTION
Translating a string like this in the rich editor is not possible - it results in an `Expected literal` error upon saving:
```
number =
    { NUMBER($var, type: "ordinal") ->
        [1] first
        [one] { $var }st
       *[other] { $var }nd
    }
```

**What's going on?**

Pontoon doesn't show selectors (in this case `NUMBER($var, type: "ordinal")`) in the rich editor, but still stores them in DOM to help with serialization. Specifically, it naïvely puts them in `data-expression` attributes, without any escaping.

So when the selector contains quotes, like in our example, content gets stripped upon serialization, resulting in the above error. The serialized string looks like this:

```
number =
    { NUMBER($var, type:  ->
        [1] first
        [one] { $var }st
       *[other] { $var }nd
    }
```

A test case:
https://github.com/mozilla-l10n/pontoon-ftl/blob/master/en-US/demo.ftl#L53