### PR TITLE
Fix bug 1604073: Tags latest activity

### DIFF
--- a/pontoon/tags/tests/utils/test_tagged.py
+++ b/pontoon/tags/tests/utils/test_tagged.py
@@ -113,7 +113,7 @@ def test_util_latest_activity():
     # check user is created if present
     activity = LatestActivity(dict(user__email=43))
     assert isinstance(activity.user, LatestActivityUser)
-    assert activity.user.user == {'user__email': 43}
+    assert activity.user.activity == {'user__email': 43}
 
     # check translation is created if present
     activity = LatestActivity(dict(string='foo'))
@@ -127,7 +127,7 @@ def test_util_latest_activity_user(avatar_mock):
     avatar_mock.return_value = 113
 
     # call with random user data - defaults
-    user = LatestActivityUser(dict(foo='bar'))
+    user = LatestActivityUser(dict(foo='bar'), 'submitted')
     assert user.email is None
     assert user.first_name is None
     assert user.name_or_email is None
@@ -135,7 +135,9 @@ def test_util_latest_activity_user(avatar_mock):
 
     # call with email - user data added
     user = LatestActivityUser(
-        dict(user__email='bar@ba.z'))
+        dict(user__email='bar@ba.z'),
+        'submitted',
+    )
     assert user.email == 'bar@ba.z'
     assert user.first_name is None
     assert user.name_or_email == 'bar@ba.z'
@@ -146,8 +148,9 @@ def test_util_latest_activity_user(avatar_mock):
 
     # call with email and name - correct name
     user = LatestActivityUser(
-        dict(user__email='bar@ba.z',
-             user__name='FOOBAR'))
+        dict(user__email='bar@ba.z', user__name='FOOBAR'),
+        'submitted',
+    )
     assert user.email == 'bar@ba.z'
     assert user.first_name is None
     assert user.name_or_email == 'bar@ba.z'

--- a/pontoon/tags/tests/utils/test_tagged.py
+++ b/pontoon/tags/tests/utils/test_tagged.py
@@ -127,7 +127,10 @@ def test_util_latest_activity_user(avatar_mock):
     avatar_mock.return_value = 113
 
     # call with random user data - defaults
-    user = LatestActivityUser(dict(foo='bar'), 'submitted')
+    user = LatestActivityUser(
+        dict(foo='bar'),
+        'submitted',
+    )
     assert user.email is None
     assert user.first_name is None
     assert user.name_or_email is None

--- a/pontoon/tags/tests/utils/test_tagged.py
+++ b/pontoon/tags/tests/utils/test_tagged.py
@@ -132,7 +132,7 @@ def test_util_latest_activity_user(avatar_mock):
         dict(foo='bar'),
         'submitted',
     )
-    assert user.prefix is ''
+    assert user.prefix == ''
     assert user.email is None
     assert user.first_name is None
     assert user.name_or_email is None
@@ -143,7 +143,7 @@ def test_util_latest_activity_user(avatar_mock):
         dict(user__email='bar@ba.z'),
         'submitted',
     )
-    assert user.prefix is ''
+    assert user.prefix == ''
     assert user.email == 'bar@ba.z'
     assert user.first_name is None
     assert user.name_or_email == 'bar@ba.z'
@@ -157,9 +157,9 @@ def test_util_latest_activity_user(avatar_mock):
         dict(user__email='bar@ba.z', user__first_name='FOOBAR'),
         'submitted',
     )
-    assert user.prefix is ''
+    assert user.prefix == ''
     assert user.email == 'bar@ba.z'
-    assert user.first_name is 'FOOBAR'
+    assert user.first_name == 'FOOBAR'
     assert user.name_or_email == 'FOOBAR'
     assert user.gravatar_url(23) == 113
     assert list(avatar_mock.call_args) == [(user, 23), {}]
@@ -174,9 +174,9 @@ def test_util_latest_activity_user(avatar_mock):
         ),
         'approved',
     )
-    assert user.prefix is 'approved_'
+    assert user.prefix == 'approved_'
     assert user.email == 'bar@ba.z'
-    assert user.first_name is 'FOOBAR'
+    assert user.first_name == 'FOOBAR'
     assert user.name_or_email == 'FOOBAR'
     assert user.gravatar_url(23) == 113
     assert list(avatar_mock.call_args) == [(user, 23), {}]

--- a/pontoon/tags/utils/latest_activity.py
+++ b/pontoon/tags/utils/latest_activity.py
@@ -8,9 +8,9 @@ from pontoon.base.models import user_gravatar_url
 
 class LatestActivityUser(object):
 
