### PR TITLE
[WIP] Fix bug 1558484 - Add ability to log users in using GitHub

### DIFF
--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -78,10 +78,12 @@ you create:
    production.
    Adds some additional django apps that can be helpful during day to day development.
 
-``DJANGO_LOGIN``
+``AUTHENTICATION_METHOD`
    Required for non-Mozilla deployments, which cannot use `Firefox Accounts`_ for
-   login. Set to True if you want to use the default Django login instead. This will
+   login. Set to 'django' if you want to use the default Django login instead. This will
    allow you to log in via accounts created using `manage.py shell`.
+   Set to 'fxa' if you want to use 'Firefox Accounts'.
+   Set to 'github' if you want to use 'GitHub Account'.
 
 ``ENABLE_BUGS_TAB``
    Optional. Enables Bugs tab on team pages, which pulls team data from

--- a/docs/dev/setup-virtualenv.rst
+++ b/docs/dev/setup-virtualenv.rst
@@ -182,8 +182,10 @@ The following extra settings can be added to your ``.env`` file.
    Set your `Google Analytics key`_ to use Google Analytics.
 ``MANUAL_SYNC``
    Enable Sync button in project Admin.
-``DJANGO_LOGIN``
-   Set to True if you want to use the default Django login instead of Firefox Accounts. This will allow you to log in via accounts created using `manage.py shell`.
+``AUTHENTICATION_METHOD``
+   Set to 'django' if you want to use the default Django login instead of Firefox Accounts. This will allow you to log in via accounts created using `manage.py shell`.
+   Set to 'fxa' if you want to use the Firefox Accounts.
+   Set to 'github' if you want to use GitHub Account.
 
 .. _Microsoft Translator API key: http://msdn.microsoft.com/en-us/library/hh454950
 .. _Google Analytics key: https://www.google.com/analytics/

--- a/pontoon/allauth_urls.py
+++ b/pontoon/allauth_urls.py
@@ -14,7 +14,7 @@ from django.contrib.auth.views import login, logout
 from allauth.account import views as account_views
 from allauth.socialaccount import views as socialaccount_views, providers
 
-if settings.DJANGO_LOGIN:
+if settings.AUTHENTICATION_METHOD == 'django' or settings.HEROKU_DEMO:
     urlpatterns = [
         url(r'^standalone-login/$', login, name='standalone_login'),
         url(r'^standalone-logout/$', logout, name='standalone_logout', kwargs={'next_page': '/'}),

--- a/pontoon/base/templates/django/base.html
+++ b/pontoon/base/templates/django/base.html
@@ -80,7 +80,7 @@
                   <li><a href="{% url 'pontoon.admin' %}">Admin</a></li>
                   {% endif %}
 
-                  {% if settings.DJANGO_LOGIN %}
+                  {% if settings.AUTHENTICATION_METHOD == 'django' or settings.HEROKU_DEMO %}
                     {% if user.is_authenticated %}
                       <li id="standalone-sign-out"><a href="{% url 'standalone_logout' %}" title="{{ user.email|nospam }}"><i class="fa fa-sign-out-alt fa-fw"></i>Sign out</a></li>
                     {% else %}

--- a/pontoon/base/templates/header.html
+++ b/pontoon/base/templates/header.html
@@ -25,7 +25,7 @@
 
         {% if not user.is_authenticated() %}
         <div class="sign-in-header">
-          {% if settings.DJANGO_LOGIN %}
+          {% if settings.AUTHENTICATION_METHOD == 'django' or settings.HEROKU_DEMO %}
           <a href="{{ url('standalone_login') }}" class="button">Sign in</a>
           {% else %}
           <a id="fxa-sign-in" href="{{ provider_login_url(request) }}" class="button">Sign in</a>
@@ -58,7 +58,7 @@
               {% if user.is_authenticated() %}
                 <li><a href="{{ url('pontoon.contributors.settings') }}"><i class="fa fa-cog fa-fw"></i>Settings</a></li>
 
-                {% if settings.DJANGO_LOGIN %}
+                {% if settings.AUTHENTICATION_METHOD == 'django' or settings.HEROKU_DEMO %}
                 <li id="standalone-sign-out"><a href="{{ url('standalone_logout') }}" title="{{ user.email|nospam }}"><i class="fa fa-sign-out-alt fa-fw"></i>Sign out</a></li>
                 {% else %}
                 <li id="sign-out"><a href="{{ url('account_logout') }}" title="{{ user.email|nospam }}">{{ SignOut.csrf_form() }}<i class="fa fa-sign-out-alt fa-fw"></i>Sign out</a></li>

--- a/pontoon/base/templates/translate.html
+++ b/pontoon/base/templates/translate.html
@@ -152,7 +152,7 @@
               <li><a href="{{ url('pontoon.contributors.settings') }}"><i class="fa fa-cog fa-fw"></i>Settings</a></li>
             {% endif %}
 
-            {% if settings.DJANGO_LOGIN %}
+            {% if settings.AUTHENTICATION_METHOD == 'django' or settings.HEROKU_DEMO %}
               {% if user.is_authenticated() %}
                 <li class="standalone-sign-out"><a href="{{ url('standalone_logout') }}"><i class="fa fa-sign-out-alt fa-fw"></i>Sign out</a></li>
               {% else %}
@@ -429,7 +429,7 @@
         </section>
         {% else %}
           <p class="banner">
-            {% if settings.DJANGO_LOGIN %}
+            {% if settings.AUTHENTICATION_METHOD == 'django' or settings.HEROKU_DEMO %}
               {% set login_url = url('standalone_login') %}
             {% else %}
               {% set login_url = provider_login_url(request) %}

--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -255,7 +255,7 @@ def nospam(self):
 
 
 @library.global_function
-def provider_login_url(request, provider_id='fxa', **query):
+def provider_login_url(request, provider_id=settings.AUTHENTICATION_METHOD, **query):
     """
     This function adapts the django-allauth templatetags that don't support jinja2.
     @TODO: land support for the jinja2 tags in the django-allauth.

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -982,7 +982,7 @@ def user_data(request):
     user = request.user
 
     if not user.is_authenticated:
-        if settings.DJANGO_LOGIN:
+        if settings.AUTHENTICATION_METHOD == 'django' or settings.HEROKU_DEMO:
             login_url = reverse('standalone_login')
         else:
             login_url = provider_login_url(request)
@@ -992,7 +992,7 @@ def user_data(request):
             'login_url': login_url,
         })
 
-    if settings.DJANGO_LOGIN:
+    if settings.AUTHENTICATION_METHOD == 'django' or settings.HEROKU_DEMO:
         logout_url = reverse('standalone_logout')
     else:
         logout_url = reverse('account_logout')

--- a/pontoon/contributors/templates/contributors/profile.html
+++ b/pontoon/contributors/templates/contributors/profile.html
@@ -32,7 +32,7 @@
       {% if user.is_authenticated() %}
       <a href="mailto:{{ contributor.email|nospam }}">{{ contributor.email|nospam }}</a>
       {% else %}
-      {% if settings.DJANGO_LOGIN %}
+      {% if settings.AUTHENTICATION_METHOD == 'django' or settings.HEROKU_DEMO %}
         {% set login_url = url('standalone_login') %}
       {% else %}
         {% set login_url = provider_login_url(request) %}

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -32,7 +32,7 @@ DEBUG = os.environ.get('DJANGO_DEBUG', 'False') != 'False'
 
 HEROKU_DEMO = os.environ.get('HEROKU_DEMO', 'False') != 'False'
 
-DJANGO_LOGIN = os.environ.get('DJANGO_LOGIN', 'False') != 'False' or HEROKU_DEMO
+AUTHENTICATION_METHOD = os.environ.get('AUTHENTICATION_METHOD', 'django')
 
 # Automatically log in the user with username 'AUTO_LOGIN_USERNAME'
 # and password 'AUTO_LOGIN_PASSWORD'
@@ -150,6 +150,7 @@ INSTALLED_APPS = (
     'allauth.account',
     'allauth.socialaccount',
     'allauth.socialaccount.providers.fxa',
+    'allauth.socialaccount.providers.github',
     'notifications',
     'graphene_django',
     'webpack_loader',


### PR DESCRIPTION
Add GitHub login thus creating 3 authentication systems:
   * Firefox Accounts
   * GitHub
   * Django (login only, user creation only possible via Django admin) - set this as default.

This fix sets 'django' as the default with the ability to change it to Firefox ('fxa') or GitHub ('github') if needed.

The GitHub authentication is not currently working and gives the following error:  
> SocialApp matching query does not exist.

I believe this is due to needing to have GitHub credentials added in order to gain access to their authentication process.
