### PR TITLE
Fix bug 1490026 - Disable keyboard triggers when editor is read only

### DIFF
--- a/frontend/src/core/editor/components/connectedEditor.js
+++ b/frontend/src/core/editor/components/connectedEditor.js
@@ -145,6 +145,11 @@ export default function connectedEditor<Object>(
 
             let handledEvent = false;
 
+            // Disable keyboard shortcuts when editor is in read only.
+            if (this.props.isReadOnlyEditor) {
+                return;
+            }
+
             // On Enter:
             //   - If unsaved changes popup is shown, proceed.
             //   - If failed checks popup is shown after approving a translation, approve it anyway.

--- a/frontend/src/core/editor/components/connectedEditor.test.js
+++ b/frontend/src/core/editor/components/connectedEditor.test.js
@@ -81,6 +81,13 @@ function createEditorBase({
         plural: {
             pluralForm,
         },
+        user: {
+            username: "michael_umanah",
+            isAuthenticated: true,
+            settings: {
+                forceSuggestions: false
+            },
+        },
         unsavedchanges,
     };
     const store = createReduxStore(initialState);


### PR DESCRIPTION
**What does this PR do?**
This pull request fixes the issue [1490026](https://bugzilla.mozilla.org/show_bug.cgi?id=1490026). It disables keyboard triggers when the editor is in read only, so that non authenticated users can not trigger keyboard updates on the editor. 

**How can this be tested**
- Go to any translate page. 
- Make sure you are logged out.
- Press Tab 2 times to focus the translation field.
- Press Enter to submit the translation