### PR TITLE
Fix bug 1625443: Show attribute label in variant labels

### DIFF
--- a/frontend/src/modules/fluenteditor/components/RichTranslationForm.css
+++ b/frontend/src/modules/fluenteditor/components/RichTranslationForm.css
@@ -32,6 +32,11 @@
     margin-left: 10px;
 }
 
+.fluent-rich-translation-form table tr > td > label .divider {
+    color: #7BC876;
+    padding: 0 3px;
+}
+
 .fluent-rich-translation-form table tr > td > label .stress {
     color: #7BC876;
 }

--- a/frontend/src/modules/fluenteditor/components/RichTranslationForm.js
+++ b/frontend/src/modules/fluenteditor/components/RichTranslationForm.js
@@ -366,6 +366,7 @@ export default class RichTranslationForm extends React.Component<EditorProps> {
         value: string,
         path: MessagePath,
         label: string,
+        attributeLabel: ?string,
         className: ?string,
         example: ?number,
     ) {
@@ -375,7 +376,14 @@ export default class RichTranslationForm extends React.Component<EditorProps> {
                     { typeof(example) === 'number' ?
                         this.renderLabel(label, example)
                         :
-                        <span>{ label }</span>
+                        attributeLabel ?
+                            <span>
+                                <span className='attribute-label'>{ attributeLabel }</span>
+                                <span className='divider'>&middot;</span>
+                                <span className='label'>{ label }</span>
+                            </span>
+                            :
+                            <span>{ label }</span>
                     }
                 </label>
             </td>
@@ -390,6 +398,7 @@ export default class RichTranslationForm extends React.Component<EditorProps> {
         eIndex: number,
         vIndex: number,
         pluralExamples: any,
+        attributeLabel: ?string,
     ): React.Node {
         const element = variant.value.elements[0];
         if (element.value === null) {
@@ -415,12 +424,18 @@ export default class RichTranslationForm extends React.Component<EditorProps> {
             value,
             [].concat(ePath, vPath),
             label,
+            attributeLabel,
             indent ? 'indented' : null,
             example,
         );
     }
 
-    renderElements(elements: Array<PatternElement>, path: MessagePath, label: string): React.Node {
+    renderElements(
+        elements: Array<PatternElement>,
+        path: MessagePath,
+        label: string,
+        attributeLabel: ?string,
+    ): React.Node {
         let indent = false;
 
         return elements.map((element, eIndex) => {
@@ -440,6 +455,7 @@ export default class RichTranslationForm extends React.Component<EditorProps> {
                         eIndex,
                         vIndex,
                         pluralExamples,
+                        attributeLabel,
                     );
                 });
 
@@ -466,14 +482,19 @@ export default class RichTranslationForm extends React.Component<EditorProps> {
             return null;
         }
 
+        let attributeLabel = null;
         if (!label) {
             label = 'Value';
+        }
+        else {
+            attributeLabel = label;
         }
 
         return this.renderElements(
             value.elements,
             [].concat(path, [ 'elements' ]),
             label,
+            attributeLabel,
         );
     }
 

--- a/frontend/src/modules/fluenteditor/components/RichTranslationForm.js
+++ b/frontend/src/modules/fluenteditor/components/RichTranslationForm.js
@@ -366,7 +366,7 @@ export default class RichTranslationForm extends React.Component<EditorProps> {
         value: string,
         path: MessagePath,
         label: string,
-        attributeLabel: ?string,
+        attributeName: ?string,
         className: ?string,
         example: ?number,
     ) {
@@ -376,9 +376,9 @@ export default class RichTranslationForm extends React.Component<EditorProps> {
                     { typeof(example) === 'number' ?
                         this.renderLabel(label, example)
                         :
-                        attributeLabel ?
+                        attributeName ?
                             <span>
-                                <span className='attribute-label'>{ attributeLabel }</span>
+                                <span className='attribute-label'>{ attributeName }</span>
                                 <span className='divider'>&middot;</span>
                                 <span className='label'>{ label }</span>
                             </span>
@@ -398,7 +398,7 @@ export default class RichTranslationForm extends React.Component<EditorProps> {
         eIndex: number,
         vIndex: number,
         pluralExamples: any,
-        attributeLabel: ?string,
+        attributeName: ?string,
     ): React.Node {
         const element = variant.value.elements[0];
         if (element.value === null) {
@@ -424,7 +424,7 @@ export default class RichTranslationForm extends React.Component<EditorProps> {
             value,
             [].concat(ePath, vPath),
             label,
-            attributeLabel,
+            attributeName,
             indent ? 'indented' : null,
             example,
         );
@@ -433,8 +433,7 @@ export default class RichTranslationForm extends React.Component<EditorProps> {
     renderElements(
         elements: Array<PatternElement>,
         path: MessagePath,
-        label: string,
-        attributeLabel: ?string,
+        attributeName: ?string,
     ): React.Node {
         let indent = false;
 
@@ -455,7 +454,7 @@ export default class RichTranslationForm extends React.Component<EditorProps> {
                         eIndex,
                         vIndex,
                         pluralExamples,
-                        attributeLabel,
+                        attributeName,
                     );
                 });
 
@@ -463,6 +462,10 @@ export default class RichTranslationForm extends React.Component<EditorProps> {
                 return variants;
             }
             else {
+                // When rendering Message attribute, set label to attribute name.
+                // When rendering Message value, set label to "Value".
+                const label = attributeName || 'Value';
+
                 indent = true;
                 if (typeof(element.value) !== 'string') {
                     return null;
@@ -477,24 +480,15 @@ export default class RichTranslationForm extends React.Component<EditorProps> {
         });
     }
 
-    renderValue(value: Pattern, path: MessagePath, label?: string): React.Node {
+    renderValue(value: Pattern, path: MessagePath, attributeName?: string): React.Node {
         if (!value) {
             return null;
-        }
-
-        let attributeLabel = null;
-        if (!label) {
-            label = 'Value';
-        }
-        else {
-            attributeLabel = label;
         }
 
         return this.renderElements(
             value.elements,
             [].concat(path, [ 'elements' ]),
-            label,
-            attributeLabel,
+            attributeName,
         );
     }
 

--- a/frontend/src/modules/fluenteditor/components/RichTranslationForm.test.js
+++ b/frontend/src/modules/fluenteditor/components/RichTranslationForm.test.js
@@ -67,6 +67,50 @@ my-entry =
         expect(wrapper.find('textarea').at(1).html()).toContain('World!');
     });
 
+    it('renders select expression in attributes properly', () => {
+        const input = `
+my-entry =
+    .label =
+        { PLATFORM() ->
+            [macosx] Preferences
+           *[other] Options
+        }
+    .accesskey =
+        { PLATFORM() ->
+            [macosx] e
+           *[other] s
+        }`;
+
+        const editor = {
+            ...EDITOR,
+            translation: fluent.parser.parseEntry(input),
+        };
+
+        const wrapper = shallow(<RichTranslationForm
+            editor={ editor }
+            locale={ DEFAULT_LOCALE }
+            updateTranslation={ sinon.stub() }
+        />);
+
+        expect(wrapper.find('textarea')).toHaveLength(4);
+
+        expect(wrapper.find('label .attribute-label').at(0).html()).toContain('label');
+        expect(wrapper.find('label .label').at(0).html()).toContain('macosx');
+        expect(wrapper.find('textarea').at(0).html()).toContain('Preferences');
+
+        expect(wrapper.find('label .attribute-label').at(1).html()).toContain('label');
+        expect(wrapper.find('label').at(1).html()).toContain('other');
+        expect(wrapper.find('textarea').at(1).html()).toContain('Options');
+
+        expect(wrapper.find('label .attribute-label').at(2).html()).toContain('accesskey');
+        expect(wrapper.find('label').at(2).html()).toContain('macosx');
+        expect(wrapper.find('textarea').at(2).html()).toContain('e');
+
+        expect(wrapper.find('label .attribute-label').at(3).html()).toContain('accesskey');
+        expect(wrapper.find('label').at(3).html()).toContain('other');
+        expect(wrapper.find('textarea').at(3).html()).toContain('s');
+    });
+
     it('renders plural string properly', () => {
         const input = `
 my-entry =

--- a/frontend/src/modules/fluentoriginal/components/RichString.css
+++ b/frontend/src/modules/fluentoriginal/components/RichString.css
@@ -24,6 +24,11 @@
     padding: 0 4px;
 }
 
+.fluent-rich-string tr > td > label .divider {
+    color: #7BC876;
+    padding: 0 3px;
+}
+
 .fluent-rich-string tr.indented > td > label {
     margin-left: 10px;
 }

--- a/frontend/src/modules/fluentoriginal/components/RichString.js
+++ b/frontend/src/modules/fluentoriginal/components/RichString.js
@@ -28,13 +28,13 @@ function renderItem(
     label: string,
     key: string,
     className: ?string,
-    attributeLabel: ?string,
+    attributeName: ?string,
 ): React.Node {
     return <tr key={ key } className={ className }>
         <td>
-            { attributeLabel ?
+            { attributeName ?
                 <label>
-                    <span className='attribute-label'>{ attributeLabel }</span>
+                    <span className='attribute-label'>{ attributeName }</span>
                     <span className='divider'>&middot;</span>
                     <span className='label'>{ label }</span>
                 </label>
@@ -55,8 +55,7 @@ function renderItem(
 
 function renderElements(
     elements: Array<PatternElement>,
-    label: string,
-    attributeLabel: ?string,
+    attributeName: ?string,
 ): React.Node {
     let indent = false;
     return elements.map((element, index) => {
@@ -74,7 +73,7 @@ function renderElements(
                     serializeVariantKey(variant.key),
                     [index, i].join('-'),
                     indent ? 'indented' : null,
-                    attributeLabel,
+                    attributeName,
                 );
             });
             indent = false;
@@ -84,6 +83,10 @@ function renderElements(
             if (typeof(element.value) !== 'string') {
                 return null;
             }
+
+            // When rendering Message attribute, set label to attribute name.
+            // When rendering Message value, set label to "Value".
+            const label = attributeName || 'Value';
 
             indent = true;
             return renderItem(
@@ -96,23 +99,14 @@ function renderElements(
 }
 
 
-function renderValue(value: Pattern, label?: string): React.Node {
+function renderValue(value: Pattern, attributeName?: string): React.Node {
     if (!value) {
         return null;
     }
 
-    let attributeLabel = null;
-    if (!label) {
-        label = 'Value';
-    }
-    else {
-        attributeLabel = label;
-    }
-
     return renderElements(
         value.elements,
-        label,
-        attributeLabel,
+        attributeName,
     );
 }
 

--- a/frontend/src/modules/fluentoriginal/components/RichString.js
+++ b/frontend/src/modules/fluentoriginal/components/RichString.js
@@ -28,10 +28,19 @@ function renderItem(
     label: string,
     key: string,
     className: ?string,
+    attributeLabel: ?string,
 ): React.Node {
     return <tr key={ key } className={ className }>
         <td>
-            <label>{ label }</label>
+            { attributeLabel ?
+                <label>
+                    <span className='attribute-label'>{ attributeLabel }</span>
+                    <span className='divider'>&middot;</span>
+                    <span className='label'>{ label }</span>
+                </label>
+                :
+                <label>{ label }</label>
+            }
         </td>
         <td>
             <span>
@@ -47,6 +56,7 @@ function renderItem(
 function renderElements(
     elements: Array<PatternElement>,
     label: string,
+    attributeLabel: ?string,
 ): React.Node {
     let indent = false;
     return elements.map((element, index) => {
@@ -64,6 +74,7 @@ function renderElements(
                     serializeVariantKey(variant.key),
                     [index, i].join('-'),
                     indent ? 'indented' : null,
+                    attributeLabel,
                 );
             });
             indent = false;
@@ -90,13 +101,18 @@ function renderValue(value: Pattern, label?: string): React.Node {
         return null;
     }
 
+    let attributeLabel = null;
     if (!label) {
         label = 'Value';
+    }
+    else {
+        attributeLabel = label;
     }
 
     return renderElements(
         value.elements,
         label,
+        attributeLabel,
     );
 }
 

--- a/frontend/src/modules/fluentoriginal/components/RichString.test.js
+++ b/frontend/src/modules/fluentoriginal/components/RichString.test.js
@@ -57,6 +57,47 @@ user-entry =
         expect(wrapper.find('ContentMarker').at(1).html()).toContain('Good Bye!');
     });
 
+    it('renders select expression in attributes properly', () => {
+        const input = `
+my-entry =
+    .label =
+        { PLATFORM() ->
+            [macosx] Preferences
+           *[other] Options
+        }
+    .accesskey =
+        { PLATFORM() ->
+            [macosx] e
+           *[other] s
+        }`;
+
+        const entity = {
+            original: input,
+        };
+
+        const wrapper = shallow(<RichString
+            entity = { entity }
+        />);
+
+        expect(wrapper.find('ContentMarker')).toHaveLength(4);
+
+        expect(wrapper.find('label .attribute-label').at(0).html()).toContain('label');
+        expect(wrapper.find('label').at(0).html()).toContain('macosx');
+        expect(wrapper.find('ContentMarker').at(0).html()).toContain('Preferences');
+
+        expect(wrapper.find('label .attribute-label').at(1).html()).toContain('label');
+        expect(wrapper.find('label').at(1).html()).toContain('other');
+        expect(wrapper.find('ContentMarker').at(1).html()).toContain('Options');
+
+        expect(wrapper.find('label .attribute-label').at(2).html()).toContain('accesskey');
+        expect(wrapper.find('label').at(2).html()).toContain('macosx');
+        expect(wrapper.find('ContentMarker').at(2).html()).toContain('e');
+
+        expect(wrapper.find('label .attribute-label').at(3).html()).toContain('accesskey');
+        expect(wrapper.find('label').at(3).html()).toContain('other');
+        expect(wrapper.find('ContentMarker').at(3).html()).toContain('s');
+    });
+
     it('calls the handleClickOnPlaceable function on click on .original', () => {
         const handleClickOnPlaceable = sinon.spy();
         const wrapper = shallow(<RichString


### PR DESCRIPTION
This patch brings support for showing attribute names in select expression variants:
https://bugzilla.mozilla.org/show_bug.cgi?id=1625443

You can test it on stage:
https://mozilla-pontoon-staging.herokuapp.com/de/fluent-test/demo.ftl/?string=205407

![Posnetek zaslona 2020-04-10 ob 21 12 23](https://user-images.githubusercontent.com/626716/79016751-0c3b7c00-7b70-11ea-8f0d-f2ef72b42bf3.png)