### PR TITLE
Fix sending comments to imported translations

### DIFF
--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -465,8 +465,8 @@ def _send_add_comment_notifications(user, comment, entity, locale, translation):
     if translation:
         recipients = set(translation.comments.values_list("author__pk", flat=True))
 
-        recipients.add(translation.user.pk)
-
+        if translation.user:
+            recipients.add(translation.user.pk)
         if translation.approved_user:
             recipients.add(translation.approved_user.pk)
         if translation.unapproved_user:


### PR DESCRIPTION
This patch fixes a server error when translation comment is submitted to a translation without an author:
```
[ERROR:django.request] 2020-03-20 11:38:41,252 Internal Server Error: /add-comment/
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/django/core/handlers/exception.py", line 41, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.7/site-packages/django/core/handlers/base.py", line 187, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/local/lib/python3.7/site-packages/django/core/handlers/base.py", line 185, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python3.7/site-packages/django/views/decorators/http.py", line 40, in inner
    return func(request, *args, **kwargs)
  File "/app/pontoon/base/utils.py", line 110, in wrap
    return f(request, *args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/django/contrib/auth/decorators.py", line 23, in _wrapped_view
    return view_func(request, *args, **kwargs)
  File "/usr/local/lib/python3.7/contextlib.py", line 74, in inner
    return func(*args, **kwds)
  File "/app/pontoon/base/views.py", line 583, in add_comment
    _send_add_comment_notifications(user, comment, entity, locale, translation)
  File "/app/pontoon/base/views.py", line 468, in _send_add_comment_notifications
    recipients.add(translation.user.pk)
AttributeError: 'NoneType' object has no attribute 'pk'
```