### PR TITLE
Bug 1588471: Fix bad reverse URL arguments

### DIFF
--- a/pontoon/base/tests/views/test_locale_agnostic.py
+++ b/pontoon/base/tests/views/test_locale_agnostic.py
@@ -70,8 +70,8 @@ def test_view_lang_agnostic_authed(redirect_mock, reverse_mock, projects_mock,
         == [('pontoon.translate',),
             {'kwargs': {
                 'locale': 23,
-                'part': u'BAR',
-                'slug': u'FOO'}}])
+                'resource': u'BAR',
+                'project': u'FOO'}}])
 
     # redirect was called with reverse result
     assert(
@@ -138,8 +138,8 @@ def test_view_lang_agnostic_anon_available_accept_language(redirect_mock,
         == [('pontoon.translate',),
             {'kwargs': {
                 'locale': 23,
-                'part': u'BAR',
-                'slug': u'FOO'}}])
+                'resource': u'BAR',
+                'project': u'FOO'}}])
 
     # redirect was called with reverse result
     assert (

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -121,14 +121,14 @@ def translate_locale_agnostic(request, slug, part):
         if locale and project_locales.filter(code=locale).exists():
             path = reverse(
                 'pontoon.translate',
-                kwargs=dict(slug=slug, locale=locale, part=part))
+                kwargs=dict(project=slug, locale=locale, resource=part))
             return redirect("%s%s" % (path, query))
 
     locale = utils.get_project_locale_from_request(request, project_locales)
     path = (
         reverse(
             'pontoon.translate',
-            kwargs=dict(slug=slug, locale=locale, part=part))
+            kwargs=dict(project=slug, locale=locale, resource=part))
         if locale
         else reverse(
             'pontoon.projects.project',


### PR DESCRIPTION
We're getting server errors:

```
Traceback:

File "/app/.heroku/python/lib/python2.7/site-packages/django/core/handlers/base.py", line 185, in _get_response
                  response = wrapped_callback(request, *callback_args, **callback_kwargs)

File "/app/.heroku/python/lib/python2.7/site-packages/newrelic/hooks/framework_django.py", line 544, in wrapper
                  return wrapped(*args, **kwargs)

File "/app/pontoon/base/views.py", line 132, in translate_locale_agnostic
          if locale

File "/app/.heroku/python/lib/python2.7/site-packages/newrelic/hooks/framework_django.py", line 647, in wrapper
          return execute(*args, **kwargs)

File "/app/.heroku/python/lib/python2.7/site-packages/newrelic/hooks/framework_django.py", line 646, in execute
              return wrapped(viewname, *args, **kwargs)

File "/app/.heroku/python/lib/python2.7/site-packages/django/urls/base.py", line 91, in reverse
      return force_text(iri_to_uri(resolver._reverse_with_prefix(view, prefix, *args, **kwargs)))

File "/app/.heroku/python/lib/python2.7/site-packages/django/urls/resolvers.py", line 497, in _reverse_with_prefix
          raise NoReverseMatch(msg)
```