### PR TITLE
Fix Bug 1584180: run quality checks using bulk_run_checks and simplify stats.

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -17,6 +17,7 @@ from django.db.models.functions import Length, Substr, Cast
 from partial_index import PartialIndex, PQ
 from six.moves import reduce
 from six.moves.urllib.parse import urlencode, urlparse
+from bulk_update.helper import bulk_update
 
 from django.conf import settings
 from django.contrib.auth.models import User, Group
@@ -3259,6 +3260,40 @@ class TranslatedResourceQuerySet(models.QuerySet):
                 )
 
         return translated_resources.aggregated_stats()
+
+    def update_stats(self, locales):
+        """Update stats on a list of TranslatedResource.
+        """
+        translated_resources = list(self)
+        projects = set()
+        for translated_resource in translated_resources:
+            projects.add(translated_resource.resource.project)
+            translated_resource.calculate_stats(save=False)
+
+        bulk_update(
+            translated_resources,
+            update_fields=[
+                "total_strings",
+                "approved_strings",
+                "fuzzy_strings",
+                "strings_with_errors",
+                "strings_with_warnings",
+                "unreviewed_strings",
+            ],
+        )
+
+        for locale in locales:
+            locale.aggregate_stats()
+
+        for project in projects:
+            project.aggregate_stats()
+            for locale in locales:
+                try:
+                    ProjectLocale.objects.get(
+                        locale=locale, project=project
+                    ).aggregate_stats()
+                except ProjectLocale.DoesNotExist:
+                    pass
 
 
 class TranslatedResource(AggregatedStats):

--- a/pontoon/batch/views.py
+++ b/pontoon/batch/views.py
@@ -132,7 +132,7 @@ def batch_edit_translations(request):
         )
 
     tr_pks = [tr.pk for tr in action_status["translated_resources"]]
-    TranslatedResource.objects.filter(pk__in=tr_pks).update_stats([locale])
+    TranslatedResource.objects.filter(pk__in=tr_pks).update_stats()
 
     mark_changed_translation(action_status["changed_entities"], locale)
 

--- a/pontoon/batch/views.py
+++ b/pontoon/batch/views.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import
 
 import logging
 
-from bulk_update.helper import bulk_update
-
 from django.contrib.auth.decorators import login_required
 from django.db import transaction
 from django.http import JsonResponse
@@ -15,9 +13,9 @@ from pontoon.base.models import (
     Entity,
     Locale,
     Project,
-    ProjectLocale,
     TranslationMemoryEntry,
     Translation,
+    TranslatedResource,
 )
 from pontoon.base.utils import (
     require_AJAX,
@@ -28,33 +26,6 @@ from pontoon.batch.actions import ACTIONS_FN_MAP
 
 
 log = logging.getLogger(__name__)
-
-
-def update_stats(translated_resources, locale):
-    """Update stats on a list of TranslatedResource.
-    """
-    projects = set()
-    for translated_resource in translated_resources:
-        projects.add(translated_resource.resource.project)
-        translated_resource.calculate_stats(save=False)
-
-    bulk_update(
-        translated_resources,
-        update_fields=[
-            "total_strings",
-            "approved_strings",
-            "fuzzy_strings",
-            "strings_with_errors",
-            "strings_with_warnings",
-            "unreviewed_strings",
-        ],
-    )
-
-    locale.aggregate_stats()
-
-    for project in projects:
-        project.aggregate_stats()
-        ProjectLocale.objects.get(locale=locale, project=project).aggregate_stats()
 
 
 def mark_changed_translation(changed_entities, locale):
@@ -160,7 +131,9 @@ def batch_edit_translations(request):
             {"count": 0, "invalid_translation_count": invalid_translation_count}
         )
 
-    update_stats(action_status["translated_resources"], locale)
+    tr_pks = [tr.pk for tr in action_status["translated_resources"]]
+    TranslatedResource.objects.filter(pk__in=tr_pks).update_stats([locale])
+
     mark_changed_translation(action_status["changed_entities"], locale)
 
     # Update latest translation.

--- a/pontoon/pretranslation/pretranslate.py
+++ b/pontoon/pretranslation/pretranslate.py
@@ -95,7 +95,6 @@ def update_changed_instances(tr_filter, tr_dict, locale_dict, translations):
             data["latest_translation_index"]
         ]
 
