### PR TITLE
Fix bug 1639492: Make SYNC_TASK_TIMEOUT an environment variable

### DIFF
--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -186,6 +186,15 @@ you create:
    on Heroku because the Python buildpack alters the path in a way that breaks
    the built-in SVN command. Set this to ``/usr/lib/x86_64-linux-gnu/``.
 
+``SYNC_TASK_TIMEOUT``
+   Optional. Multiple sync tasks for the same project cannot run concurrently to
+   prevent potential DB and VCS inconsistencies. We store the information about
+   the running task in cache and clear it after the task completes. In case of
+   an error, we might never clear the cache, so we use SYNC_TASK_TIMEOUT as the
+   longest possible period after which the cache is cleared and the subsequent
+   task can run. The value should exceed the longest sync task of the instance.
+   The default value is 3600 seconds (1 hour).
+
 ``TZ``
    Timezone for the dynos that will run the app. Pontoon operates in UTC, so set
    this to ``UTC``.

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -728,7 +728,9 @@ SYNC_TASK_TIMEOUT_DEFAULT = 60 * 60 * 1  # 1 hour
 # potential DB and VCS inconsistencies. We store the information about the
 # running task in cache and clear it after the task completes. In case of an
 # error, we might never clear the cache, so we use SYNC_TASK_TIMEOUT as the
-# longest possible period after which the cache is cleared.
+# longest possible period (in seconds) after which the cache is cleared and
+# the subsequent task can run. The value should exceed the longest sync task
+# of the instance.
 SYNC_TASK_TIMEOUT = os.environ.get("SYNC_TASK_TIMEOUT", SYNC_TASK_TIMEOUT_DEFAULT)
 
 SYNC_LOG_RETENTION = 90  # days

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -722,7 +722,14 @@ ALLOWED_ATTRIBUTES = {
     "acronym": ["title"],
 }
 
-SYNC_TASK_TIMEOUT = 60 * 60 * 1  # 1 hour
+SYNC_TASK_TIMEOUT_DEFAULT = 60 * 60 * 1  # 1 hour
+
+# Multiple sync tasks for the same project cannot run concurrently to prevent
+# potential DB and VCS inconsistencies. We store the information about the
+# running task in cache and clear it after the task completes. In case of an
+# error, we might never clear the cache, so we use SYNC_TASK_TIMEOUT as the
+# longest possible period after which the cache is cleared.
+SYNC_TASK_TIMEOUT = os.environ.get("SYNC_TASK_TIMEOUT", SYNC_TASK_TIMEOUT_DEFAULT)
 
 SYNC_LOG_RETENTION = 90  # days
 


### PR DESCRIPTION
I've added comment trying to explain what this is about.