### PR TITLE
Fix  Bug 1611512  - Add ability for Add Comment input to grow as you type

### DIFF
--- a/frontend/src/core/comments/components/AddComment.css
+++ b/frontend/src/core/comments/components/AddComment.css
@@ -1,7 +1,3 @@
-/* .comments-list .add-comment form {
-    position: relative;
-} */
-
 .comments-list .add-comment textarea {
     background-color: #333941;
     border: none;
@@ -12,7 +8,4 @@
     overflow: auto;
     line-height: 24px;
     padding: 6px;
-    /* position: absolute;
-    bottom: 5px;
-    width: 98%; */
 }

--- a/frontend/src/core/comments/components/AddComment.css
+++ b/frontend/src/core/comments/components/AddComment.css
@@ -4,7 +4,10 @@
     border-radius: 4px;
     color: #FFFFFF;
     font-size: 11px;
-    height: 24px;
+    height: auto;
+    overflow: auto;
     line-height: 24px;
     padding: 6px;
+    /* position: absolute;
+    bottom: 0; */
 }

--- a/frontend/src/core/comments/components/AddComment.css
+++ b/frontend/src/core/comments/components/AddComment.css
@@ -1,3 +1,7 @@
+/* .comments-list .add-comment form {
+    position: relative;
+} */
+
 .comments-list .add-comment textarea {
     background-color: #333941;
     border: none;
@@ -9,5 +13,6 @@
     line-height: 24px;
     padding: 6px;
     /* position: absolute;
-    bottom: 0; */
+    bottom: 5px;
+    width: 98%; */
 }

--- a/frontend/src/core/comments/components/AddComment.js
+++ b/frontend/src/core/comments/components/AddComment.js
@@ -26,7 +26,7 @@ export default function AddComments(props: Props) {
     } = props;
 
     const commentInput: any = React.useRef();
-    const [rows, setRows] = React.useState(1);
+    const rows = 1;
     const minRows = 1;
     const maxRows = 3;
 
@@ -49,12 +49,12 @@ export default function AddComments(props: Props) {
             if (currentRows === previousRows) {
                 commentInput.current.rows = currentRows;
             }
-
-            if (currentRows >= maxRows) {
+            else if (currentRows < maxRows) {
+                commentInput.current.rows = currentRows;
+            }
+            else if (currentRows >= maxRows) {
                 commentInput.current.rows = maxRows;
             }
-
-            currentRows < maxRows ? setRows(currentRows) : setRows(maxRows);
         }
     }
 

--- a/frontend/src/core/comments/components/AddComment.js
+++ b/frontend/src/core/comments/components/AddComment.js
@@ -26,9 +26,9 @@ export default function AddComments(props: Props) {
     } = props;
 
     const commentInput: any = React.useRef();
-    const rows = 1;
     const minRows = 1;
     const maxRows = 3;
