### PR TITLE
Update createsuperuser command in deployment docs

### DIFF
--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -308,7 +308,9 @@ After deploying the site, you can create a superuser account using the
 
 .. code-block:: bash
 
-   heroku run ./manage.py createsuperuser --noinput --user=admin --email=your@email.com
+   heroku run ./manage.py createsuperuser --user=admin --email=your@email.com
+
+You'll then be prompted to set a password for your new user.
 
 If you've already logged into the site with the email that you want to use,
 you'll have to use the Django shell to mark your user account as an admin:


### PR DESCRIPTION
The command given in the deployment documentation's "Creating an Admin User" section was previously using the `--noinput` flag, which results in the user being created without a password. This PR resolves the problem by removing that flag, so that a password prompt is given instead.

See [this conversation](https://matrix.to/#/!MbTYYvqUzXvkHwsqtR:mozilla.org/$gvUxEzdrsAcqdp9mN1ja-P3CdNmy-_94yPxq6t5G9zI?via=mozilla.org&via=delire.party) in the Pontoon chat for a few more details.