### PR TITLE
Bug 1607696: Fix Sign in in Translate view

### DIFF
--- a/pontoon/translate/views.py
+++ b/pontoon/translate/views.py
@@ -124,9 +124,9 @@ def translate(request, locale, project, resource):
     # django object so that it can be turned into JSON.
     notifications = messages.get_messages(request)
     if notifications:
-        context["notifications"] = map(
-            lambda x: {"content": str(x), "type": x.tags}, notifications
-        )
+        context["notifications"] = [
+            {"content": str(x), "type": x.tags} for x in notifications
+        ]
 
     if settings.DEBUG:
         return catchall_dev(request, context=context)


### PR DESCRIPTION
If you try to sign in on the translate view, authentication succeeds, but you end up with a server error.

@jotes r?

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.7/site-packages/django/core/handlers/base.py", line 115, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/local/lib/python3.7/site-packages/django/core/handlers/base.py", line 113, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/app/pontoon/translate/views.py", line 139, in translate
    return catchall_dev(request, context=context)
  File "/usr/local/lib/python3.7/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/app/pontoon/translate/views.py", line 72, in catchall_dev
    .render(request=request, context=context)
  File "/usr/local/lib/python3.7/site-packages/django_jinja/backend.py", line 63, in render
    return mark_safe(self._process_template(self.template.render, context, request))
  File "/usr/local/lib/python3.7/site-packages/django_jinja/backend.py", line 109, in _process_template
    return handler(context)
  File "/usr/local/lib/python3.7/site-packages/jinja2/environment.py", line 1090, in render
    self.environment.handle_exception()
  File "/usr/local/lib/python3.7/site-packages/jinja2/environment.py", line 832, in handle_exception
    reraise(*rewrite_traceback_stack(source=source))
  File "/usr/local/lib/python3.7/site-packages/jinja2/_compat.py", line 28, in reraise
    raise value.with_traceback(tb)
  File "<template>", line 45, in top-level template code
  File "/app/pontoon/base/templatetags/helpers.py", line 124, in to_json
    return json.dumps(value, cls=LazyObjectsJSONEncoder)
  File "/usr/local/lib/python3.7/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
  File "/usr/local/lib/python3.7/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/local/lib/python3.7/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/app/pontoon/base/templatetags/helpers.py", line 54, in default
    return super(LazyObjectsJSONEncoder, self).default(obj)
  File "/app/pontoon/base/templatetags/helpers.py", line 41, in default
    return json.JSONEncoder.default(self, obj)
  File "/usr/local/lib/python3.7/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type map is not JSON serializable
```