### PR TITLE
Fix bug 1514555 - Remove ellipsis and allow string to overflow

### DIFF
--- a/frontend/src/modules/entitieslist/components/Entity.css
+++ b/frontend/src/modules/entitieslist/components/Entity.css
@@ -33,7 +33,6 @@
 .entity .source-string,
 .entity .translation-string {
     display: inline-block;
-    height: fit-content;
     line-height: 22px;
     margin: 0;
     width: 49%;

--- a/frontend/src/modules/entitieslist/components/Entity.css
+++ b/frontend/src/modules/entitieslist/components/Entity.css
@@ -35,7 +35,7 @@
     display: inline-block;
     line-height: 22px;
     margin: 0;
-    width: 49%;
+    width: 100%;
 }
 
 .entity .translation-string {

--- a/frontend/src/modules/entitieslist/components/Entity.css
+++ b/frontend/src/modules/entitieslist/components/Entity.css
@@ -18,7 +18,6 @@
 }
 
 .entity > div {
-    height: 22px;
     line-height: 22px;
 }
 
@@ -33,9 +32,10 @@
 .entity .source-string,
 .entity .translation-string {
     display: inline-block;
+    height: 22px;
     line-height: 22px;
     margin: 0;
-    width: 100%;
+    width: 49%;
 }
 
 .entity .translation-string {

--- a/frontend/src/modules/entitieslist/components/Entity.css
+++ b/frontend/src/modules/entitieslist/components/Entity.css
@@ -32,10 +32,10 @@
 .entity .source-string,
 .entity .translation-string {
     display: inline-block;
-    height: 22px;
     line-height: 22px;
     margin: 0;
     width: 49%;
+    vertical-align: top;
 }
 
 .entity .translation-string {

--- a/frontend/src/modules/entitieslist/components/Entity.css
+++ b/frontend/src/modules/entitieslist/components/Entity.css
@@ -36,8 +36,6 @@
     height: 22px;
     line-height: 22px;
     margin: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
     white-space: nowrap;
     width: 49%;
 }

--- a/frontend/src/modules/entitieslist/components/Entity.css
+++ b/frontend/src/modules/entitieslist/components/Entity.css
@@ -33,10 +33,9 @@
 .entity .source-string,
 .entity .translation-string {
     display: inline-block;
-    height: 22px;
+    height: fit-content;
     line-height: 22px;
     margin: 0;
-    white-space: nowrap;
     width: 49%;
 }
 

--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -1168,8 +1168,6 @@ body > header aside p {
 
 #entitylist > .wrapper > ul > li p span {
   display: inline-block;
-  overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
   width: 100%;
 }

--- a/pontoon/base/static/css/translate.css
+++ b/pontoon/base/static/css/translate.css
@@ -1168,6 +1168,8 @@ body > header aside p {
 
 #entitylist > .wrapper > ul > li p span {
   display: inline-block;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
   width: 100%;
 }


### PR DESCRIPTION
#### What does this PR do?
This pull request fixes the issue [1514555](https://bugzilla.mozilla.org/show_bug.cgi?id=1514555). It allows the string list to overflow instead of ellipsis.

#### Type of change:
- [x] Bug fix (non-breaking change which fixed an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update.

#### How Has This Been Tested?
- Clone this repository 
- Git checkout to `katherine95:1514555-remove-ellipsis` branch.
- Follow the setup guidelines to set up pontoon locally
- Run `make build` then `make run`
- Login to Pontoon
- Navigate to the tutorial project to load some string, e.g
`http://localhost:8000/projects/tutorial/playground/`
- The strings in the string list should overflow instead of ellipsis.

#### Checklist:
- [x]At the tutorial project the strings in the string list should overflow.

#### Screenshots (if appropriate):
Before
![Screenshot from 2019-10-23 18-27-50](https://user-images.githubusercontent.com/17095461/67409199-ebcc3500-f5c2-11e9-94eb-c41fabbd9a84.png)

After
![Screenshot from 2019-10-23 18-23-19](https://user-images.githubusercontent.com/17095461/67409219-f1c21600-f5c2-11e9-93cf-a76cac6e2446.png)


