### PR TITLE
Fix bug 1597558 - Send errors to Raygun.io on Python 3.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,11 @@ shell-py3: shell
 pytest-py3: override PYTHON_VERSION=$(PYTHON_3_VERSION)
 pytest-py3: pytest
 
+run-py3: override PYTHON_VERSION=$(PYTHON_3_VERSION)
+run-py3: run
+
+setup-py3: override PYTHON_VERSION=$(PYTHON_3_VERSION)
+setup-py3: setup
 
 setup: .docker-build
 	${DC} run webapp /app/docker/set_up_webapp.sh

--- a/pontoon/base/middleware.py
+++ b/pontoon/base/middleware.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
 import sys
-import warnings
 
 from django.conf import settings
 from django.contrib import auth
@@ -16,7 +15,8 @@ class RaygunExceptionMiddleware(Provider):
         # Ignore non-failure exceptions. We don't need to be notified
         # of these.
         if not isinstance(exception, (Http404, PermissionDenied)):
-            # On Python 2, Raygun4py fails to send an exception with the Unicode message and throws the UnicodeDecodeError.
+            # On Python 2, Raygun4py fails to send an exception with the Unicode message
+            # and throws the UnicodeDecodeError.
             # To avoid this, the middleware casts the exception to the str object.
             # On Python 3, Raygun4py requires an instance of an Exception instead of a string.
             # This is the temporary solution and will be removed after the migration to Python 3.

--- a/pontoon/base/middleware.py
+++ b/pontoon/base/middleware.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import sys
+import warnings
 
 from django.conf import settings
 from django.contrib import auth
@@ -15,6 +16,11 @@ class RaygunExceptionMiddleware(Provider):
         # Ignore non-failure exceptions. We don't need to be notified
         # of these.
         if not isinstance(exception, (Http404, PermissionDenied)):
+            # On Python 2, Raygun4py fails to send an exception with the Unicode message and throws the UnicodeDecodeError.
+            # To avoid this, the middleware casts the exception to the str object.
+            # On Python 3, Raygun4py requires an instance of an Exception instead of a string.
+            # This is the temporary solution and will be removed after the migration to Python 3.
+            # Ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1600344
             if sys.version_info.major == 2:
                 exc_value = text_type(exception).encode('utf-8')
             else:

--- a/pontoon/base/middleware.py
+++ b/pontoon/base/middleware.py
@@ -1,4 +1,6 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
+
+import sys
 
 from django.conf import settings
 from django.contrib import auth
@@ -13,8 +15,11 @@ class RaygunExceptionMiddleware(Provider):
         # Ignore non-failure exceptions. We don't need to be notified
         # of these.
         if not isinstance(exception, (Http404, PermissionDenied)):
-            return (super(RaygunExceptionMiddleware, self)
-                    .process_exception(request, text_type(exception).encode('utf-8')))
+            if sys.version_info.major == 2:
+                exc_value = text_type(exception).encode('utf-8')
+            else:
+                exc_value = exception
+            return super(RaygunExceptionMiddleware, self).process_exception(request, exc_value)
 
 
 class BlockedIpMiddleware(object):


### PR DESCRIPTION
Unfortunately, I couldn't find a better way to handle this.
To give you the fuller background:
On Python 2, Raygun4py fails to send an exception with the Unicode message and throws the UnicodeDecodeError. To avoid this, the middleware casts the exception to the `str` object.
On Python 3, Raygun4py requires an instance of an Exception instead of a string.
@pike @adngdb r?