### PR TITLE
Fix bug 1569863: Do not trigger unsaved changes warning when switching Fluent and non-Fluent strings

### DIFF
--- a/frontend/src/core/editor/reducer.js
+++ b/frontend/src/core/editor/reducer.js
@@ -31,9 +31,22 @@ type Action =
 
 export type EditorState = {|
     +translation: string,
+
+    // Used for storing the initial translation in Fluent editor,
+    // needed for detecting unsaved changes.
     +initialTranslation: string,
+
+    // Source of the current change. 'internal' or missing if from inside the
+    // Editor, 'external' otherwise. This allows the Editor to behave
+    // differently depending on the type of change.
     +changeSource: string,
+
+    // Order to replace the currently selected text inside the Editor with
+    // this content. This is reset after that change has been made. Because
+    // we have different Editor implementations, we need to let those components
+    // perform the actual replacement logic.
     +selectionReplacementContent: string,
+
     +errors: Array<string>,
     +warnings: Array<string>,
 
@@ -71,16 +84,7 @@ function extractFailedChecksOfType(
 const initial: EditorState = {
     translation: '',
     initialTranslation: '',
-
-    // Source of the current change. 'internal' or missing if from inside the
-    // Editor, 'external' otherwise. This allows the Editor to behave
-    // differently depending on the type of change.
     changeSource: 'internal',
-
-    // Order to replace the currently selected text inside the Editor with
-    // this content. This is reset after that change has been made. Because
-    // we have different Editor implementations, we need to let those components
-    // perform the actual replacement logic.
     selectionReplacementContent: '',
     errors: [],
     warnings: [],

--- a/frontend/src/modules/genericeditor/components/GenericTranslationForm.js
+++ b/frontend/src/modules/genericeditor/components/GenericTranslationForm.js
@@ -37,6 +37,11 @@ export class GenericTranslationFormBase extends React.Component<InternalProps> {
     }
 
     componentDidUpdate(prevProps: InternalProps) {
+        // Unused by Generic Editor - reset to default value.
+        if (this.props.editor.initialTranslation) {
+            return this.props.setInitialTranslation('');
+        }
+
         // Close failed checks popup when content of the editor changes,
         // but only if the errors and warnings did not change
         // meaning they were already shown in the previous render

--- a/frontend/src/modules/unsavedchanges/actions.js
+++ b/frontend/src/modules/unsavedchanges/actions.js
@@ -77,7 +77,7 @@ export type UpdateAction = {|
     +exist: boolean,
     +type: typeof UPDATE,
 |};
-export function update(activeTranslation: string, editorTranslation: string): UpdateAction {
+export function update(editorTranslation: string, activeTranslation: string): UpdateAction {
     return {
         exist: editorTranslation !== activeTranslation,
         type: UPDATE,


### PR DESCRIPTION
On long run, we might be able to survive without `initialTranslation`. For now, this is effectively a one liner that resets its value when it's not needed.