### PR TITLE
Fix bug 1547274: Implement a 'nanoscopic' NProgress bar at the top

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "lodash.debounce": "4.0.8",
     "lodash.flattendeep": "4.4.0",
     "lodash.isequal": "4.5.0",
+    "nprogress": "0.2.0",
     "react": "16.8.6",
     "react-content-marker": "1.1.0",
     "react-dom": "16.8.6",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -32,3 +32,29 @@
     display: table-cell;
     vertical-align: middle;
 }
+
+/* NProgress: A nanoscopic progress bar. */
+#nprogress {
+    pointer-events: none;
+}
+
+#nprogress .bar {
+    background: #7BC876;
+    position: fixed;
+    z-index: 1031;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 2px;
+}
+
+#nprogress .peg {
+    display: block;
+    position: absolute;
+    right: 0px;
+    width: 100px;
+    height: 100%;
+    box-shadow: 0 0 10px #7BC876, 0 0 5px #7BC876;
+    opacity: 1.0;
+    transform: rotate(3deg) translate(0px, -4px);
+}

--- a/frontend/src/core/editor/actions.js
+++ b/frontend/src/core/editor/actions.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import NProgress from 'nprogress';
+
 import api from 'core/api';
 
 import { actions as entitiesActions } from 'core/entities';
@@ -155,6 +157,8 @@ export function sendTranslation(
     ignoreWarnings: ?boolean,
 ): Function {
     return async dispatch => {
+        NProgress.start();
+
         const content = await api.translation.updateTranslation(
             entity.pk,
             translation,
@@ -172,11 +176,7 @@ export function sendTranslation(
         else if (content.same) {
             // The translation that was provided is the same as an existing
             // translation for that entity.
-            dispatch(
-                notification.actions.add(
-                    notification.messages.SAME_TRANSLATION
-                )
-            );
+            dispatch(notification.actions.add(notification.messages.SAME_TRANSLATION));
         }
         else if (
             content.type === 'added' ||
@@ -222,6 +222,8 @@ export function sendTranslation(
                 );
             }
         }
+
+        NProgress.done();
     }
 }
 

--- a/frontend/src/modules/history/actions.js
+++ b/frontend/src/modules/history/actions.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import NProgress from 'nprogress';
+
 import api from 'core/api';
 
 import { actions as editorActions } from 'core/editor';
@@ -141,6 +143,8 @@ export function updateStatus(
     ignoreWarnings: ?boolean,
 ): Function {
     return async dispatch => {
+        NProgress.start();
+
         const results = await updateStatusOnServer(
             change, translation, resource, ignoreWarnings
         );
@@ -195,6 +199,8 @@ export function updateStatus(
                 )
             );
         }
+
+        NProgress.done();
     }
 }
 
@@ -206,11 +212,14 @@ export function deleteTranslation(
     translation: number,
 ): Function {
     return async dispatch => {
+        NProgress.start();
+
         await api.translation.delete(translation);
-        dispatch(
-            notification.actions.add(notification.messages.TRANSLATION_DELETED)
-        );
+
+        dispatch(notification.actions.add(notification.messages.TRANSLATION_DELETED));
         dispatch(get(entity, locale, pluralForm));
+
+        NProgress.done();
     }
 }
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6925,6 +6925,11 @@ npmlog@^4.0.2:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
+nprogress@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/nprogress/-/nprogress-0.2.0.tgz#cb8f34c53213d895723fcbab907e9422adbcafb1"
+  integrity sha1-y480xTIT2JVyP8urkH6UIq28r7E=
+
 nth-check@^1.0.2, nth-check@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"


### PR DESCRIPTION
Unlike in Translate.Current, where we show the progress bar for almost any AJAX call,
in Translate.Next we only show it when changes are made to a single translation,
i.e. on save, (un)approve, (un)reject and delete operations.

We already show different progress bars/loaders when searching or filtering entities,
switching resources or performing batch actions and there's no reason to duplicate them.

In fact, duplicating loaders might negatively impact perceived performance. So does
"extending" the progress bar in Translate.Current, which starts at Translation save
and ends only when Helper tabs end loading for the next entity.

We should however consider:
1. Removing or repositioning translation action notifications, because they overlap with the progress bar.
2. Removing existing loaders in the string list and using the combination of NProgress bar and content placeholder.