### PR TITLE
Fix bug 1605064: Make /machinery work again by restoring team selector

### DIFF
--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -480,12 +480,18 @@ var Pontoon = (function (my) {
               .find('.remaining').html(remaining).toggle(remaining > 0).end()
               .toggle(preferred > 0 || remaining > 0);
 
-          // No match
-          if (requests === 0 && ul.children('li').length === 0) {
-            tab.find('.count').hide();
-            ul.append('<li class="disabled">' +
-              '<p>No translations available.</p>' +
-            '</li>');
+          // All requests complete
+          if (requests === 0) {
+            // Stop the loader
+            $('#' + loader).removeClass('loading');
+
+            // No match
+            if (ul.children('li').length === 0) {
+                tab.find('.count').hide();
+                ul.append('<li class="disabled">' +
+                '<p>No translations available.</p>' +
+                '</li>');
+            }
           }
         }
       }

--- a/pontoon/machinery/templates/machinery/machinery.html
+++ b/pontoon/machinery/templates/machinery/machinery.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% import 'heading.html' as Heading %}
+{% import 'teams/widgets/team_selector.html' as team_selector %}
 
 {% block title %}Machinery{% endblock %}
 
@@ -36,7 +37,7 @@
         <input type="search" autocomplete="off" autofocus placeholder="Type and press Enter to search">
       </div>
 
-      {% include 'teams/widgets/team_selector.html' %}
+      {{ team_selector.locale(locales, locale) }}
     </menu>
 
     <div id="helpers">


### PR DESCRIPTION
This is a regression from #1474.

There's another bugfix in a followup commit.