### PR TITLE
No bug - Allow changing files from volumes in docker.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,7 +45,7 @@ RUN pip install -U 'pip>=8' && \
     pip install --no-cache-dir --require-hashes -r requirements/test.txt
 
 # Create the app user
-RUN groupadd -r pontoon && useradd --no-log-init -r -m -g pontoon pontoon
+RUN groupadd -r --gid=1000 pontoon && useradd --no-log-init -r -m -g pontoon pontoon
 RUN chown -R pontoon:pontoon /app
 USER pontoon
 


### PR DESCRIPTION
When creating containers with docker-compose, volumes containing the source code from the host are created. From inside a docker container, it was not possible to make changes in those volumes, because of a permission issue. This commit sets the GID of the pontoon group so that it matches what will, in most cases, be the group of the user in the host (1000). That allows to make changes inside volumes. Note that if a user has a different group GID (for example, 1001, because they are the second user created on the host) then this will not work. But most folks work on their personal computer so that should not happen too often, and I do not have a good solution for that anyway. This is strictly better than before.