### PR TITLE
No bug - On some of Docker images, the `pontoon` user won't have id=1000 b…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ help:
 	@echo "  setup            Configures a local instance after a fresh build"
 	@echo "  run              Runs the whole stack, served on http://localhost:8000/"
 	@echo "  clean            Forces a rebuild of docker containers"
-	@echo "  shell            Opens a Bash shell in a webpp docker container"
+	@echo "  shell            Opens a Bash shell in a webapp docker container"
 	@echo "  test             Runs the entire test suite (back and front)"
 	@echo "  jest             Runs the new frontend's test suite (Translate.Next)"
 	@echo "  pytest           Runs the backend's test suite (Python)"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,10 @@ DOCKER := $(shell which docker)
 # https://docs.djangoproject.com/en/dev/ref/django-admin/#runserver
 SITE_URL ?= http://localhost:8000
 
-.PHONY: build build-py3 setup run clean test test-py3 shell shell-py3 loaddb build-frontend build-frontend-w
+USER_ID?=$(shell id -u)
+GROUP_ID?=$(shell id -g)
+
+.PHONY: build setup run clean test shell loaddb build-frontend build-frontend-w
 
 help:
 	@echo "Welcome to Pontoon!\n"
@@ -15,7 +18,7 @@ help:
 	@echo "  setup            Configures a local instance after a fresh build"
 	@echo "  run              Runs the whole stack, served on http://localhost:8000/"
 	@echo "  clean            Forces a rebuild of docker containers"
-	@echo "  shell            Opens a Bash shell in a webapp docker container"
+	@echo "  shell            Opens a Bash shell in a webpp docker container"
 	@echo "  test             Runs the entire test suite (back and front)"
 	@echo "  jest             Runs the new frontend's test suite (Translate.Next)"
 	@echo "  pytest           Runs the backend's test suite (Python)"
@@ -33,7 +36,7 @@ build:
 	cp ./docker/config/webapp.env.template ./docker/config/webapp.env
 	sed -i -e 's/#SITE_URL#/$(subst /,\/,${SITE_URL})/g' ./docker/config/webapp.env
 
-	"${DC}" build webapp
+	"${DC}" build --build-arg USER_ID=$(USER_ID) --build-arg GROUP_ID=$(GROUP_ID) webapp
 
 	touch .docker-build
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.7.6-stretch
 
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+
 ENV DEBIAN_FRONTEND=noninteractive
 ENV HGPYTHON3=1
 
@@ -44,7 +47,7 @@ RUN pip install -U 'pip>=8' && \
     pip install --no-cache-dir --require-hashes -r requirements/test.txt
 
 # Create the app user
-RUN groupadd -r --gid=1000 pontoon && useradd --no-log-init -r -m -g pontoon pontoon
+RUN groupadd -r --gid=${GROUP_ID} pontoon && useradd --uid=${USER_ID} --no-log-init -r -m -g pontoon pontoon
 RUN chown -R pontoon:pontoon /app
 USER pontoon
 


### PR DESCRIPTION
…y default.

Changes:
* Explicitly set the user id (to avoid confusions when maintainers of the docker image will change something).
* Parametrize the user/group id in the Makefile to give people an easy way to get around that problem.

To give you more context -> I rebuild the webapp image today and had problems with permissions (e.g. making new migrations).
My user id was:
```bash
pontoon@63acee8f6019:/app$ id
uid=999(pontoon) gid=1000(pontoon) groups=1000(pontoon)
```
@adngdb @Pike can you take a look?