-    def __init__(self, activity, type):
+    def __init__(self, activity, activity_type):
         self.activity = activity
-        self.type = type
+        self.type = activity_type
 
     @property
     def prefix(self):

--- a/pontoon/tags/utils/latest_activity.py
+++ b/pontoon/tags/utils/latest_activity.py
@@ -8,16 +8,21 @@ from pontoon.base.models import user_gravatar_url
 
 class LatestActivityUser(object):
 
-    def __init__(self, user):
-        self.user = user
+    def __init__(self, activity, type):
+        self.activity = activity
+        self.type = type
+
+    @property
+    def prefix(self):
+        return 'approved_' if self.type == 'approved' else ''
 
     @property
     def email(self):
-        return self.user.get('user__email')
+        return self.activity.get(self.prefix + 'user__email')
 
     @property
     def first_name(self):
-        return self.user.get('user__first_name')
+        return self.activity.get(self.prefix + 'user__first_name')
 
     @property
     def name_or_email(self):
@@ -25,7 +30,7 @@ class LatestActivityUser(object):
 
     @property
     def username(self):
-        return self.user.get('user__username')
+        return self.activity.get(self.prefix + 'user__username')
 
     def gravatar_url(self, *args):
         if self.email:
@@ -43,6 +48,8 @@ class LatestActivity(object):
 
     @property
     def date(self):
+        if self.type == 'approved':
+            return self.approved_date
         return self.activity.get('date')
 
     @property
@@ -52,12 +59,13 @@ class LatestActivity(object):
     @property
     def user(self):
         return (
-            LatestActivityUser(self.activity)
-            if 'user__email' in self.activity
-            else None)
+            LatestActivityUser(self.activity, self.type)
+            if 'user__email' in self.activity or 'approved_user__email' in self.activity
+            else None
+        )
 
     @property
     def type(self):
-        if self.approved_date is not None and self.approved_date > self.date:
+        if self.approved_date is not None and self.approved_date > self.activity.get('date'):
             return 'approved'
         return 'submitted'

--- a/pontoon/tags/utils/translations.py
+++ b/pontoon/tags/utils/translations.py
@@ -13,7 +13,13 @@ class TagsLatestTranslationsTool(TagsTRTool):
     filter_methods = ('tag', 'projects', 'latest', 'locales', 'path')
 
     _default_annotations = (
-        ('last_change', Max('latest_translation__date')), )
+        (
+            'date', Max('latest_translation__date')
+        ),
+        (
+            'approved_date', Max('latest_translation__approved_date')
+        ),
+    )
 
     @property
     def groupby_prefix(self):
@@ -35,16 +41,31 @@ class TagsLatestTranslationsTool(TagsTRTool):
     def get_data(self):
         _translations = self.translation_manager.none()
         stats = super(TagsLatestTranslationsTool, self).get_data()
+
         for tr in stats.iterator():
+            if tr['approved_date'] is not None and tr['approved_date'] > tr['date']:
+                key = 'approved_date'
+            else:
+                key = 'date'
+
             # find translations with matching date and tag/locale
             _translations |= self.translation_manager.filter(
-                Q(**{'date': tr["last_change"],
-                     self.groupby_prefix: tr[self.get_groupby()[0]]}))
+                Q(
+                    **{
+                        key: tr[key],
+                        self.groupby_prefix: tr[self.get_groupby()[0]]
+                    }
+                )
+            )
+
         return _translations.values(
             *(
                 'string',
                 'date',
                 'approved_date',
+                'approved_user__email',
+                'approved_user__first_name',
+                'approved_user__username',
                 'user__email',
                 'user__first_name',
                 'user__username',

--- a/pontoon/tags/utils/translations.py
+++ b/pontoon/tags/utils/translations.py
@@ -41,12 +41,19 @@ class TagsLatestTranslationsTool(TagsTRTool):
                 Q(**{'date': tr["last_change"],
                      self.groupby_prefix: tr[self.get_groupby()[0]]}))
         return _translations.values(
-            *('string',
-              'date',
-              'approved_date',
-              'user__first_name',
-              'user__email')
-            + (self.groupby_prefix, ))
+            *(
+                'string',
+                'date',
+                'approved_date',
+                'user__email',
+                'user__first_name',
+                'user__username',
+            )
+            +
+            (
+                self.groupby_prefix,
+            )
+        )
 
     def filter_latest(self, qs):
         return qs.exclude(latest_translation__isnull=True)


### PR DESCRIPTION
Properly display approved translation date & user in the latest activity column of the Tags dashboard.

@jotes Could you please take a look, given that you've been working on tags in the past?