### PR TITLE
Fix bug 1510185: Add extra filters

### DIFF
--- a/frontend/public/static/locale/en-US/translate.ftl
+++ b/frontend/public/static/locale/en-US/translate.ftl
@@ -340,6 +340,9 @@ resource-ResourceMenu--all-projects = All Projects
 ## Search
 ## The search bar and filters menu.
 
+search-FiltersPanel--heading-status = Translation Status
+search-FiltersPanel--heading-extra = Extra Filters
+
 search-FiltersPanel--clear-selection = <glyph></glyph>Clear
     .title = Uncheck selected filters
 

--- a/frontend/src/core/api/entity.js
+++ b/frontend/src/core/api/entity.js
@@ -52,6 +52,7 @@ export default class EntityAPI extends APIBase {
         entity: ?string,
         search: ?string,
         status: ?string,
+        extra: ?string,
         pkOnly: ?boolean,
     ): Promise<Object> {
         const payload = new FormData();
@@ -80,6 +81,10 @@ export default class EntityAPI extends APIBase {
 
         if (status) {
             payload.append('status', status);
+        }
+
+        if (extra) {
+            payload.append('extra', extra);
         }
 
         if (pkOnly) {

--- a/frontend/src/core/entities/actions.js
+++ b/frontend/src/core/entities/actions.js
@@ -77,6 +77,7 @@ export function get(
     entity: ?string,
     search: ?string,
     status: ?string,
+    extra: ?string,
 ): Function {
     return async dispatch => {
         dispatch(request());
@@ -90,6 +91,7 @@ export function get(
             entity,
             search,
             status,
+            extra,
         );
         dispatch(receive(content.entities, content.has_next));
         dispatch(stats.actions.update(content.stats));

--- a/frontend/src/core/navigation/actions.js
+++ b/frontend/src/core/navigation/actions.js
@@ -60,6 +60,19 @@ export function updateEntity(router: Object, entity: string): Function {
 
 
 /**
+ * Update the URL with a new `extra` parameter.
+ *
+ * This function removes the `string` parameter from the URL if any, because
+ * it is possible that after the results have changed, the currently selected
+ * entity won't be available anymore.
+ * It keeps all other parameters in the URL the same.
+ */
+export function updateExtra(router: Object, extra: ?string): Function {
+    return update(router, { extra });
+}
+
+
+/**
  * Update the URL with a new `search` parameter.
  *
  * This function removes the `string` parameter from the URL if any, because
@@ -88,6 +101,7 @@ export function updateStatus(router: Object, status: ?string): Function {
 export default {
     update,
     updateEntity,
+    updateExtra,
     updateSearch,
     updateStatus,
 };

--- a/frontend/src/core/navigation/selectors.js
+++ b/frontend/src/core/navigation/selectors.js
@@ -13,6 +13,7 @@ export type NavigationParams = {|
     entity: number,
     search: ?string,
     status: ?string,
+    extra: ?string,
 |};
 
 /**
@@ -38,6 +39,7 @@ export const getNavigationParams: Function = createSelector(
         const entity = Number(params.get('string'));
         const search = params.get('search');
         const status = params.get('status');
+        const extra = params.get('extra');
 
         return {
             locale,
@@ -46,6 +48,7 @@ export const getNavigationParams: Function = createSelector(
             entity,
             search,
             status,
+            extra,
         };
     }
 );

--- a/frontend/src/modules/batchactions/actions.js
+++ b/frontend/src/modules/batchactions/actions.js
@@ -199,6 +199,7 @@ export function selectAll(
     resource: string,
     search: ?string,
     status: ?string,
+    extra: ?string,
 ): Function {
     return async dispatch => {
         dispatch(request('select-all'));
@@ -212,6 +213,7 @@ export function selectAll(
             null,
             search,
             status,
+            extra,
             true,
         );
 

--- a/frontend/src/modules/batchactions/components/BatchActions.js
+++ b/frontend/src/modules/batchactions/components/BatchActions.js
@@ -66,7 +66,7 @@ export class BatchActionsBase extends React.Component<InternalProps> {
     }
 
     selectAllEntities = () => {
-        const { locale, project, resource, search, status } = this.props.parameters;
+        const { locale, project, resource, search, status, extra } = this.props.parameters;
 
         this.props.dispatch(
             batchactions.actions.selectAll(
@@ -75,6 +75,7 @@ export class BatchActionsBase extends React.Component<InternalProps> {
                 resource,
                 search,
                 status,
+                extra,
             )
         );
     }

--- a/frontend/src/modules/entitieslist/components/EntitiesList.js
+++ b/frontend/src/modules/entitieslist/components/EntitiesList.js
@@ -97,7 +97,8 @@ export class EntitiesListBase extends React.Component<InternalProps> {
             previous.project !== current.project ||
             previous.resource !== current.resource ||
             previous.search !== current.search ||
-            previous.status !== current.status
+            previous.status !== current.status ||
+            previous.extra !== current.extra
         ) {
             this.props.dispatch(entities.actions.reset());
         }
@@ -122,7 +123,7 @@ export class EntitiesListBase extends React.Component<InternalProps> {
         if (key === 65 && !event.altKey && event.ctrlKey && event.shiftKey) {
             event.preventDefault();
 
-            const { locale, project, resource, search, status } = this.props.parameters;
+            const { locale, project, resource, search, status, extra } = this.props.parameters;
 
             this.props.dispatch(
                 batchactions.actions.selectAll(
@@ -131,6 +132,7 @@ export class EntitiesListBase extends React.Component<InternalProps> {
                     resource,
                     search,
                     status,
+                    extra,
                 )
             );
         }
@@ -253,7 +255,7 @@ export class EntitiesListBase extends React.Component<InternalProps> {
 
     getMoreEntities = () => {
         const props = this.props;
-        const { locale, project, resource, entity, search, status } = props.parameters;
+        const { locale, project, resource, entity, search, status, extra } = props.parameters;
 
         // Temporary fix for the infinite number of requests from InfiniteScroller
         // More info at:
@@ -279,6 +281,7 @@ export class EntitiesListBase extends React.Component<InternalProps> {
                 entity.toString(),
                 search,
                 status,
+                extra,
             )
         );
     }

--- a/frontend/src/modules/search/components/FiltersPanel.css
+++ b/frontend/src/modules/search/components/FiltersPanel.css
@@ -137,6 +137,10 @@
     top: 4px;
 }
 
+.filters-panel .menu li:not(.selected):not(.all) .status:hover:before {
+    content: "";
+}
+
 .filters-panel .menu li.selected .status:before {
     content: "";
 }

--- a/frontend/src/modules/search/components/FiltersPanel.js
+++ b/frontend/src/modules/search/components/FiltersPanel.js
@@ -6,7 +6,7 @@ import { Localized } from 'fluent-react';
 
 import './FiltersPanel.css';
 
-import { FILTERS_STATUS } from '..';
+import { FILTERS_STATUS, FILTERS_EXTRA } from '..';
 
 import { asLocaleString } from 'core/utils';
 
@@ -109,7 +109,9 @@ export class FiltersPanelBase extends React.Component<Props, State> {
             </div>
             { !this.state.visible ? null : <div className="menu">
                 <ul>
-                    <li className="horizontal-separator">Translation Status</li>
+                    <Localized id="search-FiltersPanel--heading-status">
+                        <li className="horizontal-separator">Translation Status</li>
+                    </Localized>
                     { FILTERS_STATUS.map((status, i) => {
                         const count = status.stat ? stats[status.stat] : stats[status.slug];
                         const selected = statuses[status.slug];
@@ -132,6 +134,30 @@ export class FiltersPanelBase extends React.Component<Props, State> {
                             <span className="count">
                                 { asLocaleString(count) }
                             </span>
+                        </li>
+                    }) }
+
+                    <Localized id="search-FiltersPanel--heading-extra">
+                        <li className="horizontal-separator">Extra Filters</li>
+                    </Localized>
+                    { FILTERS_EXTRA.map((extra, i) => {
+                        const selected = statuses[extra.slug];
+
+                        let className = extra.slug;
+                        if (selected) {
+                            className += ' selected';
+                        }
+
+                        return <li
+                            className={ className }
+                            key={ i }
+                            onClick={ this.createSetStatus(extra.slug) }
+                        >
+                            <span
+                                className="status fa"
+                                onClick={ this.createSelectStatus(extra.slug) }
+                            ></span>
+                            <span className="title">{ extra.title }</span>
                         </li>
                     }) }
                 </ul>

--- a/frontend/src/modules/search/components/FiltersPanel.js
+++ b/frontend/src/modules/search/components/FiltersPanel.js
@@ -17,11 +17,9 @@ type Props = {|
     statuses: { [string]: boolean },
     extras: { [string]: boolean },
     stats: Stats,
+    applySingleFilter: (filter: ?string, callback?: () => void) => void,
     resetFilters: () => void,
-    setSingleStatus: (status: ?string, callback?: () => void) => void,
-    setSingleExtra: (extra: ?string, callback?: () => void) => void,
-    toggleStatus: (string) => void,
-    toggleExtra: (string) => void,
+    toggleFilter: (string) => void,
     update: () => void,
 |};
 
@@ -56,35 +54,21 @@ export class FiltersPanelBase extends React.Component<Props, State> {
         return this.props.update();
     }
 
-    createSelectStatus = (status: string) => {
-        if (status === 'all') {
+    createToggleFilter = (filter: string) => {
+        if (filter === 'all') {
             return null;
         }
 
         return (event: SyntheticInputEvent<>) => {
             event.stopPropagation();
-            this.props.toggleStatus(status);
+            this.props.toggleFilter(filter);
         };
     }
 
-    createSelectExtra = (extra: string) => {
-        return (event: SyntheticInputEvent<>) => {
-            event.stopPropagation();
-            this.props.toggleExtra(extra);
-        };
-    }
-
-    createSetStatus(status: string) {
+    createApplySingleFilter(filter: string) {
         return () => {
             this.toggleVisibility();
-            this.props.setSingleStatus(status, this.props.update);
-        };
-    }
-
-    createSetExtra(extra: string) {
-        return () => {
-            this.toggleVisibility();
-            this.props.setSingleExtra(extra, this.props.update);
+            this.props.applySingleFilter(filter, this.props.update);
         };
     }
 
@@ -139,11 +123,11 @@ export class FiltersPanelBase extends React.Component<Props, State> {
                         return <li
                             className={ className }
                             key={ i }
-                            onClick={ this.createSetStatus(status.slug) }
+                            onClick={ this.createApplySingleFilter(status.slug) }
                         >
                             <span
                                 className="status fa"
-                                onClick={ this.createSelectStatus(status.slug) }
+                                onClick={ this.createToggleFilter(status.slug) }
                             ></span>
                             <span className="title">{ status.title }</span>
                             <span className="count">
@@ -167,11 +151,11 @@ export class FiltersPanelBase extends React.Component<Props, State> {
                         return <li
                             className={ className }
                             key={ i }
-                            onClick={ this.createSetExtra(extra.slug) }
+                            onClick={ this.createApplySingleFilter(extra.slug) }
                         >
                             <span
                                 className="status fa"
-                                onClick={ this.createSelectExtra(extra.slug) }
+                                onClick={ this.createToggleFilter(extra.slug) }
                             ></span>
                             <span className="title">{ extra.title }</span>
                         </li>

--- a/frontend/src/modules/search/components/FiltersPanel.js
+++ b/frontend/src/modules/search/components/FiltersPanel.js
@@ -15,10 +15,13 @@ import type { Stats } from 'core/stats';
 
 type Props = {|
     statuses: { [string]: boolean },
+    extras: { [string]: boolean },
     stats: Stats,
-    resetStatuses: () => void,
+    resetFilters: () => void,
     setSingleStatus: (status: ?string, callback?: () => void) => void,
+    setSingleExtra: (extra: ?string, callback?: () => void) => void,
     toggleStatus: (string) => void,
+    toggleExtra: (string) => void,
     update: () => void,
 |};
 
@@ -53,10 +56,6 @@ export class FiltersPanelBase extends React.Component<Props, State> {
         return this.props.update();
     }
 
-    resetFilters = () => {
-        this.props.resetStatuses();
-    }
-
     createSelectStatus = (status: string) => {
         if (status === 'all') {
             return null;
@@ -68,10 +67,24 @@ export class FiltersPanelBase extends React.Component<Props, State> {
         };
     }
 
+    createSelectExtra = (extra: string) => {
+        return (event: SyntheticInputEvent<>) => {
+            event.stopPropagation();
+            this.props.toggleExtra(extra);
+        };
+    }
+
     createSetStatus(status: string) {
         return () => {
             this.toggleVisibility();
             this.props.setSingleStatus(status, this.props.update);
+        };
+    }
+
+    createSetExtra(extra: string) {
+        return () => {
+            this.toggleVisibility();
+            this.props.setSingleExtra(extra, this.props.update);
         };
     }
 
@@ -84,16 +97,17 @@ export class FiltersPanelBase extends React.Component<Props, State> {
     }
 
     render() {
-        const { statuses, stats } = this.props;
+        const { statuses, extras, stats } = this.props;
 
         const selectedStatuses = Object.keys(statuses).filter(s => statuses[s]);
-        const selectedStatusesCount = selectedStatuses.length;
+        const selectedExtras = Object.keys(extras).filter(e => extras[e]);
+        const selectedFiltersCount = selectedExtras.length + selectedStatuses.length;
 
         // If there are zero or several selected statuses, show the "All" icon.
         let reducedStatus = { slug: 'all' };
 
         // Otherwise show the approriate status icon.
-        if (selectedStatusesCount === 1) {
+        if (selectedFiltersCount === 1) {
             const selectedStatus = FILTERS_STATUS.find(s => s.slug === selectedStatuses[0]);
             if (selectedStatus) {
                 reducedStatus = selectedStatus;
@@ -112,6 +126,7 @@ export class FiltersPanelBase extends React.Component<Props, State> {
                     <Localized id="search-FiltersPanel--heading-status">
                         <li className="horizontal-separator">Translation Status</li>
                     </Localized>
+
                     { FILTERS_STATUS.map((status, i) => {
                         const count = status.stat ? stats[status.stat] : stats[status.slug];
                         const selected = statuses[status.slug];
@@ -140,8 +155,9 @@ export class FiltersPanelBase extends React.Component<Props, State> {
                     <Localized id="search-FiltersPanel--heading-extra">
                         <li className="horizontal-separator">Extra Filters</li>
                     </Localized>
+
                     { FILTERS_EXTRA.map((extra, i) => {
-                        const selected = statuses[extra.slug];
+                        const selected = extras[extra.slug];
 
                         let className = extra.slug;
                         if (selected) {
@@ -151,17 +167,17 @@ export class FiltersPanelBase extends React.Component<Props, State> {
                         return <li
                             className={ className }
                             key={ i }
-                            onClick={ this.createSetStatus(extra.slug) }
+                            onClick={ this.createSetExtra(extra.slug) }
                         >
                             <span
                                 className="status fa"
-                                onClick={ this.createSelectStatus(extra.slug) }
+                                onClick={ this.createSelectExtra(extra.slug) }
                             ></span>
                             <span className="title">{ extra.title }</span>
                         </li>
                     }) }
                 </ul>
-                { selectedStatusesCount === 0 ? null :
+                { selectedFiltersCount === 0 ? null :
                 <div className="toolbar clearfix">
                     <Localized
                         id="search-FiltersPanel--clear-selection"
@@ -170,7 +186,7 @@ export class FiltersPanelBase extends React.Component<Props, State> {
                     >
                         <button
                             title="Uncheck selected filters"
-                            onClick={ this.resetFilters }
+                            onClick={ this.props.resetFilters }
                             className="clear-selection"
                         >
                             <i className="fa fa-times fa-lg"></i>
@@ -182,7 +198,7 @@ export class FiltersPanelBase extends React.Component<Props, State> {
                         attrs={ { title: true } }
                         glyph={ <i className="fa fa-check fa-lg"></i> }
                         stress={ <span className="applied-count"></span> }
-                        $count={ selectedStatusesCount }
+                        $count={ selectedFiltersCount }
                     >
                         <button
                             title="Apply Selected Filters"

--- a/frontend/src/modules/search/components/FiltersPanel.js
+++ b/frontend/src/modules/search/components/FiltersPanel.js
@@ -92,9 +92,13 @@ export class FiltersPanelBase extends React.Component<Props, State> {
 
         // Otherwise show the approriate status icon.
         if (selectedFiltersCount === 1) {
-            const selectedStatus = FILTERS_STATUS.find(s => s.slug === selectedStatuses[0]);
+            const selectedStatus = FILTERS_STATUS.find(f => f.slug === selectedStatuses[0]);
             if (selectedStatus) {
                 reducedStatus = selectedStatus;
+            }
+            const selectedExtra = FILTERS_EXTRA.find(f => f.slug === selectedExtras[0]);
+            if (selectedExtra) {
+                reducedStatus = selectedExtra;
             }
         }
 

--- a/frontend/src/modules/search/components/FiltersPanel.test.js
+++ b/frontend/src/modules/search/components/FiltersPanel.test.js
@@ -9,9 +9,14 @@ import { FILTERS_STATUS } from '..';
 describe('<FiltersPanelBase>', () => {
     it('shows a panel with filters on click', () => {
         const statuses = {};
+        const extras = {};
         const stats = {};
         const wrapper = shallow(
-            <FiltersPanelBase statuses={ statuses } stats={ stats } />
+            <FiltersPanelBase
+                statuses={ statuses }
+                extras={ extras }
+                stats={ stats }
+            />
         );
 
         expect(wrapper.find('div.menu')).toHaveLength(0);
@@ -24,10 +29,15 @@ describe('<FiltersPanelBase>', () => {
             const statuses = {
                 [filter.slug]: true,
             };
+            const extras = {};
             const stats = {};
 
             const wrapper = shallow(
-                <FiltersPanelBase statuses={ statuses } stats={ stats } />
+                <FiltersPanelBase
+                    statuses={ statuses }
+                    extras={ extras }
+                    stats={ stats }
+                />
             );
 
             expect(
@@ -42,9 +52,14 @@ describe('<FiltersPanelBase>', () => {
             errors: false,
             missing: true,
         };
+        const extras = {};
         const stats = {};
         const wrapper = shallow(
-            <FiltersPanelBase statuses={ statuses } stats={ stats } />
+            <FiltersPanelBase
+                statuses={ statuses }
+                extras={ extras }
+                stats={ stats }
+            />
         );
 
         wrapper.find('.visibility-switch').simulate('click');
@@ -70,6 +85,7 @@ describe('<FiltersPanelBase>', () => {
             const statuses = {
                 [filter.slug]: true,
             };
+            const extras = {};
             const stats = {};
             setSingleStatus = sinon.spy()
 
@@ -77,6 +93,7 @@ describe('<FiltersPanelBase>', () => {
                 <FiltersPanelBase
                     stats={ stats }
                     statuses={ statuses }
+                    extras={ extras }
                     setSingleStatus= { setSingleStatus }
                 />
             );
@@ -94,6 +111,7 @@ describe('<FiltersPanelBase>', () => {
             const statuses = {
                 [filter.slug]: false,
             };
+            const extras = {};
             const stats = {};
             toggleStatus = sinon.spy()
 
@@ -101,6 +119,7 @@ describe('<FiltersPanelBase>', () => {
                 <FiltersPanelBase
                     stats={ stats }
                     statuses={ statuses }
+                    extras={ extras }
                     toggleStatus= { toggleStatus }
                 />
             );
@@ -125,9 +144,14 @@ describe('<FiltersPanelBase>', () => {
             errors: false,
             missing: false,
         };
+        const extras = {};
         const stats = {};
         const wrapper = shallow(
-            <FiltersPanelBase statuses={ statuses } stats={ stats } />
+            <FiltersPanelBase
+                statuses={ statuses }
+                extras={ extras }
+                stats={ stats }
+            />
         );
 
         wrapper.find('.visibility-switch').simulate('click');
@@ -140,9 +164,14 @@ describe('<FiltersPanelBase>', () => {
             errors: true,
             missing: true,
         };
+        const extras = {};
         const stats = {};
         const wrapper = shallow(
-            <FiltersPanelBase statuses={ statuses } stats={ stats } />
+            <FiltersPanelBase
+                statuses={ statuses }
+                extras={ extras }
+                stats={ stats }
+            />
         );
 
         wrapper.find('.visibility-switch').simulate('click');
@@ -150,25 +179,27 @@ describe('<FiltersPanelBase>', () => {
     });
 
     it('resets selected filters on click on the Clear button', () => {
-        const resetStatuses = sinon.spy();
+        const resetFilters = sinon.spy();
 
         const statuses = {
             warnings: false,
             errors: true,
         };
+        const extras = {};
         const stats = {};
         const wrapper = shallow(
             <FiltersPanelBase
                 statuses={ statuses }
+                extras={ extras }
                 stats={ stats }
-                resetStatuses={ resetStatuses }
+                resetFilters={ resetFilters }
             />
         );
 
         wrapper.find('.visibility-switch').simulate('click');
         wrapper.find('.toolbar .clear-selection').simulate('click');
 
-        expect(resetStatuses.called).toBeTruthy();
+        expect(resetFilters.called).toBeTruthy();
     });
 
     it('applies selected filters on click on the Apply button', () => {
@@ -178,10 +209,12 @@ describe('<FiltersPanelBase>', () => {
             warnings: false,
             errors: true,
         };
+        const extras = {};
         const stats = {};
         const wrapper = shallow(
             <FiltersPanelBase
                 statuses={ statuses }
+                extras={ extras }
                 stats={ stats }
                 update={ update }
             />

--- a/frontend/src/modules/search/components/FiltersPanel.test.js
+++ b/frontend/src/modules/search/components/FiltersPanel.test.js
@@ -79,7 +79,7 @@ describe('<FiltersPanelBase>', () => {
     });
 
     it('sets a single status on click on a status title', () => {
-        let setSingleStatus;
+        let applySingleFilter;
 
         for (let filter of FILTERS_STATUS) {
             const statuses = {
@@ -87,25 +87,25 @@ describe('<FiltersPanelBase>', () => {
             };
             const extras = {};
             const stats = {};
-            setSingleStatus = sinon.spy()
+            applySingleFilter = sinon.spy()
 
             const wrapper = shallow(
                 <FiltersPanelBase
                     stats={ stats }
                     statuses={ statuses }
                     extras={ extras }
-                    setSingleStatus= { setSingleStatus }
+                    applySingleFilter= { applySingleFilter }
                 />
             );
             wrapper.find('.visibility-switch').simulate('click');
             wrapper.find(`.menu .${filter.slug}`).simulate('click');
 
-            expect(setSingleStatus.calledWith(filter.slug)).toBeTruthy();
+            expect(applySingleFilter.calledWith(filter.slug)).toBeTruthy();
         }
     });
 
     it('selects a status on click on a status icon', () => {
-        let toggleStatus;
+        let toggleFilter;
 
         for (let filter of FILTERS_STATUS) {
             const statuses = {
@@ -113,14 +113,14 @@ describe('<FiltersPanelBase>', () => {
             };
             const extras = {};
             const stats = {};
-            toggleStatus = sinon.spy()
+            toggleFilter = sinon.spy()
 
             const wrapper = shallow(
                 <FiltersPanelBase
                     stats={ stats }
                     statuses={ statuses }
                     extras={ extras }
-                    toggleStatus= { toggleStatus }
+                    toggleFilter= { toggleFilter }
                 />
             );
             wrapper.find('.visibility-switch').simulate('click');
@@ -130,10 +130,10 @@ describe('<FiltersPanelBase>', () => {
             );
 
             if (filter.slug === 'all') {
-                expect(toggleStatus.called).toBeFalsy();
+                expect(toggleFilter.called).toBeFalsy();
             }
             else {
-                expect(toggleStatus.calledWith(filter.slug)).toBeTruthy();
+                expect(toggleFilter.calledWith(filter.slug)).toBeTruthy();
             }
         }
     });

--- a/frontend/src/modules/search/components/FiltersPanel.test.js
+++ b/frontend/src/modules/search/components/FiltersPanel.test.js
@@ -3,7 +3,13 @@ import { shallow } from 'enzyme';
 import sinon from 'sinon';
 
 import { FiltersPanelBase } from './FiltersPanel';
-import { FILTERS_STATUS } from '..';
+import { FILTERS_STATUS, FILTERS_EXTRA } from '..';
+
+
+const FILTERS = [].concat(
+    FILTERS_STATUS,
+    FILTERS_EXTRA,
+);
 
 
 describe('<FiltersPanelBase>', () => {
@@ -25,12 +31,21 @@ describe('<FiltersPanelBase>', () => {
     });
 
     it('has the correct icon based on parameters', () => {
-        for (let filter of FILTERS_STATUS) {
-            const statuses = {
+        for (let filter of FILTERS) {
+            let statuses = {};
+            let extras = {};
+            const stats = {};
+
+            const set = {
                 [filter.slug]: true,
             };
-            const extras = {};
-            const stats = {};
+
+            if (FILTERS_STATUS.includes(filter)) {
+                statuses = set;
+            }
+            else if (FILTERS_EXTRA.includes(filter)) {
+                extras = set;
+            }
 
             const wrapper = shallow(
                 <FiltersPanelBase
@@ -46,14 +61,20 @@ describe('<FiltersPanelBase>', () => {
         }
     });
 
-    it('correctly sets statuses as selected', () => {
+    it('correctly sets filter as selected', () => {
         const statuses = {
             warnings: true,
             errors: false,
             missing: true,
         };
-        const extras = {};
+
+        const extras = {
+            unchanged: false,
+            rejected: true,
+        };
+
         const stats = {};
+
         const wrapper = shallow(
             <FiltersPanelBase
                 statuses={ statuses }
@@ -64,29 +85,46 @@ describe('<FiltersPanelBase>', () => {
 
         wrapper.find('.visibility-switch').simulate('click');
 
-        for (let filter of FILTERS_STATUS) {
-            if (statuses[filter.slug]) {
-                expect(
-                    wrapper.find(`.menu .${filter.slug}`).hasClass('selected')
-                ).toBeTruthy();
+        for (let filter of FILTERS) {
+            let isFilterSelected;
+
+            if (FILTERS_STATUS.includes(filter)) {
+                isFilterSelected = statuses[filter.slug];
+            }
+            else if (FILTERS_EXTRA.includes(filter)) {
+                isFilterSelected = extras[filter.slug];
+            }
+
+            const isClassSet = wrapper.find(`.menu .${filter.slug}`).hasClass('selected');
+
+            if (isFilterSelected) {
+                expect(isClassSet).toBeTruthy();
             }
             else {
-                expect(
-                    wrapper.find(`.menu .${filter.slug}`).hasClass('selected')
-                ).toBeFalsy();
+                expect(isClassSet).toBeFalsy();
             }
         }
     });
 
-    it('sets a single status on click on a status title', () => {
+    it('applies a single filter on click on a filter title', () => {
         let applySingleFilter;
 
-        for (let filter of FILTERS_STATUS) {
-            const statuses = {
+        for (let filter of FILTERS) {
+            let statuses = {};
+            let extras = {};
+            const stats = {};
+
+            const set = {
                 [filter.slug]: true,
             };
-            const extras = {};
-            const stats = {};
+
+            if (FILTERS_STATUS.includes(filter)) {
+                statuses = set;
+            }
+            else if (FILTERS_EXTRA.includes(filter)) {
+                extras = set;
+            }
+
             applySingleFilter = sinon.spy()
 
             const wrapper = shallow(
@@ -104,15 +142,25 @@ describe('<FiltersPanelBase>', () => {
         }
     });
 
-    it('selects a status on click on a status icon', () => {
+    it('toggles a filter on click on a filter status icon', () => {
         let toggleFilter;
 
-        for (let filter of FILTERS_STATUS) {
-            const statuses = {
+        for (let filter of FILTERS) {
+            let statuses = {};
+            let extras = {};
+            const stats = {};
+
+            const set = {
                 [filter.slug]: false,
             };
-            const extras = {};
-            const stats = {};
+
+            if (FILTERS_STATUS.includes(filter)) {
+                statuses = set;
+            }
+            else if (FILTERS_EXTRA.includes(filter)) {
+                extras = set;
+            }
+
             toggleFilter = sinon.spy()
 
             const wrapper = shallow(
@@ -144,7 +192,10 @@ describe('<FiltersPanelBase>', () => {
             errors: false,
             missing: false,
         };
-        const extras = {};
+        const extras = {
+            unchanged: false,
+            rejected: false,
+        };
         const stats = {};
         const wrapper = shallow(
             <FiltersPanelBase
@@ -164,7 +215,10 @@ describe('<FiltersPanelBase>', () => {
             errors: true,
             missing: true,
         };
-        const extras = {};
+        const extras = {
+            unchanged: false,
+            rejected: true,
+        };
         const stats = {};
         const wrapper = shallow(
             <FiltersPanelBase
@@ -185,7 +239,10 @@ describe('<FiltersPanelBase>', () => {
             warnings: false,
             errors: true,
         };
-        const extras = {};
+        const extras = {
+            unchanged: false,
+            rejected: true,
+        };
         const stats = {};
         const wrapper = shallow(
             <FiltersPanelBase
@@ -209,7 +266,10 @@ describe('<FiltersPanelBase>', () => {
             warnings: false,
             errors: true,
         };
-        const extras = {};
+        const extras = {
+            unchanged: false,
+            rejected: true,
+        };
         const stats = {};
         const wrapper = shallow(
             <FiltersPanelBase

--- a/frontend/src/modules/search/components/FiltersPanel.test.js
+++ b/frontend/src/modules/search/components/FiltersPanel.test.js
@@ -36,15 +36,15 @@ describe('<FiltersPanelBase>', () => {
             let extras = {};
             const stats = {};
 
-            const set = {
+            const value = {
                 [filter.slug]: true,
             };
 
             if (FILTERS_STATUS.includes(filter)) {
-                statuses = set;
+                statuses = value;
             }
             else if (FILTERS_EXTRA.includes(filter)) {
-                extras = set;
+                extras = value;
             }
 
             const wrapper = shallow(
@@ -114,15 +114,15 @@ describe('<FiltersPanelBase>', () => {
             let extras = {};
             const stats = {};
 
-            const set = {
+            const value = {
                 [filter.slug]: true,
             };
 
             if (FILTERS_STATUS.includes(filter)) {
-                statuses = set;
+                statuses = value;
             }
             else if (FILTERS_EXTRA.includes(filter)) {
-                extras = set;
+                extras = value;
             }
 
             applySingleFilter = sinon.spy()
@@ -150,15 +150,15 @@ describe('<FiltersPanelBase>', () => {
             let extras = {};
             const stats = {};
 
-            const set = {
+            const value = {
                 [filter.slug]: false,
             };
 
             if (FILTERS_STATUS.includes(filter)) {
-                statuses = set;
+                statuses = value;
             }
             else if (FILTERS_EXTRA.includes(filter)) {
-                extras = set;
+                extras = value;
             }
 
             toggleFilter = sinon.spy()

--- a/frontend/src/modules/search/components/SearchBox.css
+++ b/frontend/src/modules/search/components/SearchBox.css
@@ -62,10 +62,6 @@
     font-size: 19px;
 }
 
-.search-box .unreviewed .status:before {
-    font-size: 18px;
-}
-
 .search-box .translated .status:before {
     color: #7BC876;
 }
@@ -89,6 +85,22 @@
 .search-box .unreviewed .status:before {
     color: #4FC4F6;
     content: "";
+    font-size: 18px;
+}
+
+.search-box .untranslated .status:before {
+    color: #AAAAAA;
+    content: "";
+}
+
+.search-box .unchanged .status:before {
+    color: #AAAAAA;
+    content: "";
+}
+
+.search-box .rejected .status:before {
+    color: #AAAAAA;
+    content: "";
 }
 
 .search-box .missing:hover .status:before {

--- a/frontend/src/modules/search/components/SearchBox.css
+++ b/frontend/src/modules/search/components/SearchBox.css
@@ -88,6 +88,11 @@
     font-size: 18px;
 }
 
+.search-box .unreviewed.selected .status:before,
+.search-box .unreviewed .status:hover:before {
+  font-size: 16px;
+}
+
 .search-box .untranslated .status:before {
     color: #AAAAAA;
     content: "";

--- a/frontend/src/modules/search/components/SearchBox.css
+++ b/frontend/src/modules/search/components/SearchBox.css
@@ -93,11 +93,6 @@
   font-size: 16px;
 }
 
-.search-box .untranslated .status:before {
-    color: #AAAAAA;
-    content: "";
-}
-
 .search-box .unchanged .status:before {
     color: #AAAAAA;
     content: "";

--- a/frontend/src/modules/search/components/SearchBox.js
+++ b/frontend/src/modules/search/components/SearchBox.js
@@ -119,10 +119,10 @@ export class SearchBoxBase extends React.Component<InternalProps, State> {
 
     toggleFilter = (filter: string) => {
         let type;
-        if (filter in this.getInitialStatuses()) {
+        if (filter in this.state.statuses) {
             type = 'statuses';
         }
-        else if (filter in this.getInitialExtras()) {
+        else if (filter in this.state.extras) {
             type = 'extras';
         }
 
@@ -219,12 +219,14 @@ export class SearchBoxBase extends React.Component<InternalProps, State> {
     }
 
     composePlaceholder() {
+        const statuses = this.getSelectedStatuses();
         const selectedStatuses = FILTERS_STATUS.filter(
-            f => this.getSelectedStatuses().includes(f.slug)
+            f => statuses.includes(f.slug)
         );
 
+        const extras = this.getSelectedExtras();
         const selectedExtras = FILTERS_EXTRA.filter(
-            f => this.getSelectedExtras().includes(f.slug)
+            f => extras.includes(f.slug)
         );
 
         let selectedFilters = [].concat(

--- a/frontend/src/modules/search/components/SearchBox.js
+++ b/frontend/src/modules/search/components/SearchBox.js
@@ -117,49 +117,37 @@ export class SearchBoxBase extends React.Component<InternalProps, State> {
         return Object.keys(this.state.extras).filter(e => this.state.extras[e]);
     }
 
-    toggleStatus = (status: string) => {
+    toggleFilter = (filter: string) => {
+        let type;
+        if (filter in this.getInitialStatuses()) {
+            type = 'statuses';
+        }
+        else if (filter in this.getInitialExtras()) {
+            type = 'extras';
+        }
+
         this.setState(state => {
             return {
-                statuses: {
-                    ...state.statuses,
-                    [status]: !state.statuses[status],
+                [type]: {
+                    ...state[type],
+                    [filter]: !state[type][filter],
                 },
             };
         });
     }
 
-    toggleExtra = (extra: string) => {
-        this.setState(state => {
-            return {
-                extras: {
-                    ...state.extras,
-                    [extra]: !state.extras[extra],
-                },
-            };
-        });
-    }
-
-    setSingleStatus = (status: string, callback?: () => void) => {
+    applySingleFilter = (filter: string, callback?: () => void) => {
         const statuses = this.getInitialStatuses();
         const extras = this.getInitialExtras();
 
-        if (status !== 'all') {
-            statuses[status] = true;
+        if (filter !== 'all') {
+            if (filter in statuses) {
+                statuses[filter] = true;
+            }
+            else if (filter in extras) {
+                extras[filter] = true;
+            }
         }
-
-        if (callback) {
-            this.setState({ statuses, extras }, callback);
-        }
-        else {
-            this.setState({ statuses, extras });
-        }
-    }
-
-    setSingleExtra = (extra: string, callback?: () => void) => {
-        const statuses = this.getInitialStatuses();
-        const extras = this.getInitialExtras();
-
-        extras[extra] = true;
 
         if (callback) {
             this.setState({ statuses, extras }, callback);
@@ -274,11 +262,9 @@ export class SearchBoxBase extends React.Component<InternalProps, State> {
                 statuses={ this.state.statuses }
                 extras={ this.state.extras }
                 stats={ stats }
+                applySingleFilter={ this.applySingleFilter }
                 resetFilters={ this.resetFilters }
-                setSingleStatus={ this.setSingleStatus }
-                setSingleExtra={ this.setSingleExtra }
-                toggleStatus={ this.toggleStatus }
-                toggleExtra={ this.toggleExtra }
+                toggleFilter={ this.toggleFilter }
                 update={ this.update }
             />
         </div>;

--- a/frontend/src/modules/search/components/SearchBox.test.js
+++ b/frontend/src/modules/search/components/SearchBox.test.js
@@ -107,7 +107,7 @@ describe('<SearchBoxBase>', () => {
             }
         });
 
-        wrapper.instance().resetStatuses();
+        wrapper.instance().resetFilters();
         expect(wrapper.state('statuses').warnings).toBeFalsy();
         expect(wrapper.state('statuses').errors).toBeFalsy();
         expect(wrapper.state('statuses').missing).toBeFalsy();
@@ -123,7 +123,7 @@ describe('<SearchBoxBase>', () => {
 
         wrapper.instance()._update();
         expect(
-            actions.update.calledWith({}, { status: null, search: '' })
+            actions.update.calledWith({}, { status: null, extra: '', search: '' })
         ).toBeTruthy();
     });
 
@@ -137,7 +137,7 @@ describe('<SearchBoxBase>', () => {
 
         wrapper.instance()._update();
         expect(
-            actions.update.calledWith({}, { status: 'missing,warnings', search: '' })
+            actions.update.calledWith({}, { status: 'missing,warnings', extra: '', search: '' })
         ).toBeTruthy();
     });
 });

--- a/frontend/src/modules/search/components/SearchBox.test.js
+++ b/frontend/src/modules/search/components/SearchBox.test.js
@@ -74,7 +74,7 @@ describe('<SearchBoxBase>', () => {
         const wrapper = shallow(<SearchBoxBase parameters={ {} } />);
         wrapper.setState({ statuses: { missing: false } });
 
-        wrapper.instance().toggleStatus('missing');
+        wrapper.instance().toggleFilter('missing');
 
         expect(wrapper.state('statuses').missing).toBeTruthy();
     });
@@ -90,7 +90,7 @@ describe('<SearchBoxBase>', () => {
             }
         });
 
-        wrapper.instance().setSingleStatus('missing');
+        wrapper.instance().applySingleFilter('missing');
         expect(wrapper.state('statuses').warnings).toBeFalsy();
         expect(wrapper.state('statuses').errors).toBeFalsy();
         expect(wrapper.state('statuses').missing).toBeTruthy();

--- a/frontend/src/modules/search/index.js
+++ b/frontend/src/modules/search/index.js
@@ -43,3 +43,21 @@ export const FILTERS_STATUS = [
         slug: 'unreviewed',
     },
 ];
+
+
+// List of available extra filters.
+// This list controls the creation of the UI.
+export const FILTERS_EXTRA = [
+    {
+        title: 'Untranslated',
+        slug: 'untranslated',
+    },
+    {
+        title: 'Unchanged',
+        slug: 'unchanged',
+    },
+    {
+        title: 'Rejected',
+        slug: 'rejected',
+    },
+];

--- a/frontend/src/modules/search/index.js
+++ b/frontend/src/modules/search/index.js
@@ -49,10 +49,6 @@ export const FILTERS_STATUS = [
 // This list controls the creation of the UI.
 export const FILTERS_EXTRA = [
     {
-        title: 'Untranslated',
-        slug: 'untranslated',
-    },
-    {
         title: 'Unchanged',
         slug: 'unchanged',
     },


### PR DESCRIPTION
In addition to fixing the bug, this patch also:
* Fixes the size of the Unreviewed checkbox (b1e79a5)
* Shows checkmark when hovering filter icons (f3e6a98)
* Brings some refactorings to better support multiple groups of filters (559c64c)

It also **drops the Untranslated filter** due to low usage compared to the code and UX complexity it comes with. The logs only show 10 hits per day, and it's impossible to tell how many of those are triggered by the Untranslated filter and how many are manual selections of the "Fuzzy, Errors, Missing" filters.