### PR TITLE
Update @fluent/bundle 0.15, @fluent/syntax 0.15

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@fluent/bundle": "^0.14.0",
+    "@fluent/bundle": "^0.15.0",
     "@fluent/langneg": "^0.3.0",
     "@fluent/react": "^0.10.0",
-    "@fluent/syntax": "^0.14.0",
+    "@fluent/syntax": "^0.15.0",
     "abortcontroller-polyfill": "1.3.0",
     "brace": "0.11.1",
     "connected-react-router": "6.6.1",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -988,10 +988,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.4.tgz#a87b4b04e5ae14a88d48ebef15015f6b7d1f5677"
   integrity sha512-kBa+cDHOR9jpRJ+kcGMsysrls0leukrm68DmFQoMIWQcXdr2cZvyvypWuGYT7U+9kAExUE7+T7r6G3C3A6L8MQ==
 
-"@fluent/bundle@^0.14.0":
-  version "0.14.1"
-  resolved "https://registry.yarnpkg.com/@fluent/bundle/-/bundle-0.14.1.tgz#634d88d0ee8c92bc69acf1f15a649325f6f8f848"
-  integrity sha512-0uguRGajpI897/Uhx0KNkSiz+F+GWhgRAPfvHfuGgWl2Szd3JNEHyxmRmPXgnsfYX51piq2O4Jdu4zgjmUBUhA==
+"@fluent/bundle@^0.15.0":
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/@fluent/bundle/-/bundle-0.15.0.tgz#c123ea08d066d8b987eae5ceaa6632451609efaf"
+  integrity sha512-pYz+TuFPwCj5yx51mFG1flPxwTaXWkpi6yt6r+rdm22Y9bkWMHWdwbUnjWLJ+9yJKQMhe2uhvMJ7YfhkF87oNg==
 
 "@fluent/langneg@^0.3.0":
   version "0.3.0"
@@ -1012,10 +1012,10 @@
   resolved "https://registry.yarnpkg.com/@fluent/sequence/-/sequence-0.4.0.tgz#ddba05770fa8a1259dca302ca3530af26c38599a"
   integrity sha512-ADP/GYbmQZ8DxBHzLGN4I1Vrq0h+ujQuIa9O8E4+Fh5MiSUtPNW0sSH/NzikmAPPQ5cnz5cb53OBv54ANrsvCw==
 
-"@fluent/syntax@^0.14.0":
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/@fluent/syntax/-/syntax-0.14.0.tgz#f3560783f062a04905a1e36d189659968135f5a9"
-  integrity sha512-E+1yHdSo/4PTS6bCbj5J+kzEpucf3eJ0U5mLk7VtnUiMvlPHSbmEL68GLCL9QNTOP3laxZtCHCYDD0Ci/2n97w==
+"@fluent/syntax@^0.15.0":
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/@fluent/syntax/-/syntax-0.15.0.tgz#4b05bc16e6d620a9b230f37cca269a4d56e35553"
+  integrity sha512-NIObEPekXiaDDO10NQSOeylOETaI2Ns/ymKJNvgkM6FcBARS+t3NVGyLPPIl/pqHDUB9v7bWeEmuVMJQjnpNeg==
 
 "@hapi/address@2.x.x":
   version "2.1.4"

--- a/package.json
+++ b/package.json
@@ -12,9 +12,6 @@
     "Safari >= 10.1",
     "iOS >= 10.3"
   ],
-  "dependencies": {
-    "fluent-syntax": "^0.12.0"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/mozilla/pontoon.git"


### PR DESCRIPTION
The following two packages are now written in TypeScript.
 
- @fluent/bundle 0.15.0
- @fluent/syntax 0.15.0

The API has not changed except for the fact that it's now not possible to pass a JSON dump of an AST to `FluentSerialize`; instead a proper `SyntaxNode` object is required. This applies to `serialize`, `serializeEntry` and `serializeExpression` and `serializeVariantKey`.

I tested this locally and everything looks fine.