### PR TITLE
Fix bug 1608660: Prevent sync tasks of any type to run concurrently for the same project

### DIFF
--- a/pontoon/sync/__init__.py
+++ b/pontoon/sync/__init__.py
@@ -1,6 +1,2 @@
-class SyncError(RuntimeError):
-    """Error class for errors relating to the project sync process."""
-
-
 # A separator used in Translation keys as proposed by Translate Toolkit.
 KEY_SEPARATOR = "\x04"

--- a/pontoon/sync/core.py
+++ b/pontoon/sync/core.py
@@ -53,8 +53,8 @@ def serial_task(timeout, lock_key="", on_error=None, **celery_args):
         @shared_task(bind=True, **celery_args)
         @wraps(func)
         def wrapped_func(self, *args, **kwargs):
-            lock_name = "serial_task.{}[{}]".format(
-                self.name, lock_key.format(*args, **kwargs)
+            lock_name = "serial_task.sync[{}]".format(
+                lock_key.format(*args, **kwargs)
             )
             # Acquire the lock
             if not cache.add(lock_name, True, timeout=timeout):

--- a/pontoon/sync/exceptions.py
+++ b/pontoon/sync/exceptions.py
@@ -1,2 +1,6 @@
 class ParseError(RuntimeError):
     """Exception to raise when parsing fails."""
+
+
+class SyncError(RuntimeError):
+    """Error class for general errors relating to the project sync process."""

--- a/pontoon/sync/formats/compare_locales.py
+++ b/pontoon/sync/formats/compare_locales.py
@@ -12,8 +12,7 @@ from compare_locales import (
     serializer,
 )
 
-from pontoon.sync import SyncError
-from pontoon.sync.exceptions import ParseError
+from pontoon.sync.exceptions import ParseError, SyncError
 from pontoon.sync.formats.base import ParsedResource
 from pontoon.sync.utils import create_parent_directory
 from pontoon.sync.vcs.models import VCSTranslation

--- a/pontoon/sync/formats/ftl.py
+++ b/pontoon/sync/formats/ftl.py
@@ -6,7 +6,7 @@ import logging
 
 from fluent.syntax import ast, FluentParser, FluentSerializer
 
-from pontoon.sync import SyncError
+from pontoon.sync.exceptions import SyncError
 from pontoon.sync.formats.base import ParsedResource
 from pontoon.sync.utils import create_parent_directory
 from pontoon.sync.vcs.models import VCSTranslation

--- a/pontoon/sync/formats/json_extensions.py
+++ b/pontoon/sync/formats/json_extensions.py
@@ -16,8 +16,7 @@ from collections import OrderedDict
 from jsonschema import validate
 from jsonschema.exceptions import ValidationError
 
-from pontoon.sync import SyncError
-from pontoon.sync.exceptions import ParseError
+from pontoon.sync.exceptions import ParseError, SyncError
 from pontoon.sync.formats.base import ParsedResource
 from pontoon.sync.utils import create_parent_directory
 from pontoon.sync.vcs.models import VCSTranslation

--- a/pontoon/sync/formats/silme.py
+++ b/pontoon/sync/formats/silme.py
@@ -15,7 +15,7 @@ from silme.format.ini import FormatParser as IniParser
 from silme.format.inc import FormatParser as IncParser
 from silme.format.properties import FormatParser as PropertiesParser
 
-from pontoon.sync import SyncError
+from pontoon.sync.exceptions import SyncError
 from pontoon.sync.utils import (
     create_parent_directory,
     escape_quotes,

--- a/pontoon/sync/tasks.py
+++ b/pontoon/sync/tasks.py
@@ -185,7 +185,7 @@ def sync_sources(db_project, now, force, no_pull):
 @serial_task(
     settings.SYNC_TASK_TIMEOUT,
     base=PontoonTask,
-    lock_key="project={0},translations",
+    lock_key="project={0}",
     on_error=sync_translations_error,
 )
 def sync_translations(

--- a/pontoon/sync/tests/test_tasks.py
+++ b/pontoon/sync/tests/test_tasks.py
@@ -412,10 +412,10 @@ class SyncExecutionTests(TestCase):
             assert_true(first_call.get(), 42)
             assert_true(second_call.get(), 24)
             mock_cache.add.assert_any_call(
-                CONTAINS("task_lock_key[param=42]"), ANY, timeout=3
+                CONTAINS("serial_task.sync[param=42]"), ANY, timeout=3
             )
             mock_cache.add.assert_any_call(
-                CONTAINS("task_lock_key[param=24]"), ANY, timeout=3
+                CONTAINS("serial_task.sync[param=24]"), ANY, timeout=3
             )
 
     def test_exception_during_sync(self):

--- a/pontoon/sync/vcs/models.py
+++ b/pontoon/sync/vcs/models.py
@@ -314,7 +314,12 @@ class VCSProject(object):
     @cached_property
     def resources(self):
         """
-        Lazy-loaded mapping of relative paths -> VCSResources.
+        Lazy-loaded mapping of relative paths -> VCSResources that need to be synced:
+            * changed in repository
+            * changed in Pontoon DB
+            * corresponding source file added
+            * corresponding source file changed
+            * all paths relevant for newly enabled (unsynced) locales
 
         Waiting until first access both avoids unnecessary file reads
         and allows tests that don't need to touch the resources to run
@@ -323,7 +328,7 @@ class VCSProject(object):
         resources = {}
 
         log.info(
-            "Changed files in {} repository and Pontoon: {}".format(
+            "Changed files in {} repository and Pontoon, relevant for enabled locales: {}".format(
                 self.db_project, self.changed_files
             )
         )
@@ -379,10 +384,11 @@ class VCSProject(object):
                 )
 
         log.info(
-            "Changed files in {} repository: {}".format(
+            "Relative paths in {} that need to be synced: {}".format(
                 self.db_project, resources.keys()
             )
         )
+
         return resources
 
     @property


### PR DESCRIPTION
I've tested this on stage by syncing Firefox:
https://mozilla-pontoon-staging.herokuapp.com/sync/log/91143/

I then tried to sync Firefox two more times:
* during `sync_sources`: https://mozilla-pontoon-staging.herokuapp.com/sync/log/91144/
* during `sync_translations`: https://mozilla-pontoon-staging.herokuapp.com/sync/log/91145/

In both cases, `RuntimeError` was raised as expected, preventing the consequent tasks from running.