### PR TITLE
Bug 1555259: Copying from Machinery to Source editor results in a broken string

### DIFF
--- a/frontend/src/modules/fluenteditor/components/Editor.js
+++ b/frontend/src/modules/fluenteditor/components/Editor.js
@@ -92,6 +92,24 @@ export class EditorBase extends React.Component<EditorProps, State> {
         ) {
             this.analyzeFluentMessage(this.props.editor.translation);
         }
+        // If translation changes from machinery tab,
+        // check if it's valid and convert syntax to comlex if no.
+        else if (
+            this.props.entity &&
+            this.state.forceSource &&
+            this.props.editor.translation !== prevProps.editor.translation &&
+            this.props.editor.changeSource === 'machinery' &&
+            typeof(this.props.editor.translation) === 'string'
+        ) {
+            const message = fluent.parser.parseEntry(this.props.editor.translation);
+            if (message.type === 'Junk') {
+                this.updateEditorContent(
+                    this.props.editor.translation,
+                    'simple',
+                    'complex',
+                );
+            }
+        }
     }
 
     /**


### PR DESCRIPTION

In editor.js->componentDidUpdate add else if to check the content copied from machinery tab.
In case parsed to fluent message content is Junk, convert it to complex

[Bug 1555259](https://bugzilla.mozilla.org/show_bug.cgi?id=1555259)