### PR TITLE
Fix bug 1593616: Replace Get in touch with Give Feedback

### DIFF
--- a/pontoon/homepage/templates/homepage_content.html
+++ b/pontoon/homepage/templates/homepage_content.html
@@ -139,7 +139,7 @@
           <a href="https://github.com/mozilla/pontoon/">Hack it on Github</a>
         </div>
         <div class="flex-col-3 contact">
-          <a href="mailto:">Get in touch</a>
+          <a href="https://discourse.mozilla.org/c/pontoon">Give Feedback</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
I'm keeping the class name unchanged, otherwise it will break the CSS for instances that update from upstream but don't update the homepage content.