### PR TITLE
Fix bug 1601002: Show full-width input if no accesskey candidates available

### DIFF
--- a/frontend/src/modules/fluenteditor/components/RichTranslationForm.js
+++ b/frontend/src/modules/fluenteditor/components/RichTranslationForm.js
@@ -345,6 +345,7 @@ export default class RichTranslationForm extends React.Component<EditorProps> {
             candidates = fluent.extractAccessKeyCandidates(message);
         }
 
+        // Access Key UI
         if (candidates && candidates.length) {
             this.accessKeyElementId = path.join('-');
             return <td>
@@ -352,6 +353,8 @@ export default class RichTranslationForm extends React.Component<EditorProps> {
                 { this.renderAccessKeys(candidates) }
             </td>;
         }
+
+        // Default UI
         else {
             return <td>
                 { this.renderTextarea(value, path) }

--- a/frontend/src/modules/fluenteditor/components/RichTranslationForm.js
+++ b/frontend/src/modules/fluenteditor/components/RichTranslationForm.js
@@ -288,7 +288,7 @@ export default class RichTranslationForm extends React.Component<EditorProps> {
         );
     }
 
-    renderInput(value: string, path: MessagePath, maxlength: ?number) {
+    renderTextarea(value: string, path: MessagePath, maxlength: ?number) {
         return <textarea
             id={ `${path.join('-')}` }
             key={ `${path.join('-')}` }
@@ -304,19 +304,7 @@ export default class RichTranslationForm extends React.Component<EditorProps> {
         />;
     }
 
-    renderAccessKeys() {
-        const message = this.props.editor.translation;
-
-        if (typeof(message) === 'string') {
-            return null;
-        }
-
-        const keys = fluent.extractAccessKeyCandidates(message);
-
-        if (!keys) {
-            return null;
-        }
-
+    renderAccessKeys(candidates: Array<string>) {
         // Get selected access key
         const id = this.accessKeyElementId;
         let accessKey = null;
@@ -328,7 +316,7 @@ export default class RichTranslationForm extends React.Component<EditorProps> {
         }
 
         return <div className="accesskeys">
-            { keys.map((key, i) => <button
+            { candidates.map((key, i) => <button
                 className={ `key ${ key === accessKey ? 'active' : '' }` }
                 key={ i }
                 onClick={ this.handleAccessKeyClick }
@@ -346,7 +334,29 @@ export default class RichTranslationForm extends React.Component<EditorProps> {
             <span className="example">
                 { '{ $plural } (e.g. <stress>{ $example }</stress>)' }
             </span>
-        </Localized>
+        </Localized>;
+    }
+
+    renderInput(value: string, path: MessagePath, label: string) {
+        const message = this.props.editor.translation;
+
+        let candidates = null;
+        if (typeof(message) !== 'string' && label === 'accesskey') {
+            candidates = fluent.extractAccessKeyCandidates(message);
+        }
+
+        if (candidates && candidates.length) {
+            this.accessKeyElementId = path.join('-');
+            return <td>
+                { this.renderTextarea(value, path, 1) }
+                { this.renderAccessKeys(candidates) }
+            </td>;
+        }
+        else {
+            return <td>
+                { this.renderTextarea(value, path) }
+            </td>;
+        }
     }
 
     renderItem(
@@ -356,10 +366,6 @@ export default class RichTranslationForm extends React.Component<EditorProps> {
         className: ?string,
         example: ?number,
     ) {
-        const isAccessKey = label === 'accesskey';
-        const maxlength = isAccessKey ? 1 : null;
-        this.accessKeyElementId = isAccessKey ? path.join('-') : null;
-
         return <tr key={ `${path.join('-')}` } className={ className }>
             <td>
                 <label htmlFor={ `${path.join('-')}` }>
@@ -370,10 +376,7 @@ export default class RichTranslationForm extends React.Component<EditorProps> {
                     }
                 </label>
             </td>
-            <td>
-                { this.renderInput(value, path, maxlength) }
-                { isAccessKey ? this.renderAccessKeys() : null }
-            </td>
+            { this.renderInput(value, path, label) }
         </tr>;
     }
 

--- a/frontend/src/modules/fluenteditor/components/RichTranslationForm.js
+++ b/frontend/src/modules/fluenteditor/components/RichTranslationForm.js
@@ -346,7 +346,7 @@ export default class RichTranslationForm extends React.Component<EditorProps> {
         }
 
         // Access Key UI
-        if (candidates && candidates.length) {
+        if (candidates && candidates.length && value.length < 2) {
             this.accessKeyElementId = path.join('-');
             return <td>
                 { this.renderTextarea(value, path, 1) }

--- a/frontend/src/modules/fluenteditor/components/RichTranslationForm.test.js
+++ b/frontend/src/modules/fluenteditor/components/RichTranslationForm.test.js
@@ -135,6 +135,46 @@ title = Title
         expect(wrapper.find('.accesskeys button').at(7).text()).toEqual('s');
     });
 
+    it('does not render the access key UI if no candidates can be generated', () => {
+        const input = `
+title =
+    .label = { reference }
+    .accesskey = C`;
+
+        const editor = {
+            ...EDITOR,
+            translation: fluent.parser.parseEntry(input),
+        };
+
+        const wrapper = shallow(<RichTranslationForm
+            editor={ editor }
+            locale={ DEFAULT_LOCALE }
+            updateTranslation={ sinon.stub() }
+        />);
+
+        expect(wrapper.find('.accesskeys')).toHaveLength(0);
+    });
+
+    it('does not render the access key UI if access key is longer than 1 character', () => {
+        const input = `
+title =
+    .label = Candidates
+    .accesskey = { reference }`;
+
+        const editor = {
+            ...EDITOR,
+            translation: fluent.parser.parseEntry(input),
+        };
+
+        const wrapper = shallow(<RichTranslationForm
+            editor={ editor }
+            locale={ DEFAULT_LOCALE }
+            updateTranslation={ sinon.stub() }
+        />);
+
+        expect(wrapper.find('.accesskeys')).toHaveLength(0);
+    });
+
     it('calls the updateTranslation function on mount and change', () => {
         const updateMock = sinon.spy();
 


### PR DESCRIPTION
Should we also generate accesskeys from the attribute positioned right before the "accesskey" attribute if none of the attributes is called "label"?

That would cover cases like https://github.com/mozilla-l10n/pontoon-ftl/commit/5a67087243f6017f4bf5c66aacda30f0b5ec80c4.