### PR TITLE
Bug 1585251 fix typeerorr bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,9 @@ test-py3: test
 shell-py3: override PYTHON_VERSION=3.7.3
 shell-py3: shell
 
+pytest-py3: override PYTHON_VERSION=3.7.3
+pytest-py3: pytest
+
 
 setup: .docker-build
 	${DC} run webapp /app/docker/set_up_webapp.sh
@@ -69,6 +72,9 @@ flow:
 
 lint-frontend:
 	${DC} run --rm -w /app/frontend webapp ./node_modules/.bin/eslint src/
+
+pytest:
+	${DC} run --rm -w /app webapp pytest --cov-append --cov-report=term --cov=. $(opts)
 
 shell:
 	${DC} run --rm webapp /bin/bash

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -731,7 +731,7 @@ class Locale(AggregatedStats):
         if self.cldr_plurals == '':
             return [1]
         else:
-            return map(int, self.cldr_plurals.split(','))
+            return [int(p) for p in self.cldr_plurals.split(',')]
 
     def cldr_plurals_list(self):
         return ', '.join(
@@ -1928,7 +1928,7 @@ class EntityQuerySet(models.QuerySet):
                         lambda x: x.plural_form == i,
                         candidate.fetched_translations
                     )
-                    if len(candidate_translations) and rule(candidate_translations[0]):
+                    if len(list(candidate_translations)) and rule(candidate_translations[0]):
                         count += 1
 
                         # No point going on if we don't care about matching all.

--- a/pontoon/base/tests/__init__.py
+++ b/pontoon/base/tests/__init__.py
@@ -297,7 +297,7 @@ def create_named_tempfile(contents, prefix=None, suffix=None, directory=None):
         dir=directory,
         delete=False,
     ) as temp:
-        temp.write(contents)
+        temp.write(bytes(contents, 'utf-8'))
         temp.flush()
 
     return temp.name

--- a/pontoon/base/tests/__init__.py
+++ b/pontoon/base/tests/__init__.py
@@ -297,7 +297,7 @@ def create_named_tempfile(contents, prefix=None, suffix=None, directory=None):
         dir=directory,
         delete=False,
     ) as temp:
-        temp.write(bytes(contents, 'utf-8'))
+        temp.write(contents.encode('utf-8'))
         temp.flush()
 
     return temp.name

--- a/pontoon/batch/tests/test_views.py
+++ b/pontoon/batch/tests/test_views.py
@@ -87,12 +87,12 @@ def test_batch_edit_translations_bad_request(batch_action, member, locale_a):
     # No `locale` parameter.
     response = batch_action(action='reject')
     assert response.status_code == 400
-    assert 'locale' in response.content
+    assert b'locale' in response.content
 
     # No `action` parameter.
     response = batch_action(locale=locale_a.code)
     assert response.status_code == 400
-    assert 'action' in response.content
+    assert b'action' in response.content
 
     # Incorrect `action` parameter.
     response = batch_action(
@@ -101,7 +101,7 @@ def test_batch_edit_translations_bad_request(batch_action, member, locale_a):
     )
 
     assert response.status_code == 400
-    assert 'action' in response.content
+    assert b'action' in response.content
 
 
 @pytest.mark.django_db

--- a/pontoon/sync/changeset.py
+++ b/pontoon/sync/changeset.py
@@ -60,7 +60,7 @@ class ChangeSet(object):
     @property
     def changed_translations(self):
         """A list of Translation objects that have been created or updated."""
