### PR TITLE
No bug - Reorganize FTL files

### DIFF
--- a/frontend/public/static/locale/en-US/translate.ftl
+++ b/frontend/public/static/locale/en-US/translate.ftl
@@ -1,5 +1,9 @@
 ### Localization for the Translate page of Pontoon
 
+# Naming convention for l10n IDs: "module-ComponentName--sentence-summary".
+# This allows us to minimize the risk of conflicting IDs throughout the app.
+# Please sort alphabetically by (module name, component name).
+
 
 ## Editor
 ## Allows contributors to modify or propose a translation
@@ -12,7 +16,7 @@ editor-editor-button-save = Save
 editor-editor-button-suggest = Suggest
 
 
-## Failed Checks
+## Editor Failed Checks
 ## Renders the failed checks popup
 
 editor-FailedChecks--close = ×
@@ -23,29 +27,7 @@ editor-FailedChecks--suggest-anyway = Suggest anyway
 editor-FailedChecks--approve-anyway = Approve anyway
 
 
-## Unsaved Changes
-## Renders the unsaved changes popup
-
-editor-UnsavedChanges--close = ×
-    .aria-label = Close unsaved changes popup
-editor-UnsavedChanges--title = You have unsaved changes
-editor-UnsavedChanges--body = Sure you want to leave?
-editor-UnsavedChanges--leave-anyway = Leave anyway
-
-
-## EditorSettings
-## Shows options to update user settings regarding the editor.
-
-editor-settings-toolkit-checks = <glyph></glyph>Translate Toolkit Checks
-    .title = Run Translate Toolkit checks before submitting translations
-
-editor-settings-force-suggestions = <glyph></glyph>Make Suggestions
-    .title = Save suggestions instead of translations
-
-editor-settings-change-all = Change All Settings
-
-
-## KeyboardShortcuts
+## Editor Keyboard Shortcuts
 ## Shows a list of keyboard shortcuts.
 
 editor-keyboard-shortcuts-button =
@@ -84,33 +66,37 @@ editor-keyboard-shortcuts-copy-from-helpers = Copy From Helpers
 editor-keyboard-shortcuts-copy-from-helpers-shortcut = <accel>Tab</accel>
 
 
-## Machinery
-## Shows a list of translations from machines.
+## Editor Settings
+## Shows options to update user settings regarding the editor.
 
-machinery-machinery-search-placeholder =
-    .placeholder = Type to search machinery
+editor-settings-toolkit-checks = <glyph></glyph>Translate Toolkit Checks
+    .title = Run Translate Toolkit checks before submitting translations
 
+editor-settings-force-suggestions = <glyph></glyph>Make Suggestions
+    .title = Save suggestions instead of translations
 
-## Machinery Translation
-## Shows a specific translation from machinery
-
-machinery-translation-copy =
-    .title = Copy Into Translation (Tab)
-
-machinery-translation-number-occurrences =
-    .title = Number of translation occurrences
+editor-settings-change-all = Change All Settings
 
 
-## Entity Navigation
-## Shows next/previous buttons.
+## Editor Unsaved Changes
+## Renders the unsaved changes popup
 
-entitynavigation-next = <glyph></glyph>Next
-    .title = Go To Next String (Alt + Down)
-entitynavigation-previous = <glyph></glyph>Previous
-    .title = Go To Previous String (Alt + Up)
+editor-UnsavedChanges--close = ×
+    .aria-label = Close unsaved changes popup
+editor-UnsavedChanges--title = You have unsaved changes
+editor-UnsavedChanges--body = Sure you want to leave?
+editor-UnsavedChanges--leave-anyway = Leave anyway
 
 
-## Metadata
+## Entity Details Helpers
+## Shows helper tabs
+
+entitydetails-Helpers--history = History
+entitydetails-Helpers--machinery = Machinery
+entitydetails-Helpers--locales = Locales
+
+
+## Entity Details Metadata
 ## Shows metadata about an entity (original string)
 
 entitydetails-metadata-plural = Plural
@@ -132,12 +118,13 @@ entitydetails-metadata-project =
     .title = Project
 
 
-## Helpers
-## Shows helper tabs
+## Entity Navigation
+## Shows next/previous buttons.
 
-entitydetails-Helpers--history = History
-entitydetails-Helpers--machinery = Machinery
-entitydetails-Helpers--locales = Locales
+entitynavigation-next = <glyph></glyph>Next
+    .title = Go To Next String (Alt + Down)
+entitynavigation-previous = <glyph></glyph>Previous
+    .title = Go To Previous String (Alt + Up)
 
 
 ## History
@@ -173,48 +160,21 @@ history-translation-button-unreject =
     .title = Unreject
 
 
-## OtherLocales Translation
-## Shows a specific translation from a different locale
+## Machinery
+## Shows a list of translations from machines.
 
-otherlocales-translation-copy =
+machinery-machinery-search-placeholder =
+    .placeholder = Type to search machinery
+
+
+## Machinery Translation
+## Shows a specific translation from machinery
+
+machinery-translation-copy =
     .title = Copy Into Translation (Tab)
 
-
-## User Notifications
-## Shows user notifications menu.
-
-user-UserNotificationsMenu--no-notifications-title = No new notifications.
-user-UserNotificationsMenu--no-notifications-description = Here you’ll see updates for localizations you contribute to.
-user-UserNotificationsMenu--see-all-notifications = See all Notifications
-
-
-## User Menu
-## Shows user menu entries and options to sign in or out.
-
-user-AppSwitcher--leave-translate-next = Leave Translate.Next
-user-SignIn--sign-in = Sign in
-
-user-UserMenu--download-tm = <glyph></glyph>Download Translation Memory
-user-UserMenu--download-translations = <glyph></glyph>Download Translations
-user-UserMenu--upload-translations = <glyph></glyph>Upload Translations
-
-user-UserMenu--top-contributors = <glyph></glyph>Top Contributors
-user-UserMenu--machinery = <glyph></glyph>Machinery
-user-UserMenu--terms = <glyph></glyph>Terms of Use
-user-UserMenu--help = <glyph></glyph>Help
-
-user-UserMenu--admin = <glyph></glyph>Admin
-user-UserMenu--admin-project = <glyph></glyph>Admin · Current Project
-
-user-UserMenu--settings = <glyph></glyph>Settings
-user-SignOut--sign-out = <glyph></glyph>Sign out
-
-
-## Resource menu
-## Used in the resource menu in the main navigation bar.
-navigation-ResourceMenu-no-results = No results
-navigation-ResourceMenu-all-resources = All Resources
-navigation-ResourceMenu-all-projects = All Projects
+machinery-translation-number-occurrences =
+    .title = Number of translation occurrences
 
 
 ## Notification
@@ -237,8 +197,14 @@ notification--tt-checks-enabled = Translate Toolkit Checks enabled
 notification--tt-checks-disabled = Translate Toolkit Checks disabled
 notification--make-suggestions-enabled = Make Suggestions enabled
 notification--make-suggestions-disabled = Make Suggestions disabled
-notification--ftl-not-supported-rich-editor = Translation not supported in rich editor
 notification--entity-not-found = Can’t load specified string
+
+
+## OtherLocales Translation
+## Shows a specific translation from a different locale
+
+otherlocales-translation-copy =
+    .title = Copy Into Translation (Tab)
 
 
 ## Placeable parsers
@@ -298,3 +264,40 @@ placeable-parser-xmlEntity =
     .title = XML entity
 placeable-parser-xmlTag =
     .title = XML tag
+
+
+## Resource menu
+## Used in the resource menu in the main navigation bar.
+navigation-ResourceMenu-no-results = No results
+navigation-ResourceMenu-all-resources = All Resources
+navigation-ResourceMenu-all-projects = All Projects
+
+
+## User Menu
+## Shows user menu entries and options to sign in or out.
+
+user-AppSwitcher--leave-translate-next = Leave Translate.Next
+user-SignIn--sign-in = Sign in
+
+user-UserMenu--download-tm = <glyph></glyph>Download Translation Memory
+user-UserMenu--download-translations = <glyph></glyph>Download Translations
+user-UserMenu--upload-translations = <glyph></glyph>Upload Translations
+
+user-UserMenu--top-contributors = <glyph></glyph>Top Contributors
+user-UserMenu--machinery = <glyph></glyph>Machinery
+user-UserMenu--terms = <glyph></glyph>Terms of Use
+user-UserMenu--help = <glyph></glyph>Help
+
+user-UserMenu--admin = <glyph></glyph>Admin
+user-UserMenu--admin-project = <glyph></glyph>Admin · Current Project
+
+user-UserMenu--settings = <glyph></glyph>Settings
+user-SignOut--sign-out = <glyph></glyph>Sign out
+
+
+## User Notifications
+## Shows user notifications menu.
+
+user-UserNotificationsMenu--no-notifications-title = No new notifications.
+user-UserNotificationsMenu--no-notifications-description = Here you’ll see updates for localizations you contribute to.
+user-UserNotificationsMenu--see-all-notifications = See all Notifications

--- a/frontend/public/static/locale/en-US/translate.ftl
+++ b/frontend/public/static/locale/en-US/translate.ftl
@@ -1,8 +1,32 @@
 ### Localization for the Translate page of Pontoon
 
-# Naming convention for l10n IDs: "module-ComponentName--sentence-summary".
+# Naming convention for l10n IDs: "module-ComponentName--string-summary".
 # This allows us to minimize the risk of conflicting IDs throughout the app.
-# Please sort alphabetically by (module name, component name).
+# Please sort alphabetically by (module name, component name). For each module,
+# keep strings in order of appearance.
+
+
+## Editor Menu
+## Allows contributors to modify or propose a translation
+
+editor-EditorMenu--sign-in-to-translate = <a>Sign in</a> to translate.
+editor-EditorMenu--read-only-localization = This is a read-only localization.
+editor-EditorMenu--button-copy = Copy
+editor-EditorMenu--button-clear = Clear
+editor-EditorMenu--button-save = Save
+editor-EditorMenu--button-suggest = Suggest
+
+
+## Editor Settings
+## Shows options to update user settings regarding the editor.
+
+editor-EditorSettings--toolkit-checks = <glyph></glyph>Translate Toolkit Checks
+    .title = Run Translate Toolkit checks before submitting translations
+
+editor-EditorSettings--force-suggestions = <glyph></glyph>Make Suggestions
+    .title = Save suggestions instead of translations
+
+editor-EditorSettings--change-all = Change All Settings
 
 
 ## Editor Failed Checks
