### PR TITLE
Invert diff in the History panel

### DIFF
--- a/frontend/src/core/diff/withDiff.js
+++ b/frontend/src/core/diff/withDiff.js
@@ -43,7 +43,7 @@ export default function withDiff<Config: Object>(
 ): React.AbstractComponent<Config> {
     return function WithDiff(props: { ...Config, ...Props }) {
         return <WrappedComponent { ...props }>
-            { getDiff(props.children, props.diffTarget) }
+            { getDiff(props.diffTarget, props.children) }
         </WrappedComponent>;
     };
 }

--- a/frontend/src/modules/machinery/components/Translation.js
+++ b/frontend/src/modules/machinery/components/Translation.js
@@ -73,8 +73,8 @@ export default class Translation extends React.Component<Props> {
                 <p className="original">
                     { types.indexOf('caighdean') === -1 ?
                         <GenericTranslation
-                            content={ sourceString }
-                            diffTarget={ translation.original }
+                            content={ translation.original }
+                            diffTarget={ sourceString }
                         />
                     :
                         /*


### PR DESCRIPTION
This patch makes the diff consistent in the Machinery and History tab.

Before:
https://pontoon.mozilla.org/sl/firefox/browser/chrome/browser/browser.dtd/?string=153898

After
https://mozilla-pontoon-staging.herokuapp.com/sl/firefox/browser/chrome/browser/browser.dtd/?string=153898