### PR TITLE
Fix bug 1637851: Use exact search in tag getter

### DIFF
--- a/pontoon/tags/tests/utils/test_tags.py
+++ b/pontoon/tags/tests/utils/test_tags.py
@@ -198,7 +198,7 @@ def test_util_tags_tool_get_tags(tag_mock):
 
     # slug provided, `values` is filtered
     assert tags_tool.get_tags("FOO") == 23
-    assert list(filter_mock.filter.call_args) == [(), {"slug__contains": "FOO"}]
+    assert list(filter_mock.filter.call_args) == [(), {"slug": "FOO"}]
     assert list(tag_mock.return_value.filter.return_value.values.call_args) == [
         ("pk", "name", "slug", "priority", "project"),
         {},

--- a/pontoon/tags/utils/tags.py
+++ b/pontoon/tags/utils/tags.py
@@ -72,7 +72,7 @@ class TagsTool(Clonable):
             "pk", "name", "slug", "priority", "project"
         )
         if slug:
-            return tags.filter(slug__contains=slug)
+            return tags.filter(slug=slug)
         return tags
 
     def iter_tags(self, tags):


### PR DESCRIPTION
There's a bug in the Tags widget in the Project Admin, which doesn't show the right resources under the 'Shared' tag. We never "search" for tags, we just filter, so the query should be exact (instead of using contains).

@jotes You were the last one touching this code, could you please review? :-)