@@ -55,29 +79,6 @@ editor-KeyboardShortcuts--copy-from-helpers = Copy From Helpers
 editor-KeyboardShortcuts--copy-from-helpers-shortcut = <accel>Tab</accel>
 
 
-## Editor Menu
-## Allows contributors to modify or propose a translation
-
-editor-EditorMenu--sign-in-to-translate = <a>Sign in</a> to translate.
-editor-EditorMenu--read-only-localization = This is a read-only localization.
-editor-EditorMenu--button-copy = Copy
-editor-EditorMenu--button-clear = Clear
-editor-EditorMenu--button-save = Save
-editor-EditorMenu--button-suggest = Suggest
-
-
-## Editor Settings
-## Shows options to update user settings regarding the editor.
-
-editor-EditorSettings--toolkit-checks = <glyph></glyph>Translate Toolkit Checks
-    .title = Run Translate Toolkit checks before submitting translations
-
-editor-EditorSettings--force-suggestions = <glyph></glyph>Make Suggestions
-    .title = Save suggestions instead of translations
-
-editor-EditorSettings--change-all = Change All Settings
-
-
 ## Editor Unsaved Changes
 ## Renders the unsaved changes popup
 
@@ -86,6 +87,15 @@ editor-UnsavedChanges--close = ×
 editor-UnsavedChanges--title = You have unsaved changes
 editor-UnsavedChanges--body = Sure you want to leave?
 editor-UnsavedChanges--leave-anyway = Leave anyway
+
+
+## Entity Details Navigation
+## Shows next/previous buttons.
+
+entitydetails-EntityNavigation--next = <glyph></glyph>Next
+    .title = Go To Next String (Alt + Down)
+entitydetails-EntityNavigation--previous = <glyph></glyph>Previous
+    .title = Go To Previous String (Alt + Up)
 
 
 ## Entity Details Helpers
@@ -116,15 +126,6 @@ entitydetails-Metadata--resource =
 
 entitydetails-Metadata--project =
     .title = Project
-
-
-## Entity Details Navigation
-## Shows next/previous buttons.
-
-entitydetails-EntityNavigation--next = <glyph></glyph>Next
-    .title = Go To Next String (Alt + Down)
-entitydetails-EntityNavigation--previous = <glyph></glyph>Previous
-    .title = Go To Previous String (Alt + Up)
 
 
 ## History

--- a/frontend/public/static/locale/en-US/translate.ftl
+++ b/frontend/public/static/locale/en-US/translate.ftl
@@ -5,17 +5,6 @@
 # Please sort alphabetically by (module name, component name).
 
 
-## Editor
-## Allows contributors to modify or propose a translation
-
-editor-editor-sign-in-to-translate = <a>Sign in</a> to translate.
-editor-editor-read-only-localization = This is a read-only localization.
-editor-editor-button-copy = Copy
-editor-editor-button-clear = Clear
-editor-editor-button-save = Save
-editor-editor-button-suggest = Suggest
-
-
 ## Editor Failed Checks
 ## Renders the failed checks popup
 
@@ -30,52 +19,63 @@ editor-FailedChecks--approve-anyway = Approve anyway
 ## Editor Keyboard Shortcuts
 ## Shows a list of keyboard shortcuts.
 
-editor-keyboard-shortcuts-button =
+editor-KeyboardShortcuts--button =
     .title = Keyboard Shortcuts
 
-editor-keyboard-shortcuts-overlay-title = Keyboard Shortcuts
+editor-KeyboardShortcuts--overlay-title = Keyboard Shortcuts
 
-editor-keyboard-shortcuts-save-translation = Save Translation
-editor-keyboard-shortcuts-save-translation-shortcut = <accel>Enter</accel>
+editor-KeyboardShortcuts--save-translation = Save Translation
+editor-KeyboardShortcuts--save-translation-shortcut = <accel>Enter</accel>
 
-editor-keyboard-shortcuts-cancel-translation = Cancel Translation
-editor-keyboard-shortcuts-cancel-translation-shortcut = <accel>Esc</accel>
+editor-KeyboardShortcuts--cancel-translation = Cancel Translation
+editor-KeyboardShortcuts--cancel-translation-shortcut = <accel>Esc</accel>
 
-editor-keyboard-shortcuts-insert-a-new-line = Insert A New Line
-editor-keyboard-shortcuts-insert-a-new-line-shortcut = <mod1>Shift</mod1> + <accel>Enter</accel>
+editor-KeyboardShortcuts--insert-a-new-line = Insert A New Line
+editor-KeyboardShortcuts--insert-a-new-line-shortcut = <mod1>Shift</mod1> + <accel>Enter</accel>
 
-editor-keyboard-shortcuts-go-to-next-string = Go To Next String
-editor-keyboard-shortcuts-go-to-next-string-shortcut = <mod1>Alt</mod1> + <accel>Down</accel>
+editor-KeyboardShortcuts--go-to-next-string = Go To Next String
+editor-KeyboardShortcuts--go-to-next-string-shortcut = <mod1>Alt</mod1> + <accel>Down</accel>
 
-editor-keyboard-shortcuts-go-to-previous-string = Go To Previous String
-editor-keyboard-shortcuts-go-to-previous-string-shortcut = <mod1>Alt</mod1> + <accel>Up</accel>
+editor-KeyboardShortcuts--go-to-previous-string = Go To Previous String
+editor-KeyboardShortcuts--go-to-previous-string-shortcut = <mod1>Alt</mod1> + <accel>Up</accel>
 
-editor-keyboard-shortcuts-copy-from-source = Copy From Source
-editor-keyboard-shortcuts-copy-from-source-shortcut = <mod1>Ctrl</mod1> + <mod2>Shift</mod2> + <accel>C</accel>
+editor-KeyboardShortcuts--copy-from-source = Copy From Source
+editor-KeyboardShortcuts--copy-from-source-shortcut = <mod1>Ctrl</mod1> + <mod2>Shift</mod2> + <accel>C</accel>
 
-editor-keyboard-shortcuts-clear-translation = Clear Translation
-editor-keyboard-shortcuts-clear-translation-shortcut = <mod1>Ctrl</mod1> + <mod2>Shift</mod2> + <accel>Backspace</accel>
+editor-KeyboardShortcuts--clear-translation = Clear Translation
+editor-KeyboardShortcuts--clear-translation-shortcut = <mod1>Ctrl</mod1> + <mod2>Shift</mod2> + <accel>Backspace</accel>
 
-editor-keyboard-shortcuts-search-strings = Search Strings
-editor-keyboard-shortcuts-search-strings-shortcut = <mod1>Ctrl</mod1> + <mod2>Shift</mod2> + <accel>F</accel>
+editor-KeyboardShortcuts--search-strings = Search Strings
+editor-KeyboardShortcuts--search-strings-shortcut = <mod1>Ctrl</mod1> + <mod2>Shift</mod2> + <accel>F</accel>
 
-editor-keyboard-shortcuts-select-all-strings = Select All Strings
-editor-keyboard-shortcuts-select-all-strings-shortcut = <mod1>Ctrl</mod1> + <mod2>Shift</mod2> + <accel>A</accel>
+editor-KeyboardShortcuts--select-all-strings = Select All Strings
+editor-KeyboardShortcuts--select-all-strings-shortcut = <mod1>Ctrl</mod1> + <mod2>Shift</mod2> + <accel>A</accel>
 
-editor-keyboard-shortcuts-copy-from-helpers = Copy From Helpers
-editor-keyboard-shortcuts-copy-from-helpers-shortcut = <accel>Tab</accel>
+editor-KeyboardShortcuts--copy-from-helpers = Copy From Helpers
+editor-KeyboardShortcuts--copy-from-helpers-shortcut = <accel>Tab</accel>
+
+
+## Editor Menu
+## Allows contributors to modify or propose a translation
+
+editor-EditorMenu--sign-in-to-translate = <a>Sign in</a> to translate.
+editor-EditorMenu--read-only-localization = This is a read-only localization.
+editor-EditorMenu--button-copy = Copy
+editor-EditorMenu--button-clear = Clear
+editor-EditorMenu--button-save = Save
+editor-EditorMenu--button-suggest = Suggest
 
 
 ## Editor Settings
 ## Shows options to update user settings regarding the editor.
 
-editor-settings-toolkit-checks = <glyph></glyph>Translate Toolkit Checks
+editor-EditorSettings--toolkit-checks = <glyph></glyph>Translate Toolkit Checks
     .title = Run Translate Toolkit checks before submitting translations
 
-editor-settings-force-suggestions = <glyph></glyph>Make Suggestions
+editor-EditorSettings--force-suggestions = <glyph></glyph>Make Suggestions
     .title = Save suggestions instead of translations
 
-editor-settings-change-all = Change All Settings
+editor-EditorSettings--change-all = Change All Settings
 
 
 ## Editor Unsaved Changes
@@ -99,85 +99,85 @@ entitydetails-Helpers--locales = Locales
 ## Entity Details Metadata
 ## Shows metadata about an entity (original string)
 
-entitydetails-metadata-plural = Plural
-entitydetails-metadata-singular = Singular
+entitydetails-Metadata--plural = Plural
+entitydetails-Metadata--singular = Singular
 
-entitydetails-metadata-comment =
+entitydetails-Metadata--comment =
     .title = Comment
 
-entitydetails-metadata-context =
+entitydetails-Metadata--context =
     .title = Context
 
-entitydetails-metadata-placeholder =
+entitydetails-Metadata--placeholder =
     .title = Placeholder Examples
 
-entitydetails-metadata-resource =
+entitydetails-Metadata--resource =
     .title = Resource
 
-entitydetails-metadata-project =
+entitydetails-Metadata--project =
     .title = Project
 
 
-## Entity Navigation
+## Entity Details Navigation
 ## Shows next/previous buttons.
 
-entitynavigation-next = <glyph></glyph>Next
+entitydetails-EntityNavigation--next = <glyph></glyph>Next
     .title = Go To Next String (Alt + Down)
