### PR TITLE
Fix Bug 1588468 - Prevent long Locale codes to break layout

### DIFF
--- a/pontoon/base/static/css/table.css
+++ b/pontoon/base/static/css/table.css
@@ -130,6 +130,14 @@ table.table {
   color: #F36;
 }
 
+.table td.code div{
+  width: 70px;
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .table td.code a {
   color: #7BC876;
   line-height: 47px;

--- a/pontoon/base/static/css/table.css
+++ b/pontoon/base/static/css/table.css
@@ -130,9 +130,8 @@ table.table {
   color: #F36;
 }
 
-.table td.code div{
+.table td.code div {
   width: 70px;
-  display: block;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/pontoon/teams/templates/teams/widgets/team_list.html
+++ b/pontoon/teams/templates/teams/widgets/team_list.html
@@ -27,7 +27,9 @@
       </h4>
     </td>
     <td class="code">
+      <div>
         <a href="{{ main_link }}">{{ locale.code }}</a>
+      </div>
     </td>
     <td class="population">
       <span>{{ locale.population|intcomma or 'Unknown' }}</span>


### PR DESCRIPTION
This fix make a long locale code in [teams] (https://pontoon.mozilla.org/teams/) page cut out and replaced by ellipsis (...) instead of showing them in two lines. This way long codes will not break the layout of the column or the table.

The outcome of this change :
<img width="1280" alt=" Bug 1588468" src="https://user-images.githubusercontent.com/13032234/66849131-ae3e2b00-ef76-11e9-92cd-c457c04e2ae8.png">
