### PR TITLE
Fix bug 1602973 - Make sure users cannot send the same translation twice.

### DIFF
--- a/frontend/public/static/locale/en-US/translate.ftl
+++ b/frontend/public/static/locale/en-US/translate.ftl
@@ -94,8 +94,12 @@ editor-EditorMenu--button-approve = Approve
     .title = Approve Translation (Enter)
 editor-EditorMenu--button-save = Save
     .title = Save Translation (Enter)
+editor-EditorMenu--button-saving = Saving
+    .title = Saving Translation…
 editor-EditorMenu--button-suggest = Suggest
     .title = Suggest Translation (Enter)
+editor-EditorMenu--button-suggesting = Suggesting
+    .title = Suggesting Translation…
 
 
 ## Editor Settings

--- a/frontend/src/core/editor/actions.js
+++ b/frontend/src/core/editor/actions.js
@@ -16,9 +16,11 @@ import type { Locale } from 'core/locale';
 import type { FluentMessage } from 'core/utils/fluent/types';
 
 
+export const END_UPDATE_TRANSLATION: 'editor/END_UPDATE_TRANSLATION' = 'editor/END_UPDATE_TRANSLATION';
 export const RESET_FAILED_CHECKS: 'editor/RESET_FAILED_CHECKS' = 'editor/RESET_FAILED_CHECKS';
 export const RESET_SELECTION: 'editor/RESET_SELECTION' = 'editor/RESET_SELECTION';
 export const SET_INITIAL_TRANSLATION: 'editor/SET_INITIAL_TRANSLATION' = 'editor/SET_INITIAL_TRANSLATION';
+export const START_UPDATE_TRANSLATION: 'editor/START_UPDATE_TRANSLATION' = 'editor/START_UPDATE_TRANSLATION';
 export const UPDATE: 'editor/UPDATE' = 'editor/UPDATE';
 export const UPDATE_FAILED_CHECKS: 'editor/UPDATE_FAILED_CHECKS' = 'editor/UPDATE_FAILED_CHECKS';
 export const UPDATE_SELECTION: 'editor/UPDATE_SELECTION' = 'editor/UPDATE_SELECTION';
@@ -128,6 +130,26 @@ export function resetFailedChecks(): ResetFailedChecksAction {
 }
 
 
