### PR TITLE
Fix bug 1621720: Send notifications on comment submissions

### DIFF
--- a/frontend/src/core/user/components/UserNotification.css
+++ b/frontend/src/core/user/components/UserNotification.css
@@ -58,8 +58,10 @@
     padding: 10px;
 }
 
-.user-notification .message {
-    padding: 10px;
+.user-notification .message.trim {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 /* Users can include HTML tags in their messages */

--- a/frontend/src/core/user/components/UserNotification.js
+++ b/frontend/src/core/user/components/UserNotification.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import * as React from 'react';
+import Linkify from 'react-linkify';
 import ReactTimeAgo from 'react-time-ago'
 
 import './UserNotification.css';
@@ -74,15 +75,22 @@ export default class UserNotification extends React.Component<Props, State> {
                     title={ `${notification.date} UTC` }
                 />
 
-                { !notification.description ? null :
-                    <div
-                        className="message"
-                        // We can safely use notification.description as it is either generated
-                        // by the code or sanitized when coming from the DB. See:
-                        //   - pontoon.projects.forms.NotificationsForm()
-                        //   - pontoon.base.forms.HtmlField()
-                        dangerouslySetInnerHTML={{ __html: notification.description }}
-                    />
+                { !notification.description.content ? null :
+                    notification.description.safe ?
+                        <div
+                            className="message"
+                            // We can safely use notification.description as it is either generated
+                            // by the code or sanitized when coming from the DB. See:
+                            //   - pontoon.projects.forms.NotificationsForm()
+                            //   - pontoon.base.forms.HtmlField()
+                            dangerouslySetInnerHTML={ { __html: notification.description.content } }
+                        />
+                        :
+                        <div className="message trim">
+                            <Linkify properties={ { target: '_blank', rel: 'noopener noreferrer' } }>
+                                { notification.description.content }
+                            </Linkify>
+                        </div>
                 }
             </div>
         </li>;

--- a/frontend/src/core/user/components/UserNotificationsMenu.css
+++ b/frontend/src/core/user/components/UserNotificationsMenu.css
@@ -63,7 +63,6 @@
     color: #aaa;
     font-size: 14px;
     font-weight: 300;
-    padding: 0 4px;
 }
 
 .user-notifications-menu .menu li:hover {

--- a/frontend/src/core/user/reducer.js
+++ b/frontend/src/core/user/reducer.js
@@ -49,7 +49,10 @@ export type Notification = {|
     +id: number,
     +level: string,
     +unread: string,
-    +description: string,
+    +description: {
+        +content: string,
+        +safe: boolean,
+    },
     +verb: string,
     +date: string,
     +date_iso: string,

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -269,7 +269,7 @@ def menu_notifications(self):
     if unread_count > count:
         count = unread_count
 
-    return self.notifications.prefetch_related("actor", "target")[:count]
+    return self.notifications.prefetch_related("actor", "target", "action_object")[:count]
 
 
 @property
@@ -282,8 +282,10 @@ def serialized_notifications(self):
     if unread_count > count:
         count = unread_count
 
-    for notification in self.notifications.prefetch_related("actor", "target")[:count]:
+    for notification in self.notifications.prefetch_related("actor", "target", "action_object")[:count]:
         actor = None
+        description_safe = True
+
         if hasattr(notification.actor, "slug"):
             actor = {
                 "anchor": notification.actor.name,
@@ -302,20 +304,41 @@ def serialized_notifications(self):
 
         target = None
         if notification.target:
-            target = {
-                "anchor": notification.target.name,
-                "url": reverse(
-                    "pontoon.projects.project",
-                    kwargs={"slug": notification.target.slug},
-                ),
-            }
+            t = notification.target
+            # New string or Manual notification
+            if hasattr(t, "slug"):
+                target = {
+                    "anchor": t.name,
+                    "url": reverse(
+                        "pontoon.projects.project",
+                        kwargs={"slug": t.slug},
+                    ),
+                }
+
+            # Comment notifications
+            elif hasattr(t, "resource"):
+                description_safe = False
+                target = {
+                    "anchor": t.resource.project.name,
+                    "url": reverse(
+                        "pontoon.translate",
+                        kwargs={
+                            "locale": notification.action_object.code,
+                            "project": t.resource.project.slug,
+                            "resource": t.resource.path,
+                        },
+                    ) + "?string={entity}".format(entity=t.pk),
+                }
 
         notifications.append(
             {
                 "id": notification.id,
                 "level": notification.level,
                 "unread": notification.unread,
-                "description": notification.description,
+                "description": {
+                    "content": notification.description,
+                    "safe": description_safe,
+                },
                 "verb": notification.verb,
                 "date": notification.timestamp.strftime("%b %d, %Y %H:%M"),
                 "date_iso": notification.timestamp.isoformat(),

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -269,7 +269,9 @@ def menu_notifications(self):
     if unread_count > count:
         count = unread_count
 
-    return self.notifications.prefetch_related("actor", "target", "action_object")[:count]
+    return self.notifications.prefetch_related("actor", "target", "action_object")[
+        :count
+    ]
 
 
 @property
@@ -282,7 +284,9 @@ def serialized_notifications(self):
     if unread_count > count:
         count = unread_count
 
-    for notification in self.notifications.prefetch_related("actor", "target", "action_object")[:count]:
+    for notification in self.notifications.prefetch_related(
+        "actor", "target", "action_object"
+    )[:count]:
         actor = None
         description_safe = True
 
@@ -310,8 +314,7 @@ def serialized_notifications(self):
                 target = {
                     "anchor": t.name,
                     "url": reverse(
-                        "pontoon.projects.project",
-                        kwargs={"slug": t.slug},
+                        "pontoon.projects.project", kwargs={"slug": t.slug},
                     ),
                 }
 
@@ -327,7 +330,8 @@ def serialized_notifications(self):
                             "project": t.resource.project.slug,
                             "resource": t.resource.path,
                         },
-                    ) + "?string={entity}".format(entity=t.pk),
+                    )
+                    + "?string={entity}".format(entity=t.pk),
                 }
 
         notifications.append(

--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -806,8 +806,10 @@ header .right .select .menu {
   padding: 10px;
 }
 
-.notifications .menu li.notification-item .message {
-  padding: 10px;
+.notifications .menu li.notification-item .message.trim {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Users can include HTML tags in their messages */

--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -7,6 +7,7 @@ import json
 import jinja2
 from allauth.socialaccount import providers
 from allauth.utils import get_request_param
+from bleach.linkifier import Linker
 from django_jinja import library
 from fluent.syntax import FluentParser, FluentSerializer, ast
 from fluent.syntax.serializer import serialize_expression
@@ -361,3 +362,19 @@ def as_simple_translation(source):
         tree = translation_ast.attributes[0]
 
     return _serialize_value(tree.value)
+
+
+@library.filter
+def linkify(source):
+    """Render URLs in the string as links."""
+    def set_attrs(attrs, new=False):
+        attrs[(None, 'target')] = '_blank'
+        attrs[(None, 'rel')] = 'noopener noreferrer'
+        return attrs
+
+    # Escape all tags
+    linker = Linker(callbacks=[set_attrs], recognized_tags=[])
+
+    return jinja2.Markup(
+        linker.linkify(source)
+    )

--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -367,14 +367,13 @@ def as_simple_translation(source):
 @library.filter
 def linkify(source):
     """Render URLs in the string as links."""
+
     def set_attrs(attrs, new=False):
-        attrs[(None, 'target')] = '_blank'
-        attrs[(None, 'rel')] = 'noopener noreferrer'
+        attrs[(None, "target")] = "_blank"
+        attrs[(None, "rel")] = "noopener noreferrer"
         return attrs
 
     # Escape all tags
     linker = Linker(callbacks=[set_attrs], recognized_tags=[])
 
-    return jinja2.Markup(
-        linker.linkify(source)
-    )
+    return jinja2.Markup(linker.linkify(source))

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -462,7 +462,7 @@ def _send_add_comment_notifications(user, comment, entity, locale, translation):
     #   - authors of other translation comments in the thread
     #   - translation author
     if translation:
-        recipients = list(translation.comments.values_list('author__pk', flat=True))
+        recipients = list(translation.comments.values_list("author__pk", flat=True))
         recipients.append(translation.user.pk)
 
     # On team comment, notify:
@@ -475,8 +475,7 @@ def _send_add_comment_notifications(user, comment, entity, locale, translation):
     else:
         recipients = []
         project_locale = ProjectLocale.objects.get(
-            project=entity.resource.project,
-            locale=locale,
+            project=entity.resource.project, locale=locale,
         )
         translations = Translation.objects.filter(entity=entity, locale=locale)
 
@@ -485,27 +484,27 @@ def _send_add_comment_notifications(user, comment, entity, locale, translation):
             project_locale.translators_group,
             locale.managers_group,
         ):
-            recipients.append(group.user_set.values_list('pk', flat=True))
+            recipients.append(group.user_set.values_list("pk", flat=True))
 
         recipients.append(
-            Comment.objects.filter(
-                entity=entity, locale=locale
-            ).values_list('author__pk', flat=True)
+            Comment.objects.filter(entity=entity, locale=locale).values_list(
+                "author__pk", flat=True
+            )
         )
 
         recipients.append(
-            Comment.objects.filter(
-                translation__in=translations
-            ).values_list('author__pk', flat=True)
+            Comment.objects.filter(translation__in=translations).values_list(
+                "author__pk", flat=True
+            )
         )
 
-        recipients.append(
-            translations.values_list('user__pk', flat=True)
-        )
+        recipients.append(translations.values_list("user__pk", flat=True))
 
         recipients = [item for sublist in recipients for item in sublist]
 
-    for recipient in User.objects.filter(pk__in=recipients).exclude(pk=user.pk).distinct():
+    for recipient in (
+        User.objects.filter(pk__in=recipients).exclude(pk=user.pk).distinct()
+    ):
         notify.send(
             user,
             recipient=recipient,

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -498,7 +498,9 @@ def _send_add_comment_notifications(user, comment, entity, locale, translation):
             translators = locale.translators_group.user_set.values_list("pk", flat=True)
 
         recipients = recipients.union(translators)
-        recipients = recipients.union(locale.managers_group.user_set.values_list("pk", flat=True))
+        recipients = recipients.union(
+            locale.managers_group.user_set.values_list("pk", flat=True)
+        )
 
         recipients = recipients.union(
             Comment.objects.filter(entity=entity, locale=locale).values_list(
@@ -513,10 +515,18 @@ def _send_add_comment_notifications(user, comment, entity, locale, translation):
         )
 
         recipients = recipients.union(translations.values_list("user__pk", flat=True))
-        recipients = recipients.union(translations.values_list("approved_user__pk", flat=True))
-        recipients = recipients.union(translations.values_list("unapproved_user__pk", flat=True))
-        recipients = recipients.union(translations.values_list("rejected_user__pk", flat=True))
-        recipients = recipients.union(translations.values_list("unrejected_user__pk", flat=True))
+        recipients = recipients.union(
+            translations.values_list("approved_user__pk", flat=True)
+        )
+        recipients = recipients.union(
+            translations.values_list("unapproved_user__pk", flat=True)
+        )
+        recipients = recipients.union(
+            translations.values_list("rejected_user__pk", flat=True)
+        )
+        recipients = recipients.union(
+            translations.values_list("unrejected_user__pk", flat=True)
+        )
 
     for recipient in User.objects.filter(pk__in=recipients).exclude(pk=user.pk):
         notify.send(

--- a/pontoon/contributors/templates/contributors/widgets/notifications_menu.html
+++ b/pontoon/contributors/templates/contributors/widgets/notifications_menu.html
@@ -39,18 +39,37 @@
         <span class="actor">
           <a href="{{ actor_url }}">{{ actor_anchor }}</a>
         </span>
+
         <span class="verb">{{ notification.verb }}</span>
 
-        {% if notification.target %}
-          <span class="target">
-            <a href="{{ url('pontoon.projects.project', notification.target.slug) }}">{{ notification.target }}</a>
-          </span>
+        {% set target = notification.target %}
+        {% set description_safe = True %}
+
+        {% if target %}
+          {% if target.slug %}
+            <span class="target">
+              <a href="{{ url('pontoon.projects.project', target.slug) }}">{{ target }}</a>
+            </span>
+
+          {% elif target.resource %}
+            {% set description_safe = False %}
+            {% set link = url('pontoon.translate', notification.action_object.code, target.resource.project.slug, target.resource.path) %}
+            <span class="target">
+              <a href="{{ link + '?string=' + target.pk|string }}">{{ target.resource.project.name }}</a>
+            </span>
+          {% endif %}
+        </span>
         {% endif %}
 
         <p class="timeago">{{ notification.timesince() }} ago</p>
 
-        {% if notification.description %}
-          <div class="message">{{ notification.description|safe }}</div>
+        {% set description = notification.description %}
+        {% if description %}
+          {% if description_safe %}
+            <div class="message">{{ description|safe }}</div>
+          {% else %}
+            <div class="message trim">{{ description|linkify|safe }}</div>
+          {% endif %}
         {% endif %}
       </div>
     </li>


### PR DESCRIPTION
This patch sends notifications when comments get submitted.

On translation comment (bound to translation), we notify:
- translation author
- authors of any other translation comments in the thread

On team comment (bound to entity-locale pair), we notify:
- any locale managers
- any locale translators
- any project-locale translators
- authors of any other team comments in the thread
- any translation authors
- authors of any translation comments