### PR TITLE
Fix bug 1584579: Exclude placeables from access key candidates if key not translated

### DIFF
--- a/frontend/src/core/utils/fluent/extractAccessKeyCandidates.test.js
+++ b/frontend/src/core/utils/fluent/extractAccessKeyCandidates.test.js
@@ -1,10 +1,11 @@
 import extractAccessKeyCandidates from './extractAccessKeyCandidates';
+import flattenMessage from './flattenMessage';
 import parser from './parser';
 
 
 describe('extractAccessKeyCandidates', () => {
     it('returns null if the message has no attributes', () => {
-        const message = parser.parseEntry('title = Title');
+        const message = flattenMessage(parser.parseEntry('title = Title'));
         const res = extractAccessKeyCandidates(message);
 
         expect(res).toEqual(null);
@@ -13,7 +14,7 @@ describe('extractAccessKeyCandidates', () => {
     it('returns null if the message has no accesskey attribute', () => {
         const input = 'title =' +
             '\n    .foo = Bar';
-        const message = parser.parseEntry(input);
+        const message = flattenMessage(parser.parseEntry(input));
         const res = extractAccessKeyCandidates(message);
 
         expect(res).toEqual(null);
@@ -23,7 +24,7 @@ describe('extractAccessKeyCandidates', () => {
         const input = 'title =' +
             '\n    .foo = Bar' +
             '\n    .accesskey = B';
-        const message = parser.parseEntry(input);
+        const message = flattenMessage(parser.parseEntry(input));
         const res = extractAccessKeyCandidates(message);
 
         expect(res).toEqual(null);
@@ -32,7 +33,7 @@ describe('extractAccessKeyCandidates', () => {
     it('returns a list of access keys from the message value', () => {
         const input = 'title = Candidates' +
             '\n    .accesskey = B';
-        const message = parser.parseEntry(input);
+        const message = flattenMessage(parser.parseEntry(input));
         const res = extractAccessKeyCandidates(message);
 
         expect(res).toEqual(['C', 'a', 'n', 'd', 'i', 't', 'e', 's']);
@@ -42,17 +43,17 @@ describe('extractAccessKeyCandidates', () => {
         const input = 'title = Title' +
             '\n    .label = Candidates' +
             '\n    .accesskey = B';
-        const message = parser.parseEntry(input);
+        const message = flattenMessage(parser.parseEntry(input));
         const res = extractAccessKeyCandidates(message);
 
         expect(res).toEqual(['C', 'a', 'n', 'd', 'i', 't', 'e', 's']);
     });
 
-    it('Only takes TextElements into account when generating candidates', () => {
+    it('Does not take Placeables into account when generating candidates', () => {
         const input = 'title = Title' +
             '\n    .label = Candidates { brand }' +
             '\n    .accesskey = B';
-        const message = parser.parseEntry(input);
+        const message = flattenMessage(parser.parseEntry(input));
         const res = extractAccessKeyCandidates(message);
 
         expect(res).toEqual(['C', 'a', 'n', 'd', 'i', 't', 'e', 's']);
@@ -66,7 +67,7 @@ describe('extractAccessKeyCandidates', () => {
             '\n           *[other] Cmd' +
             '\n        }' +
             '\n    .accesskey = C';
-        const message = parser.parseEntry(input);
+        const message = flattenMessage(parser.parseEntry(input));
         const res = extractAccessKeyCandidates(message);
 
         expect(res).toEqual(['C', 't', 'r', 'l', 'm', 'd']);


### PR DESCRIPTION
We remove content between each `{` and `}` pair instead of parsing messages (which doesn't work for half-translated strings) and removing non-`TextElement` elements.