-entitynavigation-previous = <glyph></glyph>Previous
+entitydetails-EntityNavigation--previous = <glyph></glyph>Previous
     .title = Go To Previous String (Alt + Up)
 
 
 ## History
 ## Shows a list of translations for a specific entity
 
-history-history-no-translations = No translations available.
+history-History--no-translations = No translations available.
 
 
 ## History Translation
 ## Shows a specific translation for an entity, and actions around it
 
-history-translation-copy =
+history-Translation--copy =
     .title = Copy Into Translation (Tab)
 
-history-translation-hide-diff = Hide diff
+history-Translation--hide-diff = Hide diff
     .title = Hide diff against the currently active translation
-history-translation-show-diff = Show diff
+history-Translation--show-diff = Show diff
     .title = Show diff against the currently active translation
 
-history-translation-button-delete =
+history-Translation--button-delete =
     .title = Delete
 
-history-translation-button-approve =
+history-Translation--button-approve =
     .title = Approve
 
-history-translation-button-unapprove =
+history-Translation--button-unapprove =
     .title = Unapprove
 
-history-translation-button-reject =
+history-Translation--button-reject =
     .title = Reject
 
-history-translation-button-unreject =
+history-Translation--button-unreject =
     .title = Unreject
 
 
 ## Machinery
 ## Shows a list of translations from machines.
 
-machinery-machinery-search-placeholder =
+machinery-Machinery--search-placeholder =
     .placeholder = Type to search machinery
 
 
 ## Machinery Translation
 ## Shows a specific translation from machinery
 
-machinery-translation-copy =
+machinery-Translation--copy =
     .title = Copy Into Translation (Tab)
 
-machinery-translation-number-occurrences =
+machinery-Translation--number-occurrences =
     .title = Number of translation occurrences
 
 
-## Notification
+## Notification Messages
 ## Messages shown to users after they perform actions.
 
 notification--translation-approved = Translation approved
@@ -203,7 +203,7 @@ notification--entity-not-found = Can’t load specified string
 ## OtherLocales Translation
 ## Shows a specific translation from a different locale
 
-otherlocales-translation-copy =
+otherlocales-Translation--copy =
     .title = Copy Into Translation (Tab)
 
 
@@ -268,9 +268,9 @@ placeable-parser-xmlTag =
 
 ## Resource menu
 ## Used in the resource menu in the main navigation bar.
-navigation-ResourceMenu-no-results = No results
-navigation-ResourceMenu-all-resources = All Resources
-navigation-ResourceMenu-all-projects = All Projects
+resource-ResourceMenu--no-results = No results
+resource-ResourceMenu--all-resources = All Resources
+resource-ResourceMenu--all-projects = All Projects
 
 
 ## User Menu
@@ -278,6 +278,7 @@ navigation-ResourceMenu-all-projects = All Projects
 
 user-AppSwitcher--leave-translate-next = Leave Translate.Next
 user-SignIn--sign-in = Sign in
+user-SignOut--sign-out = <glyph></glyph>Sign out
 
 user-UserMenu--download-tm = <glyph></glyph>Download Translation Memory
 user-UserMenu--download-translations = <glyph></glyph>Download Translations
@@ -292,7 +293,6 @@ user-UserMenu--admin = <glyph></glyph>Admin
 user-UserMenu--admin-project = <glyph></glyph>Admin · Current Project
 
 user-UserMenu--settings = <glyph></glyph>Settings
-user-SignOut--sign-out = <glyph></glyph>Sign out
 
 
 ## User Notifications

--- a/frontend/public/static/locale/es/translate.ftl
+++ b/frontend/public/static/locale/es/translate.ftl
@@ -5,42 +5,42 @@
 # Please sort alphabetically by (module name, component name).
 
 
-## Editor
+## Editor Menu
 ## Allows contributors to modify or propose a translation
 
-editor-editor-button-copy = Copiar
-editor-editor-button-clear = Borrar
-editor-editor-button-save = Guardar
-editor-editor-button-suggest = Sugerir
+editor-EditorMenu--button-copy = Copiar
+editor-EditorMenu--button-clear = Borrar
+editor-EditorMenu--button-save = Guardar
+editor-EditorMenu--button-suggest = Sugerir
 
 
 ## Entity Navigation
 ## Shows next/previous buttons.
 
-entitynavigation-next = <glyph></glyph>Siguiente
+entitydetails-EntityNavigation--next = <glyph></glyph>Siguiente
     .title = Ir a la cadena siguiente (Alt + Abajo)
-entitynavigation-previous = <glyph></glyph>Anterior
+entitydetails-EntityNavigation--previous = <glyph></glyph>Anterior
     .title = Ir a la cadena anterior (Alt + Arriba)
 
 
 ## History
 ## Shows a list of translations for a specific entity
 
-history-history-no-translations = No hay traducciones.
+history-History--no-translations = No hay traducciones.
 
 
 ## History Translation
 ## Shows a specific translation for an entity, and actions around it
 
-history-translation-button-delete =
+history-Translation--button-delete =
     .title = Eliminar
-history-translation-button-approve =
+history-Translation--button-approve =
     .title = Aprobar
-history-translation-button-unapprove =
+history-Translation--button-unapprove =
     .title = Deshacer
-history-translation-button-reject =
+history-Translation--button-reject =
     .title = Rechazar
-history-translation-button-unreject =
+history-Translation--button-unreject =
     .title = Deshacer
 
 

--- a/frontend/public/static/locale/es/translate.ftl
+++ b/frontend/public/static/locale/es/translate.ftl
@@ -1,5 +1,9 @@
 ### Localization for the Translate page of Pontoon
 
+# Naming convention for l10n IDs: "module-ComponentName--sentence-summary".
+# This allows us to minimize the risk of conflicting IDs throughout the app.
+# Please sort alphabetically by (module name, component name).
+
 
 ## Editor
 ## Allows contributors to modify or propose a translation
@@ -17,23 +21,6 @@ entitynavigation-next = <glyph></glyph>Siguiente
     .title = Ir a la cadena siguiente (Alt + Abajo)
 entitynavigation-previous = <glyph></glyph>Anterior
     .title = Ir a la cadena anterior (Alt + Arriba)
-
-
-## Metadata
-## Shows metadata about an entity (original string)
-
-entitydetails-metadata-plural = Plural
-entitydetails-metadata-singular = Singular
-entitydetails-metadata-comment =
-    .title = Comentario
-entitydetails-metadata-context =
-    .title = Contexto
-entitydetails-metadata-placeholder =
-    .title = Ejemplos de variables
-entitydetails-metadata-resource =
-    .title = Recurso
-entitydetails-metadata-project =
-    .title = Proyecto
 
 
 ## History
@@ -55,3 +42,20 @@ history-translation-button-reject =
     .title = Rechazar
 history-translation-button-unreject =
     .title = Deshacer
+
+
+## Metadata
+## Shows metadata about an entity (original string)
+
+entitydetails-metadata-plural = Plural
+entitydetails-metadata-singular = Singular
+entitydetails-metadata-comment =
+    .title = Comentario
+entitydetails-metadata-context =
+    .title = Contexto
+entitydetails-metadata-placeholder =
+    .title = Ejemplos de variables
+entitydetails-metadata-resource =
+    .title = Recurso
+entitydetails-metadata-project =
+    .title = Proyecto

--- a/frontend/public/static/locale/es/translate.ftl
+++ b/frontend/public/static/locale/es/translate.ftl
@@ -1,8 +1,9 @@
 ### Localization for the Translate page of Pontoon
 
-# Naming convention for l10n IDs: "module-ComponentName--sentence-summary".
+# Naming convention for l10n IDs: "module-ComponentName--string-summary".
 # This allows us to minimize the risk of conflicting IDs throughout the app.
-# Please sort alphabetically by (module name, component name).
+# Please sort alphabetically by (module name, component name). For each module,
+# keep strings in order of appearance.
 
 
 ## Editor Menu

--- a/frontend/public/static/locale/fr/translate.ftl
+++ b/frontend/public/static/locale/fr/translate.ftl
@@ -5,65 +5,65 @@
 # Please sort alphabetically by (module name, component name).
 
 
-## Editor
-## Allows contributors to modify or propose a translation
-
-editor-editor-sign-in-to-translate = <a>Connectez-vous</a> pour traduire.
-editor-editor-button-copy = Copier
-editor-editor-button-clear = Effacer
-editor-editor-button-save = Sauvegarder
-editor-editor-button-suggest = Suggérer
-
-
 ## Editor Keyboard Shortcuts
 ## Shows a list of keyboard shortcuts.
 
-editor-keyboard-shortcuts-button =
+editor-KeyboardShortcuts--button =
     .title = Raccourcis clavier
 
-editor-keyboard-shortcuts-overlay-title = Raccourcis clavier
+editor-KeyboardShortcuts--overlay-title = Raccourcis clavier
 
-editor-keyboard-shortcuts-save-translation = Sauvegarder une traduction
-editor-keyboard-shortcuts-save-translation-shortcut = <accel>Entrée</accel>
+editor-KeyboardShortcuts--save-translation = Sauvegarder une traduction
+editor-KeyboardShortcuts--save-translation-shortcut = <accel>Entrée</accel>
 
-editor-keyboard-shortcuts-cancel-translation = Annuler une traduction
-editor-keyboard-shortcuts-cancel-translation-shortcut = <accel>Échap</accel>
+editor-KeyboardShortcuts--cancel-translation = Annuler une traduction
+editor-KeyboardShortcuts--cancel-translation-shortcut = <accel>Échap</accel>
 
-editor-keyboard-shortcuts-insert-a-new-line = Insérer une nouvelle ligne
-editor-keyboard-shortcuts-insert-a-new-line-shortcut = <mod1>Maj</mod1> + <accel>Entrée</accel>
+editor-KeyboardShortcuts--insert-a-new-line = Insérer une nouvelle ligne
+editor-KeyboardShortcuts--insert-a-new-line-shortcut = <mod1>Maj</mod1> + <accel>Entrée</accel>
 
