### PR TITLE
Fix bug 1543345: Implement Fluent Source Editor shortcuts

### DIFF
--- a/frontend/src/modules/fluenteditor/components/SourceTranslationForm.js
+++ b/frontend/src/modules/fluenteditor/components/SourceTranslationForm.js
@@ -45,6 +45,11 @@ export default class SourceTranslationForm extends React.Component<EditorProps> 
 
     componentDidMount() {
         this.focusInput(true);
+
+        if (this.aceEditor.current) {
+            const textInput = this.aceEditor.current.editor.textInput.getElement();
+            textInput.onkeydown = this.props.handleShortcuts;
+        }
     }
 
     componentDidUpdate(prevProps: EditorProps) {

--- a/frontend/src/modules/genericeditor/components/GenericTranslationForm.js
+++ b/frontend/src/modules/genericeditor/components/GenericTranslationForm.js
@@ -2,25 +2,16 @@
 
 import * as React from 'react';
 
-import { withActionsDisabled } from 'core/utils';
-
 import type { EditorProps } from 'core/editor';
-
-
-type InternalProps = {|
-    ...EditorProps,
-    isActionDisabled: boolean,
-    disableAction: () => void,
-|};
 
 
 /*
  * Render a simple textarea to edit a translation.
  */
-export class GenericTranslationFormBase extends React.Component<InternalProps> {
+export default class GenericTranslationForm extends React.Component<EditorProps> {
     textarea: { current: any };
 
-    constructor(props: InternalProps) {
+    constructor(props: EditorProps) {
         super(props);
 
         this.textarea = React.createRef();
@@ -30,7 +21,7 @@ export class GenericTranslationFormBase extends React.Component<InternalProps> {
         this.focusInput(true);
     }
 
-    componentDidUpdate(prevProps: InternalProps) {
+    componentDidUpdate(prevProps: EditorProps) {
         // Unused by Generic Editor - reset to default value.
         if (this.props.editor.initialTranslation) {
             return this.props.setInitialTranslation('');
@@ -118,80 +109,6 @@ export class GenericTranslationFormBase extends React.Component<InternalProps> {
         this.props.updateTranslation(event.currentTarget.value);
     }
 
-    handleShortcuts = (event: SyntheticKeyboardEvent<HTMLTextAreaElement>) => {
-        const key = event.keyCode;
-
-        let handledEvent = false;
-
-        // On Enter:
-        //   - If unsaved changes popup is shown, leave anyway.
-        //   - If failed checks popup is shown after approving a translation, approve it anyway.
-        //   - In other cases, send current translation.
-        if (key === 13 && !event.ctrlKey && !event.shiftKey && !event.altKey) {
-            if (this.props.isActionDisabled) {
-                event.preventDefault();
-                return;
-            }
-            this.props.disableAction();
-
-            handledEvent = true;
-
-            const errors = this.props.editor.errors;
-            const warnings = this.props.editor.warnings;
-            const source = this.props.editor.source;
-            const ignoreWarnings = !!(errors.length || warnings.length);
-
-            // Leave anyway
-            if (this.props.unsavedchanges.shown) {
-                this.props.ignoreUnsavedChanges();
-            }
-            // Approve anyway
-            else if (typeof(source) === 'number') {
-                this.props.updateTranslationStatus(source, 'approve', ignoreWarnings);
-            }
-            // Send translation
-            else {
-                this.props.sendTranslation(ignoreWarnings);
-            }
-        }
-
-        // On Esc, close unsaved changes and failed checks popups if open.
-        if (key === 27) {
-            handledEvent = true;
-
-            const errors = this.props.editor.errors;
-            const warnings = this.props.editor.warnings;
-
-            // Close unsaved changes popup
-            if (this.props.unsavedchanges.shown) {
-                this.props.hideUnsavedChanges();
-            }
-            // Close failed checks popup
-            else if (errors.length || warnings.length) {
-                this.props.resetFailedChecks();
-            }
-        }
-
-        // On Ctrl + Shift + C, copy the original translation.
-        if (key === 67 && event.ctrlKey && event.shiftKey && !event.altKey) {
-            handledEvent = true;
-            this.props.copyOriginalIntoEditor();
-        }
-
-        // On Ctrl + Shift + Backspace, clear the content.
-        if (key === 8 && event.ctrlKey && event.shiftKey && !event.altKey) {
-            handledEvent = true;
-            this.props.updateTranslation('', true);
-        }
-
-        // On Tab, walk through current helper tab content and copy it.
-        // TODO
-
-        if (handledEvent) {
-            event.preventDefault();
-        }
-    }
-
     render() {
         return <textarea
             placeholder={
@@ -201,7 +118,7 @@ export class GenericTranslationFormBase extends React.Component<InternalProps> {
             readOnly={ this.props.isReadOnlyEditor }
             ref={ this.textarea }
             value={ this.props.editor.translation }
-            onKeyDown={ this.handleShortcuts }
+            onKeyDown={ this.props.handleShortcuts }
             onChange={ this.handleChange }
             dir={ this.props.locale.direction }
             lang={ this.props.locale.code }
@@ -209,6 +126,3 @@ export class GenericTranslationFormBase extends React.Component<InternalProps> {
         />;
     }
 }
-
-
-export default withActionsDisabled(GenericTranslationFormBase);

--- a/frontend/src/modules/genericeditor/components/GenericTranslationForm.test.js
+++ b/frontend/src/modules/genericeditor/components/GenericTranslationForm.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount, shallow } from 'enzyme';
 import sinon from 'sinon';
 
-import { GenericTranslationFormBase } from './GenericTranslationForm';
+import GenericTranslationForm from './GenericTranslationForm';
 
 
 const DEFAULT_LOCALE = {
@@ -18,9 +18,9 @@ const EDITOR = {
 };
 
 
-describe('<GenericTranslationFormBase>', () => {
+describe('<GenericTranslationForm>', () => {
     it('renders a textarea with some content', () => {
-        const wrapper = shallow(<GenericTranslationFormBase
+        const wrapper = shallow(<GenericTranslationForm
             editor={ EDITOR }
             locale={ DEFAULT_LOCALE }
         />);
@@ -31,7 +31,7 @@ describe('<GenericTranslationFormBase>', () => {
 
     it('calls the updateTranslation function on change', () => {
         const mockUpdate = sinon.spy();
-        const wrapper = shallow(<GenericTranslationFormBase
+        const wrapper = shallow(<GenericTranslationForm
             editor={ EDITOR }
             locale={ DEFAULT_LOCALE }
             updateTranslation={ mockUpdate }
@@ -46,7 +46,7 @@ describe('<GenericTranslationFormBase>', () => {
         const resetMock = sinon.stub();
         const updateMock = sinon.stub();
 
-        const wrapper = mount(<GenericTranslationFormBase
+        const wrapper = mount(<GenericTranslationForm
             editor={ EDITOR }
             locale={ DEFAULT_LOCALE }
             unsavedchanges={ { shown: false } }
@@ -60,171 +60,5 @@ describe('<GenericTranslationFormBase>', () => {
         expect(updateMock.calledOnce).toBeTruthy();
         expect(updateMock.calledWith('hello world')).toBeTruthy();
         expect(resetMock.calledOnce).toBeTruthy();
-    });
-
-    it('sends the translation on Enter', () => {
-        const mockSend = sinon.spy();
-        const wrapper = shallow(<GenericTranslationFormBase
-            editor={ EDITOR }
-            locale={ DEFAULT_LOCALE }
-            sendTranslation={ mockSend }
-            disableAction={ sinon.spy() }
-            unsavedchanges={ { shown: false } }
-        />);
-
-        const event = {
-            preventDefault: sinon.spy(),
-            keyCode: 13,  // Enter
-            altKey: false,
-            ctrlKey: false,
-            shiftKey: false,
-        };
-
-        expect(mockSend.calledOnce).toBeFalsy();
-        wrapper.find('textarea').simulate('keydown', event);
-        expect(mockSend.calledOnce).toBeTruthy();
-    });
-
-    it('approves the translation on Enter if failed checks triggered by approval', () => {
-        const mockSend = sinon.spy();
-
-        const editor = {
-            ...EDITOR,
-            errors: ['error1'],
-            warnings: ['warning1'],
-            source: 1,
-        }
-
-        const wrapper = shallow(<GenericTranslationFormBase
-            editor={ editor }
-            locale={ DEFAULT_LOCALE }
-            updateTranslationStatus={ mockSend }
-            disableAction={ sinon.spy() }
-            unsavedchanges={ { shown: false } }
-        />);
-
-        const event = {
-            preventDefault: sinon.spy(),
-            keyCode: 13,  // Enter
-            altKey: false,
-            ctrlKey: false,
-            shiftKey: false,
-        };
-
-        expect(mockSend.calledOnce).toBeFalsy();
-        wrapper.find('textarea').simulate('keydown', event);
-        expect(mockSend.calledOnce).toBeTruthy();
-    });
-
-    it('ignores unsaved changes on Enter if unsaved changes popup is shown', () => {
-        const mockSend = sinon.spy();
-        const wrapper = shallow(<GenericTranslationFormBase
-            editor={ EDITOR }
-            locale={ DEFAULT_LOCALE }
-            ignoreUnsavedChanges={ mockSend }
-            disableAction={ sinon.spy() }
-            unsavedchanges={ { shown: true } }
-        />);
-
-        const event = {
-            preventDefault: sinon.spy(),
-            keyCode: 13,  // Enter
-            altKey: false,
-            ctrlKey: false,
-            shiftKey: false,
-        };
-
-        expect(mockSend.calledOnce).toBeFalsy();
-        wrapper.find('textarea').simulate('keydown', event);
-        expect(mockSend.calledOnce).toBeTruthy();
-    });
-
-    it('closes unsaved changes popup if open on Esc', () => {
-        const mockSend = sinon.spy();
-
-        const wrapper = shallow(<GenericTranslationFormBase
-            editor={ EDITOR }
-            locale={ DEFAULT_LOCALE }
-            hideUnsavedChanges={ mockSend }
-            unsavedchanges={ { shown: true } }
-        />);
-
-        const event = {
-            preventDefault: sinon.spy(),
-            keyCode: 27,  // Esc
-        };
-
-        expect(mockSend.calledOnce).toBeFalsy();
-        wrapper.find('textarea').simulate('keydown', event);
-        expect(mockSend.calledOnce).toBeTruthy();
-    });
-
-    it('closes failed checks popup if open on Esc', () => {
-        const mockSend = sinon.spy();
-
-        const editor = {
-            ...EDITOR,
-            errors: ['error1'],
-            warnings: ['warning1'],
-        }
-
-        const wrapper = shallow(<GenericTranslationFormBase
-            editor={ editor }
-            locale={ DEFAULT_LOCALE }
-            resetFailedChecks={ mockSend }
-            unsavedchanges={ { shown: false } }
-        />);
-
-        const event = {
-            preventDefault: sinon.spy(),
-            keyCode: 27,  // Esc
-        };
-
-        expect(mockSend.calledOnce).toBeFalsy();
-        wrapper.find('textarea').simulate('keydown', event);
-        expect(mockSend.calledOnce).toBeTruthy();
-    });
-
-    it('copies the original into the Editor on Ctrl + Shift + C', () => {
-        const mockCopy = sinon.spy();
-        const wrapper = shallow(<GenericTranslationFormBase
-            editor={ EDITOR }
-            locale={ DEFAULT_LOCALE }
-            copyOriginalIntoEditor={ mockCopy }
-        />);
-
-        const event = {
-            preventDefault: sinon.spy(),
-            keyCode: 67,  // C
-            altKey: false,
-            ctrlKey: true,
-            shiftKey: true,
-        };
-
-        expect(mockCopy.calledOnce).toBeFalsy();
-        wrapper.find('textarea').simulate('keydown', event);
-        expect(mockCopy.calledOnce).toBeTruthy();
-    });
-
-    it('clears the translation on Ctrl + Shift + Backspace', () => {
-        const mockUpdate = sinon.spy();
-        const wrapper = shallow(<GenericTranslationFormBase
-            editor={ EDITOR }
-            locale={ DEFAULT_LOCALE }
-            updateTranslation={ mockUpdate }
-        />);
-
-        const event = {
-            preventDefault: sinon.spy(),
-            keyCode: 8,  // Backspace
-            altKey: false,
-            ctrlKey: true,
-            shiftKey: true,
-        };
-
-        expect(mockUpdate.calledOnce).toBeFalsy();
-        wrapper.find('textarea').simulate('keydown', event);
-        expect(mockUpdate.calledOnce).toBeTruthy();
-        expect(mockUpdate.calledWith('')).toBeTruthy();
     });
 });


### PR DESCRIPTION
This patch is basically copying and pasting code from `GenericTranslationForm.{test.}js` to `connectedEditor.{test.}js` and reusing it in the source editor.

Specifically, it:
* Wraps connectedEditor component into a withActionsDisabled HOC
* Moves handleShortcuts to connectedEditor and reuses it in Generic and Source Editor
* Moves handleShortcuts tests from GenericEditorForm to connectedEditor
* Keeps handleShortcuts in RichEditor, which uses custom functions