### PR TITLE
Bug 1579655 - Write tests for fluentoriginal module

### DIFF
--- a/frontend/src/modules/fluentoriginal/components/RichString.test.js
+++ b/frontend/src/modules/fluentoriginal/components/RichString.test.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+
+import RichString from './RichString';
+
+
+const ORIGINAL = 'song-title = Hello\n    .genre = Pop\n    .album = Hello and Good Bye';
+
+const ENTITY = {
+    original: ORIGINAL,
+};
+
+describe('<RichString>', () => {
+    it('renders correct value and each attribute of original input', () => {
+        const wrapper = shallow(<RichString
+            entity = { ENTITY }
+        />);
+
+        expect(wrapper.find('RichString')).toBeDefined();
+
+        expect(wrapper.find('ContentMarker')).toHaveLength(3);
+        expect(wrapper.find('ContentMarker').at(0).html()).toContain('Hello');
+        expect(wrapper.find('ContentMarker').at(1).html()).toContain('Pop');
+        expect(wrapper.find('ContentMarker').at(2).html()).toContain('Hello and Good Bye');
+    });
+
+    it('renders select expression correctly', () => {
+        const input = `
+user-entry =
+    { PLATFORM() ->
+        [variant-1] Hello!
+       *[variant-2] Good Bye!
+    }`;
+
+        const entity = {
+            original: input,
+        };
+
+        const wrapper = shallow(<RichString
+            entity = { entity }
+        />);
+
+        expect(wrapper.find('ContentMarker')).toHaveLength(2);
+
+        expect(wrapper.find('label').at(0).html()).toContain('variant-1');
+        expect(wrapper.find('ContentMarker').at(0).html()).toContain('Hello!');
+
+        expect(wrapper.find('label').at(1).html()).toContain('variant-2');
+        expect(wrapper.find('ContentMarker').at(1).html()).toContain('Good Bye!');
+    });
+
+    it('calls the handleClickOnPlaceable function on click on .original', () => {
+        const handleClickOnPlaceable = sinon.spy();
+        const wrapper = shallow(<RichString
+            entity = { ENTITY }
+            handleClickOnPlaceable={ handleClickOnPlaceable }
+        />);
+
+        wrapper.find('.original').simulate('click');
+        expect(handleClickOnPlaceable.called).toEqual(true);
+    });
+});

--- a/frontend/src/modules/fluentoriginal/components/RichString.test.js
+++ b/frontend/src/modules/fluentoriginal/components/RichString.test.js
@@ -5,23 +5,30 @@ import sinon from 'sinon';
 import RichString from './RichString';
 
 
-const ORIGINAL = 'song-title = Hello\n    .genre = Pop\n    .album = Hello and Good Bye';
+const ORIGINAL = `
+song-title = Hello
+.genre = Pop
+.album = Hello and Good Bye`;
 
 const ENTITY = {
     original: ORIGINAL,
 };
 
 describe('<RichString>', () => {
-    it('renders correct value and each attribute of original input', () => {
+    it('renders value and each attribute correctly', () => {
         const wrapper = shallow(<RichString
             entity = { ENTITY }
         />);
 
-        expect(wrapper.find('RichString')).toBeDefined();
-
         expect(wrapper.find('ContentMarker')).toHaveLength(3);
+
+        expect(wrapper.find('label').at(0).html()).toContain('Value');
         expect(wrapper.find('ContentMarker').at(0).html()).toContain('Hello');
+
+        expect(wrapper.find('label').at(1).html()).toContain('genre');
         expect(wrapper.find('ContentMarker').at(1).html()).toContain('Pop');
+
+        expect(wrapper.find('label').at(2).html()).toContain('album');
         expect(wrapper.find('ContentMarker').at(2).html()).toContain('Hello and Good Bye');
     });
 
@@ -60,4 +67,5 @@ user-entry =
         wrapper.find('.original').simulate('click');
         expect(handleClickOnPlaceable.called).toEqual(true);
     });
+
 });

