### PR TITLE
No bug: Scroll History, not the entire page

### DIFF
--- a/frontend/src/modules/history/components/History.css
+++ b/frontend/src/modules/history/components/History.css
@@ -1,10 +1,14 @@
 .history {
+    height: calc(60% - 125px);
     line-height: 22px;
+    overflow: hidden;
 }
 
 .history ul {
+    height: 100%;
     list-style: none;
     margin: 0;
+    overflow: auto;
     padding: 0;
 }
 


### PR DESCRIPTION
If History items overflow, the entire translate view gets a scrollbar. No good.