### PR TITLE
Fix bug 1584223 - Replace history when automatically moving to first …

### DIFF
--- a/frontend/src/core/navigation/actions.js
+++ b/frontend/src/core/navigation/actions.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { push } from 'connected-react-router';
+import { push, replace } from 'connected-react-router';
 
 
 /**
@@ -10,8 +10,12 @@ import { push } from 'connected-react-router';
  * it is possible that after the results have changed, the currently selected
  * entity won't be available anymore.
  * It keeps all other unaffected parameters in the URL the same.
+ *
+ * @param {Object} router The router data object from connected-react-router.
+ * @param {Object} params A list of parameters to update in the current URL.
+ * @param {boolean} replaceHistory Whether or not to push a new URL or replace the current one in the browser history.
  */
-export function update(router: Object, params: { [string]: ?string }): Function {
+export function update(router: Object, params: { [string]: ?string }, replaceHistory?: boolean): Function {
     return dispatch => {
         const queryString = router.location.search;
         const currentParams = new URLSearchParams(queryString);
@@ -44,7 +48,12 @@ export function update(router: Object, params: { [string]: ?string }): Function 
             currentParams.delete('string');
         }
 
-        dispatch(push('?' + currentParams.toString()));
+        let updateMethod = push;
+        if (replaceHistory) {
+            updateMethod = replace;
+        }
+
+        dispatch(updateMethod('?' + currentParams.toString()));
     }
 }
 
@@ -67,8 +76,8 @@ export function updateAuthor(router: Object, author: ?string): Function {
  *
  * This function keeps all other parameters in the URL the same.
  */
-export function updateEntity(router: Object, entity: string): Function {
-    return update(router, { string: entity });
+export function updateEntity(router: Object, entity: string, replaceHistory?: boolean): Function {
+    return update(router, { string: entity }, replaceHistory);
 }
 
 

--- a/frontend/src/modules/entitieslist/components/EntitiesList.js
+++ b/frontend/src/modules/entitieslist/components/EntitiesList.js
@@ -191,7 +191,10 @@ export class EntitiesListBase extends React.Component<InternalProps> {
         const isSelectedEntityValid = entityIds.indexOf(selectedEntity) > -1;
 
         if ((!selectedEntity || !isSelectedEntityValid) && firstEntity) {
-            this.selectEntity(firstEntity);
+            this.selectEntity(
+                firstEntity,
+                true, // Replace the last history item instead of pushing a new one.
+            );
 
             // Only do this the very first time entities are loaded.
             if (props.entities.fetchCount === 1 && selectedEntity && !isSelectedEntityValid) {
@@ -204,7 +207,7 @@ export class EntitiesListBase extends React.Component<InternalProps> {
         }
     }
 
-    selectEntity = (entity: EntityType) => {
+    selectEntity = (entity: EntityType, replaceHistory?: boolean) => {
         const { dispatch, router } = this.props;
 
         dispatch(
@@ -218,6 +221,7 @@ export class EntitiesListBase extends React.Component<InternalProps> {
                         navigation.actions.updateEntity(
                             router,
                             entity.pk.toString(),
+                            replaceHistory,
                         )
                     );
                 }


### PR DESCRIPTION
…entity.

This fixes an issue that rendered using the back button of the browser impossible, as hitting it would loop back to the first entity being selected. By using `replace` instead of `push` for that automatic redirect, we allow users to correctly walk the history.