### PR TITLE
Bug 1362323 - Fix tests for the administration app.

### DIFF
--- a/pontoon/administration/tests/test_views.py
+++ b/pontoon/administration/tests/test_views.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 import pytest
 
@@ -108,7 +108,7 @@ def test_manage_project_strings_new(client_superuser, locale_a):
         assert entity.order == index
 
     # Verify new strings appear on the page.
-    assert 'Hey, I just met you' in response.content
+    assert b'Hey, I just met you' in response.content
 
 
 @pytest.mark.django_db
@@ -226,7 +226,7 @@ def test_manage_project_strings_list(client_superuser):
     response = client_superuser.get(url)
     assert response.status_code == 200
     for i in range(nb_entities):
-        assert 'string %s' % i in response.content
+        assert ('string %s' % i).encode('utf-8') in response.content
 
     # Test editing strings and comments.
     form_data = {
@@ -244,10 +244,10 @@ def test_manage_project_strings_list(client_superuser):
 
     response = client_superuser.post(url, form_data)
     assert response.status_code == 200
-    assert 'changed 0' in response.content
-    assert 'Wubba lubba dub dub' in response.content
-    assert 'string 0' not in response.content
-    assert 'string 1' not in response.content  # It's been removed.
+    assert b'changed 0' in response.content
+    assert b'Wubba lubba dub dub' in response.content
+    assert b'string 0' not in response.content
+    assert b'string 1' not in response.content  # It's been removed.
 
     total = Entity.objects.filter(
         resource=resource, obsolete=False,
@@ -270,9 +270,9 @@ def test_manage_project_strings_list(client_superuser):
 
     response = client_superuser.post(url, form_data)
     assert response.status_code == 200
-    assert 'changed 0' in response.content
-    assert 'new string' in response.content
-    assert 'adding this entity now' in response.content
+    assert b'changed 0' in response.content
+    assert b'new string' in response.content
+    assert b'adding this entity now' in response.content
 
     total = Entity.objects.filter(
         resource=resource, obsolete=False,
@@ -314,13 +314,13 @@ def test_manage_project_strings_download_csv(client_superuser):
     assert response._headers['content-type'] == ('Content-Type', 'text/csv')
 
     # Verify the original content is here.
-    assert 'pedestal' in response.content
-    assert 'Ozymandias' in response.content
-    assert 'Mighty' in response.content
+    assert b'pedestal' in response.content
+    assert b'Ozymandias' in response.content
+    assert b'Mighty' in response.content
 
     # Verify we have the locale columns.
-    assert 'kl' in response.content
-    assert 'gs' in response.content
+    assert b'kl' in response.content
+    assert b'gs' in response.content
 
     # Now add some translations.
     entity = Entity.objects.filter(string='And on the pedestal these words appear:')[0]
@@ -368,13 +368,13 @@ def test_manage_project_strings_download_csv(client_superuser):
     response = client_superuser.get(url, {'format': 'csv'})
 
     # Verify the translated content is here.
-    assert 'pedestal' in response.content
-    assert 'piédestal' in response.content
-    assert 'Sockel' in response.content
+    assert b'pedestal' in response.content
+    assert 'piédestal'.encode('utf-8') in response.content
+    assert b'Sockel' in response.content
 
-    assert 'Mighty' in response.content
-    assert 'puissants' in response.content
-    assert 'Mächt’ge' in response.content
+    assert b'Mighty' in response.content
+    assert b'puissants' in response.content
+    assert 'Mächt’ge'.encode('utf-8') in response.content
 
 
 @pytest.mark.django_db
@@ -421,7 +421,7 @@ def test_project_add_locale(client_superuser):
 
     response = client_superuser.post(url, form_data)
     assert response.status_code == 200
-    assert '. Error.' not in response.content
+    assert b'. Error.' not in response.content
 
     # Verify we have the right ProjectLocale objects.
     pl = ProjectLocale.objects.filter(project=project)

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -99,7 +99,7 @@ def user_profile_url(self):
 
 
 def user_gravatar_url(self, size):
-    email = hashlib.md5(self.email.lower()).hexdigest()
+    email = hashlib.md5(self.email.lower().encode('utf-8')).hexdigest()
     data = {'s': str(size)}
 
     if not settings.DEBUG:

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -76,8 +76,8 @@ django-partial-index==0.5.2 \
 django-pipeline==1.5.3 \
     --hash=sha256:48e71c8b1781533adee64561cca20c9f17d40136211c2b32531e70ffe7fb0ced \
     --hash=sha256:752fa35d40cb645e6d3a54ccde01726732e441a2d54d904219c68e402f78e194
-django-cookies-samesite==0.1.2 \
-    --hash=sha256:8ffb0d4703e2cac6a4bff7c0bfb80d4153995497676556442f01804fc9918ec5
+django-cookies-samesite==0.2.0 \
+    --hash=sha256:b393f8e2e1c758af952ea10afe44fe837a68a182119fdfbab2fa00f67deded0e
 django-session-csrf==0.7.1 \
     --hash=sha256:e17177e6e2e6518ec7ce6693ad10a5c747f8571d09f4cfa9082599334421605d \
     --hash=sha256:ff8c10e30d312c77fc6a6db7710e22b9383e28c03b7fe958876ca96f39aa6cf2
@@ -135,8 +135,8 @@ pytz==2017.2 \
     --hash=sha256:39504670abb5dae77f56f8eb63823937ce727d7cdd0088e6909e6dcac0f89043 \
     --hash=sha256:ddc93b6d41cfb81266a27d23a79e13805d4a5521032b512643af8729041a81b4 \
     --hash=sha256:f5c056e8f62d45ba8215e5cb8f50dfccb198b4b9fbea8500674f3443e4689589
-raygun4py==3.1.6 \
-    --hash=sha256:1a68c3d5a5de696167aabf4d2dfa36ac1b14be66da1d07908f5cebfc827e4b08
+raygun4py==4.3.0 \
+    --hash=sha256:9a675da0215df310a929ef8fe4f9f6c7882b3ee44a925d73e5c191fd962d7c4d
 scandir==1.5 \
     --hash=sha256:c2612d1a487d80fb4701b4a91ca1b8f8a695b1ae820570815e85e8c8b23f1283
 six==1.12.0 \


### PR DESCRIPTION
Hey,

The PR fixes unittests for the administration module.
Major changes :
* I've bumped up the version of `django-cookies-samesite` because of the missing Cookie module
* The `HTTPResponse.content`  returns a bytes object (on Python 3). The `contains` method raises an exception if you check a non-bytes object.

@adngdb @mathjazz r?