### PR TITLE
Fix bug 1566869 - Reset ignored state on unsavedchanges update.

### DIFF
--- a/frontend/src/modules/unsavedchanges/reducer.js
+++ b/frontend/src/modules/unsavedchanges/reducer.js
@@ -66,6 +66,7 @@ export default function reducer(
             return {
                 ...state,
                 exist: action.exist,
+                ignored: false,
             };
         default:
             return state;


### PR DESCRIPTION
When a translation is saved or added, we set the "ignored" boolean to true in unsavedchanges to hide the check before moving to the next entity. However, that boolean was never reset, because that only happened when "hide" was called, and hide could only be called when the panel was displayed, and the panel was never displayed because ignored was true. This patch resets the "ignored" state to false every time the state is updated.