### PR TITLE
Fix bug 1602732: GitLab authentication method

### DIFF
--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -69,7 +69,7 @@ you create:
    The default value is `django`, which allows you to log in via accounts created using `manage.py shell`.
    Set to 'fxa' if you want to use 'Firefox Accounts' (corresponding FXA_* settings must be set).
    Set to 'github' if you want to use 'GitHub' (corresponding GITHUB_* settings must be set).
-   Set to 'gitlab' if you want to yse 'GitLab' (corresponding GITLAB_* settings must be set if required).
+   Set to 'gitlab' if you want to use 'GitLab' (corresponding GITLAB_* settings must be set if required).
    Set to 'google' if you want to use 'Google' (corresponding GOOGLE_* settings must be set).
 
 ``CELERY_ALWAYS_EAGER``
@@ -108,7 +108,7 @@ you create:
    a system error. See `Heroku Reference`_ for more information.
 
 ``GITLAB_URL``
-   Optional. URL of your GitLab instace when ``AUTHENTICATION_METHOD=gitlab``.
+   Optional. URL of your GitLab instance when ``AUTHENTICATION_METHOD=gitlab``.
    If not defined, ``https://gitlab.com`` will be used by default.
 
 ``GOOGLE_ANALYTICS_KEY``

--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -69,6 +69,7 @@ you create:
    The default value is `django`, which allows you to log in via accounts created using `manage.py shell`.
    Set to 'fxa' if you want to use 'Firefox Accounts' (corresponding FXA_* settings must be set).
    Set to 'github' if you want to use 'GitHub' (corresponding GITHUB_* settings must be set).
+   Set to 'gitlab' if you want to yse 'GitLab' (corresponding GITLAB_* settings must be set if required).
    Set to 'google' if you want to use 'Google' (corresponding GOOGLE_* settings must be set).
 
 ``CELERY_ALWAYS_EAGER``
@@ -105,6 +106,10 @@ you create:
 ``ERROR_PAGE_URL``
    Optional. URL to the page displayed to your users when the application encounters
    a system error. See `Heroku Reference`_ for more information.
+
+``GITLAB_URL``
+   Optional. URL of your GitLab instace when ``AUTHENTICATION_METHOD=gitlab``.
+   If not defined, ``https://gitlab.com`` will be used by default.
 
 ``GOOGLE_ANALYTICS_KEY``
    Optional. Set your `Google Analytics key`_ to use Google Analytics.

--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -107,10 +107,6 @@ you create:
    Optional. URL to the page displayed to your users when the application encounters
    a system error. See `Heroku Reference`_ for more information.
 
-``GITLAB_URL``
-   Optional. URL of your GitLab instance when ``AUTHENTICATION_METHOD=gitlab``.
-   If not defined, ``https://gitlab.com`` will be used by default.
-
 ``GOOGLE_ANALYTICS_KEY``
    Optional. Set your `Google Analytics key`_ to use Google Analytics.
 

--- a/pontoon/base/management/commands/update_auth_providers.py
+++ b/pontoon/base/management/commands/update_auth_providers.py
@@ -11,11 +11,13 @@ from django.contrib.sites.models import Site
 from allauth.socialaccount.models import SocialApp
 from allauth.socialaccount.providers.fxa.provider import FirefoxAccountsProvider
 from allauth.socialaccount.providers.github.provider import GitHubProvider
+from allauth.socialaccount.providers.gitlab.provider import GitLabProvider
 from allauth.socialaccount.providers.google.provider import GoogleProvider
 
 
 FXA_PROVIDER_ID = FirefoxAccountsProvider.id
 GITHUB_PROVIDER_ID = GitHubProvider.id
+GITLAB_PROVIDER_ID = GitLabProvider.id
 GOOGLE_PROVIDER_ID = GoogleProvider.id
 
 
@@ -65,6 +67,17 @@ class Command(BaseCommand):
             )
 
             self.update_provider(github_data)