-        return self.translations_to_create + self.translations_to_update.values()
+        return self.translations_to_create + list(self.translations_to_update.values())
 
     def update_vcs_entity(self, locale, db_entity, vcs_entity):
         """

--- a/pontoon/sync/formats/compare_locales.py
+++ b/pontoon/sync/formats/compare_locales.py
@@ -60,7 +60,7 @@ class CompareLocalesResource(ParsedResource):
                     entity.key,
                     None,
                     None,
-                    None,
+                    0,
                 )
 
         try:
@@ -109,11 +109,14 @@ class CompareLocalesResource(ParsedResource):
         with open(self.path, 'w') as output_file:
             log.debug('Saving file: %s', self.path)
             output_file.write(
-                serializer.serialize(
-                    self.path,
-                    self.source_resource.parsed_objects,
-                    self.parsed_objects,
-                    new_l10n,
+                str(
+                    serializer.serialize(
+                        self.path,
+                        self.source_resource.parsed_objects,
+                        self.parsed_objects,
+                        new_l10n,
+                    ),
+                    'utf-8',
                 )
             )
 

--- a/pontoon/sync/formats/compare_locales.py
+++ b/pontoon/sync/formats/compare_locales.py
@@ -109,15 +109,12 @@ class CompareLocalesResource(ParsedResource):
         with open(self.path, 'w') as output_file:
             log.debug('Saving file: %s', self.path)
             output_file.write(
-                str(
-                    serializer.serialize(
-                        self.path,
-                        self.source_resource.parsed_objects,
-                        self.parsed_objects,
-                        new_l10n,
-                    ),
-                    'utf-8',
-                )
+                serializer.serialize(
+                    self.path,
+                    self.source_resource.parsed_objects,
+                    self.parsed_objects,
+                    new_l10n,
+                ).decode('utf-8'),
             )
 
 

--- a/pontoon/sync/formats/silme.py
+++ b/pontoon/sync/formats/silme.py
@@ -128,7 +128,7 @@ class SilmeResource(ParsedResource):
 
     @property
     def translations(self):
-        return self.entities.values()
+        return list(self.entities.values())
 
     def save(self, locale):
         """

--- a/pontoon/sync/tests/formats/__init__.py
+++ b/pontoon/sync/tests/formats/__init__.py
@@ -363,7 +363,8 @@ class FormatTestsMixin(object):
             MissingString=Translated Missing String
         """
         path, resource = self.parse_string(input_string, source_string=source_string)
-
+        print("bbbv", resource.entities.values(),
+              [e.order for e in resource.entities.values()])
         missing_translation = match_attr(resource.translations, key=self.key('Missing String'))
         missing_translation.strings = {None: expected_translation or 'Translated Missing String'}
         resource.save(self.locale)

--- a/pontoon/sync/tests/formats/__init__.py
+++ b/pontoon/sync/tests/formats/__init__.py
@@ -363,8 +363,6 @@ class FormatTestsMixin(object):
             MissingString=Translated Missing String
         """
         path, resource = self.parse_string(input_string, source_string=source_string)
-        print("bbbv", resource.entities.values(),
-              [e.order for e in resource.entities.values()])
         missing_translation = match_attr(resource.translations, key=self.key('Missing String'))
         missing_translation.strings = {None: expected_translation or 'Translated Missing String'}
         resource.save(self.locale)

--- a/pontoon/sync/tests/formats/test_compare_locales.py
+++ b/pontoon/sync/tests/formats/test_compare_locales.py
@@ -46,7 +46,7 @@ class CompareLocalesResourceTests(TestCase):
         """)
 
         source_path = create_named_tempfile(
-            bytes(contents, 'utf-8'),
+            contents,
             prefix='strings',
             suffix='.xml',
             directory=self.tempdir,
@@ -144,14 +144,14 @@ class AndroidXMLTests(FormatTestsMixin, TestCase):
     ):
         """Android XML files must contain the word 'strings'."""
         path = create_named_tempfile(
-            string,
+            string.encode('utf-8'),
             prefix='strings',
             suffix='.xml',
             directory=self.tempdir,
         )
         if source_string is not None:
             source_path = create_named_tempfile(
-                source_string,
+                source_string.encode('utf-8'),
                 prefix='strings',
                 suffix='.xml',
                 directory=self.tempdir,

--- a/pontoon/sync/tests/formats/test_compare_locales.py
+++ b/pontoon/sync/tests/formats/test_compare_locales.py
@@ -46,7 +46,7 @@ class CompareLocalesResourceTests(TestCase):
         """)
 
         source_path = create_named_tempfile(
-            contents,
+            bytes(contents, 'utf-8'),
             prefix='strings',
             suffix='.xml',
             directory=self.tempdir,

--- a/pontoon/tags/tests/test_views.py
+++ b/pontoon/tags/tests/test_views.py
@@ -232,5 +232,5 @@ def test_view_project_tag_ajax(client, project_a, tag_a):
     # response returns html
     with pytest.raises(ValueError):
         response.json()
-    assert bytes(tag_a.name, 'utf-8') in response.content
-    assert bytes(tag_a.slug, 'utf-8') in response.content
+    assert tag_a.name.encode('utf-8') in response.content
+    assert tag_a.slug.encode('utf-8') in response.content

--- a/pontoon/tags/tests/test_views.py
+++ b/pontoon/tags/tests/test_views.py
@@ -232,5 +232,5 @@ def test_view_project_tag_ajax(client, project_a, tag_a):
     # response returns html
     with pytest.raises(ValueError):
         response.json()
-    assert tag_a.name in response.content
-    assert tag_a.slug in response.content
+    assert bytes(tag_a.name, 'utf-8') in response.content
+    assert bytes(tag_a.slug, 'utf-8') in response.content

--- a/pontoon/teams/tests/test_views.py
+++ b/pontoon/teams/tests/test_views.py
@@ -136,14 +136,14 @@ def test_users_permissions_for_ajax_permissions_view(
         locale=locale_a.code
     ))
     assert response.status_code == 403
