### PR TITLE
Fix bug 1629586: Switch order of Select All & N Strings Selected

### DIFF
--- a/frontend/src/modules/batchactions/components/BatchActions.css
+++ b/frontend/src/modules/batchactions/components/BatchActions.css
@@ -11,7 +11,7 @@
 
 .batch-actions .topbar .selecting {
     color: #CCCCCC;
-    float: left;
+    float: right;
     margin-top: 2px;
 }
 
@@ -28,16 +28,16 @@
     color: #7BC876;
 }
 
-.batch-actions .topbar button.selected-count {
+.batch-actions .topbar button.select-all {
     float: left;
+}
+
+.batch-actions .topbar button.selected-count {
+    float: right;
 }
 
 .batch-actions .topbar button.selected-count .stress {
     color: #7BC876;
-}
-
-.batch-actions .topbar button.select-all {
-    float: right;
 }
 
 .batch-actions .topbar button .fa {

--- a/frontend/src/modules/batchactions/components/BatchActions.js
+++ b/frontend/src/modules/batchactions/components/BatchActions.js
@@ -177,6 +177,19 @@ export class BatchActionsBase extends React.Component<InternalProps> {
     render() {
         return <div className="batch-actions">
             <div className="topbar clearfix">
+                <Localized
+                    id="batchactions-BatchActions--header-select-all"
+                    attrs={{ title: true }}
+                    elems={{ glyph: <i className="fa fa-check fa-lg" /> }}
+                >
+                    <button
+                        className="select-all"
+                        title="Select All Strings (Ctrl + Shift + A)"
+                        onClick={ this.selectAllEntities }
+                    >
+                        { '<glyph></glyph> Select All' }
+                    </button>
+                </Localized>
                 { this.props.batchactions.requestInProgress === 'select-all' ?
                     <div className="selecting fa fa-sync fa-spin"></div>
                     :
@@ -198,19 +211,6 @@ export class BatchActionsBase extends React.Component<InternalProps> {
                         </button>
                     </Localized>
                 }
-                <Localized
-                    id="batchactions-BatchActions--header-select-all"
-                    attrs={{ title: true }}
-                    elems={{ glyph: <i className="fa fa-check fa-lg" /> }}
-                >
-                    <button
-                        className="select-all"
-                        title="Select All Strings (Ctrl + Shift + A)"
-                        onClick={ this.selectAllEntities }
-                    >
-                        { '<glyph></glyph> Select All' }
-                    </button>
-                </Localized>
             </div>
 
             <div className="main-content">


### PR DESCRIPTION
After selecting an entity for batch editing, the batch editor opens. If you want to select all strings for batch editing, you need to move the mouse all the way to the opposite site of the screen.

By switching the Select All button and N Strings Selected title, that path becomes much shorter.

@abowler2 Could you please review this?