-editor-keyboard-shortcuts-go-to-next-string = Aller à la prochaine chaîne
-editor-keyboard-shortcuts-go-to-next-string-shortcut = <mod1>Alt</mod1> + <accel>Bas</accel>
+editor-KeyboardShortcuts--go-to-next-string = Aller à la prochaine chaîne
+editor-KeyboardShortcuts--go-to-next-string-shortcut = <mod1>Alt</mod1> + <accel>Bas</accel>
 
-editor-keyboard-shortcuts-go-to-previous-string = Aller à la chaîne précédente
-editor-keyboard-shortcuts-go-to-previous-string-shortcut = <mod1>Alt</mod1> + <accel>Haut</accel>
+editor-KeyboardShortcuts--go-to-previous-string = Aller à la chaîne précédente
+editor-KeyboardShortcuts--go-to-previous-string-shortcut = <mod1>Alt</mod1> + <accel>Haut</accel>
 
-editor-keyboard-shortcuts-copy-from-source = Copier depuis la source
-editor-keyboard-shortcuts-copy-from-source-shortcut = <mod1>Ctrl</mod1> + <mod2>Maj</mod2> + <accel>C</accel>
+editor-KeyboardShortcuts--copy-from-source = Copier depuis la source
+editor-KeyboardShortcuts--copy-from-source-shortcut = <mod1>Ctrl</mod1> + <mod2>Maj</mod2> + <accel>C</accel>
 
-editor-keyboard-shortcuts-clear-translation = Effacer la traduction
-editor-keyboard-shortcuts-clear-translation-shortcut = <mod1>Ctrl</mod1> + <mod2>Maj</mod2> + <accel>Retour arrière</accel>
+editor-KeyboardShortcuts--clear-translation = Effacer la traduction
+editor-KeyboardShortcuts--clear-translation-shortcut = <mod1>Ctrl</mod1> + <mod2>Maj</mod2> + <accel>Retour arrière</accel>
 
-editor-keyboard-shortcuts-search-strings = Chercher dans les chaînes
-editor-keyboard-shortcuts-search-strings-shortcut = <mod1>Ctrl</mod1> + <mod2>Maj</mod2> + <accel>F</accel>
+editor-KeyboardShortcuts--search-strings = Chercher dans les chaînes
+editor-KeyboardShortcuts--search-strings-shortcut = <mod1>Ctrl</mod1> + <mod2>Maj</mod2> + <accel>F</accel>
 
-editor-keyboard-shortcuts-select-all-strings = Sélectionner toutes les chaînes
-editor-keyboard-shortcuts-select-all-strings-shortcut = <mod1>Ctrl</mod1> + <mod2>Maj</mod2> + <accel>A</accel>
+editor-KeyboardShortcuts--select-all-strings = Sélectionner toutes les chaînes
+editor-KeyboardShortcuts--select-all-strings-shortcut = <mod1>Ctrl</mod1> + <mod2>Maj</mod2> + <accel>A</accel>
 
-editor-keyboard-shortcuts-copy-from-helpers = Copier depuis les utilitaires
-editor-keyboard-shortcuts-copy-from-helpers-shortcut = <accel>Tab</accel>
+editor-KeyboardShortcuts--copy-from-helpers = Copier depuis les utilitaires
+editor-KeyboardShortcuts--copy-from-helpers-shortcut = <accel>Tab</accel>
+
+
+## Editor Menu
+## Allows contributors to modify or propose a translation
+
+editor-EditorMenu--sign-in-to-translate = <a>Connectez-vous</a> pour traduire.
+editor-EditorMenu--button-copy = Copier
+editor-EditorMenu--button-clear = Effacer
+editor-EditorMenu--button-save = Sauvegarder
+editor-EditorMenu--button-suggest = Suggérer
 
 
 ## Editor Settings
 ## Shows options to update user settings regarding the editor.
 
-editor-settings-toolkit-checks = <glyph></glyph>Vérifications Translate Toolkit
+editor-EditorSettings--toolkit-checks = <glyph></glyph>Vérifications Translate Toolkit
     .title = Faire les vérifications Translate Toolkit avant d'envoyer les traductions
 
-editor-settings-force-suggestions = <glyph></glyph>Faire des suggestions
+editor-EditorSettings--force-suggestions = <glyph></glyph>Faire des suggestions
     .title = Envoyer des suggestions au lieu de traductions
 
-editor-settings-change-all = Changer tous les paramètres
+editor-EditorSettings--change-all = Changer tous les paramètres
 
 
 ## Entity Details Helpers
@@ -77,80 +77,80 @@ entitydetails-Helpers--locales = Langues
 ## Entity Details Metadata
 ## Shows metadata about an entity (original string)
 
-entitydetails-metadata-plural = Pluriel
-entitydetails-metadata-singular = Singulier
+entitydetails-Metadata--plural = Pluriel
+entitydetails-Metadata--singular = Singulier
 
-entitydetails-metadata-comment =
+entitydetails-Metadata--comment =
     .title = Commentaire
 
-entitydetails-metadata-context =
+entitydetails-Metadata--context =
     .title = Contexte
 
-entitydetails-metadata-placeholder =
+entitydetails-Metadata--placeholder =
     .title = Exemples bouche-trous
 
-entitydetails-metadata-resource =
+entitydetails-Metadata--resource =
     .title = Ressource
 
-entitydetails-metadata-project =
+entitydetails-Metadata--project =
     .title = Projet
 
 
 ## Entity Navigation
 ## Shows next/previous buttons.
 
-entitynavigation-next = <glyph></glyph>Suivant
+entitydetails-EntityNavigation--next = <glyph></glyph>Suivant
     .title = Aller à la chaîne suivante (Alt + Bas)
-entitynavigation-previous = <glyph></glyph>Précédent
+entitydetails-EntityNavigation--previous = <glyph></glyph>Précédent
     .title = Aller à la chaîne précédente (Alt + Haut)
 
 
 ## History
 ## Shows a list of translations for a specific entity
 
-history-history-no-translations = Pas de traduction disponible.
+history-History--no-translations = Pas de traduction disponible.
 
 
 ## History Translation
 ## Shows a specific translation for an entity, and actions around it
 
-history-translation-copy =
+history-Translation--copy =
     .title = Copier la traduction (Tab)
 
-history-translation-hide-diff = Cacher diff
+history-Translation--hide-diff = Cacher diff
     .title = Cacher la différence avec la traduction active
-history-translation-show-diff = Montrer diff
+history-Translation--show-diff = Montrer diff
     .title = Montrer la différence avec la traduction active
 
-history-translation-button-delete =
+history-Translation--button-delete =
     .title = Supprimer
 
-history-translation-button-approve =
+history-Translation--button-approve =
     .title = Approuver
 
-history-translation-button-unapprove =
+history-Translation--button-unapprove =
     .title = Désapprouver
 
-history-translation-button-reject =
+history-Translation--button-reject =
     .title = Rejeter
 
-history-translation-button-unreject =
+history-Translation--button-unreject =
     .title = Dérejeter
 
 
 ## Machinery
 ## Shows a list of translations from machines.
 
-machinery-machinery-search-placeholder =
+machinery-Machinery--search-placeholder =
     .placeholder = Saisir pour rechercher la machinerie
 
 ## Machinery Translation
 ## Shows a specific translation from machinery
 
-machinery-translation-copy =
+machinery-Translation--copy =
     .title = Copier la traduction (Tab)
 
-machinery-translation-number-occurrences =
+machinery-Translation--number-occurrences =
     .title = Nombre d'occurrences de la traduction
 
 
@@ -178,7 +178,7 @@ notification--make-suggestions-disabled = Faire des suggestions désactivé
 ## OtherLocales Translation
 ## Shows a specific translation from a different locale
 
-otherlocales-translation-copy =
+otherlocales-Translation--copy =
     .title = Copier la traduction (Tab)
 
 
@@ -246,6 +246,7 @@ placeable-parser-xmlTag =
 
 user-AppSwitcher--leave-translate-next = Quitter Translate.Next
 user-SignIn--sign-in = Connectez-vous
+user-SignOut--sign-out = <glyph></glyph>Se déconnecter
 
 user-UserMenu--download-tm = <glyph></glyph>Télécharger la Mémoire de traduction
 
@@ -258,4 +259,3 @@ user-UserMenu--admin = <glyph></glyph>Admin
 user-UserMenu--admin-project = <glyph></glyph>Admin · Projet actuel
 
 user-UserMenu--settings = <glyph></glyph>Paramètres
-user-SignOut--sign-out = <glyph></glyph>Se déconnecter

--- a/frontend/public/static/locale/fr/translate.ftl
+++ b/frontend/public/static/locale/fr/translate.ftl
@@ -5,6 +5,17 @@
 # Please sort alphabetically by (module name, component name).
 
 
+## Editor Failed Checks
+## Renders the failed checks popup
+
+editor-FailedChecks--close = ×
+    .aria-label = Cacher les vérifications échouées
+editor-FailedChecks--title = Les vérifications suivantes ont échoué
+editor-FailedChecks--save-anyway = Sauvegarder quand même
+editor-FailedChecks--suggest-anyway = Suggérer quand même
+editor-FailedChecks--approve-anyway = Approuver quand même
+
+
 ## Editor Keyboard Shortcuts
 ## Shows a list of keyboard shortcuts.
 
@@ -48,6 +59,7 @@ editor-KeyboardShortcuts--copy-from-helpers-shortcut = <accel>Tab</accel>
 ## Allows contributors to modify or propose a translation
 
 editor-EditorMenu--sign-in-to-translate = <a>Connectez-vous</a> pour traduire.
+editor-EditorMenu--read-only-localization = Cette traduction est en lecture seule.
 editor-EditorMenu--button-copy = Copier
 editor-EditorMenu--button-clear = Effacer
 editor-EditorMenu--button-save = Sauvegarder
@@ -64,6 +76,16 @@ editor-EditorSettings--force-suggestions = <glyph></glyph>Faire des suggestions
     .title = Envoyer des suggestions au lieu de traductions
 
 editor-EditorSettings--change-all = Changer tous les paramètres
