### PR TITLE
bug 1585251, more test fixes for python3

### DIFF
--- a/pontoon/batch/forms.py
+++ b/pontoon/batch/forms.py
@@ -26,8 +26,8 @@ class BatchActionsForm(forms.Form):
 
         Related bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1438575
         """
-        field_val = str(self.cleaned_data.get(param_name, ''))
-        return urllib.parse.unquote(field_val).decode('utf-8')
+        field_val = self.cleaned_data.get(param_name, '')
+        return urllib.parse.unquote(field_val)
 
     def clean_find(self):
         return self.decode_field('find')

--- a/pontoon/batch/tests/test_views.py
+++ b/pontoon/batch/tests/test_views.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 import pytest
 
@@ -125,7 +125,7 @@ def test_batch_edit_translations_no_permissions(
     )
 
     assert response.status_code == 403
-    assert 'Forbidden' in response.content
+    assert b'Forbidden' in response.content
 
 
 @pytest.mark.django_db

--- a/pontoon/checks/tests/test_models.py
+++ b/pontoon/checks/tests/test_models.py
@@ -179,7 +179,7 @@ def test_get_failed_checks_db_objects(translation_a):
     assert all([e.pk is None for e in errors])
 
     cl_warning, = warnings
-    p_error, cl_error = errors
+    cl_error, p_error = sorted(errors, key=lambda e: e.library)
 
     assert cl_warning.library == 'cl'
     assert cl_warning.message == 'compare-locales warning 1'

--- a/pontoon/checks/tests/test_translate_toolkit.py
+++ b/pontoon/checks/tests/test_translate_toolkit.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 import pytest
-from mock import MagicMock
 
 from pontoon.checks.libraries.translate_toolkit import run_checks
 
@@ -8,9 +7,7 @@ from pontoon.checks.libraries.translate_toolkit import run_checks
 @pytest.yield_fixture()
 def mock_locale():
     """Small mock of Locale object to make faster unit-tests."""
-    mock = MagicMock()
-    mock.code = 'en-US'
-    yield mock
+    yield 'en-US'
 
 
 def test_tt_invalid_translation(mock_locale):

--- a/pontoon/contributors/tests/test_views.py
+++ b/pontoon/contributors/tests/test_views.py
@@ -199,7 +199,7 @@ class ContributorTimelineViewTests(UserTestCase):
                     'count': count,
                     'project': self.project,
                     'translation': translations[0][0],
-                } for (dt, count), translations in self.translations.items()[10:20]
+                } for (dt, count), translations in list(self.translations.items())[10:20]
             ]
         )
 

--- a/pontoon/sync/changeset.py
+++ b/pontoon/sync/changeset.py
@@ -396,7 +396,7 @@ class ChangeSet(object):
 
     def bulk_update_translations(self):
         if len(self.translations_to_update) > 0:
-            bulk_update(self.translations_to_update.values(), update_fields=[
+            bulk_update(list(self.translations_to_update.values()), update_fields=[
                 'entity',
                 'locale',
                 'string',

--- a/pontoon/sync/formats/json_extensions.py
+++ b/pontoon/sync/formats/json_extensions.py
@@ -171,7 +171,7 @@ class JSONResource(ParsedResource):
 
         with codecs.open(self.path, 'w+', 'utf-8') as f:
             log.debug('Saving file: %s', self.path)
-            f.write(json.dumps(json_file, ensure_ascii=False, indent=2))
+            f.write(json.dumps(json_file, ensure_ascii=False, indent=2, separators=(',', ': ')))
             f.write('\n')  # Add newline
 
 

--- a/pontoon/sync/formats/lang.py
+++ b/pontoon/sync/formats/lang.py
@@ -203,6 +203,6 @@ def parse(path, source_path=None, locale=None):
         children = LangVisitor().parse(content)
     except (ParsimoniousParseError, VisitationError) as err:
         wrapped = ParseError(u'Failed to parse {path}: {err}'.format(path=path, err=err))
-        reraise(wrapped, None, sys.exc_info()[2])  # NOQA
+        reraise(ParseError, wrapped, sys.exc_info()[2])  # NOQA
 
     return LangResource(path, children)

--- a/pontoon/sync/formats/silme.py
+++ b/pontoon/sync/formats/silme.py
@@ -73,6 +73,11 @@ class SilmeEntity(VCSTranslation):
         return not self.__eq__(other)
 
     def __nonzero__(self):
+        # TODO: remove python2
+        return bool(self.strings)
+
+    def __bool__(self):
+        # python 3
         return bool(self.strings)
 
 

--- a/pontoon/sync/formats/xliff.py
+++ b/pontoon/sync/formats/xliff.py
@@ -120,8 +120,8 @@ class XLIFFResource(ParsedResource):
             if node.get('target-language'):
                 node.set('target-language', locale_code)
 
-        with open(self.path, 'w') as f:
-            f.writelines(str(self.xliff_file))
+        with open(self.path, 'wb') as f:
+            f.write(bytes(self.xliff_file))
 
 
 def parse(path, source_path=None, locale=None):

--- a/pontoon/sync/tests/formats/test_json_extensions.py
+++ b/pontoon/sync/tests/formats/test_json_extensions.py
@@ -95,11 +95,11 @@ class JsonExtensionsTests(FormatTestsMixin, TestCase):
         expected_string = dedent("""
             {
               "SourceString": {
-                "message": "New Translated String", 
+                "message": "New Translated String",
                 "description": "Comment"
               }
             }
