### PR TITLE
Fix bug 1588929 - Localize 'All Projects' & 'All resources' in the main navigation bar

### DIFF
--- a/frontend/public/static/locale/en-US/translate.ftl
+++ b/frontend/public/static/locale/en-US/translate.ftl
@@ -450,6 +450,7 @@ placeable-parser-xmlTag =
 project-ProjectMenu--no-results = No results
 project-ProjectMenu--project = Project
 project-ProjectMenu--progress = Progress
+project-ProjectMenu--all-projects = All Projects
 project-ProjectMenu--search-placeholder =
     .placeholder = Filter projects
 

--- a/frontend/src/core/project/components/ProjectMenu.js
+++ b/frontend/src/core/project/components/ProjectMenu.js
@@ -139,7 +139,7 @@ export class ProjectMenuBase extends React.Component<Props, State> {
                 className="selector unselectable"
                 onClick={ this.toggleVisibility }
             >
-                <span>{ 'All Projects' }</span>
+                <span>{ <Localized id= 'resource-ResourceMenu--all-projects'>All Projects</Localized> }</span>
                 <span className="icon fa fa-caret-down"></span>
             </div>
 

--- a/frontend/src/core/project/components/ProjectMenu.js
+++ b/frontend/src/core/project/components/ProjectMenu.js
@@ -139,7 +139,13 @@ export class ProjectMenuBase extends React.Component<Props, State> {
                 className="selector unselectable"
                 onClick={ this.toggleVisibility }
             >
-                <span>{ <Localized id= 'resource-ResourceMenu--all-projects'>All Projects</Localized> }</span>
+                <span>
+                    {
+                        <Localized id='resource-ResourceMenu--all-projects'>
+                            <span>All Projects</span>
+                        </Localized>
+                    }
+                </span>
                 <span className="icon fa fa-caret-down"></span>
             </div>
 

--- a/frontend/src/core/project/components/ProjectMenu.js
+++ b/frontend/src/core/project/components/ProjectMenu.js
@@ -139,13 +139,9 @@ export class ProjectMenuBase extends React.Component<Props, State> {
                 className="selector unselectable"
                 onClick={ this.toggleVisibility }
             >
-                <span>
-                    {
-                        <Localized id='resource-ResourceMenu--all-projects'>
-                            <span>All Projects</span>
-                        </Localized>
-                    }
-                </span>
+                <Localized id='project-ProjectMenu--all-projects'>
+                    <span>All Projects</span>
+                </Localized>
                 <span className="icon fa fa-caret-down"></span>
             </div>
 

--- a/frontend/src/core/project/components/ProjectMenu.test.js
+++ b/frontend/src/core/project/components/ProjectMenu.test.js
@@ -5,8 +5,6 @@ import ProjectItem from './ProjectItem.js';
 
 import { ProjectMenuBase } from './ProjectMenu';
 
-import { findLocalizedById } from 'test/utils';
-
 
 function createShallowProjectMenu({
     project = {
@@ -60,7 +58,7 @@ describe('<ProjectMenu>', () => {
         const wrapper = createShallowProjectMenu({ project: ALL_PROJECTS });
 
         expect(wrapper.find('.project-menu .selector')).toHaveLength(1);
-        expect(findLocalizedById(wrapper, 'resource-ResourceMenu--all-projects')).toHaveLength(1);
+        expect(wrapper.find('#resource-ResourceMenu--all-projects')).toHaveLength(1);
         expect(wrapper.find('.project-menu .selector .icon')).toHaveLength(1);
     });
 

--- a/frontend/src/core/project/components/ProjectMenu.test.js
+++ b/frontend/src/core/project/components/ProjectMenu.test.js
@@ -58,7 +58,7 @@ describe('<ProjectMenu>', () => {
         const wrapper = createShallowProjectMenu({ project: ALL_PROJECTS });
 
         expect(wrapper.find('.project-menu .selector')).toHaveLength(1);
-        expect(wrapper.find('#resource-ResourceMenu--all-projects')).toHaveLength(1);
+        expect(wrapper.find('#project-ProjectMenu--all-projects')).toHaveLength(1);
         expect(wrapper.find('.project-menu .selector .icon')).toHaveLength(1);
     });
 

--- a/frontend/src/core/project/components/ProjectMenu.test.js
+++ b/frontend/src/core/project/components/ProjectMenu.test.js
@@ -5,6 +5,8 @@ import ProjectItem from './ProjectItem.js';
 
 import { ProjectMenuBase } from './ProjectMenu';
 
+import { findLocalizedById } from 'test/utils';
+
 
 function createShallowProjectMenu({
     project = {
@@ -58,7 +60,7 @@ describe('<ProjectMenu>', () => {
         const wrapper = createShallowProjectMenu({ project: ALL_PROJECTS });
 
         expect(wrapper.find('.project-menu .selector')).toHaveLength(1);
-        expect(wrapper.find('.project-menu .selector span:first-child').text()).toEqual('All Projects');
+        expect(findLocalizedById(wrapper, 'resource-ResourceMenu--all-projects')).toHaveLength(1);
         expect(wrapper.find('.project-menu .selector .icon')).toHaveLength(1);
     });
 

--- a/frontend/src/core/resource/components/ResourceMenu.js
+++ b/frontend/src/core/resource/components/ResourceMenu.js
@@ -169,14 +169,14 @@ export class ResourceMenuBase extends React.Component<Props, State> {
                         className={"resource icon " + resourceClass}
                         onClick={ this.sortByResource }
                     />
-                    {/* <Localized id="resource-ResourceMenu--progress"> */}
-                    <span
-                        className="progress"
-                        onClick={ this.sortByProgress }
-                    >
-                        Progress
-                    </span>
-                    {/* </Localized> */}
+                    <Localized id="resource-ResourceMenu--progress">
+                        <span
+                            className="progress"
+                            onClick={ this.sortByProgress }
+                        >
+                            Progress
+                        </span>
+                    </Localized>
                     <span
                         className={"progress icon " + progressClass}
                         onClick={ this.sortByProgress }

--- a/frontend/src/core/resource/components/ResourceMenu.js
+++ b/frontend/src/core/resource/components/ResourceMenu.js
@@ -117,7 +117,7 @@ export class ResourceMenuBase extends React.Component<Props, State> {
 
         let resourceName = parameters.resource.split('/').slice(-1)[0];
         if (parameters.resource === 'all-resources') {
-            resourceName = <Localized id= 'resource-ResourceMenu--all-resources'>All Resources</Localized>;
+            resourceName = <Localized id='resource-ResourceMenu--all-resources'>All Resources</Localized>;
         }
 
         // Search resources

--- a/frontend/src/core/resource/components/ResourceMenu.js
+++ b/frontend/src/core/resource/components/ResourceMenu.js
@@ -117,7 +117,7 @@ export class ResourceMenuBase extends React.Component<Props, State> {
 
         let resourceName = parameters.resource.split('/').slice(-1)[0];
         if (parameters.resource === 'all-resources') {
-            resourceName = 'All Resources';
+            resourceName = <Localized id= 'resource-ResourceMenu--all-resources'>All Resources</Localized>;
         }
 
         // Search resources
@@ -169,14 +169,14 @@ export class ResourceMenuBase extends React.Component<Props, State> {
                         className={"resource icon " + resourceClass}
                         onClick={ this.sortByResource }
                     />
-                    <Localized id="resource-ResourceMenu--progress">
-                        <span
-                            className="progress"
-                            onClick={ this.sortByProgress }
-                        >
-                            Progress
-                        </span>
-                    </Localized>
+                    {/* <Localized id="resource-ResourceMenu--progress"> */}
+                    <span
+                        className="progress"
+                        onClick={ this.sortByProgress }
+                    >
+                        Progress
+                    </span>
+                    {/* </Localized> */}
                     <span
                         className={"progress icon " + progressClass}
                         onClick={ this.sortByProgress }

--- a/frontend/src/core/resource/components/ResourceMenu.test.js
+++ b/frontend/src/core/resource/components/ResourceMenu.test.js
@@ -5,6 +5,8 @@ import ResourceItem from './ResourceItem.js';
 
 import { ResourceMenuBase } from './ResourceMenu';
 
+import { findLocalizedById } from 'test/utils';
+
 
 function createShallowResourceMenu({
     project = 'project',
@@ -55,10 +57,10 @@ describe('<ResourceMenuBase>', () => {
         expect(wrapper.find('.resource-menu .selector .icon')).toHaveLength(1);
     });
 
-    it('sets resource name correctly for all-resources', () => {
+    it('sets a localized resource name correctly for all-resources', () => {
         const wrapper = createShallowResourceMenu({ resource: 'all-resources' });
 
-        expect(wrapper.find('.resource-menu .selector span:first-child').text()).toEqual('All Resources');
+        expect(findLocalizedById(wrapper, 'resource-ResourceMenu--all-resources')).toHaveLength(1);
     });
 
     it('renders resource menu correctly', () => {

--- a/frontend/src/core/resource/components/ResourceMenu.test.js
+++ b/frontend/src/core/resource/components/ResourceMenu.test.js
@@ -5,8 +5,6 @@ import ResourceItem from './ResourceItem.js';
 
 import { ResourceMenuBase } from './ResourceMenu';
 
-import { findLocalizedById } from 'test/utils';
-
 
 function createShallowResourceMenu({
     project = 'project',
@@ -60,7 +58,7 @@ describe('<ResourceMenuBase>', () => {
     it('sets a localized resource name correctly for all-resources', () => {
         const wrapper = createShallowResourceMenu({ resource: 'all-resources' });
 
-        expect(findLocalizedById(wrapper, 'resource-ResourceMenu--all-resources')).toHaveLength(1);
+        expect(wrapper.find('#resource-ResourceMenu--all-resources')).toHaveLength(1);
     });
 
     it('renders resource menu correctly', () => {


### PR DESCRIPTION
#### What does this PR do?
This pull request fixes the issue [1588929](https://bugzilla.mozilla.org/show_bug.cgi?id=1588929). It has "All Resources" and "All Projects"  unaccented (unlocalized) in the main navigation bar:

#### Type of change:
- [x] Bug fix (non-breaking change which fixed an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update.

#### How Has This Been Tested?
- Clone this repository 
- Git checkout to `katherine95:1588929-localize-resources-projects` branch.
- Follow the setup guidelines to set up pontoon locally
- Run `make build` then `make run`
- Login to Pontoon
- Navigate to Resource menu (access it by clicking on "playground" in `http://localhost:8000/projects/tutorial/playground/`)
- "All Resources" and "All Projects" should both be localized
`localhost:8000/projects/tutorial/all-resources/?pseudolocalization=accented`
`localhost:8000/projects/all-projects/all-resources/?pseudolocalization=accented`

#### Checklist:
 [x] Both "All Resources" and "All Projects"  using pseudo-localization should be localized.

#### Screenshots (if appropriate):
![Screenshot from 2019-10-24 19-32-19](https://user-images.githubusercontent.com/17095461/67506830-7467d580-f696-11e9-97f3-ec3d34b3a3ec.png)

![Screenshot from 2019-10-24 19-49-36](https://user-images.githubusercontent.com/17095461/67507389-767e6400-f697-11e9-8f7a-c76c177645a1.png)