### PR TITLE
A followup to the 3-column layout

### DIFF
--- a/frontend/src/modules/entitieslist/components/Entity.css
+++ b/frontend/src/modules/entitieslist/components/Entity.css
@@ -41,6 +41,7 @@
 
 .entity .translation-string {
     color: #AAAAAA;
+    min-height: 20px;
     text-align: start;
 }
 


### PR DESCRIPTION
Empty translations should occupy vertical space to prevent jumping on save