### PR TITLE
Fix bug 1635743 [API] Exclude system projects from default

### DIFF
--- a/pontoon/api/schema.py
+++ b/pontoon/api/schema.py
@@ -48,12 +48,16 @@ class ProjectLocale(DjangoObjectType, Stats):
 
 class Project(DjangoObjectType, Stats):
     class Meta:
+        convert_choices_to_enum = False
         model = ProjectModel
         only_fields = (
             "name",
             "slug",
             "disabled",
             "sync_disabled",
+            "pretranslation_enabled",
+            "visibility",
+            "system_project",
             "info",
             "deadline",
             "priority",

--- a/pontoon/api/tests/test_schema.py
+++ b/pontoon/api/tests/test_schema.py
@@ -24,7 +24,7 @@ class TestCyclicQueries(TestCase):
     def test_projects(self):
         body = {
             "query": """{
-                projects {
+                projects(includeSystem: true) {
                     name
                 }
             }"""


### PR DESCRIPTION
Introduces includeSystem parameter which is by default false. Tested with below graphql query on local box and getting expected result.

```
query {
  projects(includeDisabled: true, includeSystem: false) {
    name
  }
  locale(code:"mr") {
    name
    googleTranslateCode
    
    localizations(includeSystem: true) {
      project {
        name
      }
    }
  }
}
```
@mathjazz r?