+    const rows = minRows;
 
     if (!user) {
         return null;

--- a/frontend/src/core/comments/components/AddComment.js
+++ b/frontend/src/core/comments/components/AddComment.js
@@ -41,15 +41,11 @@ export default function AddComments(props: Props) {
         }
         else {
             const textAreaLineHeight = 24;
-            const previousRows = commentInput.current.rows;
             commentInput.current.rows = minRows;
 
             const currentRows = Math.trunc(commentInput.current.scrollHeight / textAreaLineHeight);
 
-            if (currentRows === previousRows) {
-                commentInput.current.rows = currentRows;
-            }
-            else if (currentRows < maxRows) {
+            if (currentRows < maxRows) {
                 commentInput.current.rows = currentRows;
             }
             else if (currentRows >= maxRows) {

--- a/frontend/src/core/comments/components/AddComment.js
+++ b/frontend/src/core/comments/components/AddComment.js
@@ -82,7 +82,7 @@ export default function AddComments(props: Props) {
                     rows={ minRows }
                     ref={ commentInput }
                     onChange={ handleOnChange }
-                    onKeyUp={ submitComment }
+                    onKeyDown={ submitComment }
                 />
             </Localized>
         </form>

--- a/frontend/src/core/comments/components/AddComment.js
+++ b/frontend/src/core/comments/components/AddComment.js
@@ -27,44 +27,39 @@ export default function AddComments(props: Props) {
 
     const commentInput: any = React.useRef();
     const minRows = 1;
-    const maxRows = 3;
-    const rows = minRows;
+    const maxRows = 6;
 
     if (!user) {
         return null;
     }
 
-    const handleKeyUp = (event: SyntheticKeyboardEvent<HTMLTextAreaElement>) => {
-        if (event.keyCode === 13 && event.shiftKey === false) {
-            event.preventDefault();
-            submitComment(event);
+    const handleOnChange = () => {
+        const textAreaLineHeight = 24;
+        commentInput.current.rows = minRows;
+
+        const currentRows = Math.trunc(commentInput.current.scrollHeight / textAreaLineHeight);
+
+        if (currentRows < maxRows) {
+            commentInput.current.rows = currentRows;
         }
         else {
-            const textAreaLineHeight = 24;
-            commentInput.current.rows = minRows;
-
-            const currentRows = Math.trunc(commentInput.current.scrollHeight / textAreaLineHeight);
-
-            if (currentRows < maxRows) {
-                commentInput.current.rows = currentRows;
-            }
-            else if (currentRows >= maxRows) {
-                commentInput.current.rows = maxRows;
-            }
+            commentInput.current.rows = maxRows;
         }
     }
 
     const submitComment = (event: SyntheticKeyboardEvent<>) => {
-        event.preventDefault();
-        const comment = commentInput.current.value;
+        if (event.keyCode === 13 && event.shiftKey === false) {
+            event.preventDefault();
+            const comment = commentInput.current.value;
 
-        if (!comment) {
-            return null;
+            if (!comment) {
+                return null;
+            }
+
+            addComment(comment, translationId);
+            commentInput.current.value = '';
+            commentInput.current.rows = minRows;
         }
-
-        addComment(comment, translationId);
-        commentInput.current.value = '';
-        commentInput.current.rows = minRows;
     };
 
     return <div className='comment add-comment'>
@@ -84,9 +79,10 @@ export default function AddComments(props: Props) {
                     name='comment'
                     dir='auto'
                     placeholder={ `Write a comment…` }
-                    rows={ rows }
+                    rows={ minRows }
                     ref={ commentInput }
-                    onKeyUp={ handleKeyUp }
+                    onChange={ handleOnChange }
+                    onKeyUp={ submitComment }
                 />
             </Localized>
         </form>

--- a/frontend/src/core/comments/components/AddComment.js
+++ b/frontend/src/core/comments/components/AddComment.js
@@ -25,16 +25,36 @@ export default function AddComments(props: Props) {
         addComment,
     } = props;
 
-    let commentInput: any = React.useRef();
+    const commentInput: any = React.useRef();
+    const [rows, setRows] = React.useState(1);
+    const minRows = 1;
+    const maxRows = 3;
 
     if (!user) {
         return null;
     }
 
-    const onEnterSubmit = (event: SyntheticKeyboardEvent<HTMLTextAreaElement>) => {
+    const handleKeyUp = (event: SyntheticKeyboardEvent<HTMLTextAreaElement>) => {
         if (event.keyCode === 13 && event.shiftKey === false) {
             event.preventDefault();
             submitComment(event);
+        }
+        else {
+            const textAreaLineHeight = 24;
+            const previousRows = commentInput.current.rows;
+            commentInput.current.rows = minRows;
+
+            const currentRows = Math.trunc(commentInput.current.scrollHeight / textAreaLineHeight);
+
+            if (currentRows === previousRows) {
+                commentInput.current.rows = currentRows;
+            }
+
+            if (currentRows >= maxRows) {
+                commentInput.current.rows = maxRows;
+            }
+
+            currentRows < maxRows ? setRows(currentRows) : setRows(maxRows);
         }
     }
 
@@ -48,6 +68,7 @@ export default function AddComments(props: Props) {
 
         addComment(comment, translationId);
         commentInput.current.value = '';
+        commentInput.current.rows = minRows;
     };
 
     return <div className='comment add-comment'>
@@ -67,8 +88,9 @@ export default function AddComments(props: Props) {
                     name='comment'
                     dir='auto'
                     placeholder={ `Write a comment…` }
+                    rows={ rows }
                     ref={ commentInput }
-                    onKeyDown={ onEnterSubmit }
+                    onKeyUp={ handleKeyUp }
                 />
             </Localized>
         </form>

--- a/frontend/src/core/comments/components/Comment.css
+++ b/frontend/src/core/comments/components/Comment.css
@@ -5,6 +5,7 @@
 .comments-list .comment a {
     color: #7BC876;
     font-weight: 400;
+    white-space: nowrap;
 }
 
 .comments-list .comment .content {
@@ -15,10 +16,6 @@
     font-size: 11px;
     padding: 6px;
     white-space: pre-wrap;
-}
-
-.comments-list .comment .content a {
-    white-space: nowrap;
 }
 
 .comments-list .comment .content p {

--- a/frontend/src/core/comments/components/Comment.css
+++ b/frontend/src/core/comments/components/Comment.css
@@ -14,6 +14,11 @@
     display: flex;
     font-size: 11px;
     padding: 6px;
+    white-space: pre-wrap;
+}
+
+.comments-list .comment .content a {
+    white-space: nowrap;
 }
 
 .comments-list .comment .content p {

--- a/frontend/src/modules/history/components/Translation.js
+++ b/frontend/src/modules/history/components/Translation.js
@@ -246,7 +246,7 @@ export class TranslationBase extends React.Component<InternalProps, State> {
         } = this.props;
 
         // TODO: Uncomment as part of bug 1361318
-        // const commentCount = translation.comments.length;
+        const commentCount = translation.comments.length;
 
         // Does the currently logged in user own this translation?
         const ownTranslation = (
@@ -306,7 +306,7 @@ export class TranslationBase extends React.Component<InternalProps, State> {
                             { (index === 0 || !canComment) ? null : <span className='divider'>&bull;</span> }
 
                             { /* TODO: Uncomment as part of bug 1361318 */}
-                            {/* { (!canComment && commentCount === 0) ? null : this.renderCommentToggle(commentCount) } */}
+                            { (!canComment && commentCount === 0) ? null : this.renderCommentToggle(commentCount) }
 
                             { (!translation.rejected || !canDelete ) ? null :
                                 // Delete Button

--- a/frontend/src/modules/history/components/Translation.js
+++ b/frontend/src/modules/history/components/Translation.js
@@ -246,7 +246,7 @@ export class TranslationBase extends React.Component<InternalProps, State> {
         } = this.props;
 
         // TODO: Uncomment as part of bug 1361318
-        const commentCount = translation.comments.length;
+        // const commentCount = translation.comments.length;
 
         // Does the currently logged in user own this translation?
         const ownTranslation = (
@@ -306,7 +306,7 @@ export class TranslationBase extends React.Component<InternalProps, State> {
                             { (index === 0 || !canComment) ? null : <span className='divider'>&bull;</span> }
 
                             { /* TODO: Uncomment as part of bug 1361318 */}
-                            { (!canComment && commentCount === 0) ? null : this.renderCommentToggle(commentCount) }
+                            {/* { (!canComment && commentCount === 0) ? null : this.renderCommentToggle(commentCount) } */}
 
                             { (!translation.rejected || !canDelete ) ? null :
                                 // Delete Button

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -493,10 +493,10 @@ def delete_translation(request):
 @transaction.atomic
 def add_comment(request):
     # TODO: Remove as part of bug 1361318
-    return JsonResponse(
-        {"status": False, "message": "Not Implemented"},
-        status=501,
-    )
+    # return JsonResponse(
+    #     {"status": False, "message": "Not Implemented"},
+    #     status=501,
+    # )
 
     """Add a comment."""
     try:

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -493,10 +493,7 @@ def delete_translation(request):
 @transaction.atomic
 def add_comment(request):
     TODO: Remove as part of bug 1361318
-    return JsonResponse(
-        {"status": False, "message": "Not Implemented"},
-        status=501,
-    )
+    return JsonResponse({"status": False, "message": "Not Implemented"}, status=501,)
 
     """Add a comment."""
     try:

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -492,7 +492,7 @@ def delete_translation(request):
 @login_required(redirect_field_name="", login_url="/403")
 @transaction.atomic
 def add_comment(request):
-    TODO: Remove as part of bug 1361318
+    # TODO: Remove as part of bug 1361318
     return JsonResponse({"status": False, "message": "Not Implemented"}, status=501,)
 
     """Add a comment."""

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -492,11 +492,11 @@ def delete_translation(request):
 @login_required(redirect_field_name="", login_url="/403")
 @transaction.atomic
 def add_comment(request):
-    # TODO: Remove as part of bug 1361318
-    # return JsonResponse(
-    #     {"status": False, "message": "Not Implemented"},
-    #     status=501,
-    # )
+    TODO: Remove as part of bug 1361318
+    return JsonResponse(
+        {"status": False, "message": "Not Implemented"},
+        status=501,
+    )
 
     """Add a comment."""
     try:


### PR DESCRIPTION
This fix allows for the textarea in Add Comment to grow as the user types.

________________
I have actually set up a way to grow the textarea either in a downward direction or an upward direction (similar to Slack). However, both options pose additional challenges that I have not yet found solutions for.

**Downward growth** (which is what is active): If there are multiple comments and the Add Comment textarea grows to the point that the outer `history` div begins scrolling then every keypress causes the `history` scroll to jump back up which is not a good experience.

**Upward growth** (can be activated by uncommenting the CSS in `AddComent.css`): This has a fluid growth action, but it does not effect the `history` div which means the overflow is never switched to scroll and the textarea grows up and covers the comment above it.

I have tried implementing lifecycle methods/hooks using a `ref` on the History `ul` and/or on the existing `ref` on the textarea to set or remember the scroll position but have not had success. The closest I came was with the downward growth and calling a function with `onScroll` that scrolled to the bottom, but this option disabled the ability to scroll back up.

Let me know which option is preferable (upward or downward growth) and your thoughts on how I can address the associated scrolling issue for that option. ~ Thanks