### PR TITLE
Show default avatar for users without Gravatar URLs

### DIFF
--- a/frontend/src/core/comments/components/AddComment.js
+++ b/frontend/src/core/comments/components/AddComment.js
@@ -65,7 +65,6 @@ export default function AddComments(props: Props) {
     return <div className='comment add-comment'>
         <UserAvatar
             username={ username }
-            title=''
             imageUrl={ imageURL }
         />
         <form className='container'>

--- a/frontend/src/core/comments/components/AddComment.js
+++ b/frontend/src/core/comments/components/AddComment.js
@@ -64,7 +64,6 @@ export default function AddComments(props: Props) {
 
     return <div className='comment add-comment'>
         <UserAvatar
-            user={ user }
             username={ username }
             title=''
             imageUrl={ imageURL }

--- a/frontend/src/core/comments/components/Comment.js
+++ b/frontend/src/core/comments/components/Comment.js
@@ -24,7 +24,6 @@ export default function Comment(props: Props) {
 
     return <li className='comment'>
         <UserAvatar
-            user={ comment.author }
             username={ comment.username }
             imageUrl={ comment.userGravatarUrlSmall }
         />

--- a/frontend/src/core/user/components/UserAvatar.js
+++ b/frontend/src/core/user/components/UserAvatar.js
@@ -13,7 +13,7 @@ type Props = {|
 export default function UserAvatar(props: Props) {
     const { user, username, title, imageUrl } = props;
 
-    if (!user) {
+    if (!imageUrl) {
         return <div className='user-avatar'>
             <Localized id='user-UserAvatar--anon-alt-text' attrs={{ alt: true }} >
                 <img

--- a/frontend/src/core/user/components/UserAvatar.js
+++ b/frontend/src/core/user/components/UserAvatar.js
@@ -4,14 +4,13 @@ import React from 'react'
 import { Localized } from '@fluent/react';
 
 type Props = {|
-    user: string,
     username: string,
     title?: string,
     imageUrl: string,
 |};
 
 export default function UserAvatar(props: Props) {
-    const { user, username, title, imageUrl } = props;
+    const { username, title, imageUrl } = props;
 
     if (!imageUrl) {
         return <div className='user-avatar'>

--- a/frontend/src/modules/history/components/Translation.js
+++ b/frontend/src/modules/history/components/Translation.js
@@ -284,7 +284,6 @@ export class TranslationBase extends React.Component<InternalProps, State> {
                     onClick={ this.copyTranslationIntoEditor }
                 >
                     <UserAvatar
-                        user={ translation.user }
                         username={ translation.username }
                         title={ this.getApprovalTitle() }
                         imageUrl={ translation.userGravatarUrlSmall }


### PR DESCRIPTION
@abowler2 Could you please review this?

We broke user avatars for users that don't have Gravatar URLs, e.g. if Translation is Imported:
https://pontoon.mozilla.org/it/firefox/all-resources/?string=74127