+
+
+## Editor Unsaved Changes
+## Renders the unsaved changes popup
+
+editor-UnsavedChanges--close = ×
+    .aria-label = Cacher les changements non-sauvegardés
+editor-UnsavedChanges--title = Vous avez des changements non-sauvegardés
+editor-UnsavedChanges--body = Voulez-vous vraiment quitter ?
+editor-UnsavedChanges--leave-anyway = Quitter quand même
 
 
 ## Entity Details Helpers
@@ -144,6 +166,7 @@ history-Translation--button-unreject =
 machinery-Machinery--search-placeholder =
     .placeholder = Saisir pour rechercher la machinerie
 
+
 ## Machinery Translation
 ## Shows a specific translation from machinery
 
@@ -154,8 +177,9 @@ machinery-Translation--number-occurrences =
     .title = Nombre d'occurrences de la traduction
 
 
-## Notification
+## Notification Messages
 ## Messages shown to users after they perform actions.
+
 notification--translation-approved = Traduction approuvée
 notification--translation-unaproved = Traduction désapprouvée
 notification--translation-rejected = Traduction rejetée
@@ -173,6 +197,7 @@ notification--tt-checks-enabled = Vérifications Translate Toolkit activées
 notification--tt-checks-disabled = Vérifications Translate Toolkit désactivées
 notification--make-suggestions-enabled = Faire des suggestions activé
 notification--make-suggestions-disabled = Faire des suggestions désactivé
+notification--entity-not-found = Impossible de charger la chaîne spécifiée
 
 
 ## OtherLocales Translation
@@ -241,7 +266,14 @@ placeable-parser-xmlTag =
     .title = Balise XML
 
 
-## User
+## Resource menu
+## Used in the resource menu in the main navigation bar.
+resource-ResourceMenu--no-results = Pas de résultat
+resource-ResourceMenu--all-resources = Toutes les ressources
+resource-ResourceMenu--all-projects = Tous les projets
+
+
+## User Menu
 ## Shows user menu entries and options to sign in or out.
 
 user-AppSwitcher--leave-translate-next = Quitter Translate.Next
@@ -249,6 +281,8 @@ user-SignIn--sign-in = Connectez-vous
 user-SignOut--sign-out = <glyph></glyph>Se déconnecter
 
 user-UserMenu--download-tm = <glyph></glyph>Télécharger la Mémoire de traduction
+user-UserMenu--download-translations = <glyph></glyph>Télécharger les traductions
+user-UserMenu--upload-translations = <glyph></glyph>Envoyer des traductions
 
 user-UserMenu--top-contributors = <glyph></glyph>Contributeurs et contributrices remarquables
 user-UserMenu--machinery = <glyph></glyph>Machinerie
@@ -259,3 +293,11 @@ user-UserMenu--admin = <glyph></glyph>Admin
 user-UserMenu--admin-project = <glyph></glyph>Admin · Projet actuel
 
 user-UserMenu--settings = <glyph></glyph>Paramètres
+
+
+## User Notifications
+## Shows user notifications menu.
+
+user-UserNotificationsMenu--no-notifications-title = Pas de nouvelle notification.
+user-UserNotificationsMenu--no-notifications-description = Vous trouverez ici des mises à jour sur les langues auxquelles vous contribuez.
+user-UserNotificationsMenu--see-all-notifications = Voir toutes les notifications

--- a/frontend/public/static/locale/fr/translate.ftl
+++ b/frontend/public/static/locale/fr/translate.ftl
@@ -1,8 +1,32 @@
 ### Localization for the Translate page of Pontoon
 
-# Naming convention for l10n IDs: "module-ComponentName--sentence-summary".
+# Naming convention for l10n IDs: "module-ComponentName--string-summary".
 # This allows us to minimize the risk of conflicting IDs throughout the app.
-# Please sort alphabetically by (module name, component name).
+# Please sort alphabetically by (module name, component name). For each module,
+# keep strings in order of appearance.
+
+
+## Editor Menu
+## Allows contributors to modify or propose a translation
+
+editor-EditorMenu--sign-in-to-translate = <a>Connectez-vous</a> pour traduire.
+editor-EditorMenu--read-only-localization = Cette traduction est en lecture seule.
+editor-EditorMenu--button-copy = Copier
+editor-EditorMenu--button-clear = Effacer
+editor-EditorMenu--button-save = Sauvegarder
+editor-EditorMenu--button-suggest = Suggérer
+
+
+## Editor Settings
+## Shows options to update user settings regarding the editor.
+
+editor-EditorSettings--toolkit-checks = <glyph></glyph>Vérifications Translate Toolkit
+    .title = Faire les vérifications Translate Toolkit avant d'envoyer les traductions
+
+editor-EditorSettings--force-suggestions = <glyph></glyph>Faire des suggestions
+    .title = Envoyer des suggestions au lieu de traductions
+
+editor-EditorSettings--change-all = Changer tous les paramètres
 
 
 ## Editor Failed Checks
@@ -55,29 +79,6 @@ editor-KeyboardShortcuts--copy-from-helpers = Copier depuis les utilitaires
 editor-KeyboardShortcuts--copy-from-helpers-shortcut = <accel>Tab</accel>
 
 
-## Editor Menu
-## Allows contributors to modify or propose a translation
-
-editor-EditorMenu--sign-in-to-translate = <a>Connectez-vous</a> pour traduire.
-editor-EditorMenu--read-only-localization = Cette traduction est en lecture seule.
-editor-EditorMenu--button-copy = Copier
-editor-EditorMenu--button-clear = Effacer
-editor-EditorMenu--button-save = Sauvegarder
-editor-EditorMenu--button-suggest = Suggérer
-
-
-## Editor Settings
-## Shows options to update user settings regarding the editor.
-
-editor-EditorSettings--toolkit-checks = <glyph></glyph>Vérifications Translate Toolkit
-    .title = Faire les vérifications Translate Toolkit avant d'envoyer les traductions
-
-editor-EditorSettings--force-suggestions = <glyph></glyph>Faire des suggestions
-    .title = Envoyer des suggestions au lieu de traductions
-
-editor-EditorSettings--change-all = Changer tous les paramètres
-
-
 ## Editor Unsaved Changes
 ## Renders the unsaved changes popup
 
@@ -86,6 +87,15 @@ editor-UnsavedChanges--close = ×
 editor-UnsavedChanges--title = Vous avez des changements non-sauvegardés
 editor-UnsavedChanges--body = Voulez-vous vraiment quitter ?
 editor-UnsavedChanges--leave-anyway = Quitter quand même
+
+
+## Entity Navigation
+## Shows next/previous buttons.
+
+entitydetails-EntityNavigation--next = <glyph></glyph>Suivant
+    .title = Aller à la chaîne suivante (Alt + Bas)
+entitydetails-EntityNavigation--previous = <glyph></glyph>Précédent
+    .title = Aller à la chaîne précédente (Alt + Haut)
 
 
 ## Entity Details Helpers
@@ -116,15 +126,6 @@ entitydetails-Metadata--resource =
 
 entitydetails-Metadata--project =
     .title = Projet
-
-
-## Entity Navigation
-## Shows next/previous buttons.
-
-entitydetails-EntityNavigation--next = <glyph></glyph>Suivant
-    .title = Aller à la chaîne suivante (Alt + Bas)
-entitydetails-EntityNavigation--previous = <glyph></glyph>Précédent
-    .title = Aller à la chaîne précédente (Alt + Haut)
 
 
 ## History

--- a/frontend/public/static/locale/fr/translate.ftl
+++ b/frontend/public/static/locale/fr/translate.ftl
@@ -1,5 +1,9 @@
 ### Localization for the Translate page of Pontoon
 
+# Naming convention for l10n IDs: "module-ComponentName--sentence-summary".
+# This allows us to minimize the risk of conflicting IDs throughout the app.
+# Please sort alphabetically by (module name, component name).
+
 
 ## Editor
 ## Allows contributors to modify or propose a translation
@@ -11,19 +15,7 @@ editor-editor-button-save = Sauvegarder
 editor-editor-button-suggest = Suggérer
 
 
-## EditorSettings
-## Shows options to update user settings regarding the editor.
-
-editor-settings-toolkit-checks = <glyph></glyph>Vérifications Translate Toolkit
-    .title = Faire les vérifications Translate Toolkit avant d'envoyer les traductions
-
-editor-settings-force-suggestions = <glyph></glyph>Faire des suggestions
-    .title = Envoyer des suggestions au lieu de traductions
-
-editor-settings-change-all = Changer tous les paramètres
-
-
-## KeyboardShortcuts
+## Editor Keyboard Shortcuts
 ## Shows a list of keyboard shortcuts.
 
 editor-keyboard-shortcuts-button =
@@ -62,32 +54,27 @@ editor-keyboard-shortcuts-copy-from-helpers = Copier depuis les utilitaires
 editor-keyboard-shortcuts-copy-from-helpers-shortcut = <accel>Tab</accel>
 
 
-## Machinery
-## Shows a list of translations from machines.
+## Editor Settings
+## Shows options to update user settings regarding the editor.
 
-machinery-machinery-search-placeholder =
-    .placeholder = Saisir pour rechercher la machinerie
+editor-settings-toolkit-checks = <glyph></glyph>Vérifications Translate Toolkit
+    .title = Faire les vérifications Translate Toolkit avant d'envoyer les traductions
 
-## Machinery Translation
-## Shows a specific translation from machinery
+editor-settings-force-suggestions = <glyph></glyph>Faire des suggestions
+    .title = Envoyer des suggestions au lieu de traductions
 
-machinery-translation-copy =
-    .title = Copier la traduction (Tab)
-
-machinery-translation-number-occurrences =
-    .title = Nombre d'occurrences de la traduction
+editor-settings-change-all = Changer tous les paramètres
 
 
-## Entity Navigation
-## Shows next/previous buttons.
+## Entity Details Helpers
+## Shows helper tabs
 
-entitynavigation-next = <glyph></glyph>Suivant
-    .title = Aller à la chaîne suivante (Alt + Bas)
-entitynavigation-previous = <glyph></glyph>Précédent
-    .title = Aller à la chaîne précédente (Alt + Haut)
+entitydetails-Helpers--history = Historique
+entitydetails-Helpers--machinery = Machinerie
+entitydetails-Helpers--locales = Langues
 
 
-## Metadata
+## Entity Details Metadata
 ## Shows metadata about an entity (original string)
 
 entitydetails-metadata-plural = Pluriel