-        """) # noqa
+        """)
 
         self.run_save_basic(
             input_string,

--- a/pontoon/sync/tests/formats/test_silme.py
+++ b/pontoon/sync/tests/formats/test_silme.py
@@ -189,10 +189,10 @@ class DTDTests(FormatTestsMixin, TestCase):
         input_strings = dedent("""
             <!ENTITY SingleQuote "\'">
             <!ENTITY SingleQuoteHTMLEntity "\\&apos;">
-            <!ENTITY SingleQuoteUnicode "\u0027">
-            <!ENTITY DoubleQuote '\"'>
+            <!ENTITY SingleQuoteUnicode "\\u0027">
+            <!ENTITY DoubleQuote '\\"'>
             <!ENTITY DoubleQuoteHTMLEntity "\\&quot;">
-            <!ENTITY DoubleQuoteUnicode "\u0022">
+            <!ENTITY DoubleQuoteUnicode "\\u0022">
         """)
 
         # Make sure path contains 'mobile/android/base'

--- a/pontoon/sync/vcs/models.py
+++ b/pontoon/sync/vcs/models.py
@@ -355,7 +355,7 @@ class VCSProject(object):
                 locales = []
 
             locales = set([l for l in locales if l in self.locales])
-            map(self.synced_locales.add, locales)
+            self.synced_locales.update(locales)
 
             log.debug(
                 'Detected resource file {} for {}'.format(

--- a/pontoon/sync/vcs/repositories.py
+++ b/pontoon/sync/vcs/repositories.py
@@ -343,7 +343,7 @@ class GitRepository(VCSRepository):
         code, output, error = self.execute(
             ['git', 'rev-parse', 'HEAD'],
         )
-        return output.strip() if code == 0 else None
+        return output.strip().decode('utf-8') if code == 0 else None
 
     def get_changed_files(self, path, from_revision, statuses=None):
         statuses = statuses or ('A', 'M')
@@ -366,7 +366,7 @@ class HgRepository(VCSRepository):
             cwd=self.path,
             log_errors=True
         )
-        return output.strip() if code == 0 else None
+        return output.strip().decode('utf-8') if code == 0 else None
 
     def _strip(self, rev):
         "Ignore trailing + in revision number. It marks local changes."


### PR DESCRIPTION
There's an intentional change to the serialization of the json for web extensions, it's now dropping the trailing `" "` in `, \n`.