### PR TITLE
Fix bug 1579745: Set Locale-specific attributes in Fluent Rich Editor

### DIFF
--- a/frontend/src/modules/fluenteditor/components/RichTranslationForm.js
+++ b/frontend/src/modules/fluenteditor/components/RichTranslationForm.js
@@ -237,6 +237,9 @@ export default class RichTranslationForm extends React.Component<EditorProps> {
             value={ value }
             onChange={ this.createHandleChange(path) }
             onFocus={ this.setFocusedInput }
+            dir={ this.props.locale.direction }
+            lang={ this.props.locale.code }
+            data-script={ this.props.locale.script }
         />;
     }
 

--- a/frontend/src/modules/fluenteditor/components/RichTranslationForm.test.js
+++ b/frontend/src/modules/fluenteditor/components/RichTranslationForm.test.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+import sinon from 'sinon';
+
+import { fluent } from 'core/utils';
+
+import RichTranslationForm from './RichTranslationForm';
+
+
+const DEFAULT_LOCALE = {
+    direction: 'ltr',
+    code: 'kg',
+    script: 'Latin',
+};
+
+const TRANSLATION = fluent.parser.parseEntry(
+    'message = Value\n    .attr-1 = And\n    .attr-2 = Attributes'
+)
+
+const EDITOR = {
+    translation: TRANSLATION,
+    errors: [],
+    warnings: [],
+};
+
+
+describe('<RichTranslationForm>', () => {
+    it('renders textarea for a value and each attribute', () => {
+        const updateMock = sinon.stub();
+
+        const wrapper = shallow(<RichTranslationForm
+            editor={ EDITOR }
+            locale={ DEFAULT_LOCALE }
+            updateTranslation={ updateMock }
+        />);
+
+        expect(wrapper.find('textarea')).toHaveLength(3);
+        expect(wrapper.find('textarea').at(0).html()).toContain('Value');
+        expect(wrapper.find('textarea').at(1).html()).toContain('And');
+        expect(wrapper.find('textarea').at(2).html()).toContain('Attributes');
+    });
+
+    it('calls the updateTranslation function on mount and change', () => {
+        const updateMock = sinon.spy();
+
+        const wrapper = shallow(<RichTranslationForm
+            editor={ EDITOR }
+            locale={ DEFAULT_LOCALE }
+            updateTranslation={ updateMock }
+        />);
+
+        expect(updateMock.calledOnce).toBeTruthy();
+        wrapper.find('textarea').at(0).simulate('change', { currentTarget: { value: 'good bye' } });
+        expect(updateMock.calledTwice).toBeTruthy();
+    });
+});


### PR DESCRIPTION
And add basic tests for `RichTranslationForm.js`.