### PR TITLE
Fix bug 1579746: Set read-only attribute in Fluent Rich Editor

### DIFF
--- a/frontend/src/core/editor/components/connectedEditor.css
+++ b/frontend/src/core/editor/components/connectedEditor.css
@@ -30,6 +30,7 @@
 
 .editor textarea[readonly] {
     background: #C7CACF;
+    cursor: default;
 }
 
 .editor textarea[data-script="Arabic"] {

--- a/frontend/src/modules/fluenteditor/components/RichTranslationForm.js
+++ b/frontend/src/modules/fluenteditor/components/RichTranslationForm.js
@@ -234,6 +234,7 @@ export default class RichTranslationForm extends React.Component<EditorProps> {
         return <textarea
             id={ `${path.join('-')}` }
             key={ `${path.join('-')}` }
+            readOnly={ this.props.isReadOnlyEditor }
             value={ value }
             onChange={ this.createHandleChange(path) }
             onFocus={ this.setFocusedInput }

--- a/frontend/src/modules/fluenteditor/components/RichTranslationForm.test.js
+++ b/frontend/src/modules/fluenteditor/components/RichTranslationForm.test.js
@@ -26,12 +26,10 @@ const EDITOR = {
 
 describe('<RichTranslationForm>', () => {
     it('renders textarea for a value and each attribute', () => {
-        const updateMock = sinon.stub();
-
         const wrapper = shallow(<RichTranslationForm
             editor={ EDITOR }
             locale={ DEFAULT_LOCALE }
-            updateTranslation={ updateMock }
+            updateTranslation={ sinon.stub() }
         />);
 
         expect(wrapper.find('textarea')).toHaveLength(3);
@@ -52,5 +50,24 @@ describe('<RichTranslationForm>', () => {
         expect(updateMock.calledOnce).toBeTruthy();
         wrapper.find('textarea').at(0).simulate('change', { currentTarget: { value: 'good bye' } });
         expect(updateMock.calledTwice).toBeTruthy();
+    });
+
+    it('updates the translation when selectionReplacementContent is passed', () => {
+        const resetMock = sinon.stub();
+        const updateMock = sinon.stub();
+
+        const wrapper = mount(<RichTranslationForm
+            editor={ EDITOR }
+            locale={ DEFAULT_LOCALE }
+            unsavedchanges={ { shown: false } }
+            resetSelectionContent={ resetMock }
+            updateTranslation={ updateMock }
+            updateUnsavedChanges={ sinon.stub() }
+        />);
+
+        wrapper.setProps({ editor: { ...EDITOR, selectionReplacementContent: 'hello ' } });
+
+        expect(updateMock.calledTwice).toBeTruthy();
+        expect(resetMock.calledOnce).toBeTruthy();
     });
 });


### PR DESCRIPTION
And keep default cursor above read-only `<textarea>` elements.