### PR TITLE
Fix bug 1567394 - Allow access to issue tracker

### DIFF
--- a/frontend/public/static/locale/en-US/translate.ftl
+++ b/frontend/public/static/locale/en-US/translate.ftl
@@ -478,6 +478,8 @@ user-UserMenu--upload-translations = <glyph></glyph>Upload Translations
 user-UserMenu--top-contributors = <glyph></glyph>Top Contributors
 user-UserMenu--machinery = <glyph></glyph>Machinery
 user-UserMenu--terms = <glyph></glyph>Terms of Use
+user-UserMenu--github = <glyph></glyph>Hack it on GitHub
+user-UserMenu--feedback = <glyph></glyph>Give Feedback
 user-UserMenu--help = <glyph></glyph>Help
 
 user-UserMenu--admin = <glyph></glyph>Admin

--- a/frontend/public/static/locale/en-US/translate.ftl
+++ b/frontend/public/static/locale/en-US/translate.ftl
@@ -475,8 +475,6 @@ user-UserMenu--download-tm = <glyph></glyph>Download Translation Memory
 user-UserMenu--download-translations = <glyph></glyph>Download Translations
 user-UserMenu--upload-translations = <glyph></glyph>Upload Translations
 
-user-UserMenu--top-contributors = <glyph></glyph>Top Contributors
-user-UserMenu--machinery = <glyph></glyph>Machinery
 user-UserMenu--terms = <glyph></glyph>Terms of Use
 user-UserMenu--github = <glyph></glyph>Hack it on GitHub
 user-UserMenu--feedback = <glyph></glyph>Give Feedback

--- a/frontend/public/static/locale/fr/translate.ftl
+++ b/frontend/public/static/locale/fr/translate.ftl
@@ -299,8 +299,6 @@ user-UserMenu--download-tm = <glyph></glyph>Télécharger la Mémoire de traduct
 user-UserMenu--download-translations = <glyph></glyph>Télécharger les traductions
 user-UserMenu--upload-translations = <glyph></glyph>Envoyer des traductions
 
-user-UserMenu--top-contributors = <glyph></glyph>Contributeurs et contributrices remarquables
-user-UserMenu--machinery = <glyph></glyph>Machinerie
 user-UserMenu--terms = <glyph></glyph>Conditions d’utilisation
 user-UserMenu--help = <glyph></glyph>Aide
 

--- a/frontend/src/core/user/components/UserMenu.css
+++ b/frontend/src/core/user/components/UserMenu.css
@@ -84,7 +84,8 @@
     width: 100%;
 }
 
-.user-menu .menu li i.fa {
+.user-menu .menu li i.fa,
+.user-menu .menu li i.fab {
     margin: 0 8px 0 -2px;
 }
 

--- a/frontend/src/core/user/components/UserMenu.js
+++ b/frontend/src/core/user/components/UserMenu.js
@@ -136,38 +136,14 @@ export class UserMenuBase extends React.Component<Props, State> {
 
                 <li>
                     <Localized
-                        id="user-UserMenu--top-contributors"
-                        glyph={
-                            <i className="fa fa-trophy fa-fw"></i>
-                        }
-                    >
-                        <a href="/contributors/">
-                            { '<glyph></glyph>Top Contributors' }
-                        </a>
-                    </Localized>
-                </li>
-
-                <li>
-                    <Localized
-                        id="user-UserMenu--machinery"
-                        glyph={
-                            <i className="fa fa-search fa-fw"></i>
-                        }
-                    >
-                        <a href="/machinery/">
-                            { '<glyph></glyph>Machinery' }
-                        </a>
-                    </Localized>
-                </li>
-
-                <li>
-                    <Localized
                         id="user-UserMenu--terms"
                         glyph={
                             <i className="fa fa-gavel fa-fw"></i>
                         }
                     >
-                        <a href="/terms/">
+                        <a href="/terms/"
+                        rel="noopener noreferrer"
+                        target="_blank">
                             { '<glyph></glyph>Terms of Use' }
                         </a>
                     </Localized>
@@ -180,7 +156,9 @@ export class UserMenuBase extends React.Component<Props, State> {
                             <i className="fab fa-github fa-fw"></i>
                         }
                     >
-                        <a href="https://github.com/mozilla/pontoon/">
+                        <a href="https://github.com/mozilla/pontoon/"
+                        rel="noopener noreferrer"
+                        target="_blank">
                             { '<glyph></glyph>Hack it on GitHub' }
                         </a>
                     </Localized>
@@ -193,7 +171,9 @@ export class UserMenuBase extends React.Component<Props, State> {
                             <i className="fa fa-comment-dots fa-fw"></i>
                         }
                     >
-                        <a href="https://discourse.mozilla.org/c/pontoon">
+                        <a href="https://discourse.mozilla.org/c/pontoon"
+                        rel="noopener noreferrer"
+                        target="_blank">
                             { '<glyph></glyph>Give Feedback' }
                         </a>
                     </Localized>
@@ -206,7 +186,9 @@ export class UserMenuBase extends React.Component<Props, State> {
                             <i className="fa fa-life-ring fa-fw"></i>
                         }
                     >
-                        <a href="https://mozilla-l10n.github.io/localizer-documentation/tools/pontoon/">
+                        <a href="https://mozilla-l10n.github.io/localizer-documentation/tools/pontoon/"
+                        rel="noopener noreferrer"
+                        target="_blank">
                             { '<glyph></glyph>Help' }
                         </a>
                     </Localized>

--- a/frontend/src/core/user/components/UserMenu.js
+++ b/frontend/src/core/user/components/UserMenu.js
@@ -175,6 +175,32 @@ export class UserMenuBase extends React.Component<Props, State> {
 
                 <li>
                     <Localized
+                        id="user-UserMenu--github"
+                        glyph={
+                            <i className="fab fa-github fa-fw"></i>
+                        }
+                    >
+                        <a href="https://github.com/mozilla/pontoon/">
+                            { '<glyph></glyph>Hack it on GitHub' }
+                        </a>
+                    </Localized>
+                </li>
+
+                <li>
+                    <Localized
+                        id="user-UserMenu--feedback"
+                        glyph={
+                            <i className="fa fa-comment-dots fa-fw"></i>
+                        }
+                    >
+                        <a href="https://discourse.mozilla.org/c/pontoon">
+                            { '<glyph></glyph>Give Feedback' }
+                        </a>
+                    </Localized>
+                </li>
+
+                <li>
+                    <Localized
                         id="user-UserMenu--help"
                         glyph={
                             <i className="fa fa-life-ring fa-fw"></i>

--- a/frontend/src/core/user/components/UserMenu.js
+++ b/frontend/src/core/user/components/UserMenu.js
@@ -141,9 +141,11 @@ export class UserMenuBase extends React.Component<Props, State> {
                             <i className="fa fa-gavel fa-fw"></i>
                         }
                     >
-                        <a href="/terms/"
-                        rel="noopener noreferrer"
-                        target="_blank">
+                        <a
+                            href="/terms/"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                        >
                             { '<glyph></glyph>Terms of Use' }
                         </a>
                     </Localized>
@@ -156,9 +158,11 @@ export class UserMenuBase extends React.Component<Props, State> {
                             <i className="fab fa-github fa-fw"></i>
                         }
                     >
-                        <a href="https://github.com/mozilla/pontoon/"
-                        rel="noopener noreferrer"
-                        target="_blank">
+                        <a
+                            href="https://github.com/mozilla/pontoon/"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                        >
                             { '<glyph></glyph>Hack it on GitHub' }
                         </a>
                     </Localized>
@@ -171,9 +175,11 @@ export class UserMenuBase extends React.Component<Props, State> {
                             <i className="fa fa-comment-dots fa-fw"></i>
                         }
                     >
-                        <a href="https://discourse.mozilla.org/c/pontoon"
-                        rel="noopener noreferrer"
-                        target="_blank">
+                        <a
+                            href="https://discourse.mozilla.org/c/pontoon"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                        >
                             { '<glyph></glyph>Give Feedback' }
                         </a>
                     </Localized>
@@ -186,9 +192,11 @@ export class UserMenuBase extends React.Component<Props, State> {
                             <i className="fa fa-life-ring fa-fw"></i>
                         }
                     >
-                        <a href="https://mozilla-l10n.github.io/localizer-documentation/tools/pontoon/"
-                        rel="noopener noreferrer"
-                        target="_blank">
+                        <a
+                            href="https://mozilla-l10n.github.io/localizer-documentation/tools/pontoon/"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                        >
                             { '<glyph></glyph>Help' }
                         </a>
                     </Localized>

--- a/pontoon/base/static/css/fontawesome-all.css
+++ b/pontoon/base/static/css/fontawesome-all.css
@@ -15,10 +15,6 @@
   text-rendering: auto;
   line-height: 1;}
 
-.fab-gh {
-  width: 1.8em;
-}
-
 .fa-lg {
   font-size: 1.33333em;
   line-height: 0.75em;

--- a/pontoon/base/static/css/fontawesome-all.css
+++ b/pontoon/base/static/css/fontawesome-all.css
@@ -13,7 +13,7 @@
   font-style: normal;
   font-variant: normal;
   text-rendering: auto;
-  line-height: 1;}
+  line-height: 1; }
 
 .fa-lg {
   font-size: 1.33333em;

--- a/pontoon/base/static/css/fontawesome-all.css
+++ b/pontoon/base/static/css/fontawesome-all.css
@@ -13,7 +13,11 @@
   font-style: normal;
   font-variant: normal;
   text-rendering: auto;
-  line-height: 1; }
+  line-height: 1;}
+
+.fab-gh {
+  width: 1.8em;
+}
 
 .fa-lg {
   font-size: 1.33333em;

--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -948,7 +948,8 @@ header .right .select .menu {
   line-height: 22px;
 }
 
-#profile .menu li i.fa {
+#profile .menu li i.fa,
+#profile .menu li i.fab {
   margin: 0 8px 0 -2px;
 }
 

--- a/pontoon/base/templates/django/base.html
+++ b/pontoon/base/templates/django/base.html
@@ -69,8 +69,10 @@
                   <li class="horizontal-separator"></li>
                   {% endif %}
 
-                  <li><a href="{% url 'pontoon.terms' %}"><i class="fa fa-gavel fa-fw"></i>Terms of Use</a></li>
-                  <li><a href="https://mozilla-l10n.github.io/localizer-documentation/tools/pontoon/"><i class="fa fa-life-ring fa-fw"></i>Help</a></li>
+                  <li><a href="{% url 'pontoon.terms' %}" rel="noopener noreferrer" target="_blank"><i class="fa fa-gavel fa-fw"></i>Terms of Use</a></li>
+                  <li><a href="https://github.com/mozilla/pontoon/" rel="noopener noreferrer" target="_blank"><i class="fab fa-github fa-fw"></i>Hack it on GitHub</a></li>
+                  <li><a href="https://discourse.mozilla.org/c/pontoon" rel="noopener noreferrer" target="_blank"><i class="fa fa-comment-dots fa-fw"></i>Give Feedback</a></li>
+                  <li><a href="https://mozilla-l10n.github.io/localizer-documentation/tools/pontoon/" rel="noopener noreferrer" target="_blank"><i class="fa fa-life-ring fa-fw"></i>Help</a></li>
 
                   <li class="horizontal-separator"></li>
 

--- a/pontoon/base/templates/header.html
+++ b/pontoon/base/templates/header.html
@@ -39,8 +39,10 @@
             <ul>
               {{ Profile.top_menu() }}
 
-              <li><a href="{{ url('pontoon.terms') }}"><i class="fa fa-gavel fa-fw"></i>Terms of Use</a></li>
-              <li><a href="https://mozilla-l10n.github.io/localizer-documentation/tools/pontoon/"><i class="fa fa-life-ring fa-fw"></i>Help</a></li>
+              <li><a href="{{ url('pontoon.terms') }}" rel="noopener noreferrer" target="_blank"><i class="fa fa-gavel fa-fw"></i>Terms of Use</a></li>
+              <li><a href="https://github.com/mozilla/pontoon/" rel="noopener noreferrer" target="_blank"><i class="fab fa-github fab-gh"></i>Hack it on GitHub</a></li>
+              <li><a href="https://discourse.mozilla.org/c/pontoon" rel="noopener noreferrer" target="_blank"><i class="fa fa-comment-dots fa-fw"></i>Give Feedback</a></li>
+              <li><a href="https://mozilla-l10n.github.io/localizer-documentation/tools/pontoon/" rel="noopener noreferrer" target="_blank"><i class="fa fa-life-ring fa-fw"></i>Help</a></li>
 
               {% if user.is_authenticated() %}
               <li class="horizontal-separator"></li>

--- a/pontoon/base/templates/header.html
+++ b/pontoon/base/templates/header.html
@@ -40,7 +40,7 @@
               {{ Profile.top_menu() }}
 
               <li><a href="{{ url('pontoon.terms') }}" rel="noopener noreferrer" target="_blank"><i class="fa fa-gavel fa-fw"></i>Terms of Use</a></li>
-              <li><a href="https://github.com/mozilla/pontoon/" rel="noopener noreferrer" target="_blank"><i class="fab fa-github fab-gh"></i>Hack it on GitHub</a></li>
+              <li><a href="https://github.com/mozilla/pontoon/" rel="noopener noreferrer" target="_blank"><i class="fab fa-github fa-fw"></i>Hack it on GitHub</a></li>
               <li><a href="https://discourse.mozilla.org/c/pontoon" rel="noopener noreferrer" target="_blank"><i class="fa fa-comment-dots fa-fw"></i>Give Feedback</a></li>
               <li><a href="https://mozilla-l10n.github.io/localizer-documentation/tools/pontoon/" rel="noopener noreferrer" target="_blank"><i class="fa fa-life-ring fa-fw"></i>Help</a></li>
 


### PR DESCRIPTION
#### What does this PR do?
This pull request fixes the issue [1567394](https://bugzilla.mozilla.org/show_bug.cgi?id=1567394). It allows a user to access the issue tracker from the Pontoon app and also give feedback via [pontoon's](https://discourse.mozilla.org/c/pontoon) feedback page.

#### Type of change:
- [x] Bug fix (non-breaking change which fixed an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update.

#### How Has This Been Tested?
- Clone this repository 
- Git checkout to `katherine95:access-issue-tracker`branch.
- Follow the setup guidelines to set up pontoon locally
- Run `make run`
- Login to Pontoon
- Navigate to your profile and click on it.
- Click on `Hack it on Github`  and `Give feedback`.
- Both should redirect you to Github and pontoon's feedback page respectively.

#### Checklist:
- [x] On click on all the stated links on the user's profile should open the required pages on a new tab
- [x] The added links; Hack it on Github and Give feedback should redirect to Github and pontoon's feedback page respectively.

#### Screenshots (if appropriate):
![image](http://g.recordit.co/ymjNySmG6c.gif)