@@ -109,12 +96,13 @@ entitydetails-metadata-project =
     .title = Projet
 
 
-## Helpers
-## Shows helper tabs
+## Entity Navigation
+## Shows next/previous buttons.
 
-entitydetails-Helpers--history = Historique
-entitydetails-Helpers--machinery = Machinerie
-entitydetails-Helpers--locales = Langues
+entitynavigation-next = <glyph></glyph>Suivant
+    .title = Aller à la chaîne suivante (Alt + Bas)
+entitynavigation-previous = <glyph></glyph>Précédent
+    .title = Aller à la chaîne précédente (Alt + Haut)
 
 
 ## History
@@ -150,31 +138,20 @@ history-translation-button-unreject =
     .title = Dérejeter
 
 
-## OtherLocales Translation
-## Shows a specific translation from a different locale
+## Machinery
+## Shows a list of translations from machines.
 
-otherlocales-translation-copy =
+machinery-machinery-search-placeholder =
+    .placeholder = Saisir pour rechercher la machinerie
+
+## Machinery Translation
+## Shows a specific translation from machinery
+
+machinery-translation-copy =
     .title = Copier la traduction (Tab)
 
-
-## User
-## Shows user menu entries and options to sign in or out.
-
-user-AppSwitcher--leave-translate-next = Quitter Translate.Next
-user-SignIn--sign-in = Connectez-vous
-
-user-UserMenu--download-tm = <glyph></glyph>Télécharger la Mémoire de traduction
-
-user-UserMenu--top-contributors = <glyph></glyph>Contributeurs et contributrices remarquables
-user-UserMenu--machinery = <glyph></glyph>Machinerie
-user-UserMenu--terms = <glyph></glyph>Conditions d’utilisation
-user-UserMenu--help = <glyph></glyph>Aide
-
-user-UserMenu--admin = <glyph></glyph>Admin
-user-UserMenu--admin-project = <glyph></glyph>Admin · Projet actuel
-
-user-UserMenu--settings = <glyph></glyph>Paramètres
-user-SignOut--sign-out = <glyph></glyph>Se déconnecter
+machinery-translation-number-occurrences =
+    .title = Nombre d'occurrences de la traduction
 
 
 ## Notification
@@ -195,8 +172,14 @@ notification--same-translation = Une traduction identique existe déjà
 notification--tt-checks-enabled = Vérifications Translate Toolkit activées
 notification--tt-checks-disabled = Vérifications Translate Toolkit désactivées
 notification--make-suggestions-enabled = Faire des suggestions activé
-notification--ftl-not-supported-rich-editor = Traduction non supportée dans l'éditeur avancé
 notification--make-suggestions-disabled = Faire des suggestions désactivé
+
+
+## OtherLocales Translation
+## Shows a specific translation from a different locale
+
+otherlocales-translation-copy =
+    .title = Copier la traduction (Tab)
 
 
 ## Placeable parsers
@@ -256,3 +239,23 @@ placeable-parser-xmlEntity =
     .title = Entité XML
 placeable-parser-xmlTag =
     .title = Balise XML
+
+
+## User
+## Shows user menu entries and options to sign in or out.
+
+user-AppSwitcher--leave-translate-next = Quitter Translate.Next
+user-SignIn--sign-in = Connectez-vous
+
+user-UserMenu--download-tm = <glyph></glyph>Télécharger la Mémoire de traduction
+
+user-UserMenu--top-contributors = <glyph></glyph>Contributeurs et contributrices remarquables
+user-UserMenu--machinery = <glyph></glyph>Machinerie
+user-UserMenu--terms = <glyph></glyph>Conditions d’utilisation
+user-UserMenu--help = <glyph></glyph>Aide
+
+user-UserMenu--admin = <glyph></glyph>Admin
+user-UserMenu--admin-project = <glyph></glyph>Admin · Projet actuel
+
+user-UserMenu--settings = <glyph></glyph>Paramètres
+user-SignOut--sign-out = <glyph></glyph>Se déconnecter

