### PR TITLE
Fix bug 1501356 - Add ability to generate a permalink to a string

### DIFF
--- a/frontend/public/static/locale/en-US/translate.ftl
+++ b/frontend/public/static/locale/en-US/translate.ftl
@@ -154,8 +154,10 @@ editor-UnsavedChanges--leave-anyway = Leave anyway
 
 
 ## Entity Details Navigation
-## Shows next/previous buttons.
+## Copies string link - Shows next/previous buttons.
 
+entitydetails-EntityNavigation--link = <glyph></glyph>Copy Link
+    .title = Copy Link to String
 entitydetails-EntityNavigation--next = <glyph></glyph>Next
     .title = Go To Next String (Alt + Down)
 entitydetails-EntityNavigation--previous = <glyph></glyph>Previous

--- a/frontend/public/static/locale/en-US/translate.ftl
+++ b/frontend/public/static/locale/en-US/translate.ftl
@@ -154,7 +154,7 @@ editor-UnsavedChanges--leave-anyway = Leave anyway
 
 
 ## Entity Details Navigation
-## Copies string link - Shows next/previous buttons.
+## Shows Copy Link and Next/Previous buttons.
 
 entitydetails-EntityNavigation--link = <glyph></glyph>Copy Link
     .title = Copy Link to String
@@ -365,6 +365,7 @@ notification--tt-checks-disabled = Translate Toolkit Checks disabled
 notification--make-suggestions-enabled = Make Suggestions enabled
 notification--make-suggestions-disabled = Make Suggestions disabled
 notification--entity-not-found = Can’t load specified string
+notification--string-link-copied = Link copied to clipboard
 
 
 ## OtherLocales Translation

--- a/frontend/src/core/notification/messages.js
+++ b/frontend/src/core/notification/messages.js
@@ -117,4 +117,10 @@ export default {
         </Localized>,
         type: 'error',
     },
+    'STRING_LINK_COPIED': {
+        content: <Localized id='notification--string-link-copied'>
+            Link copied to clipboard
+        </Localized>,
+        type: 'info',
+    },
 };

--- a/frontend/src/modules/entitydetails/components/EntityDetails.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.js
@@ -168,6 +168,10 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
         dispatch(machinery.actions.get(source, locale, pk));
     }
 
