### PR TITLE
No bug: Unify styling & sorting of  items in Progress column

### DIFF
--- a/pontoon/base/static/css/table.css
+++ b/pontoon/base/static/css/table.css
@@ -11,8 +11,9 @@ table.table.project-list.hidden {
   vertical-align: middle;
 }
 
-/* Used to designate from main style, e.g. project not active, deadline not set, no latest activity... */
-.table td .not {
+/* Used to designate from main style, e.g. deadline not set, no latest activity, project not ready... */
+.table td .not,
+.table td .not-ready {
   font-style: italic;
 }
 

--- a/pontoon/projects/templates/projects/widgets/project_list.html
+++ b/pontoon/projects/templates/projects/widgets/project_list.html
@@ -42,7 +42,7 @@
       {% if project.total_strings %}
         {{ ProgressChart.span(chart, chart_link, link_parameter) }}
       {% else %}
-        <span class="not">Not synced yet</span>
+        <span class="not-ready">Not synced yet</span>
       {% endif %}
     </td>
     {% if request %}
@@ -50,7 +50,7 @@
         {% if project.total_strings %}
           <span>{{ project.avg_string_count|intcomma }}</span>
         {% else %}
-          <span class="not">Not synced yet</span>
+          <span class="not-ready">Not synced yet</span>
         {% endif %}
       </td>
       <td class="check fa fa-fw"></td>


### PR DESCRIPTION
Just noticed styling of "Not synced yet" elements is different in the localization/teams dashboards compared to the projects/admin dashboards.