### PR TITLE
Reuse handle shortcuts

### DIFF
--- a/frontend/src/core/editor/components/connectedEditor.js
+++ b/frontend/src/core/editor/components/connectedEditor.js
@@ -64,7 +64,12 @@ export type EditorProps = {|
     user: UserState,
     clearEditor: () => void,
     copyOriginalIntoEditor: () => void,
-    handleShortcuts: (event: SyntheticKeyboardEvent<HTMLTextAreaElement>) => void,
+    handleShortcuts: (
+        event: SyntheticKeyboardEvent<HTMLTextAreaElement>,
+        sendTranslation: ?(ignoreWarnings?: boolean, translation?: string) => void,
+        clearEditor: ?() => void,
+        copyOriginalIntoEditor: ?() => void,
+    ) => void,
     resetFailedChecks: () => void,
     resetSelectionContent: () => void,
     sendTranslation: (ignoreWarnings?: boolean, translation?: string) => void,
@@ -121,7 +126,16 @@ export default function connectedEditor<Object>(
             this.props.dispatch(unsavedchanges.actions.update(translation, initial));
         }
 
-        handleShortcuts = (event: SyntheticKeyboardEvent<HTMLTextAreaElement>) => {
+        handleShortcuts = (
+            event: SyntheticKeyboardEvent<HTMLTextAreaElement>,
+            sendTranslation: ?(ignoreWarnings?: boolean, translation?: string) => void,
+            clearEditor: ?() => void,
+            copyOriginalIntoEditor: ?() => void,
+        ) => {
+            sendTranslation = sendTranslation || this.sendTranslation;
+            clearEditor = clearEditor || this.clearEditor;
+            copyOriginalIntoEditor = copyOriginalIntoEditor || this.copyOriginalIntoEditor;
+
             const key = event.keyCode;
 
             let handledEvent = false;
@@ -154,7 +168,7 @@ export default function connectedEditor<Object>(
                 }
                 // Send translation
                 else {
-                    this.sendTranslation(ignoreWarnings);
+                    sendTranslation(ignoreWarnings);
                 }
             }
 
@@ -178,13 +192,13 @@ export default function connectedEditor<Object>(
             // On Ctrl + Shift + C, copy the original translation.
             if (key === 67 && event.ctrlKey && event.shiftKey && !event.altKey) {
                 handledEvent = true;
-                this.copyOriginalIntoEditor();
+                copyOriginalIntoEditor();
             }
 
             // On Ctrl + Shift + Backspace, clear the content.
             if (key === 8 && event.ctrlKey && event.shiftKey && !event.altKey) {
                 handledEvent = true;
-                this.clearEditor();
+                clearEditor();
             }
 
             // On Tab, walk through current helper tab content and copy it.

--- a/frontend/src/modules/fluenteditor/components/RichTranslationForm.test.js
+++ b/frontend/src/modules/fluenteditor/components/RichTranslationForm.test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 
 import { fluent } from 'core/utils';
 
-import { RichTranslationFormBase } from './RichTranslationForm';
+import RichTranslationForm from './RichTranslationForm';
 
 
 const DEFAULT_LOCALE = {
@@ -25,9 +25,9 @@ const EDITOR = {
 };
 
 
-describe('<RichTranslationFormBase>', () => {
+describe('<RichTranslationForm>', () => {
     it('renders textarea for a value and each attribute', () => {
-        const wrapper = shallow(<RichTranslationFormBase
+        const wrapper = shallow(<RichTranslationForm
             editor={ EDITOR }
             locale={ DEFAULT_LOCALE }
             updateTranslation={ sinon.stub() }
@@ -52,7 +52,7 @@ my-entry =
             translation: fluent.parser.parseEntry(input),
         };
 
-        const wrapper = shallow(<RichTranslationFormBase
+        const wrapper = shallow(<RichTranslationForm
             editor={ editor }
             locale={ DEFAULT_LOCALE }
             updateTranslation={ sinon.stub() }
@@ -78,7 +78,7 @@ my-entry =
             translation: fluent.parser.parseEntry(input),
         };
 
-        const wrapper = shallow(<RichTranslationFormBase
+        const wrapper = shallow(<RichTranslationForm
             editor={ editor }
             locale={ DEFAULT_LOCALE }
             updateTranslation={ sinon.stub() }
@@ -96,7 +96,7 @@ my-entry =
     it('calls the updateTranslation function on mount and change', () => {
         const updateMock = sinon.spy();
 
-        const wrapper = shallow(<RichTranslationFormBase
+        const wrapper = shallow(<RichTranslationForm
             editor={ EDITOR }
             locale={ DEFAULT_LOCALE }
             updateTranslation={ updateMock }
@@ -111,7 +111,7 @@ my-entry =
         const resetMock = sinon.stub();
         const updateMock = sinon.stub();
 
-        const wrapper = mount(<RichTranslationFormBase
+        const wrapper = mount(<RichTranslationForm
             editor={ EDITOR }
             locale={ DEFAULT_LOCALE }
             unsavedchanges={ { shown: false } }
@@ -129,177 +129,5 @@ my-entry =
         expect(updateMock.calledTwice).toBeTruthy();
         expect(updateMock.calledWith(updatedTranslation)).toBeTruthy();
         expect(resetMock.calledOnce).toBeTruthy();
-    });
-
-    it('sends the translation on Enter', () => {
-        const mockSend = sinon.spy();
-        const wrapper = shallow(<RichTranslationFormBase
-            editor={ EDITOR }
-            locale={ DEFAULT_LOCALE }
-            sendTranslation={ mockSend }
-            disableAction={ sinon.spy() }
-            unsavedchanges={ { shown: false } }
-            updateTranslation={ sinon.stub() }
-        />);
-
-        const event = {
-            preventDefault: sinon.spy(),
-            keyCode: 13,  // Enter
-            altKey: false,
-            ctrlKey: false,
-            shiftKey: false,
-        };
-
-        expect(mockSend.calledOnce).toBeFalsy();
-        wrapper.find('textarea').at(0).simulate('keydown', event);
-        expect(mockSend.calledOnce).toBeTruthy();
-    });
-
-    it('approves the translation on Enter if failed checks triggered by approval', () => {
-        const mockSend = sinon.spy();
-
-        const editor = {
-            ...EDITOR,
-            errors: ['error1'],
-            warnings: ['warning1'],
-            source: 1,
-        }
-
-        const wrapper = shallow(<RichTranslationFormBase
-            editor={ editor }
-            locale={ DEFAULT_LOCALE }
-            updateTranslation={ sinon.stub() }
-            updateTranslationStatus={ mockSend }
-            disableAction={ sinon.spy() }
-            unsavedchanges={ { shown: false } }
-        />);
-
-        const event = {
-            preventDefault: sinon.spy(),
-            keyCode: 13,  // Enter
-            altKey: false,
-            ctrlKey: false,
-            shiftKey: false,
-        };
-
-        expect(mockSend.calledOnce).toBeFalsy();
-        wrapper.find('textarea').at(0).simulate('keydown', event);
-        expect(mockSend.calledOnce).toBeTruthy();
-    });
-
-    it('ignores unsaved changes on Enter if unsaved changes popup is shown', () => {
-        const mockSend = sinon.spy();
-        const wrapper = shallow(<RichTranslationFormBase
-            editor={ EDITOR }
-            locale={ DEFAULT_LOCALE }
-            ignoreUnsavedChanges={ mockSend }
-            disableAction={ sinon.spy() }
-            unsavedchanges={ { shown: true } }
-            updateTranslation={ sinon.stub() }
-        />);
-
-        const event = {
-            preventDefault: sinon.spy(),
-            keyCode: 13,  // Enter
-            altKey: false,
-            ctrlKey: false,
-            shiftKey: false,
-        };
-
-        expect(mockSend.calledOnce).toBeFalsy();
-        wrapper.find('textarea').at(0).simulate('keydown', event);
-        expect(mockSend.calledOnce).toBeTruthy();
-    });
-
-    it('closes unsaved changes popup if open on Esc', () => {
-        const mockSend = sinon.spy();
-
-        const wrapper = shallow(<RichTranslationFormBase
-            editor={ EDITOR }
-            locale={ DEFAULT_LOCALE }
-            hideUnsavedChanges={ mockSend }
-            unsavedchanges={ { shown: true } }
-            updateTranslation={ sinon.stub() }
-        />);
-
-        const event = {
-            preventDefault: sinon.spy(),
-            keyCode: 27,  // Esc
-        };
-
-        expect(mockSend.calledOnce).toBeFalsy();
-        wrapper.find('textarea').at(0).simulate('keydown', event);
-        expect(mockSend.calledOnce).toBeTruthy();
-    });
-
-    it('closes failed checks popup if open on Esc', () => {
-        const mockSend = sinon.spy();
-
-        const editor = {
-            ...EDITOR,
-            errors: ['error1'],
-            warnings: ['warning1'],
-        }
-
-        const wrapper = shallow(<RichTranslationFormBase
-            editor={ editor }
-            locale={ DEFAULT_LOCALE }
-            resetFailedChecks={ mockSend }
-            unsavedchanges={ { shown: false } }
-            updateTranslation={ sinon.stub() }
-        />);
-
-        const event = {
-            preventDefault: sinon.spy(),
-            keyCode: 27,  // Esc
-        };
-
-        expect(mockSend.calledOnce).toBeFalsy();
-        wrapper.find('textarea').at(0).simulate('keydown', event);
-        expect(mockSend.calledOnce).toBeTruthy();
-    });
-
-    it('copies the original into the Editor on Ctrl + Shift + C', () => {
-        const mockCopy = sinon.spy();
-        const wrapper = shallow(<RichTranslationFormBase
-            editor={ EDITOR }
-            locale={ DEFAULT_LOCALE }
-            copyOriginalIntoEditor={ mockCopy }
-            updateTranslation={ sinon.stub() }
-        />);
-
-        const event = {
-            preventDefault: sinon.spy(),
-            keyCode: 67,  // C
-            altKey: false,
-            ctrlKey: true,
-            shiftKey: true,
-        };
-
-        expect(mockCopy.calledOnce).toBeFalsy();
-        wrapper.find('textarea').at(0).simulate('keydown', event);
-        expect(mockCopy.calledOnce).toBeTruthy();
-    });
-
-    it('clears the translation on Ctrl + Shift + Backspace', () => {
-        const clearMock = sinon.spy();
-        const wrapper = shallow(<RichTranslationFormBase
-            editor={ EDITOR }
-            locale={ DEFAULT_LOCALE }
-            clearEditor={ clearMock }
-            updateTranslation={ sinon.stub() }
-        />);
-
-        const event = {
-            preventDefault: sinon.spy(),
-            keyCode: 8,  // Backspace
-            altKey: false,
-            ctrlKey: true,
-            shiftKey: true,
-        };
-
-        expect(clearMock.calledOnce).toBeFalsy();
-        wrapper.find('textarea').at(0).simulate('keydown', event);
-        expect(clearMock.calledOnce).toBeTruthy();
     });
 });

--- a/frontend/src/modules/genericeditor/components/GenericTranslationForm.js
+++ b/frontend/src/modules/genericeditor/components/GenericTranslationForm.js
@@ -105,6 +105,13 @@ export default class GenericTranslationForm extends React.Component<EditorProps>
         this.props.updateTranslation(this.textarea.current.value);
     }
 
+    handleShortcuts = (event: SyntheticKeyboardEvent<HTMLTextAreaElement>) => {
+        this.props.handleShortcuts(
+            event,
+            this.props.sendTranslation,
+        );
+    }
+
     handleChange = (event: SyntheticInputEvent<HTMLTextAreaElement>) => {
         this.props.updateTranslation(event.currentTarget.value);
     }
@@ -118,7 +125,7 @@ export default class GenericTranslationForm extends React.Component<EditorProps>
             readOnly={ this.props.isReadOnlyEditor }
             ref={ this.textarea }
             value={ this.props.editor.translation }
-            onKeyDown={ this.props.handleShortcuts }
+            onKeyDown={ this.handleShortcuts }
             onChange={ this.handleChange }
             dir={ this.props.locale.direction }
             lang={ this.props.locale.code }


### PR DESCRIPTION
In https://github.com/mozilla/pontoon/commit/ceaaa1b95104ffce5b1f26eabadd97e22c7af209 we moved `handleShortcuts` to `connectedEditor` and reused the method in Generic and Source Editor.

This patch does that for the Rich Editor as well, by adding the ability to pass overriden functions as callbacks.

It also passes the overriden `saveTranslation` function for the Generic Editor, which was left out in ceaaa1b95104ffce5b1f26eabadd97e22c7af209 and caused problems.