### PR TITLE
Fix bug 1580211: Add Support for strings with SelectExpressions

### DIFF
--- a/frontend/src/core/utils/fluent/areSupportedElements.js
+++ b/frontend/src/core/utils/fluent/areSupportedElements.js
@@ -7,21 +7,19 @@ import isSimpleElement from './isSimpleElement';
  *
  * Elements are supported if they are:
  * - simple elements or
- * - select expressions
+ * - select expressions, whose variants are simple elements
  */
 export default function areSupportedElements(elements: Array<Object>) {
-    return elements.every(isSimpleElement);
-    // We don't yet support Select Expressions, but soon.
-    // return elements.every(element => {
-    //     return (
-    //         isSimpleElement(element) ||
-    //         (
-    //             element.type === 'Placeable' &&
-    //             element.expression.type === 'SelectExpression' &&
-    //             element.expression.variants.every(variant =>  {
-    //                 return variant.value.elements.every(element => isSimpleElement(element));
-    //             })
-    //         )
-    //     );
-    // });
+    return elements.every(element => {
+        return (
+            isSimpleElement(element) ||
+            (
+                element.type === 'Placeable' &&
+                element.expression.type === 'SelectExpression' &&
+                element.expression.variants.every(variant =>  {
+                    return variant.value.elements.every(element => isSimpleElement(element));
+                })
+            )
+        );
+    });
 }