--- a/frontend/src/core/editor/components/EditorMenu.js
+++ b/frontend/src/core/editor/components/EditorMenu.js
@@ -38,7 +38,7 @@ export default class EditorMenu extends React.Component<Props> {
             <unsavedchanges.UnsavedChanges />
             { !props.user.isAuthenticated ?
                 <Localized
-                    id="editor-editor-sign-in-to-translate"
+                    id="editor-EditorMenu--sign-in-to-translate"
                     a={
                         <user.SignInLink url={ props.user.signInURL }></user.SignInLink>
                     }
@@ -49,7 +49,7 @@ export default class EditorMenu extends React.Component<Props> {
                 </Localized>
             : (props.entity && props.entity.readonly) ?
                 <Localized
-                    id="editor-editor-read-only-localization"
+                    id="editor-EditorMenu--read-only-localization"
                 >
                     <p className='banner'>This is a read-only localization.</p>
                 </Localized>
@@ -66,7 +66,7 @@ export default class EditorMenu extends React.Component<Props> {
                         translation={ props.editor.translation }
                     />
                     <div className="actions">
-                        <Localized id="editor-editor-button-copy">
+                        <Localized id="editor-EditorMenu--button-copy">
                             <button
                                 className="action-copy"
                                 onClick={ props.copyOriginalIntoEditor }
@@ -74,7 +74,7 @@ export default class EditorMenu extends React.Component<Props> {
                                 Copy
                             </button>
                         </Localized>
-                        <Localized id="editor-editor-button-clear">
+                        <Localized id="editor-EditorMenu--button-clear">
                             <button
                                 className="action-clear"
                                 onClick={ props.clearEditor }
@@ -84,7 +84,7 @@ export default class EditorMenu extends React.Component<Props> {
                         </Localized>
                         { props.user.settings.forceSuggestions ?
                         // Suggest button, will send an unreviewed translation.
-                        <Localized id="editor-editor-button-suggest">
+                        <Localized id="editor-EditorMenu--button-suggest">
                             <button
                                 className="action-suggest"
                                 onClick={ props.sendTranslation }
@@ -94,7 +94,7 @@ export default class EditorMenu extends React.Component<Props> {
                         </Localized>
                         :
                         // Save button, will send an approved translation.
-                        <Localized id="editor-editor-button-save">
+                        <Localized id="editor-EditorMenu--button-save">
                             <button
                                 className="action-save"
                                 onClick={ props.sendTranslation }

--- a/frontend/src/core/editor/components/EditorMenu.test.js
+++ b/frontend/src/core/editor/components/EditorMenu.test.js
@@ -54,7 +54,7 @@ function expectHiddenSettingsAndActions(wrapper) {
     expect(wrapper.find(EditorSettings)).toHaveLength(0);
     expect(wrapper.find(KeyboardShortcuts)).toHaveLength(0);
     expect(wrapper.find(TranslationLength)).toHaveLength(0);
-    expect(wrapper.find('#editor-editor-button-copy')).toHaveLength(0);
+    expect(wrapper.find('#editor-EditorMenu--button-copy')).toHaveLength(0);
 }
 
 
@@ -77,7 +77,7 @@ describe('<EditorMenu>', () => {
 
         expectHiddenSettingsAndActions(wrapper);
 
-        expect(wrapper.find('#editor-editor-sign-in-to-translate')).toHaveLength(1);
+        expect(wrapper.find('#editor-EditorMenu--sign-in-to-translate')).toHaveLength(1);
     });
 
     it('hides the settings and actions when the entity is read-only', () => {
@@ -89,7 +89,7 @@ describe('<EditorMenu>', () => {
 
         expectHiddenSettingsAndActions(wrapper);
 
-        expect(wrapper.find('#editor-editor-read-only-localization')).toHaveLength(1);
+        expect(wrapper.find('#editor-EditorMenu--read-only-localization')).toHaveLength(1);
     });
 
     it('accepts a firstItemHook and shows it as its first child', () => {

--- a/frontend/src/core/editor/components/EditorSettings.js
+++ b/frontend/src/core/editor/components/EditorSettings.js
@@ -64,7 +64,7 @@ export class EditorSettingsBase extends React.Component<Props, State> {
             { !this.state.visible ? null :
             <ul className="menu">
                 <Localized
-                    id="editor-settings-toolkit-checks"
+                    id="editor-EditorSettings--toolkit-checks"
                     attrs={{ title: true }}
                     glyph={
                         <i className="fa fa-fw"></i>
@@ -80,7 +80,7 @@ export class EditorSettingsBase extends React.Component<Props, State> {
                 </Localized>
 
                 <Localized
-                    id="editor-settings-force-suggestions"
+                    id="editor-EditorSettings--force-suggestions"
                     attrs={{ title: true }}
                     glyph={
                         <i className="fa fa-fw"></i>
@@ -97,7 +97,7 @@ export class EditorSettingsBase extends React.Component<Props, State> {
 
                 <li className="horizontal-separator"></li>
                 <li>
-                    <Localized id="editor-settings-change-all">
+                    <Localized id="editor-EditorSettings--change-all">
                         <a href="/settings/">
                             { 'Change All Settings' }
                         </a>

--- a/frontend/src/core/editor/components/KeyboardShortcuts.js
+++ b/frontend/src/core/editor/components/KeyboardShortcuts.js
@@ -43,7 +43,7 @@ export class KeyboardShortcutsBase extends React.Component<Props, State> {
     render() {
         return <div className="keyboard-shortcuts">
             <Localized
-                id="editor-keyboard-shortcuts-button"
+                id="editor-KeyboardShortcuts--button"
                 attrs={{ title: true }}
             >
                 <div
@@ -58,17 +58,17 @@ export class KeyboardShortcutsBase extends React.Component<Props, State> {
                 className="overlay"
                 onClick={ this.toggleVisibility }
             >
-                <Localized id="editor-keyboard-shortcuts-overlay-title">
+                <Localized id="editor-KeyboardShortcuts--overlay-title">
                     <h2>Keyboard Shortcuts</h2>
                 </Localized>
                 <table>
                     <tbody>
                         <tr>
-                            <Localized id="editor-keyboard-shortcuts-save-translation">
+                            <Localized id="editor-KeyboardShortcuts--save-translation">
                                 <td>Save Translation</td>
                             </Localized>
                             <Localized
-                                id="editor-keyboard-shortcuts-save-translation-shortcut"
+                                id="editor-KeyboardShortcuts--save-translation-shortcut"
                                 accel={ <span/> }
                             >
                                 <td>
@@ -77,11 +77,11 @@ export class KeyboardShortcutsBase extends React.Component<Props, State> {
                             </Localized>
                         </tr>
                         <tr>
-                            <Localized id="editor-keyboard-shortcuts-cancel-translation">
+                            <Localized id="editor-KeyboardShortcuts--cancel-translation">
                                 <td>Cancel Translation</td>
                             </Localized>
                             <Localized
-                                id="editor-keyboard-shortcuts-cancel-translation-shortcut"
+                                id="editor-KeyboardShortcuts--cancel-translation-shortcut"
                                 accel={ <span/> }
                             >
                                 <td>
@@ -90,11 +90,11 @@ export class KeyboardShortcutsBase extends React.Component<Props, State> {
                             </Localized>
                         </tr>
                         <tr>
-                            <Localized id="editor-keyboard-shortcuts-insert-a-new-line">
+                            <Localized id="editor-KeyboardShortcuts--insert-a-new-line">
                                 <td>Insert A New Line</td>
                             </Localized>
                             <Localized
-                                id="editor-keyboard-shortcuts-insert-a-new-line-shortcut"
+                                id="editor-KeyboardShortcuts--insert-a-new-line-shortcut"
                                 mod1={ <span/> }
                                 accel={ <span/> }
                             >
@@ -105,12 +105,12 @@ export class KeyboardShortcutsBase extends React.Component<Props, State> {
                         </tr>
                         <tr>
                             <Localized
-                                id="editor-keyboard-shortcuts-go-to-next-string"
+                                id="editor-KeyboardShortcuts--go-to-next-string"
                             >
                                 <td>Go To Next String</td>
                             </Localized>
                             <Localized
-                                id="editor-keyboard-shortcuts-go-to-next-string-shortcut"
+                                id="editor-KeyboardShortcuts--go-to-next-string-shortcut"
                                 mod1={ <span/> }
                                 accel={ <span/> }
                             >
@@ -121,11 +121,11 @@ export class KeyboardShortcutsBase extends React.Component<Props, State> {
                         </tr>
                         <tr>
                             <Localized
-                                id="editor-keyboard-shortcuts-go-to-previous-string">
+                                id="editor-KeyboardShortcuts--go-to-previous-string">
                                 <td>Go To Previous String</td>
                             </Localized>
                             <Localized
-                                id="editor-keyboard-shortcuts-go-to-previous-string-shortcut"
+                                id="editor-KeyboardShortcuts--go-to-previous-string-shortcut"
                                 mod1={ <span/> }
                                 accel={ <span/> }
                             >
@@ -136,11 +136,11 @@ export class KeyboardShortcutsBase extends React.Component<Props, State> {
                         </tr>
                         <tr>
                             <Localized
-                                id="editor-keyboard-shortcuts-copy-from-source">
+                                id="editor-KeyboardShortcuts--copy-from-source">
                                 <td>Copy From Source</td>
                             </Localized>
                             <Localized
-                                id="editor-keyboard-shortcuts-copy-from-source-shortcut"
+                                id="editor-KeyboardShortcuts--copy-from-source-shortcut"
                                 mod1={ <span/> }
                                 mod2={ <span/> }
                                 accel={ <span/> }
@@ -151,11 +151,11 @@ export class KeyboardShortcutsBase extends React.Component<Props, State> {
                             </Localized>
                         </tr>
                         <tr>
-                            <Localized id="editor-keyboard-shortcuts-clear-translation">
+                            <Localized id="editor-KeyboardShortcuts--clear-translation">
                                 <td>Clear Translation</td>
                             </Localized>
                             <Localized
-                                id="editor-keyboard-shortcuts-clear-translation-shortcut"
+                                id="editor-KeyboardShortcuts--clear-translation-shortcut"
                                 mod1={ <span/> }
                                 mod2={ <span/> }
                                 accel={ <span/> }
@@ -166,11 +166,11 @@ export class KeyboardShortcutsBase extends React.Component<Props, State> {
                             </Localized>
                         </tr>
                         <tr>
-                            <Localized id="editor-keyboard-shortcuts-search-strings">
+                            <Localized id="editor-KeyboardShortcuts--search-strings">
                                 <td>Search Strings</td>
                             </Localized>
                             <Localized
-                                id="editor-keyboard-shortcuts-search-strings-shortcut"
+                                id="editor-KeyboardShortcuts--search-strings-shortcut"
                                 mod1={ <span/> }
                                 mod2={ <span/> }
                                 accel={ <span/> }
@@ -181,11 +181,11 @@ export class KeyboardShortcutsBase extends React.Component<Props, State> {
                             </Localized>
                         </tr>
                         <tr>
-                            <Localized id="editor-keyboard-shortcuts-select-all-strings">
+                            <Localized id="editor-KeyboardShortcuts--select-all-strings">
                                 <td>Select All Strings</td>
                             </Localized>
                             <Localized
-                                id="editor-keyboard-shortcuts-select-all-strings-shortcut"
+                                id="editor-KeyboardShortcuts--select-all-strings-shortcut"
                                 mod1={ <span/> }
                                 mod2={ <span/> }
                                 accel={ <span/> }
@@ -196,11 +196,11 @@ export class KeyboardShortcutsBase extends React.Component<Props, State> {
                             </Localized>
                         </tr>
                         <tr>
-                            <Localized id="editor-keyboard-shortcuts-copy-from-helpers">
+                            <Localized id="editor-KeyboardShortcuts--copy-from-helpers">
                                 <td>Copy From Helpers</td>
                             </Localized>
                             <Localized
-                                id="editor-keyboard-shortcuts-copy-from-helpers-shortcut"
+                                id="editor-KeyboardShortcuts--copy-from-helpers-shortcut"
                                 accel={ <span/> }
                             >
                                 <td>

--- a/frontend/src/core/resource/components/ResourceMenu.js
+++ b/frontend/src/core/resource/components/ResourceMenu.js
@@ -128,7 +128,7 @@ export class ResourceMenuBase extends React.Component<Props, State> {
                         })
                         :
                         // No resources found
-                        <Localized id='navigation-ResourceMenu-no-results'>
+                        <Localized id='resource-ResourceMenu--no-results'>
                             <li className="no-results">No results</li>
                         </Localized>
                     }
@@ -140,7 +140,7 @@ export class ResourceMenuBase extends React.Component<Props, State> {
                             href={ `/${parameters.locale}/${parameters.project}/all-resources/` }
                             onClick={ this.navigateToPath }
                         >
-                            <Localized id='navigation-ResourceMenu-all-resources'>
+                            <Localized id='resource-ResourceMenu--all-resources'>
                                 <span>All Resources</span>
                             </Localized>
                             <ResourcePercent resource={ resources.allResources } />
@@ -151,7 +151,7 @@ export class ResourceMenuBase extends React.Component<Props, State> {
                             href={ `/${parameters.locale}/all-projects/all-resources/` }
                             onClick={ this.navigateToPath }
                         >
-                            <Localized id='navigation-ResourceMenu-all-projects'>
+                            <Localized id='resource-ResourceMenu--all-projects'>
                                 <span>All Projects</span>
                             </Localized>
                         </a>

--- a/frontend/src/core/resource/components/ResourceMenu.test.js
+++ b/frontend/src/core/resource/components/ResourceMenu.test.js
@@ -70,8 +70,8 @@ describe('<ResourceMenuBase>', () => {
         expect(wrapper.find('.resource-menu .menu > ul')).toHaveLength(2);
         expect(wrapper.find('.resource-menu .menu > ul').find(ResourceItem)).toHaveLength(3);
         expect(wrapper.find('.resource-menu .menu .static-links')).toHaveLength(1);
-        expect(wrapper.find('.resource-menu .menu #navigation-ResourceMenu-all-resources')).toHaveLength(1);
-        expect(wrapper.find('.resource-menu .menu #navigation-ResourceMenu-all-projects')).toHaveLength(1);
+        expect(wrapper.find('.resource-menu .menu #resource-ResourceMenu--all-resources')).toHaveLength(1);
+        expect(wrapper.find('.resource-menu .menu #resource-ResourceMenu--all-projects')).toHaveLength(1);
     });
 
     it('searches resource items correctly', () => {

--- a/frontend/src/modules/entitydetails/components/EntityNavigation.js
+++ b/frontend/src/modules/entitydetails/components/EntityNavigation.js
@@ -61,7 +61,7 @@ export default class EntityNavigation extends React.Component<Props> {
     render(): React.Node {
         return <div className='entity-navigation clearfix'>
             <Localized
-                id="entitynavigation-next"
+                id="entitydetails-EntityNavigation--next"
                 attrs={{ title: true }}
                 glyph={
                     <i className="fa fa-chevron-down fa-lg"></i>
@@ -76,7 +76,7 @@ export default class EntityNavigation extends React.Component<Props> {
                 </button>
             </Localized>
             <Localized
-                id="entitynavigation-previous"
+                id="entitydetails-EntityNavigation--previous"
                 attrs={{ title: true }}
                 glyph={
                     <i className="fa fa-chevron-up fa-lg"></i>

--- a/frontend/src/modules/entitydetails/components/Metadata.js
+++ b/frontend/src/modules/entitydetails/components/Metadata.js
@@ -101,7 +101,7 @@ export default class Metadata extends React.Component<Props> {
 
         if (locale.cldrPlurals[pluralForm] === 1) {
             return {
-                title: <Localized id='entitydetails-metadata-singular'>
+                title: <Localized id='entitydetails-Metadata--singular'>
                     <h2>Singular</h2>
                 </Localized>,
                 original: entity.original,
@@ -109,7 +109,7 @@ export default class Metadata extends React.Component<Props> {
         }
 
         return {
-            title: <Localized id='entitydetails-metadata-plural'>
+            title: <Localized id='entitydetails-Metadata--plural'>
                 <h2>Plural</h2>
             </Localized>,
             original: entity.original_plural,
@@ -143,7 +143,7 @@ export default class Metadata extends React.Component<Props> {
             comment = parts.join('\n');
         }
 
-        return <Localized id='entitydetails-metadata-comment' attrs={ { title: true } }>
+        return <Localized id='entitydetails-Metadata--comment' attrs={ { title: true } }>
             <Property title='Comment' className='comment'>
                 <Linkify properties={ { target: '_blank', rel: 'noopener noreferrer' } }>
                     { comment }
@@ -157,7 +157,7 @@ export default class Metadata extends React.Component<Props> {
             return null;
         }
 
-        return <Localized id='entitydetails-metadata-context' attrs={ { title: true } }>
+        return <Localized id='entitydetails-Metadata--context' attrs={ { title: true } }>
             <Property title='Context' className='context'>
                 { entity.key }
             </Property>
@@ -186,7 +186,7 @@ export default class Metadata extends React.Component<Props> {
             return null;
         }
 
-        return <Localized id='entitydetails-metadata-placeholder' attrs={ { title: true } }>
+        return <Localized id='entitydetails-Metadata--placeholder' attrs={ { title: true } }>
             <Property title='Placeholder Examples' className='placeholder'>
                 <Linkify properties={ { target: '_blank', rel: 'noopener noreferrer' } }>
                     { examples.join(', ') }
@@ -227,7 +227,7 @@ export default class Metadata extends React.Component<Props> {
             { this.renderComment(entity) }
             { this.renderContext(entity) }
             { this.renderSources(entity) }
-            <Localized id='entitydetails-metadata-resource' attrs={ { title: true } }>
+            <Localized id='entitydetails-Metadata--resource' attrs={ { title: true } }>
                 <Property title='Resource' className='resource'>
                     <a
                         href={ `/${locale.code}/${entity.project.slug}/${entity.path}/` }
@@ -237,7 +237,7 @@ export default class Metadata extends React.Component<Props> {
                     </a>
                 </Property>
             </Localized>
-            <Localized id='entitydetails-metadata-project' attrs={ { title: true } }>
+            <Localized id='entitydetails-Metadata--project' attrs={ { title: true } }>
                 <Property title='Project' className='project'>
                     <a href={ `/${locale.code}/${entity.project.slug}/` }>
                         { entity.project.name }

--- a/frontend/src/modules/entitydetails/components/Metadata.test.js
+++ b/frontend/src/modules/entitydetails/components/Metadata.test.js
@@ -50,13 +50,13 @@ describe('<Metadata>', () => {
         const content = wrapper.find('Linkify').map(item => item.props().children);
         expect(content).toContain(ENTITY.comment);
 
-        expect(wrapper.find('#entitydetails-metadata-resource a').text()).toContain(ENTITY.path);
+        expect(wrapper.find('#entitydetails-Metadata--resource a').text()).toContain(ENTITY.path);
     });
 
     it('renders the selected plural form as original string', () => {
         const wrapper = createShallowMetadata(ENTITY, 2);
 
-        expect(wrapper.find('#entitydetails-metadata-plural')).toHaveLength(1);
+        expect(wrapper.find('#entitydetails-Metadata--plural')).toHaveLength(1);
 
         const originalContent = wrapper.find('ContentMarker').props().children;
         expect(originalContent).toContain(ENTITY.original_plural);
@@ -65,7 +65,7 @@ describe('<Metadata>', () => {
     it('renders the selected singular form as original string', () => {
         const wrapper = createShallowMetadata(ENTITY, 0);
 
-        expect(wrapper.find('#entitydetails-metadata-singular')).toHaveLength(1);
+        expect(wrapper.find('#entitydetails-Metadata--singular')).toHaveLength(1);
 
         const originalContent = wrapper.find('ContentMarker').props().children;
         expect(originalContent).toContain(ENTITY.original);

--- a/frontend/src/modules/history/components/History.js
+++ b/frontend/src/modules/history/components/History.js
@@ -34,7 +34,7 @@ type Props = {|
 export default class History extends React.Component<Props> {
     renderNoResults() {
         return <section className="history">
-            <Localized id="history-history-no-translations">
+            <Localized id="history-History--no-translations">
                 <p>No translations available.</p>
             </Localized>
         </section>

--- a/frontend/src/modules/history/components/History.test.js
+++ b/frontend/src/modules/history/components/History.test.js
@@ -36,6 +36,6 @@ describe('<History>', () => {
         };
         const wrapper = shallow(<History history={ history } />);
 
-        expect(wrapper.find('#history-history-no-translations')).toHaveLength(1);
+        expect(wrapper.find('#history-History--no-translations')).toHaveLength(1);
     });
 });

--- a/frontend/src/modules/history/components/Translation.js
+++ b/frontend/src/modules/history/components/Translation.js
@@ -158,7 +158,7 @@ export class TranslationBase extends React.Component<InternalProps, State> {
         // Hide Diff
         if (this.state.isDiffVisible) {
             return <Localized
-                id='history-translation-hide-diff'
+                id='history-Translation--hide-diff'
                 attrs={{ title: true }}
             >
                 <button
@@ -174,7 +174,7 @@ export class TranslationBase extends React.Component<InternalProps, State> {
         // Show Diff
         else {
             return <Localized
-                id='history-translation-show-diff'
+                id='history-Translation--show-diff'
                 attrs={{ title: true }}
             >
                 <button
@@ -219,7 +219,7 @@ export class TranslationBase extends React.Component<InternalProps, State> {
 
         let canDelete = (canReview || ownTranslation) && !isReadOnlyEditor;
 
-        return <Localized id='history-translation-copy' attrs={{ title: true }}>
+        return <Localized id='history-Translation--copy' attrs={{ title: true }}>
             <li
                 className={ className }
                 title='Copy Into Translation (Tab)'
@@ -241,7 +241,7 @@ export class TranslationBase extends React.Component<InternalProps, State> {
                     { (!translation.rejected || !canDelete ) ? null :
                         // Delete Button
                         <Localized
-                            id='history-translation-button-delete'
+                            id='history-Translation--button-delete'
                             attrs={{ title: true }}
                         >
                             <button
@@ -255,7 +255,7 @@ export class TranslationBase extends React.Component<InternalProps, State> {
                     { translation.approved ?
                         // Unapprove Button
                         <Localized
-                            id='history-translation-button-unapprove'
+                            id='history-Translation--button-unapprove'
                             attrs={{ title: true }}
                         >
                             <button
@@ -269,7 +269,7 @@ export class TranslationBase extends React.Component<InternalProps, State> {
                         :
                         // Approve Button
                         <Localized
-                            id='history-translation-button-approve'
+                            id='history-Translation--button-approve'
                             attrs={{ title: true }}
                         >
                             <button
@@ -284,7 +284,7 @@ export class TranslationBase extends React.Component<InternalProps, State> {
                     { translation.rejected ?
                         // Unreject Button
                         <Localized
-                            id='history-translation-button-unreject'
+                            id='history-Translation--button-unreject'
                             attrs={{ title: true }}
                         >
                             <button
@@ -298,7 +298,7 @@ export class TranslationBase extends React.Component<InternalProps, State> {
                         :
                         // Reject Button
                         <Localized
-                            id='history-translation-button-reject'
+                            id='history-Translation--button-reject'
                             attrs={{ title: true }}
                         >
                             <button

--- a/frontend/src/modules/machinery/components/Machinery.js
+++ b/frontend/src/modules/machinery/components/Machinery.js
@@ -59,7 +59,7 @@ export default class Machinery extends React.Component<Props> {
             <div className="search-wrapper clearfix">
                 <div className="icon fa fa-search"></div>
                 <form onSubmit={ this.submitForm }>
-                    <Localized id="machinery-machinery-search-placeholder" attrs={{ placeholder: true }}>
+                    <Localized id="machinery-Machinery--search-placeholder" attrs={{ placeholder: true }}>
                         <input
                             type="search"
                             autoComplete="off"

--- a/frontend/src/modules/machinery/components/Machinery.test.js
+++ b/frontend/src/modules/machinery/components/Machinery.test.js
@@ -16,7 +16,7 @@ describe('<Machinery>', () => {
         const wrapper = shallow(<Machinery machinery={ machinery } locale={ LOCALE } />);
 
         expect(wrapper.find('.search-wrapper')).toHaveLength(1);
-        expect(wrapper.find('#machinery-machinery-search-placeholder')).toHaveLength(1);
+        expect(wrapper.find('#machinery-Machinery--search-placeholder')).toHaveLength(1);
     });
 
     it('shows the correct number of translations', () => {

--- a/frontend/src/modules/machinery/components/Translation.js
+++ b/frontend/src/modules/machinery/components/Translation.js
@@ -47,7 +47,7 @@ export default class Translation extends React.Component<Props> {
 
         const types = translation.sources.map(source => source.type);
 
-        return <Localized id="machinery-translation-copy" attrs={{ title: true }}>
+        return <Localized id="machinery-Translation--copy" attrs={{ title: true }}>
             <li
                 className="translation"
                 title="Copy Into Translation (Tab)"
@@ -70,7 +70,7 @@ export default class Translation extends React.Component<Props> {
                                 <span>{ source.type }</span>
                                 { !source.count ? null :
                                     <Localized
-                                        id="machinery-translation-number-occurrences"
+                                        id="machinery-Translation--number-occurrences"
                                         attrs={{ title: true }}
                                     >
                                         <sup title="Number of translation occurrences">

--- a/frontend/src/modules/otherlocales/components/Translation.js
+++ b/frontend/src/modules/otherlocales/components/Translation.js
@@ -46,7 +46,7 @@ export default class Translation extends React.Component<Props> {
 
         const className = lastPreferred ? 'translation last-preferred' : 'translation';
 
-        return <Localized id='otherlocales-translation-copy' attrs={{ title: true }}>
+        return <Localized id='otherlocales-Translation--copy' attrs={{ title: true }}>
             <li
                 className={ className }
                 title='Copy Into Translation (Tab)'


### PR DESCRIPTION
This is a maintenance patch to:
1. sort the content of FTL files alphabetically;
2. harmonize our usage of l10n IDs to follow our convention everywhere;
3. add the missing French translations.

Each step is a separate commit, hopefully that's easy to review. :-)