### PR TITLE
Fix bug 1567402 - Make bugs tab disabled by default

### DIFF
--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -83,6 +83,10 @@ you create:
    login. Set to True if you want to use the default Django login instead. This will
    allow you to log in via accounts created using `manage.py shell`.
 
+``ENABLE_BUGS_TAB``
+   Enables Bugs tab on team pages, which pulls team data from bugzilla.mozilla.org.
+   A Mozilla specific variable.
+
 ``ERROR_PAGE_URL``
    Optional. URL to the page displayed to your users when the application encounters
    a system error. See `Heroku Reference`_ for more information.

--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -84,8 +84,8 @@ you create:
    allow you to log in via accounts created using `manage.py shell`.
 
 ``ENABLE_BUGS_TAB``
-   Enables Bugs tab on team pages, which pulls team data from bugzilla.mozilla.org.
-   A Mozilla specific variable.
+   Optional. Enables Bugs tab on team pages, which pulls team data from
+   bugzilla.mozilla.org. Specific for Mozilla deployments.
 
 ``ERROR_PAGE_URL``
    Optional. URL to the page displayed to your users when the application encounters

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -782,8 +782,8 @@ USE_I18N = False
 # calendars according to the current locale
 USE_L10N = False
 
-#Enable Bugs tab on the team pages, pulling data from bugzilla.mozilla.org.
-#See bug 1567402 for details. A Mozilla-specific variable.
+# Enable Bugs tab on the team pages, pulling data from bugzilla.mozilla.org.
+# See bug 1567402 for details. A Mozilla-specific variable.
 ENABLE_BUGS_TAB = os.environ.get('ENABLE_BUGS_TAB', 'False') != 'False'
 
 # Bleach tags and attributes

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -28,11 +28,13 @@ SECRET_KEY = os.environ['SECRET_KEY']
 # Is this a dev instance?
 DEV = os.environ.get('DJANGO_DEV', 'False') != 'False'
 
+MAINTAINER = os.environ.get('MAINTAINER', 'False') != 'False'
+
 DEBUG = os.environ.get('DJANGO_DEBUG', 'False') != 'False'
 
 HEROKU_DEMO = os.environ.get('HEROKU_DEMO', 'False') != 'False'
 
-DJANGO_LOGIN = os.environ.get('DJANGO_LOGIN', 'False') != 'False' or HEROKU_DEMO
+DJANGO_LOGIN = os.environ.get('DJANGO_LOGIN', 'True') != 'False' or HEROKU_DEMO
 
 # Automatically log in the user with username 'AUTO_LOGIN_USERNAME'
 # and password 'AUTO_LOGIN_PASSWORD'

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -28,13 +28,11 @@ SECRET_KEY = os.environ['SECRET_KEY']
 # Is this a dev instance?
 DEV = os.environ.get('DJANGO_DEV', 'False') != 'False'
 
-MAINTAINER = os.environ.get('MAINTAINER', 'False') != 'False'
-
 DEBUG = os.environ.get('DJANGO_DEBUG', 'False') != 'False'
 
 HEROKU_DEMO = os.environ.get('HEROKU_DEMO', 'False') != 'False'
 
-DJANGO_LOGIN = os.environ.get('DJANGO_LOGIN', 'True') != 'False' or HEROKU_DEMO
+DJANGO_LOGIN = os.environ.get('DJANGO_LOGIN', 'False') != 'False' or HEROKU_DEMO
 
 # Automatically log in the user with username 'AUTO_LOGIN_USERNAME'
 # and password 'AUTO_LOGIN_PASSWORD'
@@ -783,6 +781,10 @@ USE_I18N = False
 # If you set this to False, Django will not format dates, numbers and
 # calendars according to the current locale
 USE_L10N = False
+
+#Enable Bugs tab on the team pages, pulling data from bugzilla.mozilla.org.
+#See bug 1567402 for details. A Mozilla-specific variable.
+ENABLE_BUGS_TAB = os.environ.get('ENABLE_BUGS_TAB', 'False') != 'False'
 
 # Bleach tags and attributes
 ALLOWED_TAGS = [

--- a/pontoon/teams/templates/teams/team.html
+++ b/pontoon/teams/templates/teams/team.html
@@ -90,6 +90,7 @@
           icon = 'users',
         )
       }}
+      {% if settings.MAINTAINER %}
       {{ Menu.item(
           'Bugs',
           url('pontoon.teams.bugs', locale.code),
@@ -98,6 +99,7 @@
           icon = 'bug',
         )
       }}
+      {% endif %}
       {{ Menu.item(
           'Info',
           url('pontoon.teams.info', locale.code),

--- a/pontoon/teams/templates/teams/team.html
+++ b/pontoon/teams/templates/teams/team.html
@@ -90,7 +90,7 @@
           icon = 'users',
         )
       }}
-      {% if settings.MAINTAINER %}
+      {% if settings.ENABLE_BUGS_TAB %}
       {{ Menu.item(
           'Bugs',
           url('pontoon.teams.bugs', locale.code),


### PR DESCRIPTION
The Bugs tab on the Team page (e.g. https://pontoon.mozilla.org/fr/bugs/) lists should not be enabled for those outside of Mozilla.

This fix adds an environment variable and then utilizes the value set in that variable to determine if the Bugs tab should display or not.