--- a/frontend/src/modules/fluentoriginal/components/RichString.test.js
+++ b/frontend/src/modules/fluentoriginal/components/RichString.test.js
@@ -7,8 +7,8 @@ import RichString from './RichString';
 
 const ORIGINAL = `
 song-title = Hello
-.genre = Pop
-.album = Hello and Good Bye`;
+    .genre = Pop
+    .album = Hello and Good Bye`;
 
 const ENTITY = {
     original: ORIGINAL,
@@ -67,5 +67,4 @@ user-entry =
         wrapper.find('.original').simulate('click');
         expect(handleClickOnPlaceable.called).toEqual(true);
     });
-
 });

--- a/frontend/src/modules/fluentoriginal/components/SimpleString.test.js
+++ b/frontend/src/modules/fluentoriginal/components/SimpleString.test.js
@@ -20,8 +20,6 @@ describe('<SimpleString>', () => {
             entity = { ENTITY }
         />);
 
-        expect(wrapper.find('SimpleString')).toBeDefined();
-
         expect(wrapper.find('.original ContentMarker').children()).toHaveLength(1);
         expect(wrapper.find('.original ContentMarker').children().text()).toEqual('Hello\nSimple\nString');
     });
@@ -36,4 +34,5 @@ describe('<SimpleString>', () => {
         wrapper.find('.original').simulate('click');
         expect(handleClickOnPlaceable.called).toEqual(true);
     });
+
 });

--- a/frontend/src/modules/fluentoriginal/components/SimpleString.test.js
+++ b/frontend/src/modules/fluentoriginal/components/SimpleString.test.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+
+import SimpleString from './SimpleString';
+
+
+const ORIGINAL = `header = 
+            .page-title = Hello
+            Simple
+            String`;
+
+const ENTITY = {
+    original: ORIGINAL,
+};
+
+describe('<SimpleString>', () => {
+    it('renders original input as simple string', () => {
+        const wrapper = shallow(<SimpleString
+            entity = { ENTITY }
+        />);
+
+        expect(wrapper.find('SimpleString')).toBeDefined();
+
+        expect(wrapper.find('.original ContentMarker').children()).toHaveLength(1);
+        expect(wrapper.find('.original ContentMarker').children().text()).toEqual('Hello\nSimple\nString');
+    });
+
+    it('calls the handleClickOnPlaceable function on click on .original', () => {
+        const handleClickOnPlaceable = sinon.spy();
+        const wrapper = shallow(<SimpleString
+            entity = { ENTITY }
+            handleClickOnPlaceable={ handleClickOnPlaceable }
+        />);
+
+        wrapper.find('.original').simulate('click');
+        expect(handleClickOnPlaceable.called).toEqual(true);
+    });
+});

--- a/frontend/src/modules/fluentoriginal/components/SimpleString.test.js
+++ b/frontend/src/modules/fluentoriginal/components/SimpleString.test.js
@@ -34,5 +34,4 @@ describe('<SimpleString>', () => {
         wrapper.find('.original').simulate('click');
         expect(handleClickOnPlaceable.called).toEqual(true);
     });
-
 });

--- a/frontend/src/modules/fluentoriginal/components/SourceString.test.js
+++ b/frontend/src/modules/fluentoriginal/components/SourceString.test.js
@@ -31,5 +31,4 @@ describe('<SourceString>', () => {
         wrapper.find('.original').simulate('click');
         expect(handleClickOnPlaceable.called).toEqual(true);
     });
-
 });

--- a/frontend/src/modules/fluentoriginal/components/SourceString.test.js
+++ b/frontend/src/modules/fluentoriginal/components/SourceString.test.js
@@ -17,8 +17,6 @@ describe('<SourceString>', () => {
             entity = { ENTITY }
         />);
 
-        expect(wrapper.find('SourceString')).toBeDefined();
-
         expect(wrapper.find('.original ContentMarker').children()).toHaveLength(1);
         expect(wrapper.find('.original ContentMarker').children().text()).toEqual('title = Hello From The Other Side');
     });
@@ -33,4 +31,5 @@ describe('<SourceString>', () => {
         wrapper.find('.original').simulate('click');
         expect(handleClickOnPlaceable.called).toEqual(true);
     });
+
 });

--- a/frontend/src/modules/fluentoriginal/components/SourceString.test.js
+++ b/frontend/src/modules/fluentoriginal/components/SourceString.test.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+
+import SourceString from './SourceString';
+
+
+const ORIGINAL = 'title = Hello From The Other Side';
+
+const ENTITY = {
+    original: ORIGINAL,
+};
+
+describe('<SourceString>', () => {
+    it('renders the original source input', () => {
+        const wrapper = shallow(<SourceString
+            entity = { ENTITY }
+        />);
+
+        expect(wrapper.find('SourceString')).toBeDefined();
+
+        expect(wrapper.find('.original ContentMarker').children()).toHaveLength(1);
+        expect(wrapper.find('.original ContentMarker').children().text()).toEqual('title = Hello From The Other Side');
+    });
+
+    it('calls the handleClickOnPlaceable function on click on .original', () => {
+        const handleClickOnPlaceable = sinon.spy();
+        const wrapper = shallow(<SourceString
+            entity = { ENTITY }
+            handleClickOnPlaceable={ handleClickOnPlaceable }
+        />);
+
+        wrapper.find('.original').simulate('click');
+        expect(handleClickOnPlaceable.called).toEqual(true);
+    });
+});


### PR DESCRIPTION
There are React components that are not tested in fluentoriginal module. 

The details for added tests are :
- SourceString Component 
   - [x] render output the same as original input
   - [x] call correct function when clicking placeable
- SimpleString Component 
   - [x] render output from original input as simple string
   - [x] call correct function when clicking placeable
- RichString Component 
   - [x] render correct value and attributes
   - [x] render select expression from the original input properly
   - [x] call correct function when clicking placeable

FluentOriginalString did not get tested because it will be testing getSyntaxType() which already covered in https://github.com/mozilla/pontoon/blob/master/frontend/src/core/utils/fluent/getSyntaxType.test.js