-    assert '<title>Forbidden page</title>' in response.content
+    assert b'<title>Forbidden page</title>' in response.content
 
     # Check if users without permissions for the locale can get this tab.
     response = member.client.get('/{locale}/ajax/permissions/'.format(
         locale=locale_a.code
     ))
     assert response.status_code == 403
-    assert '<title>Forbidden page</title>' in response.content
+    assert b'<title>Forbidden page</title>' in response.content
 
     locale_a.managers_group.user_set.add(member.user)
 
@@ -152,7 +152,7 @@ def test_users_permissions_for_ajax_permissions_view(
         locale=locale_a.code
     ))
     assert response.status_code == 200
-    assert '<title>Forbidden page</title>' not in response.content
+    assert b'<title>Forbidden page</title>' not in response.content
 
     # Remove permissions for user0 and check if the view is not accessible.
     locale_a.managers_group.user_set.clear()
@@ -161,7 +161,7 @@ def test_users_permissions_for_ajax_permissions_view(
         locale=locale_a.code
     ))
     assert response.status_code == 403
-    assert '<title>Forbidden page</title>' in response.content
+    assert b'<title>Forbidden page</title>' in response.content
 
     # All unauthorized attempts to POST data should be blocked
     response = member.client.post(
@@ -171,7 +171,7 @@ def test_users_permissions_for_ajax_permissions_view(
         data={'smth': 'smth'}
     )
     assert response.status_code == 403
-    assert '<title>Forbidden page</title>' in response.content
+    assert b'<title>Forbidden page</title>' in response.content
 
     response = client.post(
         '/{locale}/ajax/permissions/'.format(
@@ -180,7 +180,7 @@ def test_users_permissions_for_ajax_permissions_view(
         data={'smth': 'smth'}
     )
     assert response.status_code == 403
-    assert '<title>Forbidden page</title>' in response.content
+    assert b'<title>Forbidden page</title>' in response.content
 
 
 @pytest.mark.django_db

--- a/pontoon/translate/tests/test_views.py
+++ b/pontoon/translate/tests/test_views.py
@@ -34,7 +34,7 @@ def test_translate_template(client):
 
     with override_flag('translate_next', active=True):
         response = client.get(url)
-        assert 'Pontoon' in response.content
+        assert b'Pontoon' in response.content
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Hey!

I've decided to fix 120 tests to speed things up. ~110 left to go.
I'll update the commit message to give more context about errors that had been fixed.
List of fixed tests for Python 3:
```
file=pontoon/base/tests/managers/test_entity.py name=test_mgr_entity_reset_active_translations
file=pontoon/contributors/tests/test_views.py name=test_invalid_email
file=pontoon/contributors/tests/test_views.py name=test_invalid_first_name
file=pontoon/contributors/tests/test_views.py name=test_missing_profile_fields
file=pontoon/contributors/tests/test_views.py name=test_user_locales_order
file=pontoon/contributors/tests/test_views.py name=test_valid_first_name
file=pontoon/pretranslation/tests/test_pretranslate.py name=test_get_translations
file=pontoon/sync/tests/test_changeset.py name=test_changed_translations_created
file=pontoon/sync/tests/test_changeset.py name=test_changed_translations_no_changes
file=pontoon/sync/tests/test_changeset.py name=test_create_db
file=pontoon/sync/tests/test_changeset.py name=test_execute_called_once
file=pontoon/sync/tests/test_changeset.py name=test_obsolete_db
file=pontoon/sync/tests/test_changeset.py name=test_update_db_clean_entity_translation
file=pontoon/sync/tests/test_changeset.py name=test_update_db_new_translation
file=pontoon/sync/tests/test_changeset.py name=test_update_db_unapprove_clean
file=pontoon/sync/tests/test_changeset.py name=test_update_vcs_entity
file=pontoon/sync/tests/test_changeset.py name=test_update_vcs_entity_fuzzy
file=pontoon/sync/tests/test_changeset.py name=test_update_vcs_entity_not_fuzzy
file=pontoon/sync/tests/test_changeset.py name=test_update_vcs_entity_unapproved
file=pontoon/sync/tests/test_changeset.py name=test_update_vcs_entity_user
file=pontoon/sync/tests/test_changeset.py name=test_update_vcs_last_translation_no_translations
file=pontoon/sync/tests/formats/test_compare_locales.py name=test_init_missing_resource_with_source
file=pontoon/sync/tests/formats/test_compare_locales.py name=test_save_create_dirs
file=pontoon/sync/tests/formats/test_ftl.py name=test_init_missing_resource
file=pontoon/sync/tests/formats/test_ftl.py name=test_init_missing_resource_with_source
file=pontoon/sync/tests/formats/test_ftl.py name=test_parse_with_no_source_path
file=pontoon/sync/tests/formats/test_ftl.py name=test_parse_with_source_path
file=pontoon/sync/tests/formats/test_ftl.py name=test_save_create_dirs
file=pontoon/sync/tests/formats/test_ftl.py name=test_parse_basic
file=pontoon/sync/tests/formats/test_ftl.py name=test_parse_multiple_comments
file=pontoon/sync/tests/formats/test_ftl.py name=test_parse_no_comments_no_sources
file=pontoon/sync/tests/formats/test_ftl.py name=test_save_basic
file=pontoon/sync/tests/formats/test_ftl.py name=test_save_remove
file=pontoon/sync/tests/formats/test_ftl.py name=test_save_source_no_translation
file=pontoon/sync/tests/formats/test_ftl.py name=test_save_source_removed
file=pontoon/sync/tests/formats/test_ftl.py name=test_save_translation_identical
file=pontoon/sync/tests/formats/test_ftl.py name=test_save_translation_missing
file=pontoon/sync/tests/formats/test_json_extensions.py name=test_parse_basic
file=pontoon/sync/tests/formats/test_json_extensions.py name=test_parse_multiple_comments
file=pontoon/sync/tests/formats/test_json_extensions.py name=test_parse_no_comments_no_sources
file=pontoon/sync/tests/formats/test_json_extensions.py name=test_parse_placeholder
file=pontoon/sync/tests/formats/test_json_extensions.py name=test_save_remove
file=pontoon/sync/tests/formats/test_lang.py name=test_load_utf8_bom
file=pontoon/sync/tests/formats/test_lang.py name=test_parse_basic
file=pontoon/sync/tests/formats/test_lang.py name=test_parse_comments_arbitrary_hash
file=pontoon/sync/tests/formats/test_lang.py name=test_parse_eof
file=pontoon/sync/tests/formats/test_lang.py name=test_parse_multiple_comments
file=pontoon/sync/tests/formats/test_lang.py name=test_parse_no_comments_no_sources
file=pontoon/sync/tests/formats/test_lang.py name=test_preserve_comment_hashes
file=pontoon/sync/tests/formats/test_lang.py name=test_save_basic
file=pontoon/sync/tests/formats/test_lang.py name=test_save_remove
file=pontoon/sync/tests/formats/test_po.py name=test_parse_basic
file=pontoon/sync/tests/formats/test_po.py name=test_parse_context
file=pontoon/sync/tests/formats/test_po.py name=test_parse_fuzzy
file=pontoon/sync/tests/formats/test_po.py name=test_parse_missing_translation
file=pontoon/sync/tests/formats/test_po.py name=test_parse_multiple_comments
file=pontoon/sync/tests/formats/test_po.py name=test_parse_multiple_sources
file=pontoon/sync/tests/formats/test_po.py name=test_parse_no_comments_no_sources
file=pontoon/sync/tests/formats/test_po.py name=test_parse_plural_translation
file=pontoon/sync/tests/formats/test_po.py name=test_parse_plural_translation_missing
file=pontoon/sync/tests/formats/test_po.py name=test_save_basic
file=pontoon/sync/tests/formats/test_po.py name=test_save_extra_metadata
file=pontoon/sync/tests/formats/test_po.py name=test_save_metadata
file=pontoon/sync/tests/formats/test_po.py name=test_save_plural
file=pontoon/sync/tests/formats/test_po.py name=test_save_plural_remove
file=pontoon/sync/tests/formats/test_po.py name=test_save_preserve_fuzzy
file=pontoon/sync/tests/formats/test_po.py name=test_save_remove
file=pontoon/sync/tests/formats/test_po.py name=test_save_remove_fuzzy
file=pontoon/sync/tests/formats/test_silme.py name=test_init_missing_resource_with_source
file=pontoon/sync/tests/formats/test_silme.py name=test_save_create_dirs
file=pontoon/sync/tests/formats/test_silme.py name=test_parse_basic
file=pontoon/sync/tests/formats/test_silme.py name=test_parse_empty_translation
file=pontoon/sync/tests/formats/test_silme.py name=test_parse_multiple_comments
file=pontoon/sync/tests/formats/test_silme.py name=test_parse_no_comments_no_sources
file=pontoon/sync/tests/formats/test_silme.py name=test_save_basic
file=pontoon/sync/tests/formats/test_silme.py name=test_save_remove
file=pontoon/sync/tests/formats/test_silme.py name=test_save_source_no_translation
file=pontoon/sync/tests/formats/test_silme.py name=test_save_source_removed
file=pontoon/sync/tests/formats/test_silme.py name=test_save_translation_identical
file=pontoon/sync/tests/formats/test_silme.py name=test_save_translation_missing
file=pontoon/sync/tests/formats/test_silme.py name=test_parse_basic
file=pontoon/sync/tests/formats/test_silme.py name=test_parse_empty_translation
file=pontoon/sync/tests/formats/test_silme.py name=test_parse_multiple_comments
file=pontoon/sync/tests/formats/test_silme.py name=test_parse_no_comments_no_sources
file=pontoon/sync/tests/formats/test_silme.py name=test_save_basic
file=pontoon/sync/tests/formats/test_silme.py name=test_save_remove
file=pontoon/sync/tests/formats/test_silme.py name=test_save_source_no_translation
file=pontoon/sync/tests/formats/test_silme.py name=test_save_source_removed
file=pontoon/sync/tests/formats/test_silme.py name=test_save_translation_identical
file=pontoon/sync/tests/formats/test_silme.py name=test_save_translation_missing
file=pontoon/sync/tests/formats/test_silme.py name=test_parse_basic
file=pontoon/sync/tests/formats/test_silme.py name=test_parse_empty_translation
file=pontoon/sync/tests/formats/test_silme.py name=test_parse_multiple_comments
file=pontoon/sync/tests/formats/test_silme.py name=test_parse_no_comments_no_sources
file=pontoon/sync/tests/formats/test_silme.py name=test_save_basic
file=pontoon/sync/tests/formats/test_silme.py name=test_save_remove
file=pontoon/sync/tests/formats/test_silme.py name=test_save_source_no_translation
file=pontoon/sync/tests/formats/test_silme.py name=test_save_source_removed
file=pontoon/sync/tests/formats/test_silme.py name=test_save_translation_identical
file=pontoon/sync/tests/formats/test_silme.py name=test_save_translation_missing
file=pontoon/sync/tests/formats/test_silme.py name=test_moz_langpack_contributors
file=pontoon/sync/tests/formats/test_silme.py name=test_moz_langpack_contributors_source
file=pontoon/sync/tests/formats/test_silme.py name=test_parse_basic
file=pontoon/sync/tests/formats/test_silme.py name=test_parse_empty_translation
file=pontoon/sync/tests/formats/test_silme.py name=test_parse_multiple_comments
file=pontoon/sync/tests/formats/test_silme.py name=test_parse_no_comments_no_sources
file=pontoon/sync/tests/formats/test_silme.py name=test_save_basic
file=pontoon/sync/tests/formats/test_silme.py name=test_save_moz_langpack_contributors
file=pontoon/sync/tests/formats/test_silme.py name=test_save_remove
file=pontoon/sync/tests/formats/test_silme.py name=test_save_source_no_translation
file=pontoon/sync/tests/formats/test_silme.py name=test_save_source_removed
file=pontoon/sync/tests/formats/test_silme.py name=test_save_translation_identical
file=pontoon/sync/tests/formats/test_silme.py name=test_save_translation_missing
file=pontoon/sync/tests/formats/test_xliff.py name=test_parse_basic
file=pontoon/sync/tests/formats/test_xliff.py name=test_parse_missing_translation
file=pontoon/sync/tests/formats/test_xliff.py name=test_parse_multiple_comments
file=pontoon/sync/tests/formats/test_xliff.py name=test_parse_no_comments_no_sources
file=pontoon/tags/tests/test_views.py name=test_view_project_tag_ajax
file=pontoon/teams/tests/test_views.py name=test_users_permissions_for_ajax_permissions_view
file=pontoon/translate/tests/test_views.py name=test_translate_template
```
I would love to get your feedback about those changes! ping: @mathjazz @adngdb