### PR TITLE
No bug: Edit Homepage button should not cover menus

### DIFF
--- a/pontoon/homepage/static/css/homepage.css
+++ b/pontoon/homepage/static/css/homepage.css
@@ -108,7 +108,7 @@ h2 {
 #edit-homepage .select {
   float: right;
   top: 70px;
-  z-index: 10;
+  z-index: 5;
 }
 
 #edit-homepage .button {


### PR DESCRIPTION
This is the problem we're fixing:
<img width="327" alt="Screenshot 2019-10-31 at 13 28 03" src="https://user-images.githubusercontent.com/626716/67946766-517f7900-fbe2-11e9-9c10-eef7cc15fa68.png">