-        # Since the translations fall into fuzzy category.
         locale.fuzzy_strings += data["fuzzy_translation_count"]
         projectlocale.fuzzy_strings += data["fuzzy_translation_count"]
 

--- a/pontoon/pretranslation/pretranslate.py
+++ b/pontoon/pretranslation/pretranslate.py
@@ -79,26 +79,59 @@ def update_changed_instances(tr_filter, tr_dict, locale_dict, translations):
     )
 
     for tr in translatedresources:
-        index, diff = tr_dict[tr.locale_resource]
-        tr.latest_translation = translations[index]
-        tr.fuzzy_strings += diff
+        data = tr_dict[tr.locale_resource]
+        tr.latest_translation = translations[data["latest_translation_index"]]
+        tr.fuzzy_strings += data["fuzzy_translation_count"]
+        tr.strings_with_warnings += data["warning_count"]
+        tr.strings_with_errors += data["error_count"]
         tr_list.append(tr)
 
-    for locale, index, diff in locale_dict.values():
+    for data in locale_dict.values():
+        locale = data["locale"]
         projectlocale = locale.fetched_project_locale[0]
 
-        locale.latest_translation = translations[index]
-        projectlocale.latest_translation = translations[index]
+        locale.latest_translation = translations[data["latest_translation_index"]]
+        projectlocale.latest_translation = translations[
+            data["latest_translation_index"]
+        ]
 
         # Since the translations fall into fuzzy category.
-        locale.fuzzy_strings += diff
-        projectlocale.fuzzy_strings += diff
+        locale.fuzzy_strings += data["fuzzy_translation_count"]
+        projectlocale.fuzzy_strings += data["fuzzy_translation_count"]
+
+        locale.strings_with_errors += data["error_count"]
+        projectlocale.strings_with_errors += data["error_count"]
+
+        locale.strings_with_warnings += data["warning_count"]
+        projectlocale.strings_with_warnings += data["warning_count"]
 
         locale_list.append(locale)
         projectlocale_list.append(projectlocale)
 
-    bulk_update(locale_list, update_fields=["latest_translation", "fuzzy_strings"])
     bulk_update(
-        projectlocale_list, update_fields=["latest_translation", "fuzzy_strings"]
+        locale_list,
+        update_fields=[
+            "latest_translation",
+            "fuzzy_strings",
+            "strings_with_warnings",
+            "strings_with_errors",
+        ],
     )
-    bulk_update(tr_list, update_fields=["latest_translation", "fuzzy_strings"])
+    bulk_update(
+        projectlocale_list,
+        update_fields=[
+            "latest_translation",
+            "fuzzy_strings",
+            "strings_with_warnings",
+            "strings_with_errors",
+        ],
+    )
+    bulk_update(
+        tr_list,
+        update_fields=[
+            "latest_translation",
+            "fuzzy_strings",
+            "strings_with_warnings",
+            "strings_with_errors",
+        ],
+    )

--- a/pontoon/pretranslation/pretranslate.py
+++ b/pontoon/pretranslation/pretranslate.py
@@ -56,7 +56,7 @@ def get_translations(entity, locale):
     return strings
 
 
