### PR TITLE
Fix bug 1344120 - Reset search placeholder icon

### DIFF
--- a/frontend/src/modules/search/components/FiltersPanel.js
+++ b/frontend/src/modules/search/components/FiltersPanel.js
@@ -36,6 +36,7 @@ type Props = {|
     toggleFilter: (string, string) => void,
     update: () => void,
     updateTimeRange: (filter: string) => void,
+    updateFiltersFromURLParams: () => void,
 |};
 
 type State = {|
@@ -78,6 +79,7 @@ export class FiltersPanelBase extends React.Component<Props, State> {
         this.setState(state => {
             return { visible: !state.visible };
         });
+        this.props.updateFiltersFromURLParams();
     }
 
     // This method is called by the Higher-Order Component `onClickOutside`
@@ -86,10 +88,13 @@ export class FiltersPanelBase extends React.Component<Props, State> {
         this.setState({
             visible: false,
         });
+        this.props.updateFiltersFromURLParams();
     }
 
     applyFilters = () => {
-        this.toggleVisibility();
+        this.setState({
+            visible: false,
+        });
         return this.props.update();
     }
 

--- a/frontend/src/modules/search/components/FiltersPanel.test.js
+++ b/frontend/src/modules/search/components/FiltersPanel.test.js
@@ -29,6 +29,7 @@ describe('<FiltersPanelBase>', () => {
                 stats={ {} }
                 parameters={ {} }
                 getAuthorsAndTimeRangeData={ sinon.spy() }
+                updateFiltersFromURLParams={ sinon.spy() }
             />
         );
 
@@ -98,6 +99,7 @@ describe('<FiltersPanelBase>', () => {
                 stats={ {} }
                 parameters={ {} }
                 getAuthorsAndTimeRangeData={ sinon.spy() }
+                updateFiltersFromURLParams={ sinon.spy() }
             />
         );
 
@@ -157,6 +159,7 @@ describe('<FiltersPanelBase>', () => {
                     parameters={ {} }
                     getAuthorsAndTimeRangeData={ sinon.spy() }
                     applySingleFilter= { applySingleFilter }
+                    updateFiltersFromURLParams={ sinon.spy() }
                 />
             );
             wrapper.find('.visibility-switch').simulate('click');
@@ -199,6 +202,7 @@ describe('<FiltersPanelBase>', () => {
                     parameters={ {} }
                     getAuthorsAndTimeRangeData={ sinon.spy() }
                     toggleFilter= { toggleFilter }
+                    updateFiltersFromURLParams={ sinon.spy() }
                 />
             );
             wrapper.find('.visibility-switch').simulate('click');
@@ -239,6 +243,7 @@ describe('<FiltersPanelBase>', () => {
                 stats={ {} }
                 parameters={ {} }
                 getAuthorsAndTimeRangeData={ sinon.spy() }
+                updateFiltersFromURLParams={ sinon.spy() }
             />
         );
 
@@ -269,6 +274,7 @@ describe('<FiltersPanelBase>', () => {
                 stats={ {} }
                 parameters={ {} }
                 getAuthorsAndTimeRangeData={ sinon.spy() }
+                updateFiltersFromURLParams={ sinon.spy() }
             />
         );
 
@@ -301,6 +307,7 @@ describe('<FiltersPanelBase>', () => {
                 parameters={ {} }
                 getAuthorsAndTimeRangeData={ sinon.spy() }
                 resetFilters={ resetFilters }
+                updateFiltersFromURLParams={ sinon.spy() }
             />
         );
 
@@ -335,6 +342,7 @@ describe('<FiltersPanelBase>', () => {
                 parameters={ {} }
                 getAuthorsAndTimeRangeData={ sinon.spy() }
                 update={ update }
+                updateFiltersFromURLParams={ sinon.spy() }
             />
         );
 

--- a/frontend/src/modules/search/components/SearchBox.js
+++ b/frontend/src/modules/search/components/SearchBox.js
@@ -65,6 +65,21 @@ export class SearchBoxBase extends React.Component<InternalProps, State> {
     constructor(props: InternalProps) {
         super(props);
 
+        this.state = {
+            search : '',
+            statuses: {},
+            extras: {},
+            tags: {},
+            timeRange: null,
+            authors: {},
+        };
+        
+        this.searchInput = React.createRef();
+    }
+
+    updateFiltersFromURLParams = () => {
+        const { props } = this;
+        
         const statuses = this.getInitialStatuses();
         if (props.parameters.status) {
             props.parameters.status.split(',').forEach(f => {
@@ -100,21 +115,20 @@ export class SearchBoxBase extends React.Component<InternalProps, State> {
 
         const searchParam = props.parameters.search;
 
-        this.state = {
+        this.setState({
             search: searchParam ? searchParam.toString() : '',
             statuses,
             extras,
             tags,
             timeRange,
             authors,
-        };
-
-        this.searchInput = React.createRef();
+        });
     }
 
     componentDidMount() {
         // $FLOW_IGNORE (errors that I don't understand, no help from the Web)
         document.addEventListener('keydown', this.handleShortcuts);
+        this.updateFiltersFromURLParams();
     }
 
     componentDidUpdate(prevProps: InternalProps) {
@@ -443,6 +457,7 @@ export class SearchBoxBase extends React.Component<InternalProps, State> {
                 toggleFilter={ this.toggleFilter }
                 update={ this.update }
                 updateTimeRange={ this.updateTimeRange }
+                updateFiltersFromURLParams={ this.updateFiltersFromURLParams }
             />
         </div>;
     }


### PR DESCRIPTION
Reset search placeholder icon when the filter selection is not applied

[1344120](https://bugzilla.mozilla.org/show_bug.cgi?id=1344120) 