### PR TITLE
Fix bug 1395179 - Fix status numbers in progress menu to be clickable

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "lodash.escaperegexp": "^4.1.2",
     "lodash.flattendeep": "4.4.0",
     "lodash.isequal": "4.5.0",
+    "lodash.mapvalues": "4.6.0",
     "nprogress": "0.2.0",
     "react": "16.8.6",
     "react-content-marker": "1.1.1",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -104,6 +104,7 @@ class App extends React.Component<InternalProps> {
                 <Navigation />
                 <ResourceProgress
                     stats={ state.stats }
+                    parameters={ state.parameters }
                 />
                 <ProjectInfo
                     projectSlug={ state.parameters.project }

--- a/frontend/src/modules/resourceprogress/components/ResourceProgress.css
+++ b/frontend/src/modules/resourceprogress/components/ResourceProgress.css
@@ -135,4 +135,5 @@
     font-size: 22px;
     font-weight: 300;
     padding: 5px 0 10px;
+    cursor: pointer;
 }

--- a/frontend/src/modules/resourceprogress/components/ResourceProgress.css
+++ b/frontend/src/modules/resourceprogress/components/ResourceProgress.css
@@ -135,5 +135,4 @@
     font-size: 22px;
     font-weight: 300;
     padding: 5px 0 10px;
-    cursor: pointer;
 }

--- a/frontend/src/modules/resourceprogress/components/ResourceProgress.js
+++ b/frontend/src/modules/resourceprogress/components/ResourceProgress.js
@@ -47,6 +47,14 @@ export class ResourceProgressBase extends React.Component<Props, State> {
         });
     }
 
