### PR TITLE
Fix bug 1616918 - Enforce newline at end of Fluent strings when compa…

### DIFF
--- a/frontend/src/core/editor/selectors.js
+++ b/frontend/src/core/editor/selectors.js
@@ -73,8 +73,17 @@ export function _existingTranslation(
                     fluent.getReconstructedMessage(entity.original, translation)
                 );
                 existingTranslation = history.translations.find(
-                    t => t.string === reconstructed
-                )
+                    t => {
+                        // Some Fluent strings are missing the trailing newline
+                        // character while stored in the database. In order for this
+                        // comparison to work, we need to make sure it is there.
+                        let str = t.string;
+                        if (!str.endsWith('\n')) {
+                            str += '\n';
+                        }
+                        return str === reconstructed;
+                    }
+                );
             }
             else {
                 existingTranslation = history.translations.find(

--- a/frontend/src/core/editor/selectors.js
+++ b/frontend/src/core/editor/selectors.js
@@ -70,17 +70,17 @@ export function _existingTranslation(
                 // we want to turn the string into a Fluent message, as that's simpler
                 // to handle and less prone to errors. We do the same for each history
                 // entry.
-                let ftlMessage = fluent.parser.parseEntry(translation);
-                if (ftlMessage.type === 'Junk') {
+                let fluentTranslation = fluent.parser.parseEntry(translation);
+                if (fluentTranslation.type === 'Junk') {
                     // If the message was junk, it means we are likely in the Simple
                     // editor, and we thus want to reconstruct the Fluent message.
                     // Note that if the user is actually in the Source editor, and
                     // entered an invalid value (which creates this junk entry),
                     // it doesn't matter as there shouldn't be anything matching anyway.
-                    ftlMessage = fluent.getReconstructedMessage(entity.original, translation);
+                    fluentTranslation = fluent.getReconstructedMessage(entity.original, translation);
                 }
                 existingTranslation = history.translations.find(
-                    t => ftlMessage.equals(fluent.parser.parseEntry(t.string))
+                    t => fluentTranslation.equals(fluent.parser.parseEntry(t.string))
                 );
             }
             else {

--- a/frontend/src/modules/fluenteditor/components/Editor.js
+++ b/frontend/src/modules/fluenteditor/components/Editor.js
@@ -146,7 +146,11 @@ export class EditorBase extends React.Component<EditorProps, State> {
             }
         }
 
-        props.setInitialTranslation(translationContent);
+        // Update the initial translation content only when the entity changed, not
+        // when new content is loaded from an external source.
+        if (typeof translation === 'undefined') {
+            props.setInitialTranslation(translationContent);
+        }
         props.updateTranslation(translationContent, true);
     }
 

--- a/frontend/src/modules/genericeditor/components/Editor.js
+++ b/frontend/src/modules/genericeditor/components/Editor.js
@@ -12,6 +12,7 @@ import type { EditorProps } from 'core/editor';
 
 export class EditorBase extends React.Component<EditorProps> {
     componentDidMount() {
+        this.props.setInitialTranslation(this.props.activeTranslationString);
         this.props.updateTranslation(this.props.activeTranslationString, true);
     }
 
@@ -22,6 +23,7 @@ export class EditorBase extends React.Component<EditorProps> {
             pluralForm !== prevProps.pluralForm ||
             entity !== prevProps.entity
         ) {
+            this.props.setInitialTranslation(activeTranslationString);
             this.props.updateTranslation(activeTranslationString, true);
         }
     }

--- a/frontend/src/modules/genericeditor/components/Editor.test.js
+++ b/frontend/src/modules/genericeditor/components/Editor.test.js
@@ -22,26 +22,33 @@ const ENTITIES = [
 
 
 function createEditorBase() {
+    const setInitialTranslationMock = sinon.stub();
     const updateTranslationMock = sinon.stub();
     const wrapper = shallow(<EditorBase
         editor={ { translation: '' } }
         pluralForm={ -1 }
         entity={ ENTITIES[0] }
         activeTranslationString={ ENTITIES[0].translation[0].string }
+        setInitialTranslation={ setInitialTranslationMock }
         updateTranslation={ updateTranslationMock }
     />);
 
-    return [wrapper, updateTranslationMock];
+    return [wrapper, setInitialTranslationMock, updateTranslationMock];
 }
 
 
 describe('<Editor>', () => {
     it('updates translation on mount', () => {
-        const [, updateTranslationMock] = createEditorBase();
+        const [, , updateTranslationMock] = createEditorBase();
         expect(updateTranslationMock.calledOnce).toBeTruthy();
     });
 
-    it('updates translation on component update', () => {
+    it('sets initial translation on mount', () => {
+        const [, setInitialTranslationMock, ] = createEditorBase();
+        expect(setInitialTranslationMock.calledOnce).toBeTruthy();
+    });
+
+    it('updates translation when entity or plural change', () => {
         const [wrapper, updateTranslationMock] = createEditorBase();
         expect(updateTranslationMock.calledOnce).toBeTruthy();
 
@@ -50,5 +57,32 @@ describe('<Editor>', () => {
 
         wrapper.setProps({ pluralForm: 1 });
         expect(updateTranslationMock.calledThrice).toBeTruthy();
+    });
+
+    it('sets initial translation when entity or plural change', () => {
+        const [wrapper, setInitialTranslationMock, ] = createEditorBase();
+        expect(setInitialTranslationMock.calledOnce).toBeTruthy();
+
+        wrapper.setProps({ entity: ENTITIES[1] });
+        expect(setInitialTranslationMock.calledTwice).toBeTruthy();
+
+        wrapper.setProps({ pluralForm: 1 });
+        expect(setInitialTranslationMock.calledThrice).toBeTruthy();
+    });
+
+    it('does not update translation when translation changes', () => {
+        const [wrapper, updateTranslationMock] = createEditorBase();
+        expect(updateTranslationMock.calledOnce).toBeTruthy();
+
+        wrapper.setProps({ editor: { translation: 'hello' } });
+        expect(updateTranslationMock.calledOnce).toBeTruthy();
+    });
+
+    it('does not set initial translation when translation changes', () => {
+        const [wrapper, setInitialTranslationMock, ] = createEditorBase();
+        expect(setInitialTranslationMock.calledOnce).toBeTruthy();
+
+        wrapper.setProps({ editor: { translation: 'hello' } });
+        expect(setInitialTranslationMock.calledOnce).toBeTruthy();
     });
 });

--- a/frontend/src/modules/genericeditor/components/GenericTranslationForm.js
+++ b/frontend/src/modules/genericeditor/components/GenericTranslationForm.js
@@ -22,11 +22,6 @@ export default class GenericTranslationForm extends React.Component<EditorProps>
     }
 
     componentDidUpdate(prevProps: EditorProps) {
-        // Unused by Generic Editor - reset to default value.
-        if (this.props.editor.initialTranslation) {
-            return this.props.setInitialTranslation('');
-        }
-
         // Close failed checks popup when content of the editor changes,
         // but only if the errors and warnings did not change
         // meaning they were already shown in the previous render


### PR DESCRIPTION
…ring.

This solves a detection problem with simple Fluent strings, where the newline is missing from some Fluent string in history. This enforces trailing newlines, making the selector find the correct similar translation.