### PR TITLE
Update date-and-time to a version that handles YYYY correctly

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
     "abortcontroller-polyfill": "1.3.0",
     "brace": "0.11.1",
     "connected-react-router": "4.5.0",
-    "date-and-time": "0.9.0",
+    "date-and-time": "0.10.0",
     "diff-match-patch": "1.0.4",
     "flow-bin": "0.95.1",
     "fluent": "0.12.0",

--- a/frontend/src/modules/search/components/TimeRangeFilter.js
+++ b/frontend/src/modules/search/components/TimeRangeFilter.js
@@ -21,17 +21,6 @@ const INPUT_FORMAT = 'DD/MM/YYYY HH:mm';
 const URL_FORMAT = 'YYYYMMDDHHmm';
 
 
-// Workaround to force a 4-digit YYYY until #28 is fixed:
-// https://github.com/knowledgecode/date-and-time/issues/28
-date.extend({
-    parser: {
-        YYYY: function (str) {
-            return this.exec(/^\d{4}/, str);
-        }
-    }
-});
-
-
 type Props = {|
     project: string,
     timeRange: ?TimeRangeType,

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3190,10 +3190,10 @@ data-urls@^1.0.0, data-urls@^1.1.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-date-and-time@0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/date-and-time/-/date-and-time-0.9.0.tgz#1524579e56dc07675c640b41735a7665c0659240"
-  integrity sha512-4JybB6PbR+EebpFx/KyR5Ybl+TcdXMLIJkyYsCx3P4M4CWGMuDyFF19yh6TyasMAIF5lrsgIxiSHBXh2FFc7Fg==
+date-and-time@0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/date-and-time/-/date-and-time-0.10.0.tgz#53825b774167b55fbdf0bbd0f17f19357df7bc70"
+  integrity sha512-IbIzxtvK80JZOVsWF6+NOjunTaoFVYxkAQoyzmflJyuRCJAJebehy48mPiCAedcGp4P7/UO3QYRWa0fe6INftg==
 
 date-now@^0.1.4:
   version "0.1.4"


### PR DESCRIPTION
That way we no longer need a workaround to force a 4-digit YYYY format.