+export type StartUpdateTranslationAction = {|
+   +type: typeof START_UPDATE_TRANSLATION,
+|};
+function startUpdateTranslation(): StartUpdateTranslationAction {
+    return {
+        type: START_UPDATE_TRANSLATION,
+    };
+}
+
+
+export type EndUpdateTranslationAction = {|
+   +type: typeof END_UPDATE_TRANSLATION,
+|};
+function endUpdateTranslation(): EndUpdateTranslationAction {
+    return {
+        type: END_UPDATE_TRANSLATION,
+    };
+}
+
+
 function _getOperationNotif(change: 'added' | 'saved' | 'updated') {
     switch (change) {
         case 'added':
@@ -158,6 +180,7 @@ export function sendTranslation(
 ): Function {
     return async dispatch => {
         NProgress.start();
+        dispatch(startUpdateTranslation());
 
         const content = await api.translation.updateTranslation(
             entity.pk,
@@ -223,6 +246,7 @@ export function sendTranslation(
             }
         }
 
+        dispatch(endUpdateTranslation());
         NProgress.done();
     }
 }

--- a/frontend/src/core/editor/components/EditorMainAction.js
+++ b/frontend/src/core/editor/components/EditorMainAction.js
@@ -97,7 +97,7 @@ export default function EditorMainAction(props: Props) {
             title={ btn.title}
             disabled={ isRunningRequest }
         >
-            { !isRunningRequest ? null : <i className="fa fa-spinner fa-spin" /> }
+            { !isRunningRequest ? null : <i className="fa fa-circle-notch fa-spin" /> }
             { btn.label }
         </button>
     </Localized>;

--- a/frontend/src/core/editor/components/EditorMainAction.js
+++ b/frontend/src/core/editor/components/EditorMainAction.js
@@ -8,6 +8,7 @@ import type { ChangeOperation } from 'modules/history';
 
 
 type Props = {
+    isRunningRequest: boolean,
     isTranslator: boolean,
     forceSuggestions: boolean,
     sameExistingTranslation: ?EntityTranslation,
@@ -29,6 +30,7 @@ type Props = {
  */
 export default function EditorMainAction(props: Props) {
     const {
+        isRunningRequest,
         isTranslator,
         forceSuggestions,
         sameExistingTranslation,
@@ -42,49 +44,61 @@ export default function EditorMainAction(props: Props) {
         }
     }
 
+    let btn;
+
     if (isTranslator && sameExistingTranslation && !sameExistingTranslation.approved) {
         // Approve button, will approve the translation.
-        return <Localized
-            id="editor-EditorMenu--button-approve"
-            attrs={{ title: true }}
-        >
-            <button
-                className="action-approve"
-                onClick={ approveTranslation }
-                title="Approve Translation (Enter)"
-            >
-                Approve
-            </button>
-        </Localized>;
+        btn = {
+            id: 'editor-EditorMenu--button-approve',
+            className: 'action-approve',
+            action: approveTranslation,
+            title: 'Approve Translation (Enter)',
+            label: 'Approve',
+        };
     }
-
-    if (forceSuggestions || !isTranslator) {
+    else if (forceSuggestions || !isTranslator) {
         // Suggest button, will send an unreviewed translation.
-        return <Localized
-            id="editor-EditorMenu--button-suggest"
-            attrs={{ title: true }}
-        >
-            <button
-                className="action-suggest"
-                onClick={ sendTranslation }
-                title="Suggest Translation (Enter)"
-            >
-                Suggest
-            </button>
-        </Localized>;
+        btn = {
+            id: 'editor-EditorMenu--button-suggest',
+            className: 'action-suggest',
+            action: sendTranslation,
+            title: 'Suggest Translation (Enter)',
+            label: 'Suggest',
+        };
+
+        if (isRunningRequest) {
+            btn.id = 'editor-EditorMenu--button-suggesting';
+            btn.label = 'Suggesting';
+        }
+    }
+    else {
+        // Save button, will send an approved translation.
+        btn = {
+            id: 'editor-EditorMenu--button-save',
+            className: 'action-save',
+            action: sendTranslation,
+            title: 'Save Translation (Enter)',
+            label: 'Save',
+        };
+
+        if (isRunningRequest) {
+            btn.id = 'editor-EditorMenu--button-saving';
+            btn.label = 'Saving';
+        }
     }
 
-    // Save button, will send an approved translation.
     return <Localized
-        id="editor-EditorMenu--button-save"
+        id={ btn.id }
         attrs={{ title: true }}
     >
         <button
-            className="action-save"
-            onClick={ sendTranslation }
-            title="Save Translation (Enter)"
+            className={ btn.className }
+            onClick={ btn.action }
+            title={ btn.title}
+            disabled={ isRunningRequest }
         >
-            Save
+            { !isRunningRequest ? null : <i className="fa fa-spinner fa-spin" /> }
+            { btn.label }
         </button>
     </Localized>;
 }

--- a/frontend/src/core/editor/components/EditorMainAction.test.js
+++ b/frontend/src/core/editor/components/EditorMainAction.test.js
@@ -20,7 +20,6 @@ describe('<EditorMainAction>', () => {
         expect(wrapper.find('.action-save')).toHaveLength(0);
 
         wrapper.find('.action-approve').simulate('click');
-
         expect(updateStatus.calledWith(1, 'approve')).toBeTruthy();
     });
 
@@ -47,6 +46,19 @@ describe('<EditorMainAction>', () => {
         expect(wrapper.find('.action-approve')).toHaveLength(0);
     });
 
+    it('shows a spinner and a disabled Suggesting button when running request', () => {
+        const updateStatus = sinon.mock();
+        const params = {
+            isTranslator: true,
+            forceSuggestions: true,
+            isRunningRequest: true,
+        }
+        const wrapper = shallow(<EditorMainAction { ...params } />);
+
+        expect(wrapper.find('.action-suggest')).toHaveLength(1);
+        expect(wrapper.find('.action-suggest .fa-spin')).toHaveLength(1);
+    });
+
     it('renders the Save button when force suggestion is off', () => {
         const params = {
             isTranslator: true,
@@ -69,5 +81,17 @@ describe('<EditorMainAction>', () => {
         expect(wrapper.find('.action-save')).toHaveLength(1);
         expect(wrapper.find('.action-suggest')).toHaveLength(0);
         expect(wrapper.find('.action-approve')).toHaveLength(0);
+    });
+
+    it('shows a spinner and a disabled Saving button when running request', () => {
+        const updateStatus = sinon.mock();
+        const params = {
+            isTranslator: true,
+            isRunningRequest: true,
+        }
+        const wrapper = shallow(<EditorMainAction { ...params } />);
+
+        expect(wrapper.find('.action-save')).toHaveLength(1);
+        expect(wrapper.find('.action-save .fa-spin')).toHaveLength(1);
     });
 });

--- a/frontend/src/core/editor/components/EditorMainAction.test.js
+++ b/frontend/src/core/editor/components/EditorMainAction.test.js
@@ -47,7 +47,6 @@ describe('<EditorMainAction>', () => {
     });
 
     it('shows a spinner and a disabled Suggesting button when running request', () => {
-        const updateStatus = sinon.mock();
         const params = {
             isTranslator: true,
             forceSuggestions: true,
@@ -84,7 +83,6 @@ describe('<EditorMainAction>', () => {
     });
 
     it('shows a spinner and a disabled Saving button when running request', () => {
-        const updateStatus = sinon.mock();
         const params = {
             isTranslator: true,
             isRunningRequest: true,

--- a/frontend/src/core/editor/components/EditorMenu.css
+++ b/frontend/src/core/editor/components/EditorMenu.css
@@ -22,6 +22,10 @@
     color: #7BC876;
 }
 
+.editor-menu .actions button .fa {
+    margin-right: 4px;
+}
+
 .editor-menu .actions .action-approve,
 .editor-menu .actions .action-save,
 .editor-menu .actions .action-suggest {

--- a/frontend/src/core/editor/components/EditorMenu.js
+++ b/frontend/src/core/editor/components/EditorMenu.js
@@ -91,6 +91,7 @@ export default class EditorMenu extends React.Component<Props> {
                             </button>
                         </Localized>
                         <EditorMainAction
+                            isRunningRequest={ props.editor.isRunningRequest }
                             isTranslator={ props.isTranslator }
                             forceSuggestions={ props.user.settings.forceSuggestions }
                             sameExistingTranslation={ props.sameExistingTranslation }

--- a/frontend/src/core/editor/components/connectedEditor.js
+++ b/frontend/src/core/editor/components/connectedEditor.js
@@ -253,7 +253,7 @@ export default function connectedEditor<Object>(
         sendTranslation = (ignoreWarnings?: boolean, translation?: string) => {
             const props = this.props;
 
-            if (!props.selectedEntity || !props.locale) {
+            if (props.editor.isRunningRequest || !props.selectedEntity || !props.locale) {
                 return;
             }
 

--- a/frontend/src/core/editor/reducer.js
+++ b/frontend/src/core/editor/reducer.js
@@ -1,9 +1,11 @@
 /* @flow */
 
 import {
+    END_UPDATE_TRANSLATION,
     RESET_FAILED_CHECKS,
     RESET_SELECTION,
     SET_INITIAL_TRANSLATION,
+    START_UPDATE_TRANSLATION,
     UPDATE,
     UPDATE_FAILED_CHECKS,
     UPDATE_SELECTION,
@@ -11,9 +13,11 @@ import {
 
 import type {
     FailedChecks,
+    EndUpdateTranslationAction,
+    InitialTranslationAction,
     ResetFailedChecksAction,
     ResetSelectionAction,
-    InitialTranslationAction,
+    StartUpdateTranslationAction,
     Translation,
     UpdateAction,
     UpdateFailedChecksAction,
@@ -22,9 +26,11 @@ import type {
 
 
 type Action =
+    | EndUpdateTranslationAction
+    | InitialTranslationAction
     | ResetFailedChecksAction
     | ResetSelectionAction
-    | InitialTranslationAction
+    | StartUpdateTranslationAction
     | UpdateAction
     | UpdateFailedChecksAction
     | UpdateSelectionAction
@@ -58,6 +64,11 @@ export type EditorState = {|
     //   - 'submitted': failed checks of the submitted translation
     //   - number (translationId): failed checks of the approved translation
     +source: '' | 'stored' | 'submitted' | number,
+
+    // True when there is a request to send a new translation running, false
+    // otherwise. Used to prevent duplicate actions from users spamming their
+    // keyboard or mouse.
+    +isRunningRequest: boolean,
 |};
 
 
@@ -91,6 +102,7 @@ const initial: EditorState = {
     errors: [],
     warnings: [],
     source: '',
+    isRunningRequest: false,
 };
 
 export default function reducer(
@@ -98,11 +110,17 @@ export default function reducer(
     action: Action,
 ): EditorState {
     switch (action.type) {
+        case END_UPDATE_TRANSLATION:
+            return {
+                ...state,
+                isRunningRequest: false,
+            };
         case UPDATE:
             return {
                 ...state,
                 translation: action.translation,
                 changeSource: action.changeSource,
+                source: '',
             };
         case UPDATE_FAILED_CHECKS:
             return {
@@ -121,6 +139,11 @@ export default function reducer(
             return {
                 ...state,
                 initialTranslation: action.translation,
+            };
+        case START_UPDATE_TRANSLATION:
+            return {
+                ...state,
+                isRunningRequest: true,
             };
         case RESET_FAILED_CHECKS:
             return {

--- a/frontend/src/modules/batchactions/components/ApproveAll.js
+++ b/frontend/src/modules/batchactions/components/ApproveAll.js
@@ -92,7 +92,7 @@ export default class ApproveAll extends React.Component<Props> {
         >
             { this.renderTitle() }
             { this.props.batchactions.requestInProgress !== 'approve' ? null :
-                <i className="fa fa-2x fa-spinner fa-spin"></i>
+                <i className="fa fa-2x fa-circle-notch fa-spin"></i>
             }
         </button>;
     }

--- a/frontend/src/modules/batchactions/components/ApproveAll.js
+++ b/frontend/src/modules/batchactions/components/ApproveAll.js
@@ -92,7 +92,7 @@ export default class ApproveAll extends React.Component<Props> {
         >
             { this.renderTitle() }
             { this.props.batchactions.requestInProgress !== 'approve' ? null :
-                <span className="fa fa-2x fa-sync fa-spin"></span>
+                <i className="fa fa-2x fa-spinner fa-spin"></i>
             }
         </button>;
     }

--- a/frontend/src/modules/batchactions/components/RejectAll.js
+++ b/frontend/src/modules/batchactions/components/RejectAll.js
@@ -129,7 +129,7 @@ export default class RejectAll extends React.Component<Props, State> {
         >
             { this.renderTitle() }
             { this.props.batchactions.requestInProgress !== 'reject' ? null :
-                <span className="fa fa-2x fa-sync fa-spin"></span>
+                <i className="fa fa-2x fa-spinner fa-spin"></i>
             }
         </button>;
     }

--- a/frontend/src/modules/batchactions/components/RejectAll.js
+++ b/frontend/src/modules/batchactions/components/RejectAll.js
@@ -129,7 +129,7 @@ export default class RejectAll extends React.Component<Props, State> {
         >
             { this.renderTitle() }
             { this.props.batchactions.requestInProgress !== 'reject' ? null :
-                <i className="fa fa-2x fa-spinner fa-spin"></i>
+                <i className="fa fa-2x fa-circle-notch fa-spin"></i>
             }
         </button>;
     }

--- a/frontend/src/modules/batchactions/components/ReplaceAll.js
+++ b/frontend/src/modules/batchactions/components/ReplaceAll.js
@@ -92,7 +92,7 @@ export default class ReplaceAll extends React.Component<Props> {
         >
             { this.renderTitle() }
             { this.props.batchactions.requestInProgress !== 'replace' ? null :
-                <span className="fa fa-2x fa-sync fa-spin"></span>
+                <i className="fa fa-2x fa-spinner fa-spin"></i>
             }
         </button>;
     }

--- a/frontend/src/modules/batchactions/components/ReplaceAll.js
+++ b/frontend/src/modules/batchactions/components/ReplaceAll.js
@@ -92,7 +92,7 @@ export default class ReplaceAll extends React.Component<Props> {
         >
             { this.renderTitle() }
             { this.props.batchactions.requestInProgress !== 'replace' ? null :
-                <i className="fa fa-2x fa-spinner fa-spin"></i>
+                <i className="fa fa-2x fa-circle-notch fa-spin"></i>
             }
         </button>;
     }


### PR DESCRIPTION
This prevents users from spamming the "save" button, which if done fast enough can lead to the same translation being sent several times. Now as soon as the user clicks the Save button, it becomes disabled until the `sendTranslation` action is entirely finished. I am also using this opportunity to introduce spinners and label update on buttons, as a proposal. It is a pattern that I like, so I would like to generalize it on the app.

TODO:
- [ ] File a bug to replace `withActionsDisabled` with this kind of approach.