-def update_changed_instances(tr_filter, tr_dict, locale_list, translations):
+def update_changed_instances(tr_filter, tr_dict, translations):
     """
     Update the latest activity and stats for changed Locales, ProjectLocales
     & TranslatedResources
@@ -73,7 +73,7 @@ def update_changed_instances(tr_filter, tr_dict, locale_list, translations):
         )
     )
 
-    translatedresources.update_stats(locale_list)
+    translatedresources.update_stats()
 
     for tr in translatedresources:
         index = tr_dict[tr.locale_resource]

--- a/pontoon/pretranslation/pretranslate.py
+++ b/pontoon/pretranslation/pretranslate.py
@@ -81,7 +81,7 @@ def update_changed_instances(tr_filter, tr_dict, locale_dict, translations):
     for tr in translatedresources:
         index, diff = tr_dict[tr.locale_resource]
         tr.latest_translation = translations[index]
-        tr.unreviewed_strings += diff
+        tr.fuzzy_strings += diff
         tr_list.append(tr)
 
     for locale, index, diff in locale_dict.values():
@@ -90,15 +90,15 @@ def update_changed_instances(tr_filter, tr_dict, locale_dict, translations):
         locale.latest_translation = translations[index]
         projectlocale.latest_translation = translations[index]
 
-        # Since the translations fall into unreviewed category.
-        locale.unreviewed_strings += diff
-        projectlocale.unreviewed_strings += diff
+        # Since the translations fall into fuzzy category.
+        locale.fuzzy_strings += diff
+        projectlocale.fuzzy_strings += diff
 
         locale_list.append(locale)
         projectlocale_list.append(projectlocale)
 
-    bulk_update(locale_list, update_fields=["latest_translation", "unreviewed_strings"])
+    bulk_update(locale_list, update_fields=["latest_translation", "fuzzy_strings"])
     bulk_update(
-        projectlocale_list, update_fields=["latest_translation", "unreviewed_strings"]
+        projectlocale_list, update_fields=["latest_translation", "fuzzy_strings"]
     )
-    bulk_update(tr_list, update_fields=["latest_translation", "unreviewed_strings"])
+    bulk_update(tr_list, update_fields=["latest_translation", "fuzzy_strings"])

--- a/pontoon/pretranslation/pretranslate.py
+++ b/pontoon/pretranslation/pretranslate.py
@@ -81,50 +81,9 @@ def update_changed_instances(tr_filter, tr_dict, locale_dict, translations):
     for tr in translatedresources:
         data = tr_dict[tr.locale_resource]
         tr.latest_translation = translations[data["latest_translation_index"]]
-        tr.fuzzy_strings += data["fuzzy_translation_count"]
-        tr.strings_with_warnings += data["warning_count"]
-        tr.strings_with_errors += data["error_count"]
+        tr.calculate_stats(save=False)
         tr_list.append(tr)
 
-    for data in locale_dict.values():
-        locale = data["locale"]
-        projectlocale = locale.fetched_project_locale[0]
-
-        locale.latest_translation = translations[data["latest_translation_index"]]
-        projectlocale.latest_translation = translations[
-            data["latest_translation_index"]
-        ]
-
-        locale.fuzzy_strings += data["fuzzy_translation_count"]
-        projectlocale.fuzzy_strings += data["fuzzy_translation_count"]
-
-        locale.strings_with_errors += data["error_count"]
-        projectlocale.strings_with_errors += data["error_count"]
-
-        locale.strings_with_warnings += data["warning_count"]
-        projectlocale.strings_with_warnings += data["warning_count"]
-
-        locale_list.append(locale)
-        projectlocale_list.append(projectlocale)
-
-    bulk_update(
-        locale_list,
-        update_fields=[
-            "latest_translation",
-            "fuzzy_strings",
-            "strings_with_warnings",
-            "strings_with_errors",
-        ],
-    )
-    bulk_update(
-        projectlocale_list,
-        update_fields=[
-            "latest_translation",
-            "fuzzy_strings",
-            "strings_with_warnings",
-            "strings_with_errors",
-        ],
-    )
     bulk_update(
         tr_list,
         update_fields=[
@@ -133,4 +92,25 @@ def update_changed_instances(tr_filter, tr_dict, locale_dict, translations):
             "strings_with_warnings",
             "strings_with_errors",
         ],
+    )
+
+    for data in locale_dict.values():
+        locale = data["locale"]
+        projectlocale = locale.fetched_project_locale[0]
+        locale.aggregate_stats()
+        projectlocale.aggregate_stats()
+
+        locale.latest_translation = translations[data["latest_translation_index"]]
+        projectlocale.latest_translation = translations[
+            data["latest_translation_index"]
+        ]
+
+        locale_list.append(locale)
+        projectlocale_list.append(projectlocale)
+
+    bulk_update(
+        locale_list, update_fields=["latest_translation"],
+    )
+    bulk_update(
+        projectlocale_list, update_fields=["latest_translation"],
     )

--- a/pontoon/pretranslation/tasks.py
+++ b/pontoon/pretranslation/tasks.py
@@ -176,9 +176,7 @@ def pretranslate(self, project_pk, locales=None, entities=None):
 
     # Update latest activity and fuzzy count for the project.
     project.latest_translation = translations[-1]
-    project.save(
-        update_fields=["latest_translation"]
-    )
+    project.save(update_fields=["latest_translation"])
     project.aggregate_stats()
 
     print("####Update Stats Finished:", time.time() - start)

--- a/pontoon/pretranslation/tasks.py
+++ b/pontoon/pretranslation/tasks.py
@@ -223,7 +223,7 @@ def pretranslate(self, project_pk, locales=None, entities=None):
         ]
     )
 
-    # Update latest activity and fuzzy count for changed instances.
+    # Update latest activity and stats for changed instances.
     update_changed_instances(tr_filter, tr_dict, locale_dict, translations)
 
     log.info("Fetching pretranslations for project {} done".format(project.name))

--- a/pontoon/pretranslation/tasks.py
+++ b/pontoon/pretranslation/tasks.py
@@ -85,9 +85,7 @@ def pretranslate(self, project_pk, locales=None, entities=None):
 
     translations = []
 
-    # To keep track of changed Locales and TranslatedResources
-    # Also, their latest_translation and stats count
-    locale_set = set()
+    # To keep track of changed TranslatedResources and their latest_translation
     tr_dict = {}
 
     tr_filter = []
@@ -120,7 +118,6 @@ def pretranslate(self, project_pk, locales=None, entities=None):
 
                 index += 1
                 translations.append(t)
-                locale_set.add(locale)
 
                 if locale_resource not in tr_dict:
                     tr_dict[locale_resource] = index
@@ -140,6 +137,7 @@ def pretranslate(self, project_pk, locales=None, entities=None):
 
     translations = Translation.objects.bulk_create(translations)
 
+    # Run checks on all translations
     translation_pks = {translation.pk for translation in translations}
     bulk_run_checks(Translation.objects.for_checks().filter(pk__in=translation_pks))
 
@@ -156,6 +154,6 @@ def pretranslate(self, project_pk, locales=None, entities=None):
     ChangedEntityLocale.objects.bulk_create(changed_entities.values())
 
     # Update latest activity and stats for changed instances.
-    update_changed_instances(tr_filter, tr_dict, list(locale_set), translations)
+    update_changed_instances(tr_filter, tr_dict, translations)
 
     log.info("Fetching pretranslations for project {} done".format(project.name))

--- a/pontoon/pretranslation/tasks.py
+++ b/pontoon/pretranslation/tasks.py
@@ -4,6 +4,7 @@ from django.db.models import Q, CharField, Value as V
 from django.db.models.functions import Concat
 from django.conf import settings
 from pontoon.base.models import (
+    Project,
     Entity,
     TranslatedResource,
     Translation,

--- a/pontoon/pretranslation/tests/test_tasks.py
+++ b/pontoon/pretranslation/tests/test_tasks.py
@@ -49,8 +49,8 @@ def test_pretranslate(gt_mock, project_a, locale_a, resource_a, locale_b):
     # Total pretranslations = 2(tr_ax) + 2(tr_bx) + 2(tr_ay)
     assert len(translations) == 6
 
-    # unreviewed count == total pretranslations.
-    assert project_a.unreviewed_strings == 6
+    # fuzzy count == total pretranslations.
+    assert project_a.fuzzy_strings == 6
 
     # latest_translation belongs to pretranslations.
     assert project_a.latest_translation in translations


### PR DESCRIPTION
Hey! There are two changes from #1553 
* Run checks "elegantly" using the `bulk_run_checks` method the downside of which I thought was time taken for stats calculation
* Use [bulk_update](https://github.com/mozilla/pontoon/blob/master/pontoon/batch/views.py#L33-L57) logic for stats calculation (We can also try to modify the original method a bit to make it suitable for pretranslation use case i.e. single project & multiple locales. 

I tested both versions on [pontoon-test](https://github.com/mathjazz/pontoon-test/) for a single locale. Here are the time taken for different parts:

**The current PR** 
- Collecting Translations Finished: 50.1863968372345
- Checks Finished: 0.5103518962860107
- Mark as changed Finished: 0.08880019187927246
- Update Stats Finished: 0.5324735641479492

#1553 
- Collecting Translations Finished: 43.390445709228516
- Checks Finished: 0.0789637565612793
- Mark Translation Active Finished: 0.023960351943969727
- Stats and latest activity Finished: 0.04465889930725098

As @mathjazz pointed out earlier, the most time-consuming part is collecting pretranslation, We can simplify the code for stats calculation (and may be latest_translation)