### PR TITLE
Fix bug 1583764: Properly detect multiple peer Fluent placeables

### DIFF
--- a/frontend/src/core/placeable/parsers/fluentFunction.js
+++ b/frontend/src/core/placeable/parsers/fluentFunction.js
@@ -16,7 +16,7 @@ import { Localized } from 'fluent-react';
  *   { NUMBER($ratio, minimumFractionDigits: 2) }
  */
 const fluentFunction = {
-    rule: /({ ?[A-W0-9\-_]+.* ?})/,
+    rule: /({ ?[A-W0-9\-_]+[^}]* ?})/,
     tag: (x: string) => {
         return <Localized
             id='placeable-parser-fluentFunction'

--- a/frontend/src/core/placeable/parsers/fluentFunction.test.js
+++ b/frontend/src/core/placeable/parsers/fluentFunction.test.js
@@ -18,4 +18,15 @@ describe('fluentFunction', () => {
         expect(wrapper.find('mark')).toHaveLength(1);
         expect(wrapper.find('mark').text()).toEqual(mark);
     });
+
+    each([
+        ['{ DATETIME($date) }', '{ COPY() }', 'Hello { DATETIME($date) } and { COPY() }'],
+    ])
+    .it('marks `%s` and `%s` in `%s`', (mark1, mark2, content) => {
+        const Marker = createMarker([fluentFunction]);
+        const wrapper = shallow(<Marker>{ content }</Marker>);
+        expect(wrapper.find('mark')).toHaveLength(2);
+        expect(wrapper.find('mark').at(0).text()).toEqual(mark1);
+        expect(wrapper.find('mark').at(1).text()).toEqual(mark2);
+    });
 });

--- a/frontend/src/core/placeable/parsers/fluentParametrizedTerm.js
+++ b/frontend/src/core/placeable/parsers/fluentParametrizedTerm.js
@@ -16,7 +16,7 @@ import { Localized } from 'fluent-react';
  *   { -brand-name(foo-bar: "now that's a value!") }
  */
 const fluentParametrizedTerm = {
-    rule: /({ ?-.*(.*: ?.*) ?})/,
+    rule: /({ ?-.*(.*: ?[^}]*) ?})/,
     matchIndex: 1,
     tag: (x: string) => {
         return <Localized

--- a/frontend/src/core/placeable/parsers/fluentParametrizedTerm.js
+++ b/frontend/src/core/placeable/parsers/fluentParametrizedTerm.js
@@ -16,7 +16,7 @@ import { Localized } from 'fluent-react';
  *   { -brand-name(foo-bar: "now that's a value!") }
  */
 const fluentParametrizedTerm = {
-    rule: /({ ?-.*([^}]*: ?[^}]*) ?})/,
+    rule: /({ ?-[^}]*([^}]*: ?[^}]*) ?})/,
     matchIndex: 1,
     tag: (x: string) => {
         return <Localized

--- a/frontend/src/core/placeable/parsers/fluentParametrizedTerm.js
+++ b/frontend/src/core/placeable/parsers/fluentParametrizedTerm.js
@@ -16,7 +16,7 @@ import { Localized } from 'fluent-react';
  *   { -brand-name(foo-bar: "now that's a value!") }
  */
 const fluentParametrizedTerm = {
-    rule: /({ ?-.*(.*: ?[^}]*) ?})/,
+    rule: /({ ?-.*([^}]*: ?[^}]*) ?})/,
     matchIndex: 1,
     tag: (x: string) => {
         return <Localized

--- a/frontend/src/core/placeable/parsers/fluentParametrizedTerm.test.js
+++ b/frontend/src/core/placeable/parsers/fluentParametrizedTerm.test.js
@@ -18,4 +18,15 @@ describe('fluentParametrizedTerm', () => {
         expect(wrapper.find('mark')).toHaveLength(1);
         expect(wrapper.find('mark').text()).toEqual(mark);
     });
+
+    each([
+        ['{-brand(case: "test")}', '{-vendor(case: "right")}', 'Hello {-brand(case: "test")} and {-vendor(case: "right")}'],
+    ])
+    .it('marks `%s` and `%s` in `%s`', (mark1, mark2, content) => {
+        const Marker = createMarker([fluentParametrizedTerm]);
+        const wrapper = shallow(<Marker>{ content }</Marker>);
+        expect(wrapper.find('mark')).toHaveLength(2);
+        expect(wrapper.find('mark').at(0).text()).toEqual(mark1);
+        expect(wrapper.find('mark').at(1).text()).toEqual(mark2);
+    });
 });

--- a/frontend/src/core/placeable/parsers/fluentString.js
+++ b/frontend/src/core/placeable/parsers/fluentString.js
@@ -15,7 +15,7 @@ import { Localized } from 'fluent-react';
  *   { "Hello, World" }
  */
 const fluentString = {
-    rule: /({ ?".*" ?})/,
+    rule: /({ ?"[^}]*" ?})/,
     tag: (x: string) => {
         return <Localized
             id='placeable-parser-fluentString'

--- a/frontend/src/core/placeable/parsers/fluentString.test.js
+++ b/frontend/src/core/placeable/parsers/fluentString.test.js
@@ -18,4 +18,15 @@ describe('fluentString', () => {
         expect(wrapper.find('mark')).toHaveLength(1);
         expect(wrapper.find('mark').text()).toEqual(mark);
     });
+
+    each([
+        ['{ "hello!" }', '{ "world!" }', 'Hello { "hello!" } from { "world!" }'],
+    ])
+    .it('marks `%s` and `%s` in `%s`', (mark1, mark2, content) => {
+        const Marker = createMarker([fluentString]);
+        const wrapper = shallow(<Marker>{ content }</Marker>);
+        expect(wrapper.find('mark')).toHaveLength(2);
+        expect(wrapper.find('mark').at(0).text()).toEqual(mark1);
+        expect(wrapper.find('mark').at(1).text()).toEqual(mark2);
+    });
 });

--- a/frontend/src/core/placeable/parsers/fluentTerm.js
+++ b/frontend/src/core/placeable/parsers/fluentTerm.js
@@ -16,7 +16,7 @@ import { Localized } from 'fluent-react';
  *   { -brand-name }
  */
 const fluentTerm = {
-    rule: /({ ?-.* ?})/,
+    rule: /({ ?-[^}]* ?})/,
     tag: (x: string) => {
         return <Localized
             id='placeable-parser-fluentTerm'

--- a/frontend/src/core/placeable/parsers/fluentTerm.test.js
+++ b/frontend/src/core/placeable/parsers/fluentTerm.test.js
@@ -18,4 +18,15 @@ describe('fluentTerm', () => {
         expect(wrapper.find('mark')).toHaveLength(1);
         expect(wrapper.find('mark').text()).toEqual(mark);
     });
+
+    each([
+        ['{-brand}', '{-vendor}', 'Hello {-brand} from {-vendor}'],
+    ])
+    .it('marks `%s` and `%s` in `%s`', (mark1, mark2, content) => {
+        const Marker = createMarker([fluentTerm]);
+        const wrapper = shallow(<Marker>{ content }</Marker>);
+        expect(wrapper.find('mark')).toHaveLength(2);
+        expect(wrapper.find('mark').at(0).text()).toEqual(mark1);
+        expect(wrapper.find('mark').at(1).text()).toEqual(mark2);
+    });
 });


### PR DESCRIPTION
I've also checked other similar (but non-Fluent) placeables (e.g. python*, java*) and they work fine.