### PR TITLE
Bug 1607696 - Migrate middlewares to Django 2.0 and replace `django.c…

### DIFF
--- a/pontoon/administration/tests/test_views.py
+++ b/pontoon/administration/tests/test_views.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 
 import pytest
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from pontoon.administration.forms import ProjectForm
 from pontoon.administration.views import _create_or_update_translated_resources

--- a/pontoon/api/tests/test_urls.py
+++ b/pontoon/api/tests/test_urls.py
@@ -5,7 +5,7 @@ import unittest
 
 from django.test import TestCase
 from django.conf import settings
-from django.core.urlresolvers import clear_url_caches
+from django.urls import clear_url_caches
 
 from six.moves import reload_module
 

--- a/pontoon/base/middleware.py
+++ b/pontoon/base/middleware.py
@@ -4,10 +4,11 @@ from django.conf import settings
 from django.contrib import auth
 from django.core.exceptions import PermissionDenied
 from django.http import Http404, HttpResponseForbidden
+from django.utils.deprecation import MiddlewareMixin
 from raygun4py.middleware.django import Provider
 
 
-class RaygunExceptionMiddleware(Provider):
+class RaygunExceptionMiddleware(Provider, MiddlewareMixin):
     def process_exception(self, request, exception):
         # Ignore non-failure exceptions. We don't need to be notified
         # of these.
@@ -17,7 +18,7 @@ class RaygunExceptionMiddleware(Provider):
             )
 
 
-class BlockedIpMiddleware(object):
+class BlockedIpMiddleware(MiddlewareMixin):
     def process_request(self, request):
         try:
             ip = request.META["HTTP_X_FORWARDED_FOR"]
@@ -36,7 +37,7 @@ class BlockedIpMiddleware(object):
         return None
 
 
-class AutomaticLoginUserMiddleware(object):
+class AutomaticLoginUserMiddleware(MiddlewareMixin):
     """
     This middleware automatically logs in the user specified for AUTO_LOGIN.
     """

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -22,7 +22,6 @@ from django.conf import settings
 from django.contrib.auth.models import User, Group
 from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ValidationError
-from django.core.urlresolvers import reverse
 from django.core.validators import validate_email
 from django.db import models
 from django.db.models import (
@@ -37,6 +36,7 @@ from django.db.models import (
     ExpressionWrapper,
 )
 from django.templatetags.static import static
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.functional import cached_property

--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -17,8 +17,8 @@ from django import template
 from django.conf import settings
 from django.contrib.humanize.templatetags import humanize
 from django.contrib.staticfiles.storage import staticfiles_storage
-from django.core.urlresolvers import reverse
 from django.db.models import QuerySet
+from django.urls import reverse
 from django.utils.encoding import smart_str
 from django.utils.encoding import force_text
 from django.utils.functional import Promise

--- a/pontoon/contributors/tests/test_views.py
+++ b/pontoon/contributors/tests/test_views.py
@@ -9,8 +9,8 @@ from mock import patch
 from random import randint
 from six.moves import range
 
-from django.core.urlresolvers import reverse
 from django.http import HttpResponse
+from django.urls import reverse
 from django.utils.timezone import now, make_aware
 from django_nose.tools import assert_equal, assert_true, assert_code, assert_contains
 

--- a/pontoon/localizations/tests/test_views.py
+++ b/pontoon/localizations/tests/test_views.py
@@ -4,7 +4,7 @@ import pytest
 
 from mock import patch
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.shortcuts import render
 
 from pontoon.base.models import Locale

--- a/pontoon/machinery/tests/test_views.py
+++ b/pontoon/machinery/tests/test_views.py
@@ -6,7 +6,7 @@ import caighdean
 import pytest
 import requests_mock
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from six.moves import urllib
 

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -156,7 +156,7 @@ INSTALLED_APPS = (
 
 BLOCKED_IPS = os.environ.get("BLOCKED_IPS", "").split(",")
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django_cookies_samesite.middleware.CookiesSameSite",

--- a/pontoon/settings/dev.py
+++ b/pontoon/settings/dev.py
@@ -19,9 +19,9 @@ INSTALLED_APPS = base.INSTALLED_APPS + (
 # In development, we want to remove the WhiteNoise middleware, because we need
 # precise control of static files loading in order to properly load frontend
 # resources. See the `pontoon.translate` module.
-MIDDLEWARE_CLASSES = tuple(
+MIDDLEWARE = tuple(
     middleware
-    for middleware in base.MIDDLEWARE_CLASSES
+    for middleware in base.MIDDLEWARE
     if middleware != "whitenoise.middleware.WhiteNoiseMiddleware"
 ) + ("debug_toolbar.middleware.DebugToolbarMiddleware",)
 

--- a/pontoon/sync/admin.py
+++ b/pontoon/sync/admin.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from django.contrib import admin
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.safestring import mark_safe
 
 from pontoon.sync import models

--- a/pontoon/sync/models.py
+++ b/pontoon/sync/models.py
@@ -4,7 +4,7 @@ import logging
 
 from bulk_update.helper import bulk_update
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import models
 from django.db.models import F, Max, Sum
 from django.utils import timezone

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -52,8 +52,9 @@ django-bmemcached==0.2.3 \
 django-bulk-update==2.2.0 \
     --hash=sha256:49a403392ae05ea872494d74fb3dfa3515f8df5c07cc277c3dc94724c0ee6985 \
     --hash=sha256:5ab7ce8a65eac26d19143cc189c0f041d5c03b9d1b290ca240dc4f3d6aaeb337
-django-cors-headers==1.1.0 \
-    --hash=sha256:fcd96e2be47c8eef34c650e007a6d546e19e7ee61041b89edbbbbe7619aa3987
+django-cors-headers==3.2.1 \
+    --hash=sha256:a5960addecc04527ab26617e51b8ed42f0adab4594b24bb0f3c33e2bd3857c3f \
+    --hash=sha256:a785b5f446f6635810776d9f5f5d23e6a2a2f728ea982648370afaf0dfdf2627
 django_csp==3.4 \
     --hash=sha256:096b634430d8ea81c3d9f216f87be890f3a975c17bb9a4631f6a1619ac09c91e \
     --hash=sha256:04c0ccd4e1339e8f6af48c55c3347dc996fde2d22d79e8bf2f6b7a920412e408

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -23,9 +23,8 @@
 # requirements/default.txt contains all dependencies required to run python in the production environment.
 -r default.txt
 
-django-debug-toolbar==1.4 \
-    --hash=sha256:0cbae8760f4851d480a70b72ace5b075f8191ecf899bc97427715e50fb0e90b9 \
-    --hash=sha256:852a37b80df9597048591ebc87d0ce85a4edceaef015dc5360ad89cc5960c27b
+django-debug-toolbar==2.2 \
+    --hash=sha256:ff94725e7aae74b133d0599b9bf89bd4eb8f5d2c964106e61d11750228c8774c
 django-extensions==1.6.7 \
     --hash=sha256:7c33f1be6acf7414539cfdef2967bf6240d3c9317551b5d84622dff7824cd3c6 \
     --hash=sha256:ebdfc329207231f63b5ccb591407aadbc1a524af752e52690f0646eb7ff52943


### PR DESCRIPTION
I had to upgrade some of the dependencies because their middlewares didn't support Django 2.0.
@Pike @adngdb r?