### PR TITLE
Fix bug 1601564: Allows reading dotenv config in WSGI application

### DIFF
--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -45,6 +45,20 @@ Environment Variables
 The following is a list of environment variables you'll want to set on the app
 you create:
 
+.. NOTE::
+
+   Alternatively, you can put all variables below in a `dotenv
+   <https://github.com/theskumar/python-dotenv>`_ text file::
+
+      VAR="value 1"
+      OTHER_VAR="other value"
+
+   If you do so, you will only have to give the path of this file to Pontoon
+   through the ``DOTENV_PATH`` environment variable::
+
+      DOTENV_PATH=/path/to/my/config.env
+
+
 ``ADMIN_EMAIL``
    Optional. Email address for the ``ADMINS`` setting.
 

--- a/pontoon/wsgi.py
+++ b/pontoon/wsgi.py
@@ -8,9 +8,13 @@ from __future__ import absolute_import
 
 import os
 
+import dotenv
 from django.core.wsgi import get_wsgi_application
 from wsgi_sslify import sslify
 
+
+if 'DOTENV_PATH' in os.environ:
+    dotenv.read_dotenv(os.environ["DOTENV_PATH"])
 
 # Set settings env var before importing whitenoise as it depends on
 # some settings.


### PR DESCRIPTION
This PR allows to use a dotenv file to configure Pontoon when deployed as a WSGI app. The path of the dotenv file can be configured through the `DOTENV_PATH` environment variable.

To test this PR, you can do the following:

1. Write a dotenv file with the Pontoon configuration in it,
2. install gunicorn or any other WSGI server (`pip install gunicorn`)
3. run the application (`DOTENV_PATH=./dotenv.conf gunicorn pontoon.wsgi:application`)

Pontoon should have its config read from the file.