+
+        # Check if GITLAB_* settings are configured
+        if settings.GITLAB_CLIENT_ID is not None and settings.GITLAB_SECRET_KEY is not None:
+            gitlab_data = dict(
+                name='GitLab',
+                provider=GITLAB_PROVIDER_ID,
+                client_id=settings.GITLAB_CLIENT_ID,
+                secret=settings.GITLAB_SECRET_KEY
+            )
+
+            self.update_provider(gitlab_data)
 
         if settings.GOOGLE_CLIENT_ID is not None or settings.GOOGLE_SECRET_KEY is not None:
             google_data = dict(

--- a/pontoon/base/management/commands/update_auth_providers.py
+++ b/pontoon/base/management/commands/update_auth_providers.py
@@ -47,7 +47,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         # Check if FXA_* settings are configured
-        if settings.FXA_CLIENT_ID is not None or settings.FXA_SECRET_KEY is not None:
+        if settings.FXA_CLIENT_ID is not None and settings.FXA_SECRET_KEY is not None:
             fxa_data = dict(
                 name='FxA',
                 provider=FXA_PROVIDER_ID,
@@ -57,8 +57,8 @@ class Command(BaseCommand):
 
             self.update_provider(fxa_data)
 
-        # Check if GitHub_* settings are configured
-        if settings.GITHUB_CLIENT_ID is not None or settings.GITHUB_SECRET_KEY is not None:
+        # Check if GITHUB_* settings are configured
+        if settings.GITHUB_CLIENT_ID is not None and settings.GITHUB_SECRET_KEY is not None:
             github_data = dict(
                 name='GitHub',
                 provider=GITHUB_PROVIDER_ID,
@@ -79,7 +79,8 @@ class Command(BaseCommand):
 
             self.update_provider(gitlab_data)
 
-        if settings.GOOGLE_CLIENT_ID is not None or settings.GOOGLE_SECRET_KEY is not None:
+        # Check if GOOGLE_* settings are configured
+        if settings.GOOGLE_CLIENT_ID is not None and settings.GOOGLE_SECRET_KEY is not None:
             google_data = dict(
                 name='Google',
                 provider=GOOGLE_PROVIDER_ID,

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -796,7 +796,7 @@ CORS_URLS_REGEX = r'^/(pontoon\.js|graphql/?)$'
 SOCIALACCOUNT_ENABLED = True
 SOCIALACCOUNT_ADAPTER = 'pontoon.base.adapter.PontoonSocialAdapter'
 
-# Supported values: 'django', 'fxa', 'github', 'google'
+# Supported values: 'django', 'fxa', 'github', 'gitlab', 'google'
 AUTHENTICATION_METHOD = os.environ.get('AUTHENTICATION_METHOD', 'django')
 
 

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -152,6 +152,7 @@ INSTALLED_APPS = (
     'allauth.socialaccount.providers.fxa',
     'allauth.socialaccount.providers.github',
     'allauth.socialaccount.providers.google',
+    'allauth.socialaccount.providers.gitlab',
     'notifications',
     'graphene_django',
     'webpack_loader',
@@ -827,7 +828,11 @@ SOCIALACCOUNT_PROVIDERS = {
         'SCOPE': FXA_SCOPE,
         'OAUTH_ENDPOINT': FXA_OAUTH_ENDPOINT,
         'PROFILE_ENDPOINT': FXA_PROFILE_ENDPOINT,
-    }
+    },
+    'gitlab': {
+        'GITLAB_URL': os.environ.get('GITLAB_URL', 'https://gitlab.com'),
+        'SCOPE': ['read_user'],
+    },
 }
 
 # Defined all trusted origins that will be returned in pontoon.js file.

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -89,9 +89,6 @@ MICROSOFT_TRANSLATOR_API_KEY = os.environ.get('MICROSOFT_TRANSLATOR_API_KEY', ''
 # Google Analytics Key
 GOOGLE_ANALYTICS_KEY = os.environ.get('GOOGLE_ANALYTICS_KEY', '')
 
-# GitLab
-GITLAB_URL = os.environ.get('GITLAB_URL', 'https://gitlab.com')
-
 # Raygun.io configuration
 RAYGUN4PY_CONFIG = {
     'api_key': os.environ.get('RAYGUN_APIKEY', '')
@@ -820,6 +817,9 @@ FXA_SCOPE = ['profile:uid', 'profile:display_name', 'profile:email']
 # Github
 GITHUB_CLIENT_ID = os.environ.get('GITHUB_CLIENT_ID', '')
 GITHUB_SECRET_KEY = os.environ.get('GITHUB_SECRET_KEY', '')
+
+# GitLab
+GITLAB_URL = os.environ.get('GITLAB_URL', 'https://gitlab.com')
 
 # Google Accounts
 GOOGLE_CLIENT_ID = os.environ.get('GOOGLE_CLIENT_ID', '')

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -89,6 +89,9 @@ MICROSOFT_TRANSLATOR_API_KEY = os.environ.get('MICROSOFT_TRANSLATOR_API_KEY', ''
 # Google Analytics Key
 GOOGLE_ANALYTICS_KEY = os.environ.get('GOOGLE_ANALYTICS_KEY', '')
 
+# GitLab
+GITLAB_URL = os.environ.get('GITLAB_URL', 'https://gitlab.com')
+
 # Raygun.io configuration
 RAYGUN4PY_CONFIG = {
     'api_key': os.environ.get('RAYGUN_APIKEY', '')
@@ -830,7 +833,7 @@ SOCIALACCOUNT_PROVIDERS = {
         'PROFILE_ENDPOINT': FXA_PROFILE_ENDPOINT,
     },
     'gitlab': {
-        'GITLAB_URL': os.environ.get('GITLAB_URL', 'https://gitlab.com'),
+        'GITLAB_URL': GITLAB_URL,
         'SCOPE': ['read_user'],
     },
 }

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -820,6 +820,8 @@ GITHUB_SECRET_KEY = os.environ.get('GITHUB_SECRET_KEY', '')
 
 # GitLab
 GITLAB_URL = os.environ.get('GITLAB_URL', 'https://gitlab.com')
+GITLAB_CLIENT_ID = os.environ.get('GITLAB_CLIENT_ID')
+GITLAB_SECRET_KEY = os.environ.get('GITLAB_SECRET_KEY')
 
 # Google Accounts
 GOOGLE_CLIENT_ID = os.environ.get('GOOGLE_CLIENT_ID', '')

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -808,15 +808,15 @@ ACCOUNT_EMAIL_VERIFICATION = 'none'
 ACCOUNT_USER_DISPLAY = account_username
 
 # Firefox Accounts
-FXA_CLIENT_ID = os.environ.get('FXA_CLIENT_ID', '')
-FXA_SECRET_KEY = os.environ.get('FXA_SECRET_KEY', '')
+FXA_CLIENT_ID = os.environ.get('FXA_CLIENT_ID')
+FXA_SECRET_KEY = os.environ.get('FXA_SECRET_KEY')
 FXA_OAUTH_ENDPOINT = os.environ.get('FXA_OAUTH_ENDPOINT', '')
 FXA_PROFILE_ENDPOINT = os.environ.get('FXA_PROFILE_ENDPOINT', '')
 FXA_SCOPE = ['profile:uid', 'profile:display_name', 'profile:email']
 
 # Github
-GITHUB_CLIENT_ID = os.environ.get('GITHUB_CLIENT_ID', '')
-GITHUB_SECRET_KEY = os.environ.get('GITHUB_SECRET_KEY', '')
+GITHUB_CLIENT_ID = os.environ.get('GITHUB_CLIENT_ID')
+GITHUB_SECRET_KEY = os.environ.get('GITHUB_SECRET_KEY')
 
 # GitLab
 GITLAB_URL = os.environ.get('GITLAB_URL', 'https://gitlab.com')
@@ -824,8 +824,8 @@ GITLAB_CLIENT_ID = os.environ.get('GITLAB_CLIENT_ID')
 GITLAB_SECRET_KEY = os.environ.get('GITLAB_SECRET_KEY')
 
 # Google Accounts
-GOOGLE_CLIENT_ID = os.environ.get('GOOGLE_CLIENT_ID', '')
-GOOGLE_SECRET_KEY = os.environ.get('GOOGLE_SECRET_KEY', '')
+GOOGLE_CLIENT_ID = os.environ.get('GOOGLE_CLIENT_ID')
+GOOGLE_SECRET_KEY = os.environ.get('GOOGLE_SECRET_KEY')
 
 # All settings related to the AllAuth
 SOCIALACCOUNT_PROVIDERS = {


### PR DESCRIPTION
This PR adds the support of the GitLab authentication method to Pontoon.

To try it out, you will need a GitLab instance (you can probably use gitlab.com).

1. Set following environment variable: 
  * `AUTHENTICATION_METHOD=gitlab`
  * `GITLAB_URL=https://gitlab.com`

2. Follow the instructions of [this article](https://www.wanadev.fr/196-pontoon-sauthentifier-avec-gitlab/) to setup the applications, but skip the part about patching Pontoon as this patch is provided by this PR (the article is in French but [Google Translate should help](https://translate.google.com/translate?sl=auto&tl=en&u=https%3A%2F%2Fwww.wanadev.fr%2F196-pontoon-sauthentifier-avec-gitlab%2F)). If you do not have an admin account on the GitLab server (on gitlab.com for example), you may be able to [create an app](https://docs.gitlab.com/ce/integration/oauth_provider.html) linked to your own account. 

3. You should now be able to sign in using a GitLab account.

:)