### PR TITLE
Validate priority before comparison

### DIFF
--- a/pontoon/base/templates/widgets/priority.html
+++ b/pontoon/base/templates/widgets/priority.html
@@ -1,5 +1,5 @@
 {% macro priority(priority) %}
   {% for n in range(5) %}
-  <span class="fa fa-star{% if loop.index <= priority %}{{ ' active' }}{% endif %}"></span>
+  <span class="fa fa-star{% if priority and loop.index <= priority %}{{ ' active' }}{% endif %}"></span>
   {% endfor %}
 {% endmacro %}


### PR DESCRIPTION
Python 3.0 has simplified the rules for ordering comparisons: The ordering
comparison operators (<, <=, >=, >) raise a TypeError exception when the
operands don’t have a meaningful natural ordering.

Thus, expressions like 0 > None are no longer valid, and raise a TypeError
instead of returning False.