### PR TITLE
Fix bug 1611666 - Prevent loss of letters while typing in the search …

### DIFF
--- a/frontend/src/modules/search/components/SearchBox.js
+++ b/frontend/src/modules/search/components/SearchBox.js
@@ -113,10 +113,7 @@ export class SearchBoxBase extends React.Component<InternalProps, State> {
             });
         }
 
-        const searchParam = props.parameters.search;
-
         this.setState({
-            search: searchParam ? searchParam.toString() : '',
             statuses,
             extras,
             tags,
@@ -129,6 +126,14 @@ export class SearchBoxBase extends React.Component<InternalProps, State> {
         // $FLOW_IGNORE (errors that I don't understand, no help from the Web)
         document.addEventListener('keydown', this.handleShortcuts);
         this.updateFiltersFromURLParams();
+
+        // On mount, update the search input content based on URL.
+        // This is not in the `updateFiltersFromURLParams` method because we want to
+        // do this *only* on mount. The behavior is slightly different on update.
+        const searchParam = this.props.parameters.search;
+        this.setState({
+            search: searchParam ? searchParam.toString() : '',
+        });
     }
 
     componentDidUpdate(prevProps: InternalProps) {


### PR DESCRIPTION
…input.

There was a concurrency issue created by the fact that the search input content was being loaded from the URL params every time those changed. That meant that, if the user was typing at just the right time, they would 1. update the search state variable 2. trigger a search after a delay, which updates the URL 3. update the search state variable with a new letter 4. the search content gets set to the previous state because of the URL update, erasing the last letter the user typed. This patch fixes this problem by only updating the search state variable on mount or if it is empty in the new URL.