### PR TITLE
Style "Sign In" button on standalone login page

### DIFF
--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -1259,11 +1259,16 @@ body > form,
     font-weight: 300;
 }
 
-#standalone-sign-in input {
+#standalone-sign-in input[type=text],
+#standalone-sign-in input[type=password] {
     float: none;
     background-color: white;
     padding: 10px;
     margin: 10px;
+}
+
+#standalone-sign-in .controls .button {
+  font-size: 14px;
 }
 
 .controls {

--- a/pontoon/base/templates/registration/login.html
+++ b/pontoon/base/templates/registration/login.html
@@ -24,7 +24,7 @@
         {{ form.password.errors }}
     </div>
     <div class="controls clearfix">
-        <input class="button" type="submit" name="sign-in" id="sign-in" value="Sign in" />
+        <input class="button active" type="submit" name="sign-in" id="sign-in" value="Sign in" />
     </div>
     <input type="hidden" name="next" value="{{ request.GET.next }}">
     {% csrf_token %}


### PR DESCRIPTION
The "Sign In" button on the standalone page appeared (to me, anyhow) disabled.  (I think this is because it was getting the default button colors, which seem to be designed for a green, not white, background.)

Before:

<img width="391" alt="Screen Shot 2019-09-23 at 3 22 44 PM" src="https://user-images.githubusercontent.com/4974151/65455970-564c5280-de16-11e9-8ea0-5fc539ff98d5.png">

After:

<img width="428" alt="Screen Shot 2019-09-23 at 3 21 12 PM" src="https://user-images.githubusercontent.com/4974151/65455980-5b110680-de16-11e9-8e5c-2ba16d193a10.png">