+    // This method is called when a user clicks on the status numbers in progress menu.
+    handleClickStatusNumbers = (statusValue) => {
+        const url = window.location.pathname;
+        const params = new URLSearchParams({'status' : statusValue});
+        const newUrl = url + '?' + params.toString(); 
+        return newUrl;
+    }
+
     render() {
         const { approved, fuzzy, warnings, errors, missing, unreviewed, total } = this.props.stats;
         const complete = approved + warnings;
@@ -92,7 +100,7 @@ export class ResourceProgressBase extends React.Component<Props, State> {
                                 Translated
                             </Localized>
                         </span>
-                        <p className="value">{ asLocaleString(approved) }</p>
+                        <p className="value"><a href={ this.handleClickStatusNumbers('translated') } >{ asLocaleString(approved) }</a></p>
                     </div>
                     <div className="fuzzy">
                         <span className="title">
@@ -100,7 +108,7 @@ export class ResourceProgressBase extends React.Component<Props, State> {
                                 Fuzzy
                             </Localized>
                         </span>
-                        <p className="value">{ asLocaleString(fuzzy) }</p>
+                        <p className="value"><a href={ this.handleClickStatusNumbers('fuzzy') } >{ asLocaleString(fuzzy) }</a></p>
                     </div>
                     <div className="warnings">
                         <span className="title">
@@ -108,7 +116,7 @@ export class ResourceProgressBase extends React.Component<Props, State> {
                                 Warnings
                             </Localized>
                         </span>
-                        <p className="value">{ asLocaleString(warnings) }</p>
+                        <p className="value"><a href={ this.handleClickStatusNumbers('warnings') } >{ asLocaleString(warnings) }</a></p>
                     </div>
                     <div className="errors">
                         <span className="title">
@@ -116,7 +124,7 @@ export class ResourceProgressBase extends React.Component<Props, State> {
                                 Errors
                             </Localized>
                         </span>
-                        <p className="value">{ asLocaleString(errors) }</p>
+                        <p className="value"><a href={ this.handleClickStatusNumbers('errors') } >{ asLocaleString(errors) }</a></p>
                     </div>
                     <div className="missing">
                         <span className="title">
@@ -124,7 +132,7 @@ export class ResourceProgressBase extends React.Component<Props, State> {
                                 Missing
                             </Localized>
                         </span>
-                        <p className="value">{ asLocaleString(missing) }</p>
+                        <p className="value"><a href={ this.handleClickStatusNumbers('missing') } >{ asLocaleString(missing) }</a></p>
                     </div>
                 </div>
             </aside>

--- a/frontend/src/modules/resourceprogress/components/ResourceProgress.js
+++ b/frontend/src/modules/resourceprogress/components/ResourceProgress.js
@@ -11,10 +11,12 @@ import ProgressChart from './ProgressChart';
 
 import { asLocaleString } from 'core/utils';
 
+import type { NavigationParams } from 'core/navigation';
 import type { Stats } from 'core/stats';
 
 
 type Props = {|
+    parameters: NavigationParams,
     stats: Stats,
 |};
 
@@ -49,7 +51,9 @@ export class ResourceProgressBase extends React.Component<Props, State> {
     }
 
     render() {
-        const { approved, fuzzy, warnings, errors, missing, unreviewed, total } = this.props.stats;
+        const { parameters, stats } = this.props;
+        const { approved, fuzzy, warnings, errors, missing, unreviewed, total } = stats;
+        const currentPath = `/${parameters.locale}/${parameters.project}/${parameters.resource}/`;
         const complete = approved + warnings;
 
         let percent = 0;
@@ -94,7 +98,12 @@ export class ResourceProgressBase extends React.Component<Props, State> {
                             </Localized>
                         </span>
                         <p className="value" onClick={ this.toggleVisibility }>
-                            <Link to={{ search: "?status=translated" }}>
+                            <Link
+                                to={{
+                                    pathname: currentPath,
+                                    search: "?status=translated"
+                                }}
+                            >
                                 { asLocaleString(approved) }
                             </Link>
                         </p>
@@ -106,7 +115,12 @@ export class ResourceProgressBase extends React.Component<Props, State> {
                             </Localized>
                         </span>
                         <p className="value" onClick={ this.toggleVisibility }>
-                            <Link to={{ search: "?status=fuzzy" }}>
+                            <Link
+                                to={{
+                                    pathname: currentPath,
+                                    search: "?status=fuzzy"
+                                }}
+                            >
                                 { asLocaleString(fuzzy) }
                             </Link>
                         </p>
@@ -118,7 +132,12 @@ export class ResourceProgressBase extends React.Component<Props, State> {
                             </Localized>
                         </span>
                         <p className="value" onClick={ this.toggleVisibility }>
-                            <Link to={{ search: "?status=warnings" }}>
+                            <Link
+                                to={{
+                                    pathname: currentPath,
+                                    search: "?status=warnings"
+                                }}
+                            >
                                 { asLocaleString(warnings) }
                             </Link>
                         </p>
@@ -130,7 +149,12 @@ export class ResourceProgressBase extends React.Component<Props, State> {
                             </Localized>
                         </span>
                         <p className="value" onClick={ this.toggleVisibility }>
-                            <Link to={{ search: "?status=errors" }}>
+                            <Link
+                                to={{
+                                    pathname: currentPath,
+                                    search: "?status=errors"
+                                }}
+                            >
                                 { asLocaleString(errors) }
                             </Link>
                         </p>
@@ -142,7 +166,12 @@ export class ResourceProgressBase extends React.Component<Props, State> {
                             </Localized>
                         </span>
                         <p className="value" onClick={ this.toggleVisibility }>
-                            <Link to={{search: "?status=missing" }}>
+                            <Link
+                                to={{
+                                    pathname: currentPath,
+                                    search: "?status=missing"
+                                }}
+                            >
                                 { asLocaleString(missing) }
                             </Link>
                         </p>

--- a/frontend/src/modules/resourceprogress/components/ResourceProgress.js
+++ b/frontend/src/modules/resourceprogress/components/ResourceProgress.js
@@ -93,7 +93,11 @@ export class ResourceProgressBase extends React.Component<Props, State> {
                                 Translated
                             </Localized>
                         </span>
-                        <p className="value"><Link to={{ search:"?status=translated" }}>{ asLocaleString(approved) }</Link></p>
+                        <p className="value" onClick={ this.handleClickOutside }>
+                            <Link to={{ search: "?status=translated" }}>
+                                { asLocaleString(approved) }
+                            </Link>
+                        </p>
                     </div>
                     <div className="fuzzy">
                         <span className="title">
@@ -101,7 +105,11 @@ export class ResourceProgressBase extends React.Component<Props, State> {
                                 Fuzzy
                             </Localized>
                         </span>
-                        <p className="value"><Link to={{ search:"?status=fuzzy" }}>{ asLocaleString(fuzzy) }</Link></p>
+                        <p className="value" onClick={ this.toggleVisibility }>
+                            <Link to={{ search: "?status=fuzzy" }}>
+                                { asLocaleString(fuzzy) }
+                            </Link>
+                        </p>
                     </div>
                     <div className="warnings">
                         <span className="title">
@@ -109,7 +117,11 @@ export class ResourceProgressBase extends React.Component<Props, State> {
                                 Warnings
                             </Localized>
                         </span>
-                        <p className="value"><Link to={{ search:"?status=warnings" }}>{ asLocaleString(warnings) }</Link></p>
+                        <p className="value" onClick={ this.toggleVisibility }>
+                            <Link to={{ search: "?status=warnings" }}>
+                                { asLocaleString(warnings) }
+                            </Link>
+                        </p>
                     </div>
                     <div className="errors">
                         <span className="title">
@@ -117,7 +129,11 @@ export class ResourceProgressBase extends React.Component<Props, State> {
                                 Errors
                             </Localized>
                         </span>
-                        <p className="value"><Link to={{ search:"?status=errors" }}>{ asLocaleString(errors) }</Link></p>
+                        <p className="value" onClick={ this.toggleVisibility }>
+                            <Link to={{ search: "?status=errors" }}>
+                                { asLocaleString(errors) }
+                            </Link>
+                        </p>
                     </div>
                     <div className="missing">
                         <span className="title">
@@ -125,7 +141,11 @@ export class ResourceProgressBase extends React.Component<Props, State> {
                                 Missing
                             </Localized>
                         </span>
-                        <p className="value"><Link to={{search:"?status=missing" }}>{ asLocaleString(missing) }</Link></p>
+                        <p className="value" onClick={ this.toggleVisibility }>
+                            <Link to={{search: "?status=missing" }}>
+                                { asLocaleString(missing) }
+                            </Link>
+                        </p>
                     </div>
                 </div>
             </aside>

--- a/frontend/src/modules/resourceprogress/components/ResourceProgress.js
+++ b/frontend/src/modules/resourceprogress/components/ResourceProgress.js
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { Localized } from '@fluent/react';
+import { Link } from 'react-router-dom';
 import onClickOutside from 'react-onclickoutside';
 
 import './ResourceProgress.css';
@@ -45,14 +46,6 @@ export class ResourceProgressBase extends React.Component<Props, State> {
         this.setState({
             visible: false,
         });
-    }
-
-    // This method is called when a user clicks on the status numbers in progress menu.
-    handleClickStatusNumbers = (statusValue: string) => {
-        const url = window.location.pathname;
-        const params = new URLSearchParams({'status' : statusValue});
-        const newUrl = url + '?' + params.toString(); 
-        return newUrl;
     }
 
     render() {
@@ -100,7 +93,7 @@ export class ResourceProgressBase extends React.Component<Props, State> {
                                 Translated
                             </Localized>
                         </span>
-                        <p className="value"><a href={ this.handleClickStatusNumbers('translated') } >{ asLocaleString(approved) }</a></p>
+                        <p className="value"><Link to={{ search:"?status=translated" }}>{ asLocaleString(approved) }</Link></p>
                     </div>
                     <div className="fuzzy">
                         <span className="title">
@@ -108,7 +101,7 @@ export class ResourceProgressBase extends React.Component<Props, State> {
                                 Fuzzy
                             </Localized>
                         </span>
-                        <p className="value"><a href={ this.handleClickStatusNumbers('fuzzy') } >{ asLocaleString(fuzzy) }</a></p>
+                        <p className="value"><Link to={{ search:"?status=fuzzy" }}>{ asLocaleString(fuzzy) }</Link></p>
                     </div>
                     <div className="warnings">
                         <span className="title">
@@ -116,7 +109,7 @@ export class ResourceProgressBase extends React.Component<Props, State> {
                                 Warnings
                             </Localized>
                         </span>
-                        <p className="value"><a href={ this.handleClickStatusNumbers('warnings') } >{ asLocaleString(warnings) }</a></p>
+                        <p className="value"><Link to={{ search:"?status=warnings" }}>{ asLocaleString(warnings) }</Link></p>
                     </div>
                     <div className="errors">
                         <span className="title">
@@ -124,7 +117,7 @@ export class ResourceProgressBase extends React.Component<Props, State> {
                                 Errors
                             </Localized>
                         </span>
-                        <p className="value"><a href={ this.handleClickStatusNumbers('errors') } >{ asLocaleString(errors) }</a></p>
+                        <p className="value"><Link to={{ search:"?status=errors" }}>{ asLocaleString(errors) }</Link></p>
                     </div>
                     <div className="missing">
                         <span className="title">
@@ -132,7 +125,7 @@ export class ResourceProgressBase extends React.Component<Props, State> {
                                 Missing
                             </Localized>
                         </span>
-                        <p className="value"><a href={ this.handleClickStatusNumbers('missing') } >{ asLocaleString(missing) }</a></p>
+                        <p className="value"><Link to={{search:"?status=missing" }}>{ asLocaleString(missing) }</Link></p>
                     </div>
                 </div>
             </aside>

--- a/frontend/src/modules/resourceprogress/components/ResourceProgress.js
+++ b/frontend/src/modules/resourceprogress/components/ResourceProgress.js
@@ -48,7 +48,7 @@ export class ResourceProgressBase extends React.Component<Props, State> {
     }
 
     // This method is called when a user clicks on the status numbers in progress menu.
-    handleClickStatusNumbers = (statusValue) => {
+    handleClickStatusNumbers = (statusValue: string) => {
         const url = window.location.pathname;
         const params = new URLSearchParams({'status' : statusValue});
         const newUrl = url + '?' + params.toString(); 

--- a/frontend/src/modules/resourceprogress/components/ResourceProgress.js
+++ b/frontend/src/modules/resourceprogress/components/ResourceProgress.js
@@ -93,7 +93,7 @@ export class ResourceProgressBase extends React.Component<Props, State> {
                                 Translated
                             </Localized>
                         </span>
-                        <p className="value" onClick={ this.handleClickOutside }>
+                        <p className="value" onClick={ this.toggleVisibility }>
                             <Link to={{ search: "?status=translated" }}>
                                 { asLocaleString(approved) }
                             </Link>

--- a/frontend/src/modules/resourceprogress/components/ResourceProgress.test.js
+++ b/frontend/src/modules/resourceprogress/components/ResourceProgress.test.js
@@ -15,10 +15,12 @@ describe('<ResourceProgress>', () => {
         total: 15,
     };
     const PARAMETERS = {
+        entity: 0,
         locale: "en-GB",
         project: "tutorial",
         resource: "all-resources",
-        status: "errors"
+        status: "errors",
+        search: null
     };
 
     it('shows only a selector by default', () => {

--- a/frontend/src/modules/resourceprogress/components/ResourceProgress.test.js
+++ b/frontend/src/modules/resourceprogress/components/ResourceProgress.test.js
@@ -14,16 +14,22 @@ describe('<ResourceProgress>', () => {
         missing: 1,
         total: 15,
     };
+    const PARAMETERS = {
+        locale: "en-GB",
+        project: "tutorial",
+        resource: "all-resources",
+        status: "errors"
+    };
 
     it('shows only a selector by default', () => {
-        const wrapper = shallow(<ResourceProgressBase stats={ STATS } />);
+        const wrapper = shallow(<ResourceProgressBase stats={ STATS } parameters={ PARAMETERS } />);
 
         expect(wrapper.find('.selector').exists()).toBeTruthy();
         expect(wrapper.find('.menu').exists()).toBeFalsy();
     });
 
     it('shows the info menu after a click', () => {
-        const wrapper = shallow(<ResourceProgressBase stats={ STATS } />);
+        const wrapper = shallow(<ResourceProgressBase stats={ STATS } parameters={ PARAMETERS } />);
         wrapper.find('.selector').simulate('click');
 
         expect(wrapper.find('.menu').exists()).toBeTruthy();

--- a/frontend/src/modules/search/components/SearchBox.js
+++ b/frontend/src/modules/search/components/SearchBox.js
@@ -143,7 +143,7 @@ export class SearchBoxBase extends React.Component<InternalProps, State> {
         }
     }
 
-    static getDerivedStateFromProps(prevProps: InternalProps, nextProps) {
+    static getDerivedStateFromProps(prevProps: InternalProps, nextProps: state) {
         let initialStatuses = nextProps.statuses;
         if (prevProps.parameters.status) {
             prevProps.parameters.status.split(',').forEach((f, key) => {

--- a/frontend/src/modules/search/components/SearchBox.js
+++ b/frontend/src/modules/search/components/SearchBox.js
@@ -144,10 +144,10 @@ export class SearchBoxBase extends React.Component<InternalProps, State> {
         }
     }
 
-    static getDerivedStateFromProps(prevProps: InternalProps, nextProps: InternalProps) {
+    static getDerivedStateFromProps(prevProps: InternalProps, nextProps: Object) {
         let initialStatuses = nextProps.statuses;
         if (prevProps.parameters.status) {
-            prevProps.parameters.status.split(',').forEach((f, key) => {
+            prevProps.parameters.status.split(',').forEach(f => {
                 initialStatuses = _.mapValues(initialStatuses, () => false);
                 initialStatuses[f] = true;
             });

--- a/frontend/src/modules/search/components/SearchBox.js
+++ b/frontend/src/modules/search/components/SearchBox.js
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import debounce from 'lodash.debounce';
-import isEqual from 'lodash.isequal';
+import _ from 'lodash';
 
 import './SearchBox.css';
 
@@ -146,7 +146,8 @@ export class SearchBoxBase extends React.Component<InternalProps, State> {
     static getDerivedStateFromProps(prevProps: InternalProps, nextProps) {
         let initialStatuses = nextProps.statuses;
         if (prevProps.parameters.status) {
-            prevProps.parameters.status.split(',').forEach(f => {
+            prevProps.parameters.status.split(',').forEach((f, key) => {
+                initialStatuses = _.mapValues(initialStatuses, () => false);
                 initialStatuses[f] = true;
             });
         }
@@ -197,6 +198,7 @@ export class SearchBoxBase extends React.Component<InternalProps, State> {
     }
 
     getSelectedStatuses(): Array<string> {
+        console.log("current state is", this.state.statuses, Object.keys(this.state.statuses).filter(s => this.state.statuses[s]) )
         return Object.keys(this.state.statuses).filter(s => this.state.statuses[s]);
     }
 

--- a/frontend/src/modules/search/components/SearchBox.js
+++ b/frontend/src/modules/search/components/SearchBox.js
@@ -198,7 +198,6 @@ export class SearchBoxBase extends React.Component<InternalProps, State> {
     }
 
     getSelectedStatuses(): Array<string> {
-        console.log("current state is", this.state.statuses, Object.keys(this.state.statuses).filter(s => this.state.statuses[s]) )
         return Object.keys(this.state.statuses).filter(s => this.state.statuses[s]);
     }
 

--- a/frontend/src/modules/search/components/SearchBox.js
+++ b/frontend/src/modules/search/components/SearchBox.js
@@ -3,9 +3,8 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import debounce from 'lodash.debounce';
-import _ from 'lodash';
 import isEqual from 'lodash.isequal';
-
+import mapValues from 'lodash.mapvalues';
 import './SearchBox.css';
 
 import * as navigation from 'core/navigation';
@@ -132,7 +131,7 @@ export class SearchBoxBase extends React.Component<InternalProps, State> {
         this.updateFiltersFromURLParams();
     }
 
-    componentDidUpdate(prevProps: InternalProps) {
+    componentDidUpdate(prevProps: InternalProps, state: Object) {
         // Clear search field when navigating to a new file
         if (
             this.props.parameters.search === null &&
@@ -144,15 +143,19 @@ export class SearchBoxBase extends React.Component<InternalProps, State> {
         }
     }
 
-    static getDerivedStateFromProps(prevProps: InternalProps, nextProps: Object) {
-        let initialStatuses = nextProps.statuses;
+    static getDerivedStateFromProps(prevProps: InternalProps, state: Object) {
+        // Get the current status from props
+        let initialStatuses = state.statuses;
         if (prevProps.parameters.status) {
             prevProps.parameters.status.split(',').forEach(f => {
-                initialStatuses = _.mapValues(initialStatuses, () => false);
+                // reset all statuses value to false then set the current status value to true
+                initialStatuses = mapValues(initialStatuses, () => false);
                 initialStatuses[f] = true;
             });
         }
-        if (nextProps.statuses !== initialStatuses) {
+
+        // Compare previous state to the updated state then setState of statuses
+        if (state.statuses !== initialStatuses) {
             return {
                 statuses: initialStatuses,
             };

--- a/frontend/src/modules/search/components/SearchBox.js
+++ b/frontend/src/modules/search/components/SearchBox.js
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import debounce from 'lodash.debounce';
 import _ from 'lodash';
+import isEqual from 'lodash.isequal';
 
 import './SearchBox.css';
 

--- a/frontend/src/modules/search/components/SearchBox.js
+++ b/frontend/src/modules/search/components/SearchBox.js
@@ -143,6 +143,21 @@ export class SearchBoxBase extends React.Component<InternalProps, State> {
         }
     }
 
+    static getDerivedStateFromProps(prevProps: InternalProps, nextProps) {
+        let initialStatuses = nextProps.statuses;
+        if (prevProps.parameters.status) {
+            prevProps.parameters.status.split(',').forEach(f => {
+                initialStatuses[f] = true;
+            });
+        }
+        if (nextProps.statuses !== initialStatuses) {
+            return {
+                statuses: initialStatuses,
+            };
+        }
+        return null;
+      }
+
     componentWillUnmount() {
         // $FLOW_IGNORE (errors that I don't understand, no help from the Web)
         document.removeEventListener('keydown', this.handleShortcuts);

--- a/frontend/src/modules/search/components/SearchBox.js
+++ b/frontend/src/modules/search/components/SearchBox.js
@@ -143,7 +143,7 @@ export class SearchBoxBase extends React.Component<InternalProps, State> {
         }
     }
 
-    static getDerivedStateFromProps(prevProps: InternalProps, nextProps: state) {
+    static getDerivedStateFromProps(prevProps: InternalProps, nextProps: InternalProps) {
         let initialStatuses = nextProps.statuses;
         if (prevProps.parameters.status) {
             prevProps.parameters.status.split(',').forEach((f, key) => {

--- a/frontend/src/modules/search/components/SearchBox.js
+++ b/frontend/src/modules/search/components/SearchBox.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import debounce from 'lodash.debounce';
 import isEqual from 'lodash.isequal';
 import mapValues from 'lodash.mapvalues';
+
 import './SearchBox.css';
 
 import * as navigation from 'core/navigation';
@@ -131,7 +132,7 @@ export class SearchBoxBase extends React.Component<InternalProps, State> {
         this.updateFiltersFromURLParams();
     }
 
-    componentDidUpdate(prevProps: InternalProps, state: Object) {
+    componentDidUpdate(prevProps: InternalProps) {
         // Clear search field when navigating to a new file
         if (
             this.props.parameters.search === null &&

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6361,6 +6361,11 @@ lodash.isequal@4.5.0, lodash.isequal@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
 
+lodash.mapvalues@4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz#1bafa5005de9dd6f4f26668c30ca37230cc9689c"
+  integrity sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"


### PR DESCRIPTION
#### What does this PR do?
This pull request fixes the issue [1395179](https://bugzilla.mozilla.org/show_bug.cgi?id=1395179). It ensures the status numbers in the progress menu are clickable.

#### Type of change:
- [x] Bug fix (non-breaking change which fixed an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update.

#### How Has This Been Tested?
- Clone this repository 
- Git checkout to `katherine95:1395179-clickable-status-numbers` branch.
- Follow the setup guidelines to set up pontoon locally
- Run `make run`
- Login to Pontoon
- Navigate to the progress menu and click the percentage.
- Click on the status numbers. For example, click  the number under "MISSING"

Expected result:

It navigates to `http://localhost:8000/translate/en-GB/tutorial/all-resources/?status=missing&string=1`

#### Checklist:
- [x] On click on any of the status numbers, it should navigate to the respective url.

#### Screenshot
![Screenshot from 2019-11-13 14-50-35](https://user-images.githubusercontent.com/17095461/68761764-d1b3ce80-0625-11ea-915f-ebee86c9440e.png)
