### PR TITLE
Fix bug 1552802: Add support for pretranslation in admin panel.

### DIFF
--- a/pontoon/administration/forms.py
+++ b/pontoon/administration/forms.py
@@ -48,7 +48,9 @@ class ProjectForm(forms.ModelForm):
             'contact',
             'disabled',
             'sync_disabled',
-            'tags_enabled')
+            'tags_enabled',
+            'pretranslation_enabled',
+        )
 
     def __init__(self, *args, **kwargs):
         super(ProjectForm, self).__init__(*args, **kwargs)

--- a/pontoon/administration/static/css/admin_project.css
+++ b/pontoon/administration/static/css/admin_project.css
@@ -149,13 +149,18 @@ form .button {
 }
 
 .controls .button.sync,
-.controls .button.sync:hover,
-.controls .button.pretranslate,
-.controls .button.pretranslate:hover {
-  background: #F36;
-  color: #272A2F;
+.controls .button.sync:hover {
+  background: #333941;
+  color: #fff;
   float: left;
   margin-right: 10px;
+}
+
+.controls .button.pretranslate,
+.controls .button.pretranslate:hover {
+  background: #333941;
+  color: #fff;
+  float: right;
 }
 
 form a:link, form a:visited {

--- a/pontoon/administration/static/css/admin_project.css
+++ b/pontoon/administration/static/css/admin_project.css
@@ -149,7 +149,9 @@ form .button {
 }
 
 .controls .button.sync,
-.controls .button.sync:hover {
+.controls .button.sync:hover,
+.controls .button.pretranslate,
+.controls .button.pretranslate:hover {
   background: #F36;
   color: #272A2F;
   float: left;
@@ -464,7 +466,7 @@ textarea.strings-source {
 .locales .errorlist {
   margin-top: 10px;
   text-align: center;
-  width: 100%;  
+  width: 100%;
 }
 
 .notification {

--- a/pontoon/administration/static/css/admin_project.css
+++ b/pontoon/administration/static/css/admin_project.css
@@ -151,15 +151,14 @@ form .button {
 .controls .button.sync,
 .controls .button.sync:hover {
   background: #333941;
-  color: #fff;
+  color: #aaa;
   float: left;
-  margin-right: 10px;
 }
 
 .controls .button.pretranslate,
 .controls .button.pretranslate:hover {
   background: #333941;
-  color: #fff;
+  color: #aaa;
   float: right;
 }
 

--- a/pontoon/administration/static/js/admin_project.js
+++ b/pontoon/administration/static/js/admin_project.js
@@ -72,6 +72,32 @@ $(function() {
     });
   });
 
+  // Manually Pretranslate project
+  $('.pretranslate').click(function(e) {
+    e.preventDefault();
+
+    var button = $(this),
+        title = button.html();
+
+    if (button.is('.in-progress')) {
+      return;
+    }
+
+    button.addClass('in-progress').html('Pretranslating...');
+
+    $.ajax({
+      url: '/admin/projects/' + $('#id_slug').val() + '/pretranslate/'
+    }).success(function() {
+      button.html('Pretranslation started');
+    }).error(function() {
+      button.html('Whoops!');
+    }).complete(function() {
+      setTimeout(function() {
+        button.removeClass('in-progress').html(title);
+      }, 2000);
+    });
+  });
+
   // Suggest slugified name for new projects
   $('#id_name').blur(function() {
     if ($('input[name=pk]').length > 0 || !$('#id_name').val()) {

--- a/pontoon/administration/templates/admin_project.html
+++ b/pontoon/administration/templates/admin_project.html
@@ -309,9 +309,6 @@
   </section>
 
   <div class="controls clearfix">
-      {% if settings.MANUAL_SYNC %}
-      <button class="sync button">Sync</button>
-      {% endif %}
       <div class="checkbox clearfix">
           <label for="id_disabled">
               {{ form.disabled }}{{ form.disabled.label }}
@@ -322,6 +319,9 @@
               {{ form.sync_disabled }}{{ form.sync_disabled.label }}
           </label>
       </div>
+      {% if settings.MANUAL_SYNC %}
+      <button class="sync button">Sync</button>
+      {% endif %}
       <button class="button active save">Save project</button>
       <a href="{{ url('pontoon.admin') }}" class="cancel">Cancel</a>
   </div>

--- a/pontoon/administration/templates/admin_project.html
+++ b/pontoon/administration/templates/admin_project.html
@@ -294,6 +294,20 @@
       {% endif %}
   </section>
 
+  <section class="controls clearfix">
+    <h3>
+      <span>Pretranslation</span>
+    </h3>
+    <div class="clearfix">
+      <button class="pretranslate button clearfix">Pretranslate</button>
+      <div class="checkbox clearfix">
+        <label for="id_pretranslation_enabled">
+            {{ form.pretranslation_enabled }}{{ form.pretranslation_enabled.label }}
+        </label>
+      </div>
+    </div>
+  </section>
+
   <div class="controls clearfix">
       {% if settings.MANUAL_SYNC %}
       <button class="sync button">Sync</button>

--- a/pontoon/administration/urls.py
+++ b/pontoon/administration/urls.py
@@ -41,6 +41,13 @@ urlpatterns = [
         name='pontoon.admin.project.strings'
     ),
 
+    # Pretranslate project
+    url(
+        r'^projects/(?P<slug>[\w-]+)/pretranslate/$',
+        views.manually_pretranslate_project,
+        name='pontoon.project.sync'
+    ),
+
     # Edit project
     url(
         r'^projects/(?P<slug>.+)/$',

--- a/pontoon/administration/views.py
+++ b/pontoon/administration/views.py
@@ -537,7 +537,7 @@ def manually_sync_project(request, slug):
 def manually_pretranslate_project(request, slug):
     if not request.user.has_perm('base.can_manage_project') or not settings.MANUAL_SYNC:
         return HttpResponseForbidden(
-            "Forbidden: You don't have permission for syncing projects"
+            "Forbidden: You don't have permission for pretranslating projects"
         )
 
     project = Project.objects.get(slug=slug)

--- a/pontoon/administration/views.py
+++ b/pontoon/administration/views.py
@@ -535,7 +535,7 @@ def manually_sync_project(request, slug):
 @login_required(redirect_field_name='', login_url='/403')
 @require_AJAX
 def manually_pretranslate_project(request, slug):
-    if not request.user.has_perm('base.can_manage_project') or not settings.MANUAL_SYNC:
+    if not request.user.has_perm('base.can_manage_project'):
         return HttpResponseForbidden(
             "Forbidden: You don't have permission for pretranslating projects"
         )

--- a/pontoon/pretranslation/tasks.py
+++ b/pontoon/pretranslation/tasks.py
@@ -25,15 +25,17 @@ def pretranslate(project, locales=None, entities=None):
 
     log.info('Fetching pretranslations for project {} started'.format(project.name))
 
-    if not locales:
-        locales = project.locales.filter(
-            project_locale__readonly=False,
-        ).prefetch_project_locale(project)
+    if locales:
+        locales = project.locales.filter(pk__in=locales)
     else:
-        locales = project.locales.filter(
-            project_locale__readonly=False,
-            pk__in=locales,
-        ).prefetch_project_locale(project)
+        locales = project.locales
+
+    locales = (
+        locales
+        .filter(project_locale__readonly=False)
+        .distinct()
+        .prefetch_project_locale(project)
+    )
 
     if not entities:
         entities = Entity.objects.filter(

--- a/pontoon/pretranslation/tasks.py
+++ b/pontoon/pretranslation/tasks.py
@@ -32,7 +32,7 @@ def pretranslate(project, locales=None, entities=None):
     else:
         locales = project.locales.filter(
             project_locale__readonly=False,
-            pk__in = locales,
+            pk__in=locales,
         ).prefetch_project_locale(project)
 
     if not entities:

--- a/pontoon/pretranslation/tasks.py
+++ b/pontoon/pretranslation/tasks.py
@@ -29,6 +29,11 @@ def pretranslate(project, locales=None, entities=None):
         locales = project.locales.filter(
             project_locale__readonly=False,
         ).prefetch_project_locale(project)
+    else:
+        locales = project.locales.filter(
+            project_locale__readonly=False,
+            pk__in = locales,
+        ).prefetch_project_locale(project)
 
     if not entities:
         entities = Entity.objects.filter(

--- a/pontoon/sync/changeset.py
+++ b/pontoon/sync/changeset.py
@@ -236,7 +236,7 @@ class ChangeSet(object):
                     ))
 
         self.send_notifications(new_entities)
-        self.new_entities = self.new_entities + new_entities
+        self.new_entities = new_entities
 
     def update_entity_translations_from_vcs(
             self, db_entity, locale_code, vcs_translation,

--- a/pontoon/sync/changeset.py
+++ b/pontoon/sync/changeset.py
@@ -54,6 +54,7 @@ class ChangeSet(object):
         self.entities_to_update = []
         self.translations_to_update = {}
         self.translations_to_create = []
+        self.new_entities = []
         self.commit_authors_per_locale = defaultdict(list)
         self.locales_to_commit = set()
 
@@ -235,6 +236,7 @@ class ChangeSet(object):
                     ))
 
         self.send_notifications(new_entities)
+        self.new_entities = self.new_entities + new_entities
 
     def update_entity_translations_from_vcs(
             self, db_entity, locale_code, vcs_translation,

--- a/pontoon/sync/core.py
+++ b/pontoon/sync/core.py
@@ -27,14 +27,15 @@ log = logging.getLogger(__name__)
 
 def update_originals(db_project, now, full_scan=False):
     vcs_project = VCSProject(db_project, locales=[], full_scan=full_scan)
-
+    new_entities = []
     with transaction.atomic():
         added_paths, removed_paths, changed_paths = update_resources(db_project, vcs_project)
         changeset = ChangeSet(db_project, vcs_project, now)
         update_entities(db_project, vcs_project, changeset)
         changeset.execute()
+        new_entities = changeset.new_entities
 
-    return added_paths, removed_paths, changed_paths
+    return added_paths, removed_paths, changed_paths, new_entities
 
 
 def serial_task(timeout, lock_key="", on_error=None, **celery_args):

--- a/pontoon/sync/core.py
+++ b/pontoon/sync/core.py
@@ -208,7 +208,6 @@ def update_translated_resources_with_config(db_project, vcs_project, locale):
     return flag
 
 
-
 def update_translated_resources_without_config(db_project, vcs_project, locale):
     """
     We only want to create/update the TranslatedResource object if the

--- a/pontoon/sync/core.py
+++ b/pontoon/sync/core.py
@@ -174,7 +174,7 @@ def update_translations(db_project, vcs_project, locale, changeset):
 def update_translated_resources(db_project, vcs_project, locale):
     """
     Update the TranslatedResource entries in the database.
-    Returns true if a new resource is added to the locale.
+    Returns true if a new TranslatedResource is added to the locale.
     """
     if vcs_project.configuration:
         return update_translated_resources_with_config(
@@ -202,7 +202,8 @@ def update_translated_resources_with_config(db_project, vcs_project, locale):
             TranslatedResource.objects.get_or_create(resource=resource, locale=locale)
         )
 
-        tr_created |= created  # set to true if at least one instance is created
+        if created:
+            tr_created = True
         translatedresource.calculate_stats()
 
     return tr_created
@@ -225,7 +226,8 @@ def update_translated_resources_without_config(db_project, vcs_project, locale):
                     TranslatedResource.objects.get_or_create(resource=resource, locale=locale)
                 )
 
-                tr_created |= created  # set to true if at least one instance is created
+                if created:
+                    tr_created = True
                 translatedresource.calculate_stats()
 
     return tr_created

--- a/pontoon/sync/tasks.py
+++ b/pontoon/sync/tasks.py
@@ -122,11 +122,11 @@ def sync_project(
         source_changes.get('added_paths'),
         source_changes.get('removed_paths'),
         source_changes.get('changed_paths'),
+        source_changes.get('new_entities'),
         locale=locale,
         no_pull=no_pull,
         no_commit=no_commit,
         full_scan=force,
-        new_entities=source_changes.get('new_entities')
     )
 
 
@@ -185,8 +185,8 @@ def sync_sources(db_project, now, force, no_pull):
 )
 def sync_translations(
     self, project_pk, project_sync_log_pk, now, added_paths=None, removed_paths=None,
-    changed_paths=None, locale=None, no_pull=False, no_commit=False, full_scan=False,
-    new_entities=None,
+    changed_paths=None, new_entities=None, locale=None, no_pull=False, no_commit=False,
+    full_scan=False
 ):
     db_project = get_or_fail(
         Project,

--- a/pontoon/sync/tasks.py
+++ b/pontoon/sync/tasks.py
@@ -125,14 +125,9 @@ def sync_project(
         locale=locale,
         no_pull=no_pull,
         no_commit=no_commit,
-        full_scan=force
+        full_scan=force,
+        new_entities=source_changes.get('new_entities')
     )
-
-    new_entities = source_changes.get('new_entities')
-
-    if db_project.pretranslation_enabled and new_entities:
-        new_entities = list(set(new_entities))
-        pretranslate(db_project, entities=new_entities)
 
 
 def sync_sources(db_project, now, force, no_pull):
@@ -191,6 +186,7 @@ def sync_sources(db_project, now, force, no_pull):
 def sync_translations(
     self, project_pk, project_sync_log_pk, now, added_paths=None, removed_paths=None,
     changed_paths=None, locale=None, no_pull=False, no_commit=False, full_scan=False,
+    new_entities=None,
 ):
     db_project = get_or_fail(
         Project,
@@ -405,5 +401,12 @@ def sync_translations(
         )
     repo_sync_log.end()
 
-    if db_project.pretranslation_enabled and len(new_locales):
-        pretranslate(db_project, locales=new_locales)
+    if db_project.pretranslation_enabled:
+        # Pretranslate all entities for newly added locales
+        if len(new_locales):
+            pretranslate(db_project, locales=new_locales)
+
+        # Pretranslate newly added entities for all locales
+        if new_entities:
+            new_entities = list(set(new_entities))
+            pretranslate(db_project, entities=new_entities)

--- a/pontoon/sync/tasks.py
+++ b/pontoon/sync/tasks.py
@@ -404,7 +404,7 @@ def sync_translations(
 
     if db_project.pretranslation_enabled:
         # Pretranslate all entities for newly added locales
-        # and locales with newly added resource
+        # and locales with newly added resources
         if len(new_locales):
             pretranslate(db_project, locales=new_locales)
 

--- a/pontoon/sync/tasks.py
+++ b/pontoon/sync/tasks.py
@@ -283,7 +283,8 @@ def sync_translations(
     synced_locales = set()
     failed_locales = set()
 
-    new_locales = []  # store the locales for which new resources are added
+    # Store newly added locales and locales with newly added resources
+    new_locales = []
 
     for locale in locales:
         try:
@@ -403,10 +404,13 @@ def sync_translations(
 
     if db_project.pretranslation_enabled:
         # Pretranslate all entities for newly added locales
+        # and locales with newly added resource
         if len(new_locales):
             pretranslate(db_project, locales=new_locales)
 
+        locales = db_project.locales.exclude(pk__in=new_locales).values_list('pk', flat=True)
+
         # Pretranslate newly added entities for all locales
-        if new_entities:
+        if new_entities and locales:
             new_entities = list(set(new_entities))
-            pretranslate(db_project, entities=new_entities)
+            pretranslate(db_project, locales=locales, entities=new_entities)

--- a/pontoon/sync/tasks.py
+++ b/pontoon/sync/tasks.py
@@ -131,7 +131,7 @@ def sync_project(
     new_entities = source_changes.get('new_entities')
 
     if db_project.pretranslation_enabled and new_entities:
-        new_entities = list(set(source_changes.get('new_entities')))
+        new_entities = list(set(new_entities))
         pretranslate(db_project, entities=new_entities)
 
 

--- a/pontoon/sync/tasks.py
+++ b/pontoon/sync/tasks.py
@@ -9,8 +9,7 @@ from django.utils import timezone
 from pontoon.base.models import (
     ChangedEntityLocale,
     Project,
-    Repository,
-    Locale,
+    Repository
 )
 
 from pontoon.base.tasks import PontoonTask

--- a/pontoon/sync/tests/test_tasks.py
+++ b/pontoon/sync/tests/test_tasks.py
@@ -293,6 +293,7 @@ class SyncTranslationsTests(FakeCheckoutTestCase):
         self.mock_pull_changes.return_value = [True, {
             self.repository.pk: Locale.objects.filter(pk=self.translated_locale.pk)
         }]
+        all_locales = list(self.db_project.locales.values_list('pk', flat=True))
 
         with self.patch('pontoon.sync.tasks.update_translated_resources', return_value=False):
             sync_translations(self.db_project.pk, self.project_sync_log.pk,
@@ -300,10 +301,11 @@ class SyncTranslationsTests(FakeCheckoutTestCase):
 
         assert_true(self.mock_pretranslate.called)
         assert_equal(self.mock_pretranslate.call_args[1]['entities'], ['new_entity'])
+        assert_equal(list(self.mock_pretranslate.call_args[1]['locales']), all_locales)
 
-    def test_new_resource_pretranslation(self):
+    def test_new_translated_resource_pretranslation(self):
         """
-        Test if pretranslate is called for locales with newly added resource.
+        Test if pretranslation is called for locales with newly added TranslatedResource.
         """
         self.db_project.pretranslation_enabled = True
         self.db_project.save()

--- a/pontoon/sync/tests/test_tasks.py
+++ b/pontoon/sync/tests/test_tasks.py
@@ -139,6 +139,7 @@ class SyncTranslationsTests(FakeCheckoutTestCase):
         self.mock_pull_changes = self.patch(
             'pontoon.sync.tasks.pull_changes', return_value=[True, {}])
         self.mock_commit_changes = self.patch('pontoon.sync.tasks.commit_changes')
+        self.mock_pretranslate = self.patch('pontoon.sync.tasks.pretranslate')
         self.mock_repo_checkout_path = self.patch_object(
             Repository, 'checkout_path', new_callable=PropertyMock,
             return_value=FAKE_CHECKOUT_PATH)
@@ -258,6 +259,66 @@ class SyncTranslationsTests(FakeCheckoutTestCase):
 
         log = RepositorySyncLog.objects.get(repository=repo.pk)
         assert_equal(log.repository, repo)
+
+    def test_no_pretranslation(self):
+        """
+        Ensure that pretranslation isn't called if pretranslation not enabled
+        or no new Entity, Locale or TranslatedResource is created.
+        """
+        self.mock_pull_changes.return_value = [True, {
+            self.repository.pk: Locale.objects.filter(pk=self.translated_locale.pk)
+        }]
+
+        sync_translations(self.db_project.pk, self.project_sync_log.pk,
+                          self.now, [], [], [], ['new_entity'])
+
+        # Pretranslation is not enabled
+        assert_false(self.mock_pretranslate.called)
+
+        self.db_project.pretranslation_enabled = True
+        self.db_project.save()
+
+        with self.patch('pontoon.sync.tasks.update_translated_resources', return_value=False):
+            sync_translations(self.db_project.pk, self.project_sync_log.pk, self.now)
+
+        # No new Entity, Locale or TranslatedResource
+        assert_false(self.mock_pretranslate.called)
+
+    def test_new_entities_pretranslation(self):
+        """
+        Test if pretranslation is called for newly added entities.
+        """
+        self.db_project.pretranslation_enabled = True
+        self.db_project.save()
+        self.mock_pull_changes.return_value = [True, {
+            self.repository.pk: Locale.objects.filter(pk=self.translated_locale.pk)
+        }]
+
+        with self.patch('pontoon.sync.tasks.update_translated_resources', return_value=False):
+            sync_translations(self.db_project.pk, self.project_sync_log.pk,
+                              self.now, [], [], [], ['new_entity'])
+
+        assert_true(self.mock_pretranslate.called)
+        assert_equal(self.mock_pretranslate.call_args[1]['entities'], ['new_entity'])
+
+    def test_new_resource_pretranslation(self):
+        """
+        Test if pretranslate is called for locales with newly added resource.
+        """
+        self.db_project.pretranslation_enabled = True
+        self.db_project.save()
+        self.mock_pull_changes.return_value = [True, {
+            self.repository.pk: Locale.objects.filter(pk=self.translated_locale.pk)
+        }]
+
+        sync_translations(self.db_project.pk, self.project_sync_log.pk,
+                          self.now, [], [], [], ['new_entity'])
+
+        assert_true(self.mock_pretranslate.called)
+        assert_equal(self.mock_pretranslate.call_args[1]['locales'], [self.translated_locale.pk])
+
+        # Ensure that pretranslate is called only once for the locale.
+        assert_equal(self.mock_pretranslate.call_args[1].get('entities'), None)
 
 
 class UserError(Exception):

--- a/pontoon/sync/tests/test_tasks.py
+++ b/pontoon/sync/tests/test_tasks.py
@@ -41,7 +41,7 @@ class SyncProjectTests(TestCase):
 
         self.mock_update_originals = self.patch(
             'pontoon.sync.tasks.update_originals',
-            return_value=[[], [], []]
+            return_value=[[], [], [], []]
         )
 
         self.mock_source_directory_path = self.patch(


### PR DESCRIPTION
We are looking to trigger the pretranslation in 3 cases:

- [x] Pretranslate now: starts the async job immediately.
- [x] Pretranslation enabled: execute the job as part of sync when new strings arrive.
- [x] Pretranslation enabled: also execute the job when new locales are added to the project.

I would like to know your views about the UI on the admin page and check if the all the cases work fine.  Thanks (: