### PR TITLE
Fix bug 1589137 - Autoreload django static files in dev.

### DIFF
--- a/docker/run_webapp.sh
+++ b/docker/run_webapp.sh
@@ -9,4 +9,4 @@ echo ">>> Starting frontend build process in the background"
 cd frontend && yarn start &
 
 echo ">>> Starting local server"
-python manage.py runserver --nostatic 0.0.0.0:8000
+python manage.py runserver 0.0.0.0:8000

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -134,6 +134,7 @@ INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
+    'whitenoise.runserver_nostatic',
     'django.contrib.staticfiles',
 
     # Django sites app is required by django-allauth

--- a/pontoon/settings/dev.py
+++ b/pontoon/settings/dev.py
@@ -3,7 +3,8 @@
 from __future__ import absolute_import
 
 import copy
-import base
+from . import base
+
 
 INSTALLED_APPS = base.INSTALLED_APPS + (
     # Provides a special toolbar which helps with tracking performance issues.
@@ -16,7 +17,13 @@ INSTALLED_APPS = base.INSTALLED_APPS + (
     'sslserver',
 )
 
-MIDDLEWARE_CLASSES = base.MIDDLEWARE_CLASSES + (
+# In development, we want to remove the WhiteNoise middleware, because we need
+# precise control of static files loading in order to properly load frontend
+# resources. See the `pontoon.translate` module.
+MIDDLEWARE_CLASSES = filter(
+    lambda x: x != 'whitenoise.middleware.WhiteNoiseMiddleware',
+    base.MIDDLEWARE_CLASSES
+) + (
     'debug_toolbar.middleware.DebugToolbarMiddleware',
 )
 

--- a/pontoon/translate/views.py
+++ b/pontoon/translate/views.py
@@ -32,7 +32,7 @@ from . import URL_BASE
 UPSTREAM = 'http://localhost:3000'
 
 
-def static_serve_dev(request, path, insecure=False, **kwargs):
+def static_serve_dev(request, path):
     """Proxy missing static files to the webpack server.
 
     This view replaces django's static files serve view. When a file is
@@ -47,7 +47,7 @@ def static_serve_dev(request, path, insecure=False, **kwargs):
     """
     try:
         # First try to load the file with django's regular serve view.
-        return serve(request, path, insecure=False, **kwargs)
+        return serve(request, path, insecure=True)
     except Http404:
         # If the file couldn't be found in django's static files, then we
         # try to proxy it to the webpack server.


### PR DESCRIPTION
Because of the way we set up static files for Translate.Next, in order to load them from the webpack server, we broke autoreloading of django static files. One had to rebuild the docker image in order to get updated static files. The problem was that the WhiteNoise middleware was taking over serving files, and in doing so only served from collected static files, thus never serving updated files in dev. With WhiteNoise disabled in dev, our static files serve function takes over and does the right thing at all time.

@mathjazz to be honest, I'm not sure I understand exactly what's happening there. WhiteNoise is supposed to serve files from disk when they get updated, but for whatever reason it doesn't. Anyway, this seems to work for me locally.