+    copyLinkToClipboard = () => {
+        console.log("hello");
+    }
+
     goToNextEntity = () => {
         const { dispatch, nextEntity, router } = this.props;
 
@@ -269,6 +273,7 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
 
         return <section className="entity-details">
             <EntityNavigation
+                copyLinkToClipboard={ this.copyLinkToClipboard }
                 goToNextEntity={ this.goToNextEntity }
                 goToPreviousEntity={ this.goToPreviousEntity }
             />

--- a/frontend/src/modules/entitydetails/components/EntityDetails.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.js
@@ -172,7 +172,7 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
     copyLinkToClipboard = () => {
         const { locale, project, resource, entity } = this.props.parameters;
 
-        let string_link = `${window.location.host}/${locale}/${project}/${resource}/?string=${entity}`
+        const string_link = `${location.protocol}//${location.host}/${locale}/${project}/${resource}/?string=${entity}`
         navigator.clipboard.writeText(string_link).then(() => {
             // Notify the user of the change that happened.
             const notif = notification.messages.STRING_LINK_COPIED;

--- a/frontend/src/modules/entitydetails/components/EntityDetails.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.js
@@ -20,6 +20,7 @@ import * as otherlocales from 'modules/otherlocales';
 import * as genericeditor from 'modules/genericeditor';
 import * as fluenteditor from 'modules/fluenteditor';
 import * as unsavedchanges from 'modules/unsavedchanges';
+import * as notification from 'core/notification';
 
 import EntityNavigation from './EntityNavigation';
 import Metadata from './Metadata';
@@ -170,10 +171,12 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
 
     copyLinkToClipboard = () => {
         const { locale, project, resource, entity } = this.props.parameters;
-        
+
         let string_link = `/${locale}/${project}/${resource}/?string=${entity}`
-        navigator.clipboard.writeText(string_link).then(function() {
-            //TODO  Add success message and error handling
+        navigator.clipboard.writeText(string_link).then(() => {
+            // Notify the user of the change that happened.
+            const notif = notification.messages.STRING_LINK_COPIED;
+            this.props.dispatch(notification.actions.add(notif));
         });
     }
 

--- a/frontend/src/modules/entitydetails/components/EntityDetails.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.js
@@ -172,7 +172,7 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
     copyLinkToClipboard = () => {
         const { locale, project, resource, entity } = this.props.parameters;
 
-        let string_link = `https://pontoon.mozilla.org/${locale}/${project}/${resource}/?string=${entity}`
+        let string_link = `${window.location.host}/${locale}/${project}/${resource}/?string=${entity}`
         navigator.clipboard.writeText(string_link).then(() => {
             // Notify the user of the change that happened.
             const notif = notification.messages.STRING_LINK_COPIED;

--- a/frontend/src/modules/entitydetails/components/EntityDetails.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.js
@@ -171,8 +171,9 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
 
     copyLinkToClipboard = () => {
         const { locale, project, resource, entity } = this.props.parameters;
+        const { protocol, host } = window.location;
 
-        const string_link = `${location.protocol}//${location.host}/${locale}/${project}/${resource}/?string=${entity}`
+        const string_link = `${protocol}//${host}/${locale}/${project}/${resource}/?string=${entity}`;
         navigator.clipboard.writeText(string_link).then(() => {
             // Notify the user of the change that happened.
             const notif = notification.messages.STRING_LINK_COPIED;

--- a/frontend/src/modules/entitydetails/components/EntityDetails.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.js
@@ -172,7 +172,7 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
     copyLinkToClipboard = () => {
         const { locale, project, resource, entity } = this.props.parameters;
 
-        let string_link = `/${locale}/${project}/${resource}/?string=${entity}`
+        let string_link = `https://pontoon.mozilla.org/${locale}/${project}/${resource}/?string=${entity}`
         navigator.clipboard.writeText(string_link).then(() => {
             // Notify the user of the change that happened.
             const notif = notification.messages.STRING_LINK_COPIED;

--- a/frontend/src/modules/entitydetails/components/EntityDetails.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.js
@@ -169,7 +169,12 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
     }
 
     copyLinkToClipboard = () => {
-        console.log("hello");
+        const { locale, project, resource, entity } = this.props.parameters;
+        
+        let string_link = `/${locale}/${project}/${resource}/?string=${entity}`
+        navigator.clipboard.writeText(string_link).then(function() {
+            //TODO  Add success message and error handling
+        });
     }
 
     goToNextEntity = () => {

--- a/frontend/src/modules/entitydetails/components/EntityNavigation.css
+++ b/frontend/src/modules/entitydetails/components/EntityNavigation.css
@@ -14,6 +14,10 @@
     text-transform: uppercase;
 }
 
+.entity-navigation button.link {
+    float: left;
+}
+
 .entity-navigation button.previous {
     margin-right: 30px;
 }

--- a/frontend/src/modules/entitydetails/components/EntityNavigation.js
+++ b/frontend/src/modules/entitydetails/components/EntityNavigation.js
@@ -16,7 +16,7 @@ type Props = {|
 /**
  * Component showing entity navigation toolbar.
  *
- * Shows next/previous buttons.
+ * Shows copy link and next/previous buttons.
  */
 export default class EntityNavigation extends React.Component<Props> {
     componentDidMount() {
@@ -37,13 +37,13 @@ export default class EntityNavigation extends React.Component<Props> {
         // On Alt + Up, move to the previous entity.
         if (key === 38 && event.altKey && !event.ctrlKey && !event.shiftKey) {
             handledEvent = true;
-            this.goToPreviousEntity();
+            this.props.goToPreviousEntity();
         }
 
         // On Alt + Down, move to the next entity.
         if (key === 40 && event.altKey && !event.ctrlKey && !event.shiftKey) {
             handledEvent = true;
-            this.goToNextEntity();
+            this.props.goToNextEntity();
         }
 
         if (handledEvent) {

--- a/frontend/src/modules/entitydetails/components/EntityNavigation.js
+++ b/frontend/src/modules/entitydetails/components/EntityNavigation.js
@@ -29,18 +29,6 @@ export default class EntityNavigation extends React.Component<Props> {
         document.removeEventListener('keydown', this.handleShortcuts);
     }
 
-    copyLinkToClipboard = () => {
-        this.props.copyLinkToClipboard();
-    }
-
-    goToNextEntity = () => {
-        this.props.goToNextEntity();
-    }
-
-    goToPreviousEntity = () => {
-        this.props.goToPreviousEntity();
-    }
-
     handleShortcuts = (event: SyntheticKeyboardEvent<>) => {
         const key = event.keyCode;
 
@@ -75,7 +63,7 @@ export default class EntityNavigation extends React.Component<Props> {
                 <button
                     className="link"
                     title="Copy Link to String"
-                    onClick={ this.copyLinkToClipboard }
+                    onClick={ this.props.copyLinkToClipboard }
                 >
                     { '<glyph></glyph>Copy Link' }
                 </button>
@@ -90,7 +78,7 @@ export default class EntityNavigation extends React.Component<Props> {
                 <button
                     className="next"
                     title="Go To Next String (Alt + Down)"
-                    onClick={ this.goToNextEntity }
+                    onClick={ this.props.goToNextEntity }
                 >
                     { '<glyph></glyph>Next' }
                 </button>
@@ -105,7 +93,7 @@ export default class EntityNavigation extends React.Component<Props> {
                 <button
                     className="previous"
                     title="Go To Previous String (Alt + Up)"
-                    onClick={ this.goToPreviousEntity }
+                    onClick={ this.props.goToPreviousEntity }
                 >
                     { '<glyph></glyph>Previous' }
                 </button>

--- a/frontend/src/modules/entitydetails/components/EntityNavigation.js
+++ b/frontend/src/modules/entitydetails/components/EntityNavigation.js
@@ -7,6 +7,7 @@ import './EntityNavigation.css';
 
 
 type Props = {|
+    +copyLinkToClipboard: () => void,
     +goToNextEntity: () => void,
     +goToPreviousEntity: () => void,
 |};
@@ -26,6 +27,10 @@ export default class EntityNavigation extends React.Component<Props> {
     componentWillUnmount() {
         // $FLOW_IGNORE (errors that I don't understand, no help from the Web)
         document.removeEventListener('keydown', this.handleShortcuts);
+    }
+
+    copyLinkToClipboard = () => {
+        this.props.copyLinkToClipboard();
     }
 
     goToNextEntity = () => {
@@ -60,6 +65,21 @@ export default class EntityNavigation extends React.Component<Props> {
 
     render(): React.Node {
         return <div className='entity-navigation clearfix'>
+            <Localized
+                id="entitydetails-EntityNavigation--link"
+                attrs={{ title: true }}
+                glyph={
+                    <i className="fa fa-link fa-lg"></i>
+                }
+            >
+                <button
+                    className="link"
+                    title="Copy Link to String"
+                    onClick={ this.copyLinkToClipboard }
+                >
+                    { '<glyph></glyph>Copy Link' }
+                </button>
+            </Localized>
             <Localized
                 id="entitydetails-EntityNavigation--next"
                 attrs={{ title: true }}

--- a/frontend/src/modules/entitydetails/components/EntityNavigation.js
+++ b/frontend/src/modules/entitydetails/components/EntityNavigation.js
@@ -7,7 +7,7 @@ import './EntityNavigation.css';
 
 
 type Props = {|
-    +copyLinkToClipboard: () => void,
+    copyLinkToClipboard: () => void,
     +goToNextEntity: () => void,
     +goToPreviousEntity: () => void,
 |};

--- a/frontend/src/modules/entitydetails/components/EntityNavigation.js
+++ b/frontend/src/modules/entitydetails/components/EntityNavigation.js
@@ -7,7 +7,7 @@ import './EntityNavigation.css';
 
 
 type Props = {|
-    copyLinkToClipboard: () => void,
+    +copyLinkToClipboard: () => void,
     +goToNextEntity: () => void,
     +goToPreviousEntity: () => void,
 |};

--- a/frontend/src/modules/entitydetails/components/EntityNavigation.test.js
+++ b/frontend/src/modules/entitydetails/components/EntityNavigation.test.js
@@ -11,7 +11,7 @@ describe('<EntityNavigation>', () => {
         const nextMock = sinon.stub();
         const prevMock = sinon.stub();
         const wrapper = create(<EntityNavigation
-            copyToClipboard={ copyMock }
+            copyLinkToClipboard={ copyMock }
             goToNextEntity={ nextMock }
             goToPreviousEntity={ prevMock }
         />);

--- a/frontend/src/modules/entitydetails/components/EntityNavigation.test.js
+++ b/frontend/src/modules/entitydetails/components/EntityNavigation.test.js
@@ -7,19 +7,30 @@ import EntityNavigation from './EntityNavigation';
 
 describe('<EntityNavigation>', () => {
     function getEntityNav({ create = shallow } = {}) {
+        const copyMock = sinon.stub();
         const nextMock = sinon.stub();
         const prevMock = sinon.stub();
         const wrapper = create(<EntityNavigation
+            copyToClipboard={ copyMock }
             goToNextEntity={ nextMock }
             goToPreviousEntity={ prevMock }
         />);
 
         return {
             wrapper,
+            copyMock,
             nextMock,
             prevMock,
         };
     }
+
+    it('puts a copy of string link on clipboard', () => {
+        const { wrapper, copyMock } = getEntityNav();
+
+        expect(copyMock.calledOnce).toBeFalsy();
+        wrapper.find('button.next').simulate('click');
+        expect(copyMock.calledOnce).toBeTruthy();
+    })
 
     it('goes to the next entity on click on the Next button', () => {
         const { wrapper, nextMock } = getEntityNav();

--- a/frontend/src/modules/entitydetails/components/EntityNavigation.test.js
+++ b/frontend/src/modules/entitydetails/components/EntityNavigation.test.js
@@ -28,7 +28,7 @@ describe('<EntityNavigation>', () => {
         const { wrapper, copyMock } = getEntityNav();
 
         expect(copyMock.calledOnce).toBeFalsy();
-        wrapper.find('button.next').simulate('click');
+        wrapper.find('button.link').simulate('click');
         expect(copyMock.calledOnce).toBeTruthy();
     })
 


### PR DESCRIPTION
Add a feature to generate a permanent link to a string, without any (or at least mutable) queryset parameters (e.g. status filters).

This fix adds a link which when clicked will add the correct URL (without additional parameters) to the clipboard and display a message to let the user know the copy has been made.