### PR TITLE
Fix bug 1612814 - Harcode UID and GID to fix builds on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ DOCKER := $(shell which docker)
 # https://docs.djangoproject.com/en/dev/ref/django-admin/#runserver
 SITE_URL ?= http://localhost:8000
 
-USER_ID?=$(shell id -u)
-GROUP_ID?=$(shell id -g)
+USER_ID?=1000
+GROUP_ID?=1000
 
 .PHONY: build setup run clean test shell loaddb build-frontend build-frontend-w
 


### PR DESCRIPTION
Uids and Gids on macOS start from very low numbers (e.g. 20) and they overlap with the ids of the existing services.
This commit hardcodes the UID and GID but keeps them parametrizable via commandline.

@Pike @adngdb r?