### PR TITLE
Fix Bug 1578057: update locale's latest_translation for visible projects only

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -2868,22 +2868,25 @@ class Translation(DirtyFieldsMixin, models.Model):
         resource = self.entity.resource
         project = resource.project
         locale = self.locale
-        translatedresource = TranslatedResource.objects.get(resource=resource, locale=locale)
 
-        instances = [translatedresource, project]
+        to_update = [
+            (TranslatedResource, Q(Q(resource=resource) & Q(locale=locale))),
+            (ProjectLocale, Q(Q(project=project) & Q(locale=locale))),
+            (Project, Q(pk=project.pk)),
+        ]
 
         if not project.system_project:
-            instances.append(locale)
+            to_update.append((Locale, Q(pk=locale.pk)))
 
-        project_locale = utils.get_object_or_none(ProjectLocale, project=project, locale=locale)
-        if project_locale:
-            instances.append(project_locale)
-
-        for instance in instances:
-            latest = instance.latest_translation
-            if latest is None or self.latest_activity['date'] > latest.latest_activity['date']:
-                instance.latest_translation = self
-                instance.save(update_fields=['latest_translation'])
+        for model, query in to_update:
+            model.objects.filter(
+                Q(
+                    query & Q(
+                        Q(latest_translation=None)
+                        | Q(latest_translation__date__lt=self.latest_activity['date'])
+                    )
+                )
+            ).update(latest_translation=self)
 
     def approve(self, user):
         """

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -2882,8 +2882,8 @@ class Translation(DirtyFieldsMixin, models.Model):
             model.objects.filter(
                 Q(
                     query & Q(
-                        Q(latest_translation=None)
-                        | Q(latest_translation__date__lt=self.latest_activity['date'])
+                        Q(latest_translation=None) |
+                        Q(latest_translation__date__lt=self.latest_activity['date'])
                     )
                 )
             ).update(latest_translation=self)

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -2870,7 +2870,10 @@ class Translation(DirtyFieldsMixin, models.Model):
         locale = self.locale
         translatedresource = TranslatedResource.objects.get(resource=resource, locale=locale)
 
-        instances = [project, locale, translatedresource]
+        instances = [translatedresource, project]
+
+        if Project.objects.visible().filter(pk=project.pk).first():
+            instances.append(locale)
 
         project_locale = utils.get_object_or_none(ProjectLocale, project=project, locale=locale)
         if project_locale:

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -2872,7 +2872,7 @@ class Translation(DirtyFieldsMixin, models.Model):
 
         instances = [translatedresource, project]
 
-        if Project.objects.visible().filter(pk=project.pk).first():
+        if not project.system_project:
             instances.append(locale)
 
         project_locale = utils.get_object_or_none(ProjectLocale, project=project, locale=locale)

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -1446,9 +1446,9 @@ class ProjectLocale(AggregatedStats):
         or combination of both.
 
         :param self: object to get data for,
-            instance of Projet or Locale
+            instance of Project or Locale
         :param extra: extra filter to be used,
-            instance of Projet or Locale
+            instance of Project or Locale
         """
         latest_translation = None
 
@@ -1477,9 +1477,9 @@ class ProjectLocale(AggregatedStats):
         Get chart for project, locale or combination of both.
 
         :param self: object to get data for,
-            instance of Projet or Locale
+            instance of Project or Locale
         :param extra: extra filter to be used,
-            instance of Projet or Locale
+            instance of Project or Locale
         """
         chart = None
 

--- a/pontoon/base/tests/models/test_entity.py
+++ b/pontoon/base/tests/models/test_entity.py
@@ -72,12 +72,14 @@ def translation_b(translation_a):
     This fixture provides a secondary translation
     for translation_a's entity.
     """
-
-    return TranslationFactory(
+    translation_b = TranslationFactory(
         entity=translation_a.entity,
         locale=translation_a.locale,
         string="Translation B for entity_a",
     )
+    translation_b.locale.refresh_from_db()
+    translation_b.entity.resource.project.refresh_from_db()
+    return translation_b
 
 
 @pytest.mark.django_db

--- a/pontoon/base/tests/models/test_translation.py
+++ b/pontoon/base/tests/models/test_translation.py
@@ -16,7 +16,9 @@ from pontoon.base.utils import aware_datetime
 
 
 @pytest.mark.django_db
-def test_translation_save_latest_update_first_translation(locale_a, project_a, project_locale_a, resource_a, entity_a):
+def test_translation_save_latest_update_first_translation(
+        locale_a, project_a, project_locale_a, resource_a, entity_a
+):
     """
     When a translation is saved, update the latest_translation
     attribute on the related project, locale, translatedresource,
@@ -43,7 +45,9 @@ def test_translation_save_latest_update_first_translation(locale_a, project_a, p
 
 
 @pytest.mark.django_db
-def test_translation_save_latest_update_newer_translation(locale_a, project_a, project_locale_a, resource_a, entity_a):
+def test_translation_save_latest_update_newer_translation(
+        locale_a, project_a, project_locale_a, resource_a, entity_a
+):
     """
     When a newer translation is saved, update the latest_translation
     attribute on the related project, locale, translatedresource,
@@ -77,7 +81,9 @@ def test_translation_save_latest_update_newer_translation(locale_a, project_a, p
 
 
 @pytest.mark.django_db
-def test_translation_save_latest_update_older_translation(locale_a, project_a, project_locale_a, resource_a, entity_a):
+def test_translation_save_latest_update_older_translation(
+        locale_a, project_a, project_locale_a, resource_a, entity_a
+):
     """
     When an older translation is saved, do not update the latest_translation
     attribute on the related project, locale, translatedresource,
@@ -97,7 +103,8 @@ def test_translation_save_latest_update_older_translation(locale_a, project_a, p
     assert tr.latest_translation == translation
     assert project_locale_a.latest_translation == translation
 
-    older_translation = TranslationFactory.create(
+    # older translation
+    TranslationFactory.create(
         locale=locale_a,
         entity=entity_a,
         date=aware_datetime(1970, 1, 1),
@@ -111,7 +118,9 @@ def test_translation_save_latest_update_older_translation(locale_a, project_a, p
 
 
 @pytest.mark.django_db
-def test_translation_save_latest_update_approved_translation(locale_a, project_a, project_locale_a, resource_a, entity_a):
+def test_translation_save_latest_update_approved_translation(
+        locale_a, project_a, project_locale_a, resource_a, entity_a
+):
     """
     When a translation is approved, update the latest_translation
     attribute on the related project, locale, translatedresource,

--- a/pontoon/base/tests/models/test_translation.py
+++ b/pontoon/base/tests/models/test_translation.py
@@ -16,171 +16,135 @@ from pontoon.base.utils import aware_datetime
 
 
 @pytest.mark.django_db
-def test_translation_save_latest_update_with_first_translation(locale_a, project_a):
+def test_translation_save_latest_update_first_translation(locale_a, project_a, project_locale_a, resource_a, entity_a):
     """
     When a translation is saved, update the latest_translation
     attribute on the related project, locale, translatedresource,
     and project_locale objects.
     """
-    project_locale = ProjectLocaleFactory.create(
-        project=project_a, locale=locale_a,
-    )
-    resource = ResourceFactory.create(
-        project=project_a,
-        path="resource.po",
-        format="po",
-    )
-    tr = TranslatedResourceFactory.create(locale=locale_a, resource=resource)
-    entity = EntityFactory.create(resource=resource, string="Entity X")
+    tr = TranslatedResourceFactory.create(locale=locale_a, resource=resource_a)
 
     assert locale_a.latest_translation is None
     assert project_a.latest_translation is None
     assert tr.latest_translation is None
-    assert project_locale.latest_translation is None
+    assert project_locale_a.latest_translation is None
 
     translation = TranslationFactory.create(
         locale=locale_a,
-        entity=entity,
+        entity=entity_a,
         date=aware_datetime(1970, 1, 1),
     )
-    for i in [locale_a, project_a, project_locale, tr]:
+    for i in [locale_a, project_a, project_locale_a, tr]:
         i.refresh_from_db()
     assert locale_a.latest_translation == translation
     assert project_a.latest_translation == translation
     assert tr.latest_translation == translation
-    assert project_locale.latest_translation == translation
+    assert project_locale_a.latest_translation == translation
 
 
 @pytest.mark.django_db
-def test_translation_save_latest_update_with_newer_translation(locale_a, project_a):
+def test_translation_save_latest_update_newer_translation(locale_a, project_a, project_locale_a, resource_a, entity_a):
     """
     When a newer translation is saved, update the latest_translation
     attribute on the related project, locale, translatedresource,
     and project_locale objects.
     """
-    project_locale = ProjectLocaleFactory.create(
-        project=project_a, locale=locale_a,
-    )
-    resource = ResourceFactory.create(
-        project=project_a,
-        path="resource.po",
-        format="po",
-    )
-    tr = TranslatedResourceFactory.create(locale=locale_a, resource=resource)
-    entity = EntityFactory.create(resource=resource, string="Entity X")
+    tr = TranslatedResourceFactory.create(locale=locale_a, resource=resource_a)
 
     translation = TranslationFactory.create(
         locale=locale_a,
-        entity=entity,
+        entity=entity_a,
         date=aware_datetime(1970, 1, 1),
     )
-    for i in [locale_a, project_a, project_locale, tr]:
+    for i in [locale_a, project_a, project_locale_a, tr]:
         i.refresh_from_db()
     assert locale_a.latest_translation == translation
     assert project_a.latest_translation == translation
     assert tr.latest_translation == translation
-    assert project_locale.latest_translation == translation
+    assert project_locale_a.latest_translation == translation
 
     newer_translation = TranslationFactory.create(
         locale=locale_a,
-        entity=entity,
+        entity=entity_a,
         date=aware_datetime(1970, 2, 1),
     )
-    for i in [locale_a, project_a, project_locale, tr]:
+    for i in [locale_a, project_a, project_locale_a, tr]:
         i.refresh_from_db()
     assert locale_a.latest_translation == newer_translation
     assert project_a.latest_translation == newer_translation
     assert tr.latest_translation == newer_translation
-    assert project_locale.latest_translation == newer_translation
+    assert project_locale_a.latest_translation == newer_translation
 
 
 @pytest.mark.django_db
-def test_translation_does_not_save_latest_update_with_older_translation(locale_a, project_a):
+def test_translation_save_latest_update_older_translation(locale_a, project_a, project_locale_a, resource_a, entity_a):
     """
     When an older translation is saved, do not update the latest_translation
     attribute on the related project, locale, translatedresource,
     and project_locale objects.
     """
-    project_locale = ProjectLocaleFactory.create(
-        project=project_a, locale=locale_a,
-    )
-    resource = ResourceFactory.create(
-        project=project_a,
-        path="resource.po",
-        format="po",
-    )
-    tr = TranslatedResourceFactory.create(locale=locale_a, resource=resource)
-    entity = EntityFactory.create(resource=resource, string="Entity X")
+    tr = TranslatedResourceFactory.create(locale=locale_a, resource=resource_a)
 
     translation = TranslationFactory.create(
         locale=locale_a,
-        entity=entity,
+        entity=entity_a,
         date=aware_datetime(1970, 2, 1),
     )
-    for i in [locale_a, project_a, project_locale, tr]:
+    for i in [locale_a, project_a, project_locale_a, tr]:
         i.refresh_from_db()
     assert locale_a.latest_translation == translation
     assert project_a.latest_translation == translation
     assert tr.latest_translation == translation
-    assert project_locale.latest_translation == translation
+    assert project_locale_a.latest_translation == translation
 
     older_translation = TranslationFactory.create(
         locale=locale_a,
-        entity=entity,
+        entity=entity_a,
         date=aware_datetime(1970, 1, 1),
     )
-    for i in [locale_a, project_a, project_locale, tr]:
+    for i in [locale_a, project_a, project_locale_a, tr]:
         i.refresh_from_db()
     assert locale_a.latest_translation == translation
     assert project_a.latest_translation == translation
     assert tr.latest_translation == translation
-    assert project_locale.latest_translation == translation
+    assert project_locale_a.latest_translation == translation
 
 
 @pytest.mark.django_db
-def test_translation_save_latest_update_with_later_approved_translation(locale_a, project_a):
+def test_translation_save_latest_update_approved_translation(locale_a, project_a, project_locale_a, resource_a, entity_a):
     """
     When a translation is approved, update the latest_translation
     attribute on the related project, locale, translatedresource,
     and project_locale objects if it was approved later than the last
     translation was saved before.
     """
-    project_locale = ProjectLocaleFactory.create(
-        project=project_a, locale=locale_a,
-    )
-    resource = ResourceFactory.create(
-        project=project_a,
-        path="resource.po",
-        format="po",
-    )
-    tr = TranslatedResourceFactory.create(locale=locale_a, resource=resource)
-    entity = EntityFactory.create(resource=resource, string="Entity X")
+    tr = TranslatedResourceFactory.create(locale=locale_a, resource=resource_a)
 
     translation = TranslationFactory.create(
         locale=locale_a,
-        entity=entity,
+        entity=entity_a,
         date=aware_datetime(1970, 2, 1),
         approved_date=aware_datetime(1970, 2, 1),
     )
-    for i in [locale_a, project_a, project_locale, tr]:
+    for i in [locale_a, project_a, project_locale_a, tr]:
         i.refresh_from_db()
     assert locale_a.latest_translation == translation
     assert project_a.latest_translation == translation
     assert tr.latest_translation == translation
-    assert project_locale.latest_translation == translation
+    assert project_locale_a.latest_translation == translation
 
     later_approved_translation = TranslationFactory.create(
         locale=locale_a,
-        entity=entity,
+        entity=entity_a,
         date=aware_datetime(1970, 1, 1),
         approved_date=aware_datetime(1970, 3, 1),
     )
-    for i in [locale_a, project_a, project_locale, tr]:
+    for i in [locale_a, project_a, project_locale_a, tr]:
         i.refresh_from_db()
     assert locale_a.latest_translation == later_approved_translation
     assert project_a.latest_translation == later_approved_translation
     assert tr.latest_translation == later_approved_translation
-    assert project_locale.latest_translation == later_approved_translation
+    assert project_locale_a.latest_translation == later_approved_translation
 
 
 @pytest.mark.django_db
@@ -220,24 +184,18 @@ def test_translation_save_latest_update_for_system_project(locale_a, system_proj
 
 
 @pytest.mark.django_db
-def test_translation_save_latest_missing_project_locale(locale_a, project_a):
+def test_translation_save_latest_missing_project_locale(locale_a, project_a, resource_a, entity_a):
     """
     If a translation is saved for a locale that isn't active on the
     project, do not fail due to a missing ProjectLocale.
     """
-    resource = ResourceFactory.create(
-        project=project_a,
-        path="resource.po",
-        format="po",
-    )
-    tr = TranslatedResourceFactory.create(locale=locale_a, resource=resource)
-    entity = EntityFactory.create(resource=resource, string="Entity X")
+    tr = TranslatedResourceFactory.create(locale=locale_a, resource=resource_a)
 
     # This calls .save, this should fail if we're not properly
     # handling the missing ProjectLocale.
     translation = TranslationFactory.create(
         locale=locale_a,
-        entity=entity,
+        entity=entity_a,
         date=aware_datetime(1970, 1, 1),
     )
 
@@ -249,20 +207,14 @@ def test_translation_save_latest_missing_project_locale(locale_a, project_a):
 
 
 @pytest.mark.django_db
-def test_translation_approved_in_tm(locale_a, project_a):
+def test_translation_approved_in_tm(locale_a, entity_a):
     """
     Every save of approved translation should generate a new
     entry in the translation memory.
     """
-    resource = ResourceFactory.create(
-        project=project_a,
-        path="resource.po",
-        format="po",
-    )
-    entity = EntityFactory.create(resource=resource, string="Entity X")
     translation = TranslationFactory.create(
         locale=locale_a,
-        entity=entity,
+        entity=entity_a,
         approved=True,
     )
     assert TranslationMemoryEntry.objects.get(
@@ -273,19 +225,13 @@ def test_translation_approved_in_tm(locale_a, project_a):
 
 
 @pytest.mark.django_db
-def test_translation_unapproved_not_in_tm(locale_a, project_a):
+def test_translation_unapproved_not_in_tm(locale_a, entity_a):
     """
     Unapproved translation shouldn't be in the translation memory.
     """
-    resource = ResourceFactory.create(
-        project=project_a,
-        path="resource.po",
-        format="po",
-    )
-    entity = EntityFactory.create(resource=resource, string="Entity X")
     translation = TranslationFactory.create(
         locale=locale_a,
-        entity=entity,
+        entity=entity_a,
     )
     with pytest.raises(TranslationMemoryEntry.DoesNotExist):
         TranslationMemoryEntry.objects.get(
@@ -296,20 +242,14 @@ def test_translation_unapproved_not_in_tm(locale_a, project_a):
 
 
 @pytest.mark.django_db
-def test_translation_rejected_not_in_tm(locale_a, project_a):
+def test_translation_rejected_not_in_tm(locale_a, entity_a):
     """
     When translation is deleted, its corresponding TranslationMemoryEntry
     needs to be deleted, too.
     """
-    resource = ResourceFactory.create(
-        project=project_a,
-        path="resource.po",
-        format="po",
-    )
-    entity = EntityFactory.create(resource=resource, string="Entity X")
     translation = TranslationFactory.create(
         locale=locale_a,
-        entity=entity,
+        entity=entity_a,
         rejected=True,
     )
     with pytest.raises(TranslationMemoryEntry.DoesNotExist):

--- a/pontoon/base/tests/models/test_translation.py
+++ b/pontoon/base/tests/models/test_translation.py
@@ -16,7 +16,7 @@ from pontoon.base.utils import aware_datetime
 
 
 @pytest.mark.django_db
-def test_translation_save_latest_update(locale_a, project_a):
+def test_translation_save_latest_update_with_first_translation(locale_a, project_a):
     """
     When a translation is saved, update the latest_translation
     attribute on the related project, locale, translatedresource,
@@ -43,65 +43,150 @@ def test_translation_save_latest_update(locale_a, project_a):
         entity=entity,
         date=aware_datetime(1970, 1, 1),
     )
-    locale_a.refresh_from_db()
-    project_a.refresh_from_db()
-    tr.refresh_from_db()
-    project_locale.refresh_from_db()
+    for i in [locale_a, project_a, project_locale, tr]:
+        i.refresh_from_db()
     assert locale_a.latest_translation == translation
     assert project_a.latest_translation == translation
     assert tr.latest_translation == translation
     assert project_locale.latest_translation == translation
 
-    # Ensure translation is replaced for newer translations
+
+@pytest.mark.django_db
+def test_translation_save_latest_update_with_newer_translation(locale_a, project_a):
+    """
+    When a newer translation is saved, update the latest_translation
+    attribute on the related project, locale, translatedresource,
+    and project_locale objects.
+    """
+    project_locale = ProjectLocaleFactory.create(
+        project=project_a, locale=locale_a,
+    )
+    resource = ResourceFactory.create(
+        project=project_a,
+        path="resource.po",
+        format="po",
+    )
+    tr = TranslatedResourceFactory.create(locale=locale_a, resource=resource)
+    entity = EntityFactory.create(resource=resource, string="Entity X")
+
+    translation = TranslationFactory.create(
+        locale=locale_a,
+        entity=entity,
+        date=aware_datetime(1970, 1, 1),
+    )
+    for i in [locale_a, project_a, project_locale, tr]:
+        i.refresh_from_db()
+    assert locale_a.latest_translation == translation
+    assert project_a.latest_translation == translation
+    assert tr.latest_translation == translation
+    assert project_locale.latest_translation == translation
+
     newer_translation = TranslationFactory.create(
         locale=locale_a,
         entity=entity,
         date=aware_datetime(1970, 2, 1),
     )
-    locale_a.refresh_from_db()
-    project_a.refresh_from_db()
-    tr.refresh_from_db()
-    project_locale.refresh_from_db()
+    for i in [locale_a, project_a, project_locale, tr]:
+        i.refresh_from_db()
     assert locale_a.latest_translation == newer_translation
     assert project_a.latest_translation == newer_translation
     assert tr.latest_translation == newer_translation
     assert project_locale.latest_translation == newer_translation
 
-    # Ensure translation isn't replaced for older translations.
-    TranslationFactory.create(
-        locale=locale_a,
-        entity=entity,
-        date=aware_datetime(1970, 1, 5),
+
+@pytest.mark.django_db
+def test_translation_does_not_save_latest_update_with_older_translation(locale_a, project_a):
+    """
+    When an older translation is saved, do not update the latest_translation
+    attribute on the related project, locale, translatedresource,
+    and project_locale objects.
+    """
+    project_locale = ProjectLocaleFactory.create(
+        project=project_a, locale=locale_a,
     )
-    locale_a.refresh_from_db()
-    project_a.refresh_from_db()
-    tr.refresh_from_db()
-    project_locale.refresh_from_db()
-    assert locale_a.latest_translation == newer_translation
-    assert project_a.latest_translation == newer_translation
-    assert tr.latest_translation == newer_translation
-    assert project_locale.latest_translation == newer_translation
+    resource = ResourceFactory.create(
+        project=project_a,
+        path="resource.po",
+        format="po",
+    )
+    tr = TranslatedResourceFactory.create(locale=locale_a, resource=resource)
+    entity = EntityFactory.create(resource=resource, string="Entity X")
 
-    # Ensure approved_date is taken into consideration as well.
-    newer_approved_translation = TranslationFactory.create(
+    translation = TranslationFactory.create(
         locale=locale_a,
         entity=entity,
+        date=aware_datetime(1970, 2, 1),
+    )
+    for i in [locale_a, project_a, project_locale, tr]:
+        i.refresh_from_db()
+    assert locale_a.latest_translation == translation
+    assert project_a.latest_translation == translation
+    assert tr.latest_translation == translation
+    assert project_locale.latest_translation == translation
+
+    older_translation = TranslationFactory.create(
+        locale=locale_a,
+        entity=entity,
+        date=aware_datetime(1970, 1, 1),
+    )
+    for i in [locale_a, project_a, project_locale, tr]:
+        i.refresh_from_db()
+    assert locale_a.latest_translation == translation
+    assert project_a.latest_translation == translation
+    assert tr.latest_translation == translation
+    assert project_locale.latest_translation == translation
+
+
+@pytest.mark.django_db
+def test_translation_save_latest_update_with_later_approved_translation(locale_a, project_a):
+    """
+    When a translation is approved, update the latest_translation
+    attribute on the related project, locale, translatedresource,
+    and project_locale objects if it was approved later than the last
+    translation was saved before.
+    """
+    project_locale = ProjectLocaleFactory.create(
+        project=project_a, locale=locale_a,
+    )
+    resource = ResourceFactory.create(
+        project=project_a,
+        path="resource.po",
+        format="po",
+    )
+    tr = TranslatedResourceFactory.create(locale=locale_a, resource=resource)
+    entity = EntityFactory.create(resource=resource, string="Entity X")
+
+    translation = TranslationFactory.create(
+        locale=locale_a,
+        entity=entity,
+        date=aware_datetime(1970, 2, 1),
+        approved_date=aware_datetime(1970, 2, 1),
+    )
+    for i in [locale_a, project_a, project_locale, tr]:
+        i.refresh_from_db()
+    assert locale_a.latest_translation == translation
+    assert project_a.latest_translation == translation
+    assert tr.latest_translation == translation
+    assert project_locale.latest_translation == translation
+
+    later_approved_translation = TranslationFactory.create(
+        locale=locale_a,
+        entity=entity,
+        date=aware_datetime(1970, 1, 1),
         approved_date=aware_datetime(1970, 3, 1),
     )
-    locale_a.refresh_from_db()
-    project_a.refresh_from_db()
-    tr.refresh_from_db()
-    project_locale.refresh_from_db()
-    assert locale_a.latest_translation == newer_approved_translation
-    assert project_a.latest_translation == newer_approved_translation
-    assert tr.latest_translation == newer_approved_translation
-    assert project_locale.latest_translation == newer_approved_translation
+    for i in [locale_a, project_a, project_locale, tr]:
+        i.refresh_from_db()
+    assert locale_a.latest_translation == later_approved_translation
+    assert project_a.latest_translation == later_approved_translation
+    assert tr.latest_translation == later_approved_translation
+    assert project_locale.latest_translation == later_approved_translation
 
 
 @pytest.mark.django_db
 def test_translation_save_latest_update_for_system_project(locale_a, system_project_a):
     """
-    When a translation is saved, update the latest_translation
+    When a translation is saved for a system project, update the latest_translation
     attribute on the project, translatedresource and project_locale objects,
     but not on the locale object.
     """
@@ -126,10 +211,8 @@ def test_translation_save_latest_update_for_system_project(locale_a, system_proj
         entity=entity,
         date=aware_datetime(1970, 1, 1),
     )
-    locale_a.refresh_from_db()
-    system_project_a.refresh_from_db()
-    tr.refresh_from_db()
-    project_locale.refresh_from_db()
+    for i in [locale_a, system_project_a, project_locale, tr]:
+        i.refresh_from_db()
     assert locale_a.latest_translation is None
     assert system_project_a.latest_translation == translation
     assert tr.latest_translation == translation
@@ -158,9 +241,8 @@ def test_translation_save_latest_missing_project_locale(locale_a, project_a):
         date=aware_datetime(1970, 1, 1),
     )
 
-    locale_a.refresh_from_db()
-    project_a.refresh_from_db()
-    tr.refresh_from_db()
+    for i in [locale_a, project_a, tr]:
+        i.refresh_from_db()
     assert locale_a.latest_translation == translation
     assert project_a.latest_translation == translation
     assert tr.latest_translation == translation

--- a/pontoon/test/fixtures/base.py
+++ b/pontoon/test/fixtures/base.py
@@ -126,18 +126,20 @@ def project_locale_a(project_a, locale_a):
 
 @pytest.fixture
 def translation_a(locale_a, project_locale_a, entity_a, user_a):
-    '''Return a translation.
+    """Return a translation.
 
     Note that we require the `project_locale_a` fixture because a
     valid ProjectLocale is needed in order to query Translations.
-
-    '''
-    return factories.TranslationFactory(
+    """
+    translation_a = factories.TranslationFactory(
         entity=entity_a,
         locale=locale_a,
         user=user_a,
         string='Translation for entity_a',
     )
+    translation_a.locale.refresh_from_db()
+    translation_a.entity.resource.project.refresh_from_db()
+    return translation_a
 
 
 @pytest.fixture

--- a/pontoon/test/fixtures/base.py
+++ b/pontoon/test/fixtures/base.py
@@ -82,6 +82,13 @@ def project_b():
 
 
 @pytest.fixture
+def system_project_a():
+    return factories.ProjectFactory(
+        slug="system_project_a", name="System Project A", repositories=[], system_project=True,
+    )
+
+
+@pytest.fixture
 def resource_a(project_a):
     return factories.ResourceFactory(
         project=project_a, path="resource_a.po", format="po"


### PR DESCRIPTION
As of now, translation changes to invisible projects (e.g. system project like tutorial) do update the latest activity column shown on all teams dashboard. That's kind of confusing, since you cannot click through to that system project from any dashboards. As the name suggests, the project is invisible there.

This change omits updating `latest_translation` for a locale if the translation is being saved for a system project. Note, that `latest_translation` is still updated in all other tables, including `project_locale`, because the dashboard of an invisible project is still accessible via direct link or from its translation view and the latest activity should be displayed there.

I have written a small unit test for the behaviour. Also I have tested the patch manually in local setup. Exact steps to reproduce can be found in the bug, though in the local setup you need to add at least one visible project, so the teams dashboard can show something interesting.