--- a/frontend/src/core/utils/fluent/flattenMessage.js
+++ b/frontend/src/core/utils/fluent/flattenMessage.js
@@ -19,13 +19,13 @@ import type { FluentMessage } from './types';
 export default function flattenMessage(message: FluentMessage): FluentMessage {
     const flatMessage = message.clone();
 
-    if (flatMessage.value && flatMessage.value.elements.length > 1) {
+    if (flatMessage.value && flatMessage.value.elements.length > 0) {
         flatMessage.value.elements = flattenElements(flatMessage.value.elements);
     }
 
     if (flatMessage.attributes) {
         flatMessage.attributes.forEach(attribute => {
-            if (attribute.value && attribute.value.elements.length > 1) {
+            if (attribute.value && attribute.value.elements.length > 0) {
                 attribute.value.elements = flattenElements(attribute.value.elements);
             }
         });

--- a/frontend/src/core/utils/fluent/flattenMessage.test.js
+++ b/frontend/src/core/utils/fluent/flattenMessage.test.js
@@ -6,6 +6,7 @@ describe('flattenMessage', () => {
     it('does not modify value with single element', () => {
         const message = parser.parseEntry('title = My Title');
         const res = flattenMessage(message);
+
         expect(res.value.elements).toHaveLength(1);
         expect(res.value.elements[0].value).toEqual('My Title');
     });
@@ -13,9 +14,24 @@ describe('flattenMessage', () => {
     it('does not modify attributes with single element', () => {
         const message = parser.parseEntry('title =\n    .foo = Bar');
         const res = flattenMessage(message);
+
         expect(res.attributes).toHaveLength(1);
         expect(res.attributes[0].value.elements).toHaveLength(1);
         expect(res.attributes[0].value.elements[0].value).toEqual('Bar');
+    });
+
+    it('does not modify value with a single select expression', () => {
+        const input = 'my-entry =' +
+            '\n    { PLATFORM() ->' +
+            '\n        [variant] Hello!' +
+            '\n       *[another-variant] World!' +
+            '\n    }';
+        const message = parser.parseEntry(input);
+        const res = flattenMessage(message);
+
+        expect(res.value.elements).toHaveLength(1);
+        expect(res.value.elements[0].expression.variants[0].value.elements[0].value).toEqual('Hello!');
+        expect(res.value.elements[0].expression.variants[1].value.elements[0].value).toEqual('World!');
     });
 
     it('flattens a value with several elements', () => {
@@ -24,6 +40,7 @@ describe('flattenMessage', () => {
         expect(message.value.elements).toHaveLength(3);
 
         const res = flattenMessage(message);
+
         expect(res.value.elements).toHaveLength(1);
         expect(res.value.elements[0].value).toEqual('My { $awesome } Title');
     });
@@ -34,6 +51,7 @@ describe('flattenMessage', () => {
         expect(message.attributes[0].value.elements).toHaveLength(3);
 
         const res = flattenMessage(message);
+
         expect(res.attributes).toHaveLength(1);
         expect(res.attributes[0].value.elements).toHaveLength(1);
         expect(res.attributes[0].value.elements[0].value).toEqual('Bar { -foo } Baz');
@@ -65,5 +83,31 @@ describe('flattenMessage', () => {
         expect(res.attributes[1].value.elements[0].value).toEqual(
             'Lost { 2 } parents, has { 1 } "$alfred"'
         );
+    });
+
+    it('flattens values surrounding a select expression and select expression variants', () => {
+        const input = 'my-entry =' +
+            '\n    There { $num ->' +
+            '\n        [one] is one email' +
+            '\n       *[other] are { $num } emails' +
+            '\n    } for { $awesome } { $gender ->' +
+            '\n       *[masculine] him' +
+            '\n        [feminine] her' +
+            '\n    }';
+        const message = parser.parseEntry(input);
+        const res = flattenMessage(message);
+
+        expect(res.value.elements).toHaveLength(4);
+
+        expect(res.value.elements[0].value).toEqual('There ');
+
+        expect(res.value.elements[1].expression.variants[0].value.elements[0].value).toEqual('is one email');
+        expect(res.value.elements[1].expression.variants[1].value.elements[0].value).toEqual('are { $num } emails');
+
+        expect(res.value.elements[2].value).toEqual(' for { $awesome } ');
+
+        expect(res.value.elements[3].expression.variants[0].value.elements[0].value).toEqual('him');
+        expect(res.value.elements[3].expression.variants[1].value.elements[0].value).toEqual('her');
+
     });
 });

--- a/frontend/src/core/utils/fluent/getEmptyMessage.js
+++ b/frontend/src/core/utils/fluent/getEmptyMessage.js
@@ -2,6 +2,8 @@
 
 import { Transformer } from 'fluent-syntax';
 
+import flattenMessage from './flattenMessage';
+
 import type { FluentMessage } from './types';
 
 
@@ -26,6 +28,12 @@ export default function getEmptyMessage(source: FluentMessage): FluentMessage {
     }
 
     const message = source.clone();
+
+    // Convert all simple elements to TextElements
+    const flatMessage = flattenMessage(message);
+
+    // Empty TextElements
     const transformer = new EmptyTransformer();
-    return transformer.visit(message);
+
+    return transformer.visit(flatMessage);
 }

--- a/frontend/src/core/utils/fluent/getEmptyMessage.test.js
+++ b/frontend/src/core/utils/fluent/getEmptyMessage.test.js
@@ -8,6 +8,15 @@ describe('getEmptyMessage', () => {
         const message = getEmptyMessage(source);
 
         expect(message.value.elements[0].value).toEqual('');
+        expect(message.value.elements).toHaveLength(1);
+    });
+
+    it('empties a value with multiple elements', () => {
+        const source = parser.parseEntry('my-message = Hello { $small } World');
+        const message = getEmptyMessage(source);
+
+        expect(message.value.elements[0].value).toEqual('');
+        expect(message.value.elements).toHaveLength(1);
     });
 
     it('empties a single simple attribute', () => {
@@ -15,7 +24,9 @@ describe('getEmptyMessage', () => {
         const message = getEmptyMessage(source);
 
         expect(message.attributes[0].id.name).toEqual('my-attr');
+
         expect(message.attributes[0].value.elements[0].value).toEqual('');
+        expect(message.attributes[0].value.elements).toHaveLength(1);
     });
 
     it('empties both value and attributes', () => {
@@ -23,8 +34,11 @@ describe('getEmptyMessage', () => {
         const message = getEmptyMessage(source);
 
         expect(message.value.elements[0].value).toEqual('');
+        expect(message.value.elements).toHaveLength(1);
+
         expect(message.attributes[0].id.name).toEqual('my-attr');
         expect(message.attributes[0].value.elements[0].value).toEqual('');
+        expect(message.attributes[0].value.elements).toHaveLength(1);
     });
 
     it('empties several attributes', () => {
@@ -33,7 +47,27 @@ describe('getEmptyMessage', () => {
 
         expect(message.attributes[0].id.name).toEqual('my-attr');
         expect(message.attributes[0].value.elements[0].value).toEqual('');
+        expect(message.attributes[0].value.elements).toHaveLength(1);
+
         expect(message.attributes[1].id.name).toEqual('title');
         expect(message.attributes[1].value.elements[0].value).toEqual('');
+        expect(message.attributes[1].value.elements).toHaveLength(1);
     });
+
+    it('empties a select expression', () => {
+        const input = `
+my-entry =
+    { PLATFORM() ->
+        [variant] Hello!
+       *[another-variant] { reference } World!
+    }`;
+        const source = parser.parseEntry(input);
+        const message = getEmptyMessage(source);
+
+        expect(message.value.elements[0].expression.variants[0].value.elements[0].value).toEqual('');
+        expect(message.value.elements[0].expression.variants[0].value.elements).toHaveLength(1);
+
+        expect(message.value.elements[0].expression.variants[1].value.elements[0].value).toEqual('');
+        expect(message.value.elements[0].expression.variants[1].value.elements).toHaveLength(1);
+   });
 });

--- a/frontend/src/core/utils/fluent/getSyntaxType.js
+++ b/frontend/src/core/utils/fluent/getSyntaxType.js
@@ -13,9 +13,9 @@ import type { FluentMessage, SyntaxType } from './types';
  * @param {FluentMessage} message A Fluent message (AST) to analyze.
  *
  * @returns {string} The syntax type of the Fluent message. Can be one of:
- *      - "simple": can be previewed as a simple string;
- *      - "rich": can be shown in a rich UI;
- *      - "complex": isn't supported by our system yet.
+ *      - "simple": can be shown as a simple string in generic editor;
+ *      - "rich": can be shown in a rich editor;
+ *      - "complex": can only be shown in a source editor.
  */
 export default function getSyntaxType(message: FluentMessage): SyntaxType {
     if (!isSupportedMessage(message)) {

--- a/frontend/src/core/utils/fluent/getSyntaxType.test.js
+++ b/frontend/src/core/utils/fluent/getSyntaxType.test.js
@@ -10,6 +10,66 @@ describe('getSyntaxType', () => {
         expect(getSyntaxType(message)).toEqual('simple');
     });
 
+    it('returns "simple" for a string with multiline value', () => {
+        const input = `
+my-entry =
+    Multi
+    line
+    value.`;
+        const message = parser.parseEntry(input);
+
+        expect(getSyntaxType(message)).toEqual('simple');
+    });
+
+    it('returns "simple" for a string with a reference to a built-in function', () => {
+        const input = 'my-entry = Today is { DATETIME($date, month: "long", year: "numeric", day: "numeric") }';
+        const message = parser.parseEntry(input);
+
+        expect(getSyntaxType(message)).toEqual('simple');
+    });
+
+    it('returns "simple" for a string with a Term', () => {
+        const input = '-my-entry = Hello!';
+        const message = parser.parseEntry(input);
+
+        expect(getSyntaxType(message)).toEqual('simple');
+    });
+
+    it('returns "simple" for a string with a TermReference', () => {
+        const input = 'my-entry = Term { -term } Reference';
+        const message = parser.parseEntry(input);
+
+        expect(getSyntaxType(message)).toEqual('simple');
+    });
+
+    it('returns "simple" for a string with a MessageReference', () => {
+        const input = 'my-entry = { my_id }';
+        const message = parser.parseEntry(input);
+
+        expect(getSyntaxType(message)).toEqual('simple');
+    });
+
+    it('returns "simple" for a string with a MessageReference with attribute', () => {
+        const input = 'my-entry = { my_id.title }';
+        const message = parser.parseEntry(input);
+
+        expect(getSyntaxType(message)).toEqual('simple');
+    });
+
+    it('returns "simple" for a string with a StringExpression', () => {
+        const input = 'my-entry = { "" }';
+        const message = parser.parseEntry(input);
+
+        expect(getSyntaxType(message)).toEqual('simple');
+    });
+
+    it('returns "simple" for a string with a NumberExpression', () => {
+        const input = 'my-entry = { 5 }';
+        const message = parser.parseEntry(input);
+
+        expect(getSyntaxType(message)).toEqual('simple');
+    });
+
     it('returns "simple" for a string with a single simple attribute', () => {
         const input = 'my-entry = \n    .an-atribute = Hello!';
         const message = parser.parseEntry(input);
@@ -24,8 +84,76 @@ describe('getSyntaxType', () => {
         expect(getSyntaxType(message)).toEqual('rich');
     });
 
-    it('returns "complex" for a string with a selector', () => {
-        const input = 'my-entry = Hello { $who -> \n    [world] World\n    [you] You }';
+    it('returns "rich" for a string with no value and two attributes', () => {
+        const input = `
+my-entry =
+    .an-atribute = Hello!
+    .another-atribute = World!`;
+        const message = parser.parseEntry(input);
+
+        expect(getSyntaxType(message)).toEqual('rich');
+    });
+
+    it('returns "rich" for a string with a select expression', () => {
+        const input = `
+my-entry =
+    { PLATFORM() ->
+        [variant] Hello!
+       *[another-variant] World!
+    }`;
+        const message = parser.parseEntry(input);
+
+        expect(getSyntaxType(message)).toEqual('rich');
+    });
+
+    it('returns "rich" for a string with a double select expression in attribute', () => {
+        const input = `
+my-entry =
+    .label =
+        { PLATFORM() ->
+            [macos] Choose
+           *[other] Browse
+        }
+    .accesskey =
+        { PLATFORM() ->
+            [macos] e
+           *[other] o
+        }`;
+        const message = parser.parseEntry(input);
+
+        expect(getSyntaxType(message)).toEqual('rich');
+    });
+
+    it('returns "rich" for a string with multiple select expressions and surrounding text', () => {
+        const input = `
+my-entry =
+    There { $num ->
+        [one] is one email
+       *[other] are many emails
+    } for { $gender ->
+       *[masculine] him
+        [feminine] her
+    }`;
+        const message = parser.parseEntry(input);
+
+        expect(getSyntaxType(message)).toEqual('rich');
+    });
+
+    it('returns "complex" for a string with nested select expressions', () => {
+        const input = `
+my-entry =
+    { $gender ->
+       *[masculine]
+            { $num ->
+                [one] There is one email for her
+               *[other] There are many emails for her
+            }
+        [feminine]
+            { $num ->
+                [one] There is one email for him
+               *[other] There are many emails for him
+            }
+    }`;
         const message = parser.parseEntry(input);
 
         expect(getSyntaxType(message)).toEqual('complex');

--- a/frontend/src/core/utils/fluent/types.js
+++ b/frontend/src/core/utils/fluent/types.js
@@ -1,8 +1,19 @@
 /* @flow */
 
+export type FluentExpressionVariant = {
+    key: string,
+    value: FluentValue,
+};
+
+export type FluentExpression = {
+    type: string,
+    variants: Array<FluentExpressionVariant>,
+};
+
 export type FluentElement = {
     type: string,
     value: string,
+    expression: FluentExpression,
 };
 
 export type FluentValue = {

--- a/frontend/src/modules/fluenteditor/components/RichTranslationForm.css
+++ b/frontend/src/modules/fluenteditor/components/RichTranslationForm.css
@@ -28,6 +28,10 @@
     padding: 0 4px;
 }
 
+.fluent-rich-translation-form table tr.indented > td > label {
+    margin-left: 10px;
+}
+
 .fluent-rich-translation-form table tr > td > textarea {
     min-height: 0;
     height: 24px;

--- a/frontend/src/modules/fluenteditor/components/RichTranslationForm.css
+++ b/frontend/src/modules/fluenteditor/components/RichTranslationForm.css
@@ -2,6 +2,7 @@
     height: 100%;
     line-height: 22px;
     padding: 10px;
+    overflow: auto;
 }
 
 .fluent-rich-translation-form table {

--- a/frontend/src/modules/fluenteditor/components/RichTranslationForm.js
+++ b/frontend/src/modules/fluenteditor/components/RichTranslationForm.js
@@ -312,7 +312,7 @@ export class RichTranslationFormBase extends React.Component<InternalProps> {
         this.focusedElementId = event.currentTarget.id;
     }
 
-    renderInput(value: string, index: number, path: MessagePath) {
+    renderInput(value: string, path: MessagePath) {
         return <textarea
             id={ `${path.join('-')}` }
             key={ `${path.join('-')}` }
@@ -344,7 +344,7 @@ export class RichTranslationFormBase extends React.Component<InternalProps> {
                     <label htmlFor={ `${eltPath.join('-')}` }>{ label }</label>
                 </td>
                 <td>
-                    { this.renderInput(element.value, index, eltPath) }
+                    { this.renderInput(element.value, eltPath) }
                 </td>
             </tr>;
         });

--- a/frontend/src/modules/fluenteditor/components/RichTranslationForm.js
+++ b/frontend/src/modules/fluenteditor/components/RichTranslationForm.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import * as React from 'react';
+import { serializeVariantKey } from 'fluent-syntax';
 
 import './RichTranslationForm.css';
 
@@ -327,26 +328,38 @@ export class RichTranslationFormBase extends React.Component<InternalProps> {
         />;
     }
 
-    renderElements(
-        elements: Array<FluentElement>,
-        path: MessagePath,
-        label: string,
-    ): React.Node {
+    renderItem(value: string, path: MessagePath, label: string) {
+        return <tr key={ `${path.join('-')}` }>
+            <td>
+                <label htmlFor={ `${path.join('-')}` }>{ label }</label>
+            </td>
+            <td>
+                { this.renderInput(value, path) }
+            </td>
+        </tr>;
+    }
+
+    renderElements(elements: Array<FluentElement>, path: MessagePath, label: string): React.Node {
         return elements.map((element, index) => {
-            if (element.type !== 'TextElement') {
-                return null;
+            if (element.type === 'Placeable' && element.expression.type === 'SelectExpression') {
+                return element.expression.variants.map((variant, i) => {
+                    return this.renderItem(
+                        variant.value.elements[0].value,
+                        [].concat(
+                            path,
+                            [ index, 'expression', 'variants', i, 'value', 'elements', 0, 'value' ]
+                        ),
+                        serializeVariantKey(variant.key),
+                    );
+                });
             }
-
-            const eltPath = [].concat(path, [ index, 'value' ]);
-
-            return <tr key={ `${eltPath.join('-')}` }>
-                <td>
-                    <label htmlFor={ `${eltPath.join('-')}` }>{ label }</label>
-                </td>
-                <td>
-                    { this.renderInput(element.value, eltPath) }
-                </td>
-            </tr>;
+            else {
+                return this.renderItem(
+                    element.value,
+                    [].concat(path, [ index, 'value' ]),
+                    label,
+                );
+            }
         });
     }
 

--- a/frontend/src/modules/fluenteditor/components/RichTranslationForm.js
+++ b/frontend/src/modules/fluenteditor/components/RichTranslationForm.js
@@ -328,8 +328,8 @@ export class RichTranslationFormBase extends React.Component<InternalProps> {
         />;
     }
 
-    renderItem(value: string, path: MessagePath, label: string) {
-        return <tr key={ `${path.join('-')}` }>
+    renderItem(value: string, path: MessagePath, label: string, className: ?string) {
+        return <tr key={ `${path.join('-')}` } className={ className }>
             <td>
                 <label htmlFor={ `${path.join('-')}` }>{ label }</label>
             </td>
@@ -340,9 +340,11 @@ export class RichTranslationFormBase extends React.Component<InternalProps> {
     }
 
     renderElements(elements: Array<FluentElement>, path: MessagePath, label: string): React.Node {
+        let indent = false;
+
         return elements.map((element, index) => {
             if (element.type === 'Placeable' && element.expression.type === 'SelectExpression') {
-                return element.expression.variants.map((variant, i) => {
+                const variantItems = element.expression.variants.map((variant, i) => {
                     return this.renderItem(
                         variant.value.elements[0].value,
                         [].concat(
@@ -350,10 +352,14 @@ export class RichTranslationFormBase extends React.Component<InternalProps> {
                             [ index, 'expression', 'variants', i, 'value', 'elements', 0, 'value' ]
                         ),
                         serializeVariantKey(variant.key),
+                        indent ? 'indented' : null,
                     );
                 });
+                indent = false;
+                return variantItems;
             }
             else {
+                indent = true;
                 return this.renderItem(
                     element.value,
                     [].concat(path, [ index, 'value' ]),

--- a/frontend/src/modules/fluentoriginal/components/RichString.css
+++ b/frontend/src/modules/fluentoriginal/components/RichString.css
@@ -24,6 +24,10 @@
     padding: 0 4px;
 }
 
+.fluent-rich-string tr.indented > td > label {
+    margin-left: 10px;
+}
+
 .fluent-rich-string tr > td > span {
     box-sizing: border-box;
     line-height: 28px;

--- a/frontend/src/modules/fluentoriginal/components/RichString.css
+++ b/frontend/src/modules/fluentoriginal/components/RichString.css
@@ -26,6 +26,6 @@
 
 .fluent-rich-string tr > td > span {
     box-sizing: border-box;
-    line-height: 24px;
+    line-height: 28px;
     margin: 2px 0;
 }

--- a/frontend/src/modules/fluentoriginal/components/RichString.js
+++ b/frontend/src/modules/fluentoriginal/components/RichString.js
@@ -27,8 +27,9 @@ function renderItem(
     value: string,
     label: string,
     key: string,
+    className: ?string,
 ): React.Node {
-    return <tr key={ key }>
+    return <tr key={ key } className={ className }>
         <td>
             <label>{ label }</label>
         </td>
@@ -47,17 +48,22 @@ function renderElements(
     elements: Array<FluentElement>,
     label: string,
 ): React.Node {
+    let indent = false;
     return elements.map((element, index) => {
         if (element.type === 'Placeable' && element.expression.type === 'SelectExpression') {
-            return element.expression.variants.map((variant, i) => {
+            const variantItems = element.expression.variants.map((variant, i) => {
                 return renderItem(
                     variant.value.elements[0].value,
                     serializeVariantKey(variant.key),
                     [index, i].join('-'),
+                    indent ? 'indented' : null,
                 );
             });
+            indent = false;
+            return variantItems;
         }
         else {
+            indent = true;
             return renderItem(
                 element.value,
                 label,

--- a/frontend/src/modules/fluentoriginal/components/RichString.js
+++ b/frontend/src/modules/fluentoriginal/components/RichString.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import * as React from 'react';
+import { serializeVariantKey } from 'fluent-syntax';
 
 import './RichString.css';
 
@@ -22,27 +23,47 @@ type Props = {|
 |};
 
 
+function renderItem(
+    value: string,
+    label: string,
+    key: string,
+): React.Node {
+    return <tr key={ key }>
+        <td>
+            <label>{ label }</label>
+        </td>
+        <td>
+            <span>
+                <WithPlaceablesForFluent>
+                    { value }
+                </WithPlaceablesForFluent>
+            </span>
+        </td>
+    </tr>;
+}
+
+
 function renderElements(
     elements: Array<FluentElement>,
     label: string,
 ): React.Node {
-    return elements.map((element, i) => {
-        if (element.type !== 'TextElement') {
-            return null;
+    return elements.map((element, index) => {
+        if (element.type === 'Placeable' && element.expression.type === 'SelectExpression') {
+            return element.expression.variants.map((variant, i) => {
+                return renderItem(
+                    variant.value.elements[0].value,
+                    serializeVariantKey(variant.key),
+                    [index, i].join('-'),
+                );
+            });
         }
-
-        return <tr key={ i }>
-            <td>
-                <label>{ label }</label>
-            </td>
-            <td>
-                <span>
-                    <WithPlaceablesForFluent>
-                        { element.value }
-                    </WithPlaceablesForFluent>
-                </span>
-            </td>
-        </tr>;
+        else {
+            return renderItem(
+                element.value,
+                label,
+                index.toString(),
+            );
+        }
     });
 }
 


### PR DESCRIPTION
This patch brings support for strings with `SelectExpressions` in the `RichEditor` and `RichString` components.

The first 4 commits are setting the stage by adapting the reusable functions to support `SelectExpressions`. The last 3 commits bring stylistic changes. Which leaves 197231b (editor) and 54eccdf (source string panel) to be the gist of this patch.

I'll probably block landing of this patch on [bug 1580213](https://bugzilla.mozilla.org/show_bug.cgi?id=1580213), because having just a general SelectExpression UI handle plurals might lead to some damage.