### PR TITLE
Fix bug 1595149 - Don't build frontend assets in the Heroku post depl…

### DIFF
--- a/app.json
+++ b/app.json
@@ -57,14 +57,6 @@
       "value": "False",
       "description": "Controls whether asynchronous tasks (mainly used during sync) are sent to Celery or executed immediately and synchronously. Set this to ``False`` on production."
     },
-    "DJANGO_DEBUG": {
-      "value": "True",
-      "description": "Controls ``DEBUG`` mode for the site. Should be set to `False` in production."
-    },
-    "DJANGO_DEV": {
-      "value": "False",
-      "description": "Signifies whether this is a development server or not. Should be `False` in production. Adds some additional django apps that can be helpful during day to day development."
-    },
     "SECRET_KEY": {
       "description": "Secret key used for sessions, cryptographic signing, etc.",
       "generator": "secret"

--- a/bin/heroku_postdeploy
+++ b/bin/heroku_postdeploy
@@ -6,9 +6,6 @@ set -x
 # Some of scripts like e.g. migrations require SITE_URL to be set before the database is initialized.
 export SITE_URL='http://localhost:8000'
 
-# Compile static assets
-source ./bin/post_compile
-
 MEMCACHE_SERVER=$(echo $MEMCACHE_SERVERS | cut -f1 -d:)
 MEMCACHE_PORT=$(echo $MEMCACHE_SERVERS | cut -f2 -d:)
 


### PR DESCRIPTION
Hey,
`post_compile` was mistakenly executed during the "Build app" step and later in the "Run scripts & scale dynos" step. There's no need to run it twice.
The patch will make all new deployments on Heroku faster and they won't fail because of the out of memory error.

Also, I disabled the DEBUG mode because of https://github.com/mozilla/pontoon/blob/master/pontoon/translate/views.py#L26. Additionally, I don't think that new users will need to see the debug tools.

r? @mathjazz @adngdb 
