### PR TITLE
Fix bug 1573437: Ensure strings are serialized with default Fluent serializer settings

### DIFF
--- a/frontend/src/core/utils/fluent/getReconstructedSimpleMessage.js
+++ b/frontend/src/core/utils/fluent/getReconstructedSimpleMessage.js
@@ -1,4 +1,5 @@
 import parser from './parser';
+import serializer from './serializer';
 
 
 /**
@@ -18,6 +19,7 @@ export default function getReconstructedSimpleMessage(original, translation) {
     const isMultilineTranslation = translation.indexOf('\n') > -1;
 
     let content;
+
     if (message.attributes && message.attributes.length === 1) {
         const attribute = message.attributes[0].id.name;
 
@@ -38,5 +40,8 @@ export default function getReconstructedSimpleMessage(original, translation) {
             content = `${key} = ${translation}`;
         }
     }
-    return content;
+
+    // Ensure strings are serialized with default serializer settings
+    const ast = parser.parseEntry(content);
+    return serializer.serializeEntry(ast);
 }

--- a/frontend/src/core/utils/fluent/getReconstructedSimpleMessage.test.js
+++ b/frontend/src/core/utils/fluent/getReconstructedSimpleMessage.test.js
@@ -6,34 +6,34 @@ describe('getReconstructedSimpleMessage', () => {
         const original = 'title = Marvel Cinematic Universe';
         const translation = 'Univers cinématographique Marvel';
         const res = getReconstructedSimpleMessage(original, translation);
-        expect(res).toEqual('title = Univers cinématographique Marvel');
+        expect(res).toEqual('title = Univers cinématographique Marvel\n');
     });
 
     it('returns the correct value for a single attribute', () => {
         const original = 'spoilers =\n    .who-dies = Who dies?';
         const translation = 'Qui meurt ?';
         const res = getReconstructedSimpleMessage(original, translation);
-        expect(res).toEqual('spoilers =\n    .who-dies = Qui meurt ?');
+        expect(res).toEqual('spoilers =\n    .who-dies = Qui meurt ?\n');
     });
 
     it('returns indented content for a multiline simple message', () => {
         const original = 'time-travel = They discovered Time Travel';
         const translation = 'Ils ont inventé le\nvoyage temporel';
         const res = getReconstructedSimpleMessage(original, translation);
-        expect(res).toEqual('time-travel =\n    Ils ont inventé le\n    voyage temporel');
+        expect(res).toEqual('time-travel =\n    Ils ont inventé le\n    voyage temporel\n');
     });
 
     it('returns indented content for a multiline single attribute', () => {
         const original = 'slow-walks =\n    .title = They walk in slow motion';
         const translation = 'Ils se déplacent\nen mouvement lents';
         const res = getReconstructedSimpleMessage(original, translation);
-        expect(res).toEqual('slow-walks =\n    .title =\n        Ils se déplacent\n        en mouvement lents');
+        expect(res).toEqual('slow-walks =\n    .title =\n        Ils se déplacent\n        en mouvement lents\n');
     });
 
     it('adds the leading dash to the id of Term messages', () => {
         const original = '-my-term = My Term';
         const translation = 'Mon Terme';
         const res = getReconstructedSimpleMessage(original, translation);
-        expect(res).toEqual('-my-term = Mon Terme');
+        expect(res).toEqual('-my-term = Mon Terme\n');
     });
 });

--- a/frontend/src/core/utils/fluent/index.js
+++ b/frontend/src/core/utils/fluent/index.js
@@ -5,8 +5,9 @@ import getSimplePreview from './getSimplePreview';
 import isSimpleElement from './isSimpleElement';
 import isSimpleMessage from './isSimpleMessage';
 import isSimpleSingleAttributeMessage from './isSimpleSingleAttributeMessage';
-import serialize from './serialize';
 import parser from './parser';
+import serialize from './serialize';
+import serializer from './serializer';
 
 
 export default {
@@ -15,6 +16,7 @@ export default {
     isSimpleElement,
     isSimpleMessage,
     isSimpleSingleAttributeMessage,
-    serialize,
     parser,
+    serialize,
+    serializer,
 };

--- a/frontend/src/core/utils/fluent/serializer.js
+++ b/frontend/src/core/utils/fluent/serializer.js
@@ -1,0 +1,8 @@
+/* @flow */
+
+import { FluentSerializer } from 'fluent-syntax';
+
+
+const fluentSerializer = new FluentSerializer();
+
+export default fluentSerializer;

--- a/frontend/src/modules/fluenteditor/components/Editor.test.js
+++ b/frontend/src/modules/fluenteditor/components/Editor.test.js
@@ -103,7 +103,7 @@ describe('<Editor>', () => {
         wrapper.instance().toggleForceSource();
 
         expect(wrapper.find('SourceEditor').exists()).toBeTruthy();
-        expect(updateTranslationMock.lastCall.calledWith('my-message = Salut')).toBeTruthy();
+        expect(updateTranslationMock.lastCall.calledWith('my-message = Salut\n')).toBeTruthy();
     });
 
     it('sets empty initial translation in source mode when untranslated', () => {

--- a/frontend/src/modules/fluenteditor/components/SimpleEditor.test.js
+++ b/frontend/src/modules/fluenteditor/components/SimpleEditor.test.js
@@ -59,6 +59,6 @@ describe('<SimpleEditor>', () => {
         const [wrapper, sendTranslationMock, ] = createSimpleEditor();
         wrapper.instance().sendTranslation(false, 'Coucou');
         expect(sendTranslationMock.calledOnce).toBeTruthy();
-        expect(sendTranslationMock.calledWith(false, 'my-message = Coucou')).toBeTruthy();
+        expect(sendTranslationMock.calledWith(false, 'my-message = Coucou\n')).toBeTruthy();
     });
 });


### PR DESCRIPTION
I'll probably go ahead and merge this to prevent any [DB inconsistencies](https://bugzilla.mozilla.org/show_bug.cgi?id=1573437#c0).

I'd still appreciate a review.