### PR TITLE
Use Co-authored-by in the commit message.

### DIFF
--- a/pontoon/sync/templates/sync/commit_message.jinja
+++ b/pontoon/sync/templates/sync/commit_message.jinja
@@ -1,7 +1,6 @@
 Pontoon: Update {{ locale.name }} ({{ locale.code }}) localization of {{ project.name }}
-{%- if authors %}
 
-Localization authors:
+{%- if authors %}
 {% for author in authors -%}
 Co-authored-by: {{ author.display_name_and_email|safe }}
 {% endfor %}

--- a/pontoon/sync/templates/sync/commit_message.jinja
+++ b/pontoon/sync/templates/sync/commit_message.jinja
@@ -3,6 +3,6 @@ Pontoon: Update {{ locale.name }} ({{ locale.code }}) localization of {{ project
 
 Localization authors:
 {% for author in authors -%}
-- {{ author.display_name_and_email|safe }}
+Co-authored-by: {{ author.display_name_and_email|safe }}
 {% endfor %}
 {%- endif -%}


### PR DESCRIPTION
The Co-authored-by trailer allows you to state that PR has multiple authors, and using this trailer allows platforms like GitHub to reflect that in the UI.

reference: https://help.github.com/en/github/committing-changes-to-your-project/creating-a-commit-with-multiple-authors