### PR TITLE
Fix bug 1571039: Do not hardcode locale redirects

### DIFF
--- a/pontoon/urls.py
+++ b/pontoon/urls.py
@@ -17,10 +17,6 @@ urlpatterns = [
     # Legacy: Locale redirect for compatibility with i18n ready URL scheme
     url(r'^en-US(?P<url>.+)$', RedirectView.as_view(url="%(url)s", permanent=True)),
 
-    # Redirect similar locales
-    url(r'^ga/(?P<url>.*)$', RedirectView.as_view(url="/ga-IE/%(url)s", permanent=True)),
-    url(r'^pt/(?P<url>.*)$', RedirectView.as_view(url="/pt-PT/%(url)s", permanent=True)),
-
     # Redirect legacy Aurora projects
     url(
         r'^projects/firefox-aurora/(?P<url>.*)$',


### PR DESCRIPTION
I wonder if this is an opportunity to also drop "Redirect legacy Aurora projects".

This patch is deployed to stage:
https://mozilla-pontoon-staging.herokuapp.com/ga/
https://mozilla-pontoon-staging.herokuapp.com/pt/

You can compare that with production, which still redirects:
https://pontoon.mozilla.org/ga/
https://pontoon.mozilla.org/pt/