### PR TITLE
Fix bug 1624557: Terminology presentation popup

### DIFF
--- a/frontend/public/static/locale/en-US/translate.ftl
+++ b/frontend/public/static/locale/en-US/translate.ftl
@@ -196,11 +196,14 @@ entitydetails-EntityNavigation--previous = <glyph></glyph>Previous
 ## Entity Details Helpers
 ## Shows helper tabs
 
-entitydetails-Helpers--machinery = Machinery
-entitydetails-Helpers--locales = Locales
+entitydetails-Helpers--terms = Terms
+entitydetails-Helpers--no-terms = No terms available.
+
 entitydetails-Helpers--comments = Comments
 entitydetails-Helpers--no-comments = No comments available.
 
+entitydetails-Helpers--machinery = Machinery
+entitydetails-Helpers--locales = Locales
 
 ## Entity Details Metadata
 ## Shows metadata about an entity (original string)
@@ -587,6 +590,12 @@ search-FiltersPanel--apply-filters =
 search-TimeRangeFilter--heading-time = Translation Time
 search-TimeRangeFilter--edit-range = <glyph></glyph>Edit Range
 search-TimeRangeFilter--save-range = Save Range
+
+
+## User Avatar
+## Shows term entry with its metadata
+
+term-Term--for-example = E.g.
 
 
 ## User Avatar

--- a/frontend/src/core/api/entity.js
+++ b/frontend/src/core/api/entity.js
@@ -165,4 +165,20 @@ export default class EntityAPI extends APIBase {
 
         return this.keysToCamelCase(results);
     }
+
+    async getTerms(
+        sourceString: string,
+        locale: string,
+    ) {
+        const payload = new URLSearchParams();
+        payload.append('source_string', sourceString);
+        payload.append('locale', locale);
+
+        const headers = new Headers();
+        headers.append('X-Requested-With', 'XMLHttpRequest');
+
+        const results = await this.fetch('/terminology/get-terms/', 'GET', payload, headers);
+
+        return this.keysToCamelCase(results);
+    }
 }

--- a/frontend/src/core/api/index.js
+++ b/frontend/src/core/api/index.js
@@ -18,6 +18,7 @@ export type {
     EntityTranslation,
     TranslationComment,
     TeamComment,
+    TermType,
     MachineryTranslation,
     OtherLocaleTranslations,
     OtherLocaleTranslation,

--- a/frontend/src/core/api/types.js
+++ b/frontend/src/core/api/types.js
@@ -34,6 +34,18 @@ export type TeamComment = TranslationComment;
 
 
 /**
+ * Term entry with translation.
+ */
+export type TermType = {|
+    +text: string,
+    +partOfSpeech: string,
+    +definition: string,
+    +usage: string,
+    +translation: string,
+|};
+
+
+/**
  * String that needs to be translated, along with its current metadata,
  * and its currently accepted translations.
  */

--- a/frontend/src/core/term/actions.js
+++ b/frontend/src/core/term/actions.js
@@ -1,0 +1,58 @@
+/* @flow */
+
+import api from 'core/api';
+
+import type { TermType } from 'core/api';
+
+
+export const RECEIVE: 'terms/RECEIVE' = 'terms/RECEIVE';
+export const REQUEST: 'terms/REQUEST' = 'terms/REQUEST';
+
+
+export type ReceiveAction = {|
+    +type: typeof RECEIVE,
+    +terms: Array<TermType>,
+|};
+export function receive(
+    terms: Array<TermType>,
+): ReceiveAction {
+    return {
+        type: RECEIVE,
+        terms,
+    };
+}
+
+
+export type RequestAction = {|
+    +type: typeof REQUEST,
+    +sourceString: string,
+|};
+export function request(
+    sourceString: string,
+): RequestAction {
+    return {
+        type: REQUEST,
+        sourceString,
+    };
+}
+
+
+export function get(sourceString: string, locale: string): Function {
+    return async dispatch => {
+        dispatch(request(sourceString));
+
+        // Abort all previously running requests.
+        await api.entity.abort();
+
+        let content = await api.entity.getTerms(sourceString, locale);
+
+        dispatch(receive(content));
+    }
+}
+
+
+export default {
+    get,
+    receive,
+    request,
+};

--- a/frontend/src/core/term/actions.js
+++ b/frontend/src/core/term/actions.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import isEmpty from 'lodash.isempty';
+
 import api from 'core/api';
 
 import type { TermType } from 'core/api';
@@ -45,6 +47,12 @@ export function get(sourceString: string, locale: string): Function {
         await api.entity.abort();
 
         let content = await api.entity.getTerms(sourceString, locale);
+
+        // The default return value of aborted requests is {},
+        // which is incompatible with reducer
+        if (isEmpty(content)) {
+            content = [];
+        }
 
         dispatch(receive(content));
     }

--- a/frontend/src/core/term/components/Term.css
+++ b/frontend/src/core/term/components/Term.css
@@ -1,0 +1,39 @@
+.terms-list .term {
+    border-bottom: 1px solid #5E6475;
+    cursor: pointer;
+    padding: 10px;
+}
+
+.terms-list .term.cannot-copy {
+    pointer-events: none;
+}
+
+.terms-list .term:not(.cannot-copy):hover {
+    background: #4D5967;
+    border-color: #5E6475;
+}
+
+.terms-list .term .text {
+    color: #AAA;
+}
+
+.terms-list .term .part-of-speech {
+    color: #AAA;
+    float: right;
+    font-size: 11px;
+    font-weight: 300;
+    text-transform: uppercase;
+}
+
+.terms-list .term .details {
+    color: #AAA;
+    font-style: italic;
+    padding: 5px 0 0 15px;
+}
+
+.terms-list .term .usage .title {
+    color: #7BC876;
+    font-size: 11px;
+    margin-right: 3px;
+    text-transform: uppercase;
+}

--- a/frontend/src/core/term/components/Term.css
+++ b/frontend/src/core/term/components/Term.css
@@ -25,6 +25,10 @@
     text-transform: uppercase;
 }
 
+.terms-list .term .translation {
+    color: #EBEBEB;
+}
+
 .terms-list .term .details {
     color: #AAA;
     font-style: italic;

--- a/frontend/src/core/term/components/Term.js
+++ b/frontend/src/core/term/components/Term.js
@@ -1,0 +1,63 @@
+/* @flow */
+
+import * as React from 'react';
+import { Localized } from '@fluent/react';
+
+import './Term.css';
+
+import type { TermType } from 'core/api';
+
+type Props = {|
+    term: TermType,
+    isReadOnlyEditor: boolean,
+    addTextToEditorTranslation: (string) => void,
+|};
+
+
+/**
+ * Shows term entry with its metadata.
+ */
+export default function Term(props: Props) {
+    const { term, isReadOnlyEditor } = props;
+
+    const copyTermIntoEditor = (translation: string) => {
+        if (isReadOnlyEditor) {
+            return;
+        }
+
+        // Ignore if term not translated
+        if (!translation) {
+            return;
+        }
+
+        // Ignore if selecting text
+        if (window.getSelection().toString()) {
+            return;
+        }
+
+        props.addTextToEditorTranslation(translation);
+    }
+
+    // Copying into the editor is not allowed
+    const cannotCopy = (isReadOnlyEditor || !term.translation) ? 'cannot-copy' : '';
+
+    return <li
+        className={ `term ${cannotCopy}` }
+        onClick={ () => copyTermIntoEditor(term.translation) }
+    >
+        <header>
+            <span className='text'>{ term.text }</span>
+            <span className='part-of-speech'>{ term.partOfSpeech }</span>
+        </header>
+        <p className='translation'>{ term.translation }</p>
+        <div className='details'>
+            <p className='definition'>{ term.definition }</p>
+            <p className='usage'>
+                <Localized id="term-Term--for-example">
+                    <span className='title'>E.g.</span>
+                </Localized>
+                <span className='content'>{ term.usage }</span>
+            </p>
+        </div>
+    </li>;
+}

--- a/frontend/src/core/term/components/Term.test.js
+++ b/frontend/src/core/term/components/Term.test.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+
+import Term from './Term';
+
+describe('<Term>', () => {
+    const TERM = {
+        'text': 'text',
+        'partOfSpeech': 'partOfSpeech',
+        'definition': 'definition',
+        'usage': 'usage',
+        'translation': 'translation',
+    };
+
+    let getSelectionBackup;
+
+    beforeAll(() => {
+        getSelectionBackup = window.getSelection;
+        window.getSelection = () => {
+            return {
+                toString: () => {}
+            };
+        }
+    });
+
+    afterAll(() => {
+        window.getSelection = getSelectionBackup;
+    });
+
+    it('renders term correctly', () => {
+        const wrapper = shallow(<Term
+            term={ TERM }
+        />);
+
+        expect(wrapper.find('li')).toHaveLength(1);
+        expect(wrapper.find('.text').text()).toEqual('text');
+        expect(wrapper.find('.part-of-speech').text()).toEqual('partOfSpeech');
+        expect(wrapper.find('.definition').text()).toEqual('definition');
+        expect(wrapper.find('.usage .content').text()).toEqual('usage');
+        expect(wrapper.find('.translation').text()).toEqual('translation');
+    });
+
+    it('calls the addTextToEditorTranslation function on click', () => {
+        const addTextToEditorTranslationFn = sinon.spy();
+
+        const wrapper = shallow(<Term
+            term={ TERM }
+            addTextToEditorTranslation={ addTextToEditorTranslationFn }
+        />);
+
+        wrapper.find('li').simulate('click');
+        expect(addTextToEditorTranslationFn.called).toEqual(true);
+    });
+
+    it('does not call the addTextToEditorTranslation function if term not translated', () => {
+        const term = {
+            ...TERM,
+            translation: '',
+        };
+        const addTextToEditorTranslationFn = sinon.spy();
+
+        const wrapper = shallow(<Term
+            term={ term }
+            addTextToEditorTranslation={ addTextToEditorTranslationFn }
+        />);
+
+        wrapper.find('li').simulate('click');
+        expect(addTextToEditorTranslationFn.called).toEqual(false);
+    });
+
+    it('does not call the addTextToEditorTranslation function if read-only editor', () => {
+        const addTextToEditorTranslationFn = sinon.spy();
+
+        const wrapper = shallow(<Term
+            isReadOnlyEditor={ true }
+            term={ TERM }
+            addTextToEditorTranslation={ addTextToEditorTranslationFn }
+        />);
+
+        wrapper.find('li').simulate('click');
+        expect(addTextToEditorTranslationFn.called).toEqual(false);
+    });
+});

--- a/frontend/src/core/term/components/TermsList.css
+++ b/frontend/src/core/term/components/TermsList.css
@@ -1,0 +1,5 @@
+.terms-list {
+    line-height: 22px;
+    list-style: none;
+    margin-left: 0;
+}

--- a/frontend/src/core/term/components/TermsList.js
+++ b/frontend/src/core/term/components/TermsList.js
@@ -1,0 +1,32 @@
+/* @flow */
+
+import * as React from 'react';
+
+import './TermsList.css';
+
+import Term from './Term';
+
+import type { TermType } from 'core/api';
+
+type Props = {|
+    terms: Array<TermType>,
+    isReadOnlyEditor: boolean,
+    addTextToEditorTranslation: (string) => void,
+|};
+
+
+/**
+ * Shows a list of terms.
+ */
+export default function TermsList(props: Props) {
+    return <ul className="terms-list">
+        { props.terms.map((term, i) => {
+            return <Term
+                key={ i }
+                term={ term }
+                isReadOnlyEditor={ props.isReadOnlyEditor }
+                addTextToEditorTranslation={ props.addTextToEditorTranslation }
+            />;
+        }) }
+    </ul>;
+}

--- a/frontend/src/core/term/components/TermsList.test.js
+++ b/frontend/src/core/term/components/TermsList.test.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import Term from './Term';
+import TermsList from './TermsList';
+
+describe('<TermsList>', () => {
+    const TERMS = [
+        {
+            'text': 'text1',
+        },
+        {
+            'text': 'text2',
+        },
+        {
+            'text': 'text3',
+        },
+    ];
+
+    it('renders list of terms correctly', () => {
+        const wrapper = shallow(<TermsList
+            terms={ TERMS }
+        />);
+
+        expect(wrapper.find(Term)).toHaveLength(3);
+    });
+});

--- a/frontend/src/core/term/index.js
+++ b/frontend/src/core/term/index.js
@@ -4,6 +4,7 @@ export { default as actions } from './actions';
 export { default as reducer } from './reducer';
 
 export { default as TermsList } from './components/TermsList';
+export { default as withTerms } from './withTerms';
 
 export type { TermState } from './reducer';
 

--- a/frontend/src/core/term/index.js
+++ b/frontend/src/core/term/index.js
@@ -1,0 +1,13 @@
+/* @flow */
+
+export { default as actions } from './actions';
+export { default as reducer } from './reducer';
+
+export { default as TermsList } from './components/TermsList';
+
+export type { TermState } from './reducer';
+
+
+// Name of this module.
+// Used as the key to store this module's reducer.
+export const NAME: string = 'term';

--- a/frontend/src/core/term/reducer.js
+++ b/frontend/src/core/term/reducer.js
@@ -1,0 +1,49 @@
+/* @flow */
+
+import { RECEIVE, REQUEST } from './actions';
+
+import type { TermType } from 'core/api';
+import type { ReceiveAction, RequestAction } from './actions';
+
+
+type Action =
+    | ReceiveAction
+    | RequestAction
+;
+
+
+export type TermState = {|
+    +fetching: boolean,
+    +sourceString: string,
+    +terms: Array<TermType>,
+|};
+
+
+const initialState = {
+    fetching: false,
+    sourceString: '',
+    terms: [],
+};
+
+export default function reducer(
+    state: TermState = initialState,
+    action: Action
+): TermState {
+    switch (action.type) {
+        case REQUEST:
+            return {
+                ...state,
+                fetching: true,
+                sourceString: action.sourceString,
+                terms: [],
+            };
+        case RECEIVE:
+            return {
+                ...state,
+                fetching: false,
+                terms: action.terms,
+            };
+        default:
+            return state;
+    }
+}

--- a/frontend/src/core/term/withTerms.js
+++ b/frontend/src/core/term/withTerms.js
@@ -1,0 +1,50 @@
+/* @flow */
+
+import * as React from 'react';
+import shortid from 'shortid';
+import escapeRegExp from 'lodash.escaperegexp';
+import { mark } from 'react-content-marker';
+
+import type { TermState } from 'core/term';
+
+
+export function markTerms(base: string, terms: TermState) {
+    if (terms.fetching || !terms.terms) {
+        return base;
+    }
+
+    // Sort terms by length descendingly. That allows us to mark multi-word terms
+    // when they consist of words that are terms as well. See test case for the example.
+    const sortedTerms = terms.terms.sort((a, b) => (a.text.length < b.text.length) ? 1 : -1);
+
+    for (let term of sortedTerms) {
+        const text = escapeRegExp(term.text);
+        const rule = new RegExp(`\\b${text}[a-zA-z]*\\b`, 'gi');
+        const tag = (x: string) =>
+            <mark
+                className='term'
+                data-term={ term.text }
+                key={ shortid.generate() }
+            >{ x }</mark>;
+
+        base = mark(base, rule, tag);
+    }
+
+    return base;
+}
+
+
+type Props = {|
+    terms: TermState,
+|};
+
+
+export default function withTerms<Config: Object>(
+    WrappedComponent: React.AbstractComponent<Config>
+): React.AbstractComponent<Config> {
+    return function WithTerms(props: { ...Config, ...Props }) {
+        return <WrappedComponent { ...props }>
+            { markTerms(props.children, props.terms) }
+        </WrappedComponent>;
+    };
+}

--- a/frontend/src/core/term/withTerms.test.js
+++ b/frontend/src/core/term/withTerms.test.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { markTerms } from './withTerms';
+
+
+describe('markTerms', () => {
+    it('marks terms properly', () => {
+        const string = 'foo bar baz';
+        const terms = {
+            terms: [
+                {
+                    text: 'bar'
+                },
+                {
+                    text: 'baz'
+                },
+            ]
+        };
+
+        const marked = markTerms(string, terms);
+        const wrapper = shallow(<p>{ marked }</p>);
+
+        expect(wrapper.find('mark')).toHaveLength(2);
+        expect(wrapper.find('mark').at(0).text()).toEqual('bar');
+        expect(wrapper.find('mark').at(1).text()).toEqual('baz');
+    });
+
+    it('marks entire words on partial match', () => {
+        const string = 'Download Add-Ons from the web.';
+        const terms = {
+            terms: [
+                {
+                    text: 'add-on'
+                },
+            ]
+        };
+
+        const marked = markTerms(string, terms);
+        const wrapper = shallow(<p>{ marked }</p>);
+
+        expect(wrapper.find('mark')).toHaveLength(1);
+        expect(wrapper.find('mark').text()).toEqual('Add-Ons');
+    });
+
+    it('only marks terms at the beginning of the word', () => {
+        const string = 'Consider using one of the alternatives.';
+        const terms = {
+            terms: [
+                {
+                    text: 'native'
+                },
+            ]
+        };
+
+        const marked = markTerms(string, terms);
+        const wrapper = shallow(<p>{ marked }</p>);
+
+        expect(wrapper.find('mark')).toHaveLength(0);
+    });
+
+    it('marks longer terms first', () => {
+        const string = 'This is a translation tool.';
+        const terms = {
+            terms: [
+                {
+                    text: 'translation'
+                },
+                {
+                    text: 'translation tool'
+                },
+            ]
+        };
+
+        const marked = markTerms(string, terms);
+        const wrapper = shallow(<p>{ marked }</p>);
+
+        expect(wrapper.find('mark')).toHaveLength(1);
+        expect(wrapper.find('mark').text()).toEqual('translation tool');
+    });
+});

--- a/frontend/src/modules/entitydetails/components/EntityDetails.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.js
@@ -13,6 +13,7 @@ import * as lightbox from 'core/lightbox';
 import * as locale from 'core/locale';
 import * as navigation from 'core/navigation';
 import * as plural from 'core/plural';
+import * as terms from 'core/term';
 import * as user from 'core/user';
 import * as utils from 'core/utils';
 import * as history from 'modules/history';
@@ -32,6 +33,7 @@ import type { Entity } from 'core/api';
 import type { EditorState } from 'core/editor';
 import type { Locale } from 'core/locale';
 import type { NavigationParams } from 'core/navigation';
+import type { TermState } from 'core/term';
 import type { UserState } from 'core/user';
 import type { ChangeOperation, HistoryState } from 'modules/history';
 import type { MachineryState } from 'modules/machinery';
@@ -52,6 +54,7 @@ type Props = {|
     previousEntity: Entity,
     otherlocales: LocalesState,
     teamComments: TeamCommentState,
+    terms: TermState,
     parameters: NavigationParams,
     pluralForm: number,
     router: Object,
@@ -117,13 +120,18 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
             dispatch(history.actions.get(parameters.entity, parameters.locale, pluralForm));
         }
 
-        if (selectedEntity.pk !== this.props.otherlocales.entity) {
-            dispatch(otherlocales.actions.get(parameters.entity, parameters.locale));
+        const source = utils.getOptimizedContent(selectedEntity.machinery_original, selectedEntity.format);
+
+        if (source !== this.props.terms.sourceString) {
+            dispatch(terms.actions.get(source, parameters.locale));
         }
 
         if (selectedEntity.pk !== this.props.machinery.entity) {
-            const source = utils.getOptimizedContent(selectedEntity.machinery_original, selectedEntity.format);
             dispatch(machinery.actions.get(source, locale, selectedEntity.pk));
+        }
+
+        if (selectedEntity.pk !== this.props.otherlocales.entity) {
+            dispatch(otherlocales.actions.get(parameters.entity, parameters.locale));
         }
 
         if (selectedEntity.pk !== this.props.teamComments.entity) {
@@ -349,11 +357,13 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
                     machinery={ state.machinery }
                     otherlocales={ state.otherlocales }
                     teamComments={ state.teamComments }
+                    terms={ state.terms }
                     addComment={ this.addComment }
                     parameters={ state.parameters }
                     user={ state.user }
                     updateEditorTranslation={ this.updateEditorTranslation }
                     searchMachinery={ this.searchMachinery }
+                    addTextToEditorTranslation={ this.addTextToEditorTranslation }
                 />
             </section>
         </section>;
@@ -374,6 +384,7 @@ const mapStateToProps = (state: Object): Props => {
         previousEntity: entities.selectors.getPreviousEntity(state),
         otherlocales: state[otherlocales.NAME],
         teamComments: state[teamcomments.NAME],
+        terms: state[terms.NAME],
         parameters: navigation.selectors.getNavigationParams(state),
         pluralForm: plural.selectors.getPluralForm(state),
         router: state.router,

--- a/frontend/src/modules/entitydetails/components/EntityDetails.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.js
@@ -328,6 +328,7 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
                     isReadOnlyEditor={ state.isReadOnlyEditor }
                     locale={ state.locale }
                     pluralForm={ state.pluralForm }
+                    terms={ state.terms }
                     openLightbox={ this.openLightbox }
                     addTextToEditorTranslation={ this.addTextToEditorTranslation }
                     navigateToPath={ this.navigateToPath }

--- a/frontend/src/modules/entitydetails/components/GenericOriginalString.js
+++ b/frontend/src/modules/entitydetails/components/GenericOriginalString.js
@@ -3,18 +3,24 @@
 import * as React from 'react';
 import { Localized } from '@fluent/react';
 
-import { WithPlaceables } from 'core/placeable';
+import { WithPlaceablesNoLeadingSpace } from 'core/placeable';
+import { withTerms } from 'core/term';
 
 import type { Entity } from 'core/api';
 import type { Locale } from 'core/locale';
+import type { TermState } from 'core/term';
 
 
 type Props = {|
     +entity: Entity,
     +locale: Locale,
     +pluralForm: number,
+    +terms: TermState,
     +handleClickOnPlaceable: (SyntheticMouseEvent<HTMLParagraphElement>) => void,
 |};
+
+
+const WithPlaceablesTerms = withTerms(WithPlaceablesNoLeadingSpace);
 
 
 function getOriginalContent(props: Props) {
@@ -57,9 +63,9 @@ export default function GenericOriginalString(props: Props) {
     return <>
         { title }
         <p className="original" onClick={ props.handleClickOnPlaceable }>
-            <WithPlaceables>
+            <WithPlaceablesTerms terms={ props.terms }>
                 { original }
-            </WithPlaceables>
+            </WithPlaceablesTerms>
         </p>
     </>;
 }

--- a/frontend/src/modules/entitydetails/components/GenericOriginalString.test.js
+++ b/frontend/src/modules/entitydetails/components/GenericOriginalString.test.js
@@ -29,7 +29,7 @@ describe('<GenericOriginalString>', () => {
     it('renders correctly', () => {
         const wrapper = createGenericOriginalString();
 
-        const originalContent = wrapper.find('ContentMarker').props().children;
+        const originalContent = wrapper.find('WithTerms').props().children;
         expect(originalContent).toContain(ENTITY.original);
     });
 
@@ -38,7 +38,7 @@ describe('<GenericOriginalString>', () => {
 
         expect(wrapper.find('#entitydetails-GenericOriginalString--plural')).toHaveLength(1);
 
-        const originalContent = wrapper.find('ContentMarker').props().children;
+        const originalContent = wrapper.find('WithTerms').props().children;
         expect(originalContent).toContain(ENTITY.original_plural);
     });
 
@@ -47,7 +47,7 @@ describe('<GenericOriginalString>', () => {
 
         expect(wrapper.find('#entitydetails-GenericOriginalString--singular')).toHaveLength(1);
 
-        const originalContent = wrapper.find('ContentMarker').props().children;
+        const originalContent = wrapper.find('WithTerms').props().children;
         expect(originalContent).toContain(ENTITY.original);
     });
 });

--- a/frontend/src/modules/entitydetails/components/Helpers.css
+++ b/frontend/src/modules/entitydetails/components/Helpers.css
@@ -1,3 +1,15 @@
+.third-column .top {
+    border-bottom: 1px solid #5E6475;
+    box-sizing: border-box;
+    height: calc(40% + 21px);
+    min-height: 200px;
+}
+
+.third-column .bottom {
+    box-sizing: border-box;
+    height: calc(60% - 21px);
+}
+
 /* Styling the react-tabs library */
 .react-tabs {
     overflow: hidden;

--- a/frontend/src/modules/entitydetails/components/Helpers.js
+++ b/frontend/src/modules/entitydetails/components/Helpers.js
@@ -7,10 +7,12 @@ import { Localized } from '@fluent/react';
 import './Helpers.css';
 
 import { TeamComments, CommentCount } from 'modules/teamcomments';
+import { Terms, TermCount } from 'modules/terms';
 import { Machinery, MachineryCount } from 'modules/machinery';
 import { OtherLocales, OtherLocalesCount } from 'modules/otherlocales';
 
 import type { Entity } from 'core/api';
+import type { TermState } from 'core/term';
 import type { TeamCommentState } from 'modules/teamcomments';
 import type { Locale } from 'core/locale';
 import type { NavigationParams } from 'core/navigation';
@@ -26,11 +28,13 @@ type Props = {|
     machinery: MachineryState,
     otherlocales: LocalesState,
     teamComments: TeamCommentState,
+    terms: TermState,
     parameters: NavigationParams,
     user: UserState,
     updateEditorTranslation: (string, string) => void,
     searchMachinery: (string) => void,
     addComment: (string, ?number) => void,
+    addTextToEditorTranslation: (string) => void,
 |};
 
 
@@ -48,61 +52,85 @@ export default class Helpers extends React.Component<Props> {
             machinery,
             otherlocales,
             teamComments,
+            terms,
             parameters,
             user,
             updateEditorTranslation,
             searchMachinery,
             addComment,
+            addTextToEditorTranslation,
         } = this.props;
 
-        return <Tabs>
-            <TabList>
-                <Tab>
-                    <Localized id='entitydetails-Helpers--machinery'>
-                        { 'Machinery' }
-                    </Localized>
-                    <MachineryCount machinery={ machinery } />
-                </Tab>
-                <Tab>
-                    <Localized id='entitydetails-Helpers--locales'>
-                        { 'Locales' }
-                    </Localized>
-                    <OtherLocalesCount otherlocales={ otherlocales } />
-                </Tab>
-                <Tab>
-                    <Localized id='entitydetails-Helpers--comments'>
-                        { 'Comments' }
-                    </Localized>
-                    <CommentCount teamComments={ teamComments }/>
-                </Tab>
-            </TabList>
-
-            <TabPanel>
-                <Machinery
-                    isReadOnlyEditor={ isReadOnlyEditor }
-                    locale={ locale }
-                    machinery={ machinery }
-                    updateEditorTranslation={ updateEditorTranslation }
-                    searchMachinery={ searchMachinery }
-                />
-            </TabPanel>
-            <TabPanel>
-                <OtherLocales
-                    entity={ entity }
-                    isReadOnlyEditor={ isReadOnlyEditor }
-                    otherlocales={ otherlocales }
-                    user={ user }
-                    parameters={ parameters }
-                    updateEditorTranslation={ updateEditorTranslation }
-                />
-            </TabPanel>
-            <TabPanel>
-                <TeamComments
-                    teamComments={ teamComments }
-                    user={ user }
-                    addComment={ addComment }
-                />
-            </TabPanel>
-        </Tabs>;
+        return <>
+            <div className="top">
+                <Tabs>
+                    <TabList>
+                        <Tab>
+                            <Localized id='entitydetails-Helpers--terms'>
+                                { 'Terms' }
+                            </Localized>
+                            <TermCount terms={ terms }/>
+                        </Tab>
+                        <Tab>
+                            <Localized id='entitydetails-Helpers--comments'>
+                                { 'Comments' }
+                            </Localized>
+                            <CommentCount teamComments={ teamComments }/>
+                        </Tab>
+                    </TabList>
+                    <TabPanel>
+                        <Terms
+                            isReadOnlyEditor={ isReadOnlyEditor }
+                            terms={ terms }
+                            addTextToEditorTranslation={ addTextToEditorTranslation }
+                        />
+                    </TabPanel>
+                    <TabPanel>
+                        <TeamComments
+                            teamComments={ teamComments }
+                            user={ user }
+                            addComment={ addComment }
+                        />
+                    </TabPanel>
+                </Tabs>
+            </div>
+            <div className="bottom">
+                <Tabs>
+                    <TabList>
+                        <Tab>
+                            <Localized id='entitydetails-Helpers--machinery'>
+                                { 'Machinery' }
+                            </Localized>
+                            <MachineryCount machinery={ machinery } />
+                        </Tab>
+                        <Tab>
+                            <Localized id='entitydetails-Helpers--locales'>
+                                { 'Locales' }
+                            </Localized>
+                            <OtherLocalesCount otherlocales={ otherlocales } />
+                        </Tab>
+                    </TabList>
+                    <TabPanel>
+                        <Machinery
+                            isReadOnlyEditor={ isReadOnlyEditor }
+                            locale={ locale }
+                            machinery={ machinery }
+                            updateEditorTranslation={ updateEditorTranslation }
+                            searchMachinery={ searchMachinery }
+                        />
+                    </TabPanel>
+                    <TabPanel>
+                        <OtherLocales
+                            entity={ entity }
+                            isReadOnlyEditor={ isReadOnlyEditor }
+                            otherlocales={ otherlocales }
+                            user={ user }
+                            parameters={ parameters }
+                            updateEditorTranslation={ updateEditorTranslation }
+                        />
+                    </TabPanel>
+                </Tabs>
+            </div>
+        </>;
     }
 }

--- a/frontend/src/modules/entitydetails/components/Metadata.css
+++ b/frontend/src/modules/entitydetails/components/Metadata.css
@@ -50,6 +50,15 @@
     cursor: pointer;
 }
 
+.metadata .original .term {
+    background: inherit;
+    border-bottom: 1px solid #7BC876;
+    color: inherit;
+    cursor: pointer;
+    font-weight: normal;
+    font-style: inherit;
+}
+
 .metadata ul {
     list-style: none;
     margin: 0;

--- a/frontend/src/modules/entitydetails/components/OriginalStringProxy.js
+++ b/frontend/src/modules/entitydetails/components/OriginalStringProxy.js
@@ -8,12 +8,14 @@ import GenericOriginalString from './GenericOriginalString';
 
 import type { Entity } from 'core/api';
 import type { Locale } from 'core/locale';
+import type { TermState } from 'core/term';
 
 
 type Props = {|
     +entity: Entity,
     +locale: Locale,
     +pluralForm: number,
+    +terms: TermState,
     +handleClickOnPlaceable: (SyntheticMouseEvent<HTMLParagraphElement>) => void,
 |};
 
@@ -28,6 +30,7 @@ export default function OriginalStringProxy(props: Props) {
     if (props.entity.format === 'ftl') {
         return <FluentOriginalString
             entity={ props.entity }
+            terms={ props.terms }
             handleClickOnPlaceable={ props.handleClickOnPlaceable }
         />;
     }
@@ -36,6 +39,7 @@ export default function OriginalStringProxy(props: Props) {
         entity={ props.entity }
         locale={ props.locale }
         pluralForm={ props.pluralForm }
+        terms={ props.terms }
         handleClickOnPlaceable={ props.handleClickOnPlaceable }
     />;
 }

--- a/frontend/src/modules/entitydetails/components/TermsPopup.css
+++ b/frontend/src/modules/entitydetails/components/TermsPopup.css
@@ -1,0 +1,16 @@
+.terms-popup {
+    background-color: #272A2F;
+    border: 1px solid #333941;
+    font-style: normal;
+    max-width: 500px;
+    position: absolute;
+    z-index: 20;
+}
+
+.terms-popup .terms-list .term:not(.cannot-copy):hover {
+    background-color: #3F4752;
+}
+
+.terms-popup li.term:last-child {
+    border-bottom: none;
+}

--- a/frontend/src/modules/entitydetails/components/TermsPopup.js
+++ b/frontend/src/modules/entitydetails/components/TermsPopup.js
@@ -1,0 +1,49 @@
+/* @flow */
+
+import * as React from 'react';
+import onClickOutside from 'react-onclickoutside';
+
+import './TermsPopup.css';
+
+import { TermsList } from 'core/term';
+
+import type { TermType } from 'core/api';
+
+
+type Props = {|
+    +isReadOnlyEditor: boolean,
+    +terms: Array<TermType>,
+    +addTextToEditorTranslation: (string) => void,
+    +hide: () => void,
+|};
+
+
+/**
+ * Shows a popup with a list of all terms belonging to the highlighted one.
+ */
+export function TermsPopup(props: Props) {
+    const { terms } = props;
+
+    // This method is called by the Higher-Order Component `onClickOutside`
+    // when a user clicks outside this component.
+    TermsPopup.handleClickOutside = () => props.hide();
+
+    if (!terms.length) {
+        return null;
+    }
+
+    return <div className="terms-popup" onClick={ props.hide }>
+        <TermsList
+            terms={ terms }
+            isReadOnlyEditor={ props.isReadOnlyEditor }
+            addTextToEditorTranslation={ props.addTextToEditorTranslation }
+        />
+    </div>;
+}
+
+
+const clickOutsideConfig = {
+    handleClickOutside: () => TermsPopup.handleClickOutside
+};
+
+export default onClickOutside(TermsPopup, clickOutsideConfig);

--- a/frontend/src/modules/fluentoriginal/components/FluentOriginalString.js
+++ b/frontend/src/modules/fluentoriginal/components/FluentOriginalString.js
@@ -9,10 +9,12 @@ import SimpleString from './SimpleString';
 import SourceString from './SourceString';
 
 import type { Entity } from 'core/api';
+import type { TermState } from 'core/term';
 
 
 type Props = {|
     +entity: Entity,
+    +terms: TermState,
     +handleClickOnPlaceable: (SyntheticMouseEvent<HTMLParagraphElement>) => void,
 |};
 
@@ -30,6 +32,7 @@ export default function FluentOriginalString(props: Props) {
     if (syntax === 'simple') {
         return <SimpleString
             entity={ props.entity }
+            terms={ props.terms }
             handleClickOnPlaceable={ props.handleClickOnPlaceable }
         />;
     }
@@ -37,6 +40,7 @@ export default function FluentOriginalString(props: Props) {
     if (syntax === 'rich') {
         return <RichString
             entity={ props.entity }
+            terms={ props.terms }
             handleClickOnPlaceable={ props.handleClickOnPlaceable }
         />;
     }
@@ -44,6 +48,7 @@ export default function FluentOriginalString(props: Props) {
     // Complex, unsupported strings.
     return <SourceString
         entity={ props.entity }
+        terms={ props.terms }
         handleClickOnPlaceable={ props.handleClickOnPlaceable }
     />
 }

--- a/frontend/src/modules/fluentoriginal/components/RichString.js
+++ b/frontend/src/modules/fluentoriginal/components/RichString.js
@@ -5,10 +5,12 @@ import { serializeVariantKey } from '@fluent/syntax';
 
 import './RichString.css';
 
-import { WithPlaceablesForFluent } from 'core/placeable';
+import { WithPlaceablesForFluentNoLeadingSpace } from 'core/placeable';
+import { withTerms } from 'core/term';
 import { fluent } from 'core/utils';
 
 import type { Entity } from 'core/api';
+import type { TermState } from 'core/term';
 import type {
     FluentAttribute,
     FluentAttributes,
@@ -19,14 +21,19 @@ import type {
 
 type Props = {|
     +entity: Entity,
+    +terms: TermState,
     +handleClickOnPlaceable: (SyntheticMouseEvent<HTMLParagraphElement>) => void,
 |};
+
+
+const WithPlaceablesTerms = withTerms(WithPlaceablesForFluentNoLeadingSpace);
 
 
 function renderItem(
     value: string,
     label: string,
     key: string,
+    terms: TermState,
     className: ?string,
     attributeName: ?string,
 ): React.Node {
@@ -44,9 +51,9 @@ function renderItem(
         </td>
         <td>
             <span>
-                <WithPlaceablesForFluent>
+                <WithPlaceablesTerms terms={ terms }>
                     { value }
-                </WithPlaceablesForFluent>
+                </WithPlaceablesTerms>
             </span>
         </td>
     </tr>;
@@ -55,6 +62,7 @@ function renderItem(
 
 function renderElements(
     elements: Array<PatternElement>,
+    terms: TermState,
     attributeName: ?string,
 ): React.Node {
     let indent = false;
@@ -72,6 +80,7 @@ function renderElements(
                     variant.value.elements[0].value,
                     serializeVariantKey(variant.key),
                     [index, i].join('-'),
+                    terms,
                     indent ? 'indented' : null,
                     attributeName,
                 );
@@ -93,25 +102,27 @@ function renderElements(
                 element.value,
                 label,
                 index.toString(),
+                terms,
             );
         }
     });
 }
 
 
-function renderValue(value: Pattern, attributeName?: string): React.Node {
+function renderValue(value: Pattern, terms: TermState, attributeName?: string): React.Node {
     if (!value) {
         return null;
     }
 
     return renderElements(
         value.elements,
+        terms,
         attributeName,
     );
 }
 
 
-function renderAttributes(attributes: ?FluentAttributes): React.Node {
+function renderAttributes(attributes: ?FluentAttributes, terms: TermState): React.Node {
     if (!attributes) {
         return null;
     }
@@ -119,6 +130,7 @@ function renderAttributes(attributes: ?FluentAttributes): React.Node {
     return attributes.map((attribute: FluentAttribute) => {
         return renderValue(
             attribute.value,
+            terms,
             attribute.id.name,
         );
     });
@@ -135,8 +147,8 @@ export default function RichString(props: Props) {
 
     return <table className="original fluent-rich-string" onClick={ props.handleClickOnPlaceable }>
         <tbody>
-            { renderValue(message.value) }
-            { renderAttributes(message.attributes) }
+            { renderValue(message.value, props.terms) }
+            { renderAttributes(message.attributes, props.terms) }
         </tbody>
     </table>;
 }

--- a/frontend/src/modules/fluentoriginal/components/RichString.test.js
+++ b/frontend/src/modules/fluentoriginal/components/RichString.test.js
@@ -18,18 +18,19 @@ describe('<RichString>', () => {
     it('renders value and each attribute correctly', () => {
         const wrapper = shallow(<RichString
             entity = { ENTITY }
+            terms = { {} }
         />);
 
-        expect(wrapper.find('ContentMarker')).toHaveLength(3);
+        expect(wrapper.find('WithTerms')).toHaveLength(3);
 
         expect(wrapper.find('label').at(0).html()).toContain('Value');
-        expect(wrapper.find('ContentMarker').at(0).html()).toContain('Hello');
+        expect(wrapper.find('WithTerms').at(0).html()).toContain('Hello');
 
         expect(wrapper.find('label').at(1).html()).toContain('genre');
-        expect(wrapper.find('ContentMarker').at(1).html()).toContain('Pop');
+        expect(wrapper.find('WithTerms').at(1).html()).toContain('Pop');
 
         expect(wrapper.find('label').at(2).html()).toContain('album');
-        expect(wrapper.find('ContentMarker').at(2).html()).toContain('Hello and Good Bye');
+        expect(wrapper.find('WithTerms').at(2).html()).toContain('Hello and Good Bye');
     });
 
     it('renders select expression correctly', () => {
@@ -46,15 +47,16 @@ user-entry =
 
         const wrapper = shallow(<RichString
             entity = { entity }
+            terms = { {} }
         />);
 
-        expect(wrapper.find('ContentMarker')).toHaveLength(2);
+        expect(wrapper.find('WithTerms')).toHaveLength(2);
 
         expect(wrapper.find('label').at(0).html()).toContain('variant-1');
-        expect(wrapper.find('ContentMarker').at(0).html()).toContain('Hello!');
+        expect(wrapper.find('WithTerms').at(0).html()).toContain('Hello!');
 
         expect(wrapper.find('label').at(1).html()).toContain('variant-2');
-        expect(wrapper.find('ContentMarker').at(1).html()).toContain('Good Bye!');
+        expect(wrapper.find('WithTerms').at(1).html()).toContain('Good Bye!');
     });
 
     it('renders select expression in attributes properly', () => {
@@ -77,31 +79,33 @@ my-entry =
 
         const wrapper = shallow(<RichString
             entity = { entity }
+            terms = { {} }
         />);
 
-        expect(wrapper.find('ContentMarker')).toHaveLength(4);
+        expect(wrapper.find('WithTerms')).toHaveLength(4);
 
         expect(wrapper.find('label .attribute-label').at(0).html()).toContain('label');
         expect(wrapper.find('label').at(0).html()).toContain('macosx');
-        expect(wrapper.find('ContentMarker').at(0).html()).toContain('Preferences');
+        expect(wrapper.find('WithTerms').at(0).html()).toContain('Preferences');
 
         expect(wrapper.find('label .attribute-label').at(1).html()).toContain('label');
         expect(wrapper.find('label').at(1).html()).toContain('other');
-        expect(wrapper.find('ContentMarker').at(1).html()).toContain('Options');
+        expect(wrapper.find('WithTerms').at(1).html()).toContain('Options');
 
         expect(wrapper.find('label .attribute-label').at(2).html()).toContain('accesskey');
         expect(wrapper.find('label').at(2).html()).toContain('macosx');
-        expect(wrapper.find('ContentMarker').at(2).html()).toContain('e');
+        expect(wrapper.find('WithTerms').at(2).html()).toContain('e');
 
         expect(wrapper.find('label .attribute-label').at(3).html()).toContain('accesskey');
         expect(wrapper.find('label').at(3).html()).toContain('other');
-        expect(wrapper.find('ContentMarker').at(3).html()).toContain('s');
+        expect(wrapper.find('WithTerms').at(3).html()).toContain('s');
     });
 
     it('calls the handleClickOnPlaceable function on click on .original', () => {
         const handleClickOnPlaceable = sinon.spy();
         const wrapper = shallow(<RichString
             entity = { ENTITY }
+            terms = { {} }
             handleClickOnPlaceable={ handleClickOnPlaceable }
         />);
 

--- a/frontend/src/modules/fluentoriginal/components/SimpleString.js
+++ b/frontend/src/modules/fluentoriginal/components/SimpleString.js
@@ -2,16 +2,22 @@
 
 import * as React from 'react';
 
-import { WithPlaceablesForFluent } from 'core/placeable';
+import { WithPlaceablesForFluentNoLeadingSpace } from 'core/placeable';
+import { withTerms } from 'core/term';
 import { fluent } from 'core/utils';
 
 import type { Entity } from 'core/api';
+import type { TermState } from 'core/term';
 
 
 type Props = {|
     +entity: Entity,
+    +terms: TermState,
     +handleClickOnPlaceable: (SyntheticMouseEvent<HTMLParagraphElement>) => void,
 |};
+
+
+const WithPlaceablesTerms = withTerms(WithPlaceablesForFluentNoLeadingSpace);
 
 
 /**
@@ -21,8 +27,8 @@ export default function SimpleString(props: Props) {
     const original = fluent.getSimplePreview(props.entity.original);
 
     return <p className="original" onClick={ props.handleClickOnPlaceable }>
-        <WithPlaceablesForFluent>
+        <WithPlaceablesTerms terms={ props.terms }>
             { original }
-        </WithPlaceablesForFluent>
+        </WithPlaceablesTerms>
     </p>;
 }

--- a/frontend/src/modules/fluentoriginal/components/SimpleString.test.js
+++ b/frontend/src/modules/fluentoriginal/components/SimpleString.test.js
@@ -20,8 +20,8 @@ describe('<SimpleString>', () => {
             entity = { ENTITY }
         />);
 
-        expect(wrapper.find('.original ContentMarker').children()).toHaveLength(1);
-        expect(wrapper.find('.original ContentMarker').children().text()).toEqual('Hello\nSimple\nString');
+        expect(wrapper.find('.original WithTerms').children()).toHaveLength(1);
+        expect(wrapper.find('.original WithTerms').children().text()).toEqual('Hello\nSimple\nString');
     });
 
     it('calls the handleClickOnPlaceable function on click on .original', () => {

--- a/frontend/src/modules/fluentoriginal/components/SourceString.js
+++ b/frontend/src/modules/fluentoriginal/components/SourceString.js
@@ -2,15 +2,21 @@
 
 import * as React from 'react';
 
-import { WithPlaceablesForFluent } from 'core/placeable';
+import { WithPlaceablesForFluentNoLeadingSpace } from 'core/placeable';
+import { withTerms } from 'core/term';
 
 import type { Entity } from 'core/api';
+import type { TermState } from 'core/term';
 
 
 type Props = {|
     +entity: Entity,
+    +terms: TermState,
     +handleClickOnPlaceable: (SyntheticMouseEvent<HTMLParagraphElement>) => void,
 |};
+
+
+const WithPlaceablesTerms = withTerms(WithPlaceablesForFluentNoLeadingSpace);
 
 
 /**
@@ -18,8 +24,8 @@ type Props = {|
  */
 export default function SourceString(props: Props) {
     return <p className="original" onClick={ props.handleClickOnPlaceable }>
-        <WithPlaceablesForFluent>
+        <WithPlaceablesTerms terms={ props.terms }>
             { props.entity.original }
-        </WithPlaceablesForFluent>
+        </WithPlaceablesTerms>
     </p>;
 }

--- a/frontend/src/modules/fluentoriginal/components/SourceString.test.js
+++ b/frontend/src/modules/fluentoriginal/components/SourceString.test.js
@@ -17,8 +17,8 @@ describe('<SourceString>', () => {
             entity = { ENTITY }
         />);
 
-        expect(wrapper.find('.original ContentMarker').children()).toHaveLength(1);
-        expect(wrapper.find('.original ContentMarker').children().text()).toEqual('title = Hello From The Other Side');
+        expect(wrapper.find('.original WithTerms').children()).toHaveLength(1);
+        expect(wrapper.find('.original WithTerms').children().text()).toEqual('title = Hello From The Other Side');
     });
 
     it('calls the handleClickOnPlaceable function on click on .original', () => {

--- a/frontend/src/modules/history/components/History.css
+++ b/frontend/src/modules/history/components/History.css
@@ -17,7 +17,6 @@
 }
 
 .history > p {
-    border-bottom: 1px solid #5E6475;
     color: #aaa;
     font-style: italic;
     padding: 15px 10px;

--- a/frontend/src/modules/otherlocales/components/Count.js
+++ b/frontend/src/modules/otherlocales/components/Count.js
@@ -13,11 +13,7 @@ type Props = {|
 export default function Count(props: Props) {
     const { otherlocales } = props;
 
-    if (otherlocales.fetching) {
-        return null;
-    }
-
-    if (!otherlocales.translations) {
+    if (otherlocales.fetching || !otherlocales.translations) {
         return null;
     }
 

--- a/frontend/src/modules/otherlocales/components/OtherLocales.css
+++ b/frontend/src/modules/otherlocales/components/OtherLocales.css
@@ -12,7 +12,6 @@
 }
 
 .other-locales > p {
-    border-bottom: 1px solid #5E6475;
     color: #aaa;
     font-style: italic;
     padding: 15px 10px;

--- a/frontend/src/modules/otherlocales/components/OtherLocales.js
+++ b/frontend/src/modules/otherlocales/components/OtherLocales.js
@@ -52,15 +52,11 @@ export default class OtherLocales extends React.Component<Props> {
     render() {
         const { otherlocales } = this.props;
 
-        if (!otherlocales.translations) {
+        if (otherlocales.fetching || !otherlocales.translations) {
             return null;
         }
 
         const translations = otherlocales.translations;
-
-        if (otherlocales.fetching) {
-            return null;
-        }
 
         if (!translations.other.length && !translations.preferred.length) {
             return this.renderNoResults();

--- a/frontend/src/modules/teamcomments/components/Count.js
+++ b/frontend/src/modules/teamcomments/components/Count.js
@@ -13,11 +13,7 @@ type Props = {|
 export default function Count(props: Props) {
     const { teamComments } = props;
 
-    if (teamComments.fetching) {
-        return null;
-    }
-
-    if (!teamComments.comments) {
+    if (teamComments.fetching || !teamComments.comments) {
         return null;
     }
 

--- a/frontend/src/modules/teamcomments/components/TeamComments.css
+++ b/frontend/src/modules/teamcomments/components/TeamComments.css
@@ -9,7 +9,6 @@
 }
 
 .no-team-comments {
-    border-bottom: 1px solid #5E6475;
     color: #aaa;
     font-style: italic;
     line-height: 22px;

--- a/frontend/src/modules/teamcomments/components/TeamComments.js
+++ b/frontend/src/modules/teamcomments/components/TeamComments.js
@@ -20,15 +20,11 @@ type Props = {|
 export default function TeamComments(props: Props) {
     const { teamComments, user, addComment } = props;
 
-    if (teamComments.fetching) {
+    if (teamComments.fetching || !teamComments.comments) {
         return null;
     }
 
     const comments = teamComments.comments;
-
-    if (!comments) {
-        return null;
-    }
 
     let canComment = user.isAuthenticated;
 

--- a/frontend/src/modules/teamcomments/components/TeamComments.test.js
+++ b/frontend/src/modules/teamcomments/components/TeamComments.test.js
@@ -18,7 +18,6 @@ describe('<TeamComments>', () => {
         />);
 
         expect(wrapper.find('p').text()).toEqual('No comments available.');
-
     });
 
     it('renders correctly when there are comments', () => {

--- a/frontend/src/modules/terms/components/Count.js
+++ b/frontend/src/modules/terms/components/Count.js
@@ -13,11 +13,7 @@ type Props = {|
 export default function TermCount(props: Props) {
     const { terms } = props;
 
-    if (terms.fetching) {
-        return null;
-    }
-
-    if (!terms.terms ) {
+    if (terms.fetching || !terms.terms ) {
         return null;
     }
 

--- a/frontend/src/modules/terms/components/Count.js
+++ b/frontend/src/modules/terms/components/Count.js
@@ -1,0 +1,29 @@
+/* @flow */
+
+import * as React from 'react';
+
+import type { TermState } from 'core/term';
+
+
+type Props = {|
+    terms: TermState,
+|};
+
+
+export default function TermCount(props: Props) {
+    const { terms } = props;
+
+    if (terms.fetching) {
+        return null;
+    }
+
+    if (!terms.terms ) {
+        return null;
+    }
+
+    const termCount = terms.terms.length;
+
+    return <span className='count'>
+        { termCount }
+    </span>;
+}

--- a/frontend/src/modules/terms/components/Terms.css
+++ b/frontend/src/modules/terms/components/Terms.css
@@ -1,0 +1,6 @@
+.no-terms {
+    color: #aaa;
+    font-style: italic;
+    line-height: 22px;
+    padding: 15px 10px;
+}

--- a/frontend/src/modules/terms/components/Terms.js
+++ b/frontend/src/modules/terms/components/Terms.js
@@ -1,0 +1,48 @@
+/* @flow */
+
+import * as React from 'react';
+import { Localized } from '@fluent/react';
+
+import './Terms.css';
+
+import { TermsList } from 'core/term';
+
+import type { TermState } from 'core/term';
+
+type Props = {|
+    isReadOnlyEditor: boolean,
+    terms: TermState,
+    addTextToEditorTranslation: (string) => void,
+|};
+
+
+/**
+ * Shows all terms found in the source string.
+ */
+export default function Terms(props: Props) {
+    let { isReadOnlyEditor, terms, addTextToEditorTranslation } = props;
+
+    if (terms.fetching) {
+        return null;
+    }
+
+    terms = terms.terms;
+
+    if (!terms) {
+        return null;
+    }
+
+    return <section className="terms">
+        { !terms.length ?
+            <Localized id="entitydetails-Helpers--no-terms">
+                <p className="no-terms">No terms available.</p>
+            </Localized>
+            :
+            <TermsList
+                terms={ terms }
+                isReadOnlyEditor={ isReadOnlyEditor }
+                addTextToEditorTranslation={ addTextToEditorTranslation }            
+            />
+        }
+    </section>;
+}

--- a/frontend/src/modules/terms/components/Terms.js
+++ b/frontend/src/modules/terms/components/Terms.js
@@ -22,15 +22,11 @@ type Props = {|
 export default function Terms(props: Props) {
     let { isReadOnlyEditor, terms, addTextToEditorTranslation } = props;
 
-    if (terms.fetching) {
+    if (terms.fetching || !terms.terms) {
         return null;
     }
 
     terms = terms.terms;
-
-    if (!terms) {
-        return null;
-    }
 
     return <section className="terms">
         { !terms.length ?

--- a/frontend/src/modules/terms/components/Terms.test.js
+++ b/frontend/src/modules/terms/components/Terms.test.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import Terms from './Terms';
+import { TermsList } from 'core/term';
+
+describe('<Terms>', () => {
+    it('returns null while terms are loading', () => {
+        const terms = {
+            fetching: true,
+        };
+
+        const wrapper = shallow(<Terms
+            terms={ terms }
+        />);
+
+        expect(wrapper.type()).toBeNull();
+    });
+
+    it('renders a no terms message when no terms are available', () => {
+        const terms = {
+            terms: [],
+        };
+
+        const wrapper = shallow(<Terms
+            terms={ terms }
+        />);
+
+        expect(wrapper.find('p').text()).toEqual('No terms available.');
+    });
+
+    it('renders terms list correctly', () => {
+        const terms = {
+            terms: [{}],
+        };
+
+        const wrapper = shallow(<Terms
+            terms={ terms }
+        />);
+
+        expect(wrapper.find('p')).toHaveLength(0);
+        expect(wrapper.find(TermsList)).toHaveLength(1);
+    });
+});

--- a/frontend/src/modules/terms/index.js
+++ b/frontend/src/modules/terms/index.js
@@ -1,0 +1,8 @@
+/* @flow */
+
+export { default as Terms } from './components/Terms';
+export { default as TermCount } from './components/Count';
+
+// Name of this module.
+// Used as the key to store this module's reducer.
+export const NAME: string = 'terms';

--- a/frontend/src/rootReducer.js
+++ b/frontend/src/rootReducer.js
@@ -13,6 +13,7 @@ import * as plural from 'core/plural';
 import * as project from 'core/project';
 import * as resource from 'core/resource';
 import * as stats from 'core/stats';
+import * as term from 'core/term';
 import * as user from 'core/user';
 import * as batchactions from 'modules/batchactions';
 import * as history from 'modules/history';
@@ -46,5 +47,6 @@ export default (browserHistory: any) => combineReducers({
     [otherlocales.NAME]: otherlocales.reducer,
     [search.NAME]: search.reducer,
     [teamcomments.NAME]: teamcomments.reducer,
+    [term.NAME]: term.reducer,
     [unsavedchanges.NAME]: unsavedchanges.reducer,
 });

--- a/nltk.txt
+++ b/nltk.txt
@@ -1,1 +1,0 @@
-perluniprops

--- a/pontoon/terminology/tests/test_models.py
+++ b/pontoon/terminology/tests/test_models.py
@@ -1,0 +1,67 @@
+from __future__ import absolute_import
+
+import pytest
+
+from pontoon.terminology.models import Term
+from pontoon.test.factories import TermFactory, TermTranslationFactory
+
+
+@pytest.fixture
+def available_terms():
+    """This fixture provides:
+
+    - 4 generic terms
+    - 6 terms to be used for matching in strings
+    """
+    for i in range(0, 4):
+        TermFactory.create(text="term%s" % i)
+
+    TermFactory.create(text="abnormality")
+    TermFactory.create(text="student ambassador")
+    TermFactory.create(text="track")
+    TermFactory.create(text="sensitive")
+    TermFactory.create(text="surf")
+    TermFactory.create(text="Channel", case_sensitive=True)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "string, found_terms",
+    [
+        (
+            "Mozilla detected a serious abnormality in its internal data",
+            ["abnormality"],
+        ),
+        ("Join us as a student ambassador", ["student ambassador"]),
+        ("Block third-party content that tracks you around the web", ["track"]),
+        ("So avoid sensitive activities when surfing in public", ["sensitive", "surf"]),
+        ("You are currently on the Firefox release Channel", ["Channel"]),
+        ("You are currently on the Firefox release channel", []),
+    ],
+)
+def test_terms_for_string(string, found_terms, available_terms):
+    """
+    Find available terms in the given string.
+    """
+    terms = Term.objects.for_string(string)
+    assert len(terms) == len(found_terms)
+
+    for i, term in enumerate(terms):
+        term.text = found_terms[i]
+
+
+@pytest.mark.django_db
+def test_term_translation(locale_a):
+    """
+    Find locale translation of the given term.
+    """
+    term = TermFactory.create(text="term")
+    assert term.translation(locale_a) is None
+
+    TermTranslationFactory.create(
+        locale=locale_a, term=term, text="translation",
+    )
+    assert term.translation(locale_a) == "translation"
+
+    do_not_translate = TermFactory.create(text="term", do_not_translate=True)
+    assert do_not_translate.translation(locale_a) == "term"

--- a/pontoon/terminology/urls.py
+++ b/pontoon/terminology/urls.py
@@ -1,0 +1,10 @@
+from __future__ import absolute_import
+
+from django.conf.urls import url
+
+from . import views
+
+urlpatterns = [
+    # AJAX: Retrieve terms for given Entity and Locale
+    url(r"^get-terms/", views.get_terms, name="pontoon.terms.get"),
+]

--- a/pontoon/terminology/views.py
+++ b/pontoon/terminology/views.py
@@ -1,0 +1,37 @@
+from __future__ import absolute_import
+
+from django.http import JsonResponse
+from django.shortcuts import get_object_or_404
+from django.utils.datastructures import MultiValueDictKeyError
+
+from pontoon.base.models import Locale
+from pontoon.base.utils import require_AJAX
+from pontoon.terminology.models import Term
+
+
+@require_AJAX
+def get_terms(request):
+    """Retrieve terms for given source string and Locale."""
+    try:
+        source_string = request.GET["source_string"]
+        locale_code = request.GET["locale"]
+    except MultiValueDictKeyError as e:
+        return JsonResponse(
+            {"status": False, "message": "Bad Request: {error}".format(error=e)},
+            status=400,
+        )
+
+    locale = get_object_or_404(Locale, code=locale_code)
+    payload = []
+
+    for term in Term.objects.for_string(source_string):
+        data = {
+            "text": term.text,
+            "part_of_speech": term.part_of_speech,
+            "definition": term.definition,
+            "usage": term.usage,
+            "translation": term.translation(locale),
+        }
+        payload.append(data)
+
+    return JsonResponse(payload, safe=False)

--- a/pontoon/test/factories.py
+++ b/pontoon/test/factories.py
@@ -23,6 +23,7 @@ from pontoon.base.models import (
 )
 from pontoon.checks.models import Error, Warning
 from pontoon.tags.models import Tag
+from pontoon.terminology.models import Term, TermTranslation
 
 
 class UserFactory(DjangoModelFactory):
@@ -191,3 +192,23 @@ class TagFactory(DjangoModelFactory):
 
     class Meta:
         model = Tag
+
+
+class TermFactory(DjangoModelFactory):
+    text = Sequence(lambda n: "Term {0}".format(n))
+    definition = "definition"
+    part_of_speech = "part_of_speech"
+    case_sensitive = False
+    do_not_translate = False
+
+    class Meta:
+        model = Term
+
+
+class TermTranslationFactory(DjangoModelFactory):
+    term = SubFactory(TermFactory)
+    locale = SubFactory(LocaleFactory)
+    text = Sequence(lambda n: "Term Translation {0}".format(n))
+
+    class Meta:
+        model = TermTranslation

--- a/pontoon/urls.py
+++ b/pontoon/urls.py
@@ -94,6 +94,7 @@ urlpatterns = [
     url(r"^pontoon\.js$", pontoon_js_view),
     url(r"^static/js/pontoon\.js$", pontoon_js_view),
     # Include URL configurations from installed apps
+    url(r"^terminology/", include("pontoon.terminology.urls")),
     url(r"^translations/", include("pontoon.translations.urls")),
     url(r"", include("pontoon.teams.urls")),
     url(r"", include("pontoon.tour.urls")),

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -287,11 +287,6 @@ diff-match-patch==20121119 \
     --hash=sha256:9dba5611fbf27893347349fd51cc1911cb403682a7163373adacc565d11e2e4c
 
 # caighdean
-nltk==3.4.5 \
-    --hash=sha256:a08bdb4b8a1c13de16743068d9eb61c8c71c2e5d642e8e08205c528035843f82 \
-    --hash=sha256:bed45551259aa2101381bbdd5df37d44ca2669c5c3dad72439fa459b29137d94
-
-# caighdean
 requests==2.21.0 \
     --hash=sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b
 


### PR DESCRIPTION
This is a continuation of #1608 and a final piece of the [Terminology Presenation](https://github.com/mozilla/pontoon/blob/master/specs/0101-terminology-presentation.md) feature. It's branched off of #1608, on top of which it only adds [one new commit](https://github.com/mozilla/pontoon/commit/cabc4d01c868cb126bd98c651c73db6f34de3025), which implements term highlighting in the source string and the term popup.

**TESTING**
The patch is deployed to stage. I've put the `Usage` column of the [imported Mozilla's terms](https://mozilla-pontoon-staging.herokuapp.com/a/terminology/term/) into a [`terminology.ftl`](https://github.com/mathjazz/pontoon-test/commit/feb8a1521f4fb8fd0b47c05ef475acb5eb01cf05) file, which should help with real-life testing of term matching in the strings. See:
https://mozilla-pontoon-staging.herokuapp.com/fr/pontoon-test-2/terminology.ftl/
https://mozilla-pontoon-staging.herokuapp.com/de/pontoon-test-2/terminology.ftl/