### PR TITLE
Bug 1585252 - Fix database migrations on Python 3

### DIFF
--- a/pontoon/base/migrations/0098_move_ms_locales_to_db.py
+++ b/pontoon/base/migrations/0098_move_ms_locales_to_db.py
@@ -179,7 +179,7 @@ def migrate_locales(apps, schema_editor):
         if pontoon_code in locale_map:
             locale_map[pontoon_code].ms_terminology_code = ms_code
 
-    bulk_update(locale_map.values(), update_fields=['ms_translator_code', 'ms_terminology_code'])
+    bulk_update(list(locale_map.values()), update_fields=['ms_translator_code', 'ms_terminology_code'])
 
 
 class Migration(migrations.Migration):

--- a/pontoon/base/migrations/0130_translation_active_unique_constraint.py
+++ b/pontoon/base/migrations/0130_translation_active_unique_constraint.py
@@ -19,6 +19,6 @@ class Migration(migrations.Migration):
         ),
         migrations.AddIndex(
             model_name='translation',
-            index=partial_index.PartialIndex(fields=['entity', 'locale', 'active'], name='base_transl_entity__ed9592_partial', unique=True, where=partial_index.PQ((b'active', True), (b'plural_form__isnull', True))),
+            index=partial_index.PartialIndex(fields=['entity', 'locale', 'active'], name='base_transl_entity__ed9592_partial', unique=True, where=partial_index.PQ(('active', True), ('plural_form__isnull', True))),
         ),
     ]

--- a/pontoon/base/migrations/0134_google_translate_code.py
+++ b/pontoon/base/migrations/0134_google_translate_code.py
@@ -145,7 +145,7 @@ def populate_google_translate_code(apps, schema_editor):
         if pontoon_code in locale_map:
             locale_map[pontoon_code].google_translate_code = google_translate_code
 
-    bulk_update(locale_map.values(), update_fields=['google_translate_code'])
+    bulk_update(list(locale_map.values()), update_fields=['google_translate_code'])
 
 
 class Migration(migrations.Migration):

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -50,8 +50,9 @@ django-allauth==0.34.0 \
     --hash=sha256:95a9f7fbebe3e97ce3a541d213fc52492b50dac92f0f91483f58949189e5aa4f
 django-bmemcached==0.2.3 \
     --hash=sha256:c9e4f5ca17417a26354e7d6a8899e44e34d541e8731ea0d987f2bf5a04df351a
-django-bulk-update==1.1.10 \
-    --hash=sha256:ee0b940bfaaafbdc7050887dca0eb923ac217cbb4a03bf2a426e3c8dea165ffe
+django-bulk-update==2.2.0 \
+    --hash=sha256:49a403392ae05ea872494d74fb3dfa3515f8df5c07cc277c3dc94724c0ee6985 \
+    --hash=sha256:5ab7ce8a65eac26d19143cc189c0f041d5c03b9d1b290ca240dc4f3d6aaeb337
 django-cors-headers==1.1.0 \
     --hash=sha256:fcd96e2be47c8eef34c650e007a6d546e19e7ee61041b89edbbbbe7619aa3987
 django_csp==3.4 \


### PR DESCRIPTION
Hey @mathjazz 

Tests are failing on Python 3 because the database migrations throw errors (I'll post them as comments).
I've fixed the migrations and updated the `django-bulk-update` package to the latest version.

Can you look at this? Thanks :-)
