### PR TITLE
Fix bug 1561663 Admins should be able to remove an account

### DIFF
--- a/pontoon/actionlog/models.py
+++ b/pontoon/actionlog/models.py
@@ -25,7 +25,7 @@ class ActionLog(models.Model):
     action_type = models.CharField(max_length=50, choices=ACTIONS_TYPES)
     created_at = models.DateTimeField(auto_now_add=True)
     performed_by = models.ForeignKey(
-        "auth.User", models.CASCADE, related_name="actions"
+        "auth.User", models.SET_NULL, related_name="actions", null=True
     )
 
     # Used to track on what translation related actions apply.

--- a/pontoon/actionlog/models.py
+++ b/pontoon/actionlog/models.py
@@ -25,7 +25,7 @@ class ActionLog(models.Model):
     action_type = models.CharField(max_length=50, choices=ACTIONS_TYPES)
     created_at = models.DateTimeField(auto_now_add=True)
     performed_by = models.ForeignKey(
-        "auth.User", models.SET_NULL, related_name="actions", null=True
+        "auth.User", models.CASCADE, related_name="actions"
     )
 
     # Used to track on what translation related actions apply.

--- a/pontoon/base/admin.py
+++ b/pontoon/base/admin.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import uuid
+
 from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import (
@@ -11,8 +13,10 @@ from django.forms.models import ModelForm
 from django.forms import ChoiceField
 from django.urls import reverse
 
+from pontoon.actionlog.models import ActionLog
 from pontoon.base import models
 from pontoon.base import utils
+from pontoon.terminology.models import Term
 
 from pontoon.teams.utils import log_user_groups
 
@@ -54,6 +58,44 @@ class UserAdmin(AuthUserAdmin):
             )
 
             log_user_groups(request.user, obj, (add_groups, remove_groups))
+
+    def delete_model(self, request, obj):
+        random_hash = uuid.uuid4().hex
+        new_user = User.objects.create_user(
+            username="deleted-user-" + random_hash,
+            email="deleted-user-" + random_hash + "@example.com",
+            first_name="Deleted User",
+        )
+
+        ActionLog.objects.filter(performed_by=obj).update(performed_by=new_user)
+        models.PermissionChangelog.objects.filter(performed_by=obj).update(
+            performed_by=new_user
+        )
+        models.PermissionChangelog.objects.filter(performed_on=obj).update(
+            performed_on=new_user
+        )
+        models.Project.objects.filter(contact=obj).update(contact=new_user)
+        models.Translation.objects.filter(user=obj).update(user=new_user)
+        models.Translation.objects.filter(approved_user=obj).update(
+            approved_user=new_user
+        )
+        models.Translation.objects.filter(unapproved_user=obj).update(
+            unapproved_user=new_user
+        )
+        models.Translation.objects.filter(rejected_user=obj).update(
+            rejected_user=new_user
+        )
+        models.Translation.objects.filter(unrejected_user=obj).update(
+            unrejected_user=new_user
+        )
+        Term.objects.filter(created_by=obj).update(created_by=new_user)
+        models.Comment.objects.filter(author=obj).update(author=new_user)
+
+        super(UserAdmin, self).delete_model(request, obj)
+
+    def delete_queryset(self, request, queryset):
+        for obj in queryset:
+            self.delete_model(request, obj)
 
 
 class ExternalResourceInline(admin.TabularInline):

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -3627,7 +3627,7 @@ class TranslatedResource(AggregatedStats):
 
 
 class Comment(models.Model):
-    author = models.ForeignKey(User, models.SET_NULL, null=True)
+    author = models.ForeignKey(User, models.CASCADE)
     timestamp = models.DateTimeField(default=timezone.now)
     translation = models.ForeignKey(
         Translation, models.CASCADE, related_name="comments", blank=True, null=True,

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -3627,7 +3627,7 @@ class TranslatedResource(AggregatedStats):
 
 
 class Comment(models.Model):
-    author = models.ForeignKey(User, models.CASCADE)
+    author = models.ForeignKey(User, models.SET_NULL, null=True)
     timestamp = models.DateTimeField(default=timezone.now)
     translation = models.ForeignKey(
         Translation, models.CASCADE, related_name="comments", blank=True, null=True,

--- a/pontoon/contributors/utils.py
+++ b/pontoon/contributors/utils.py
@@ -115,6 +115,9 @@ def users_with_translations_counts(start_date=None, query_filters=None, limit=10
     # Assign properties to user objects.
     contributors = User.objects.filter(pk__in=user_stats.keys())
 
+    # Exclude deleted users.
+    contributors = contributors.filter(is_active=True)
+
     if None in user_stats.keys():
         contributors = list(contributors)
         contributors.append(

--- a/pontoon/terminology/models.py
+++ b/pontoon/terminology/models.py
@@ -84,7 +84,7 @@ class Term(models.Model):
 
     created_at = models.DateTimeField(auto_now_add=True)
     created_by = models.ForeignKey(
-        "auth.User", models.CASCADE, related_name="terms", null=True, blank=True
+        "auth.User", models.SET_NULL, related_name="terms", null=True, blank=True
     )
 
     objects = TermQuerySet.as_manager()

--- a/pontoon/terminology/models.py
+++ b/pontoon/terminology/models.py
@@ -84,7 +84,7 @@ class Term(models.Model):
 
     created_at = models.DateTimeField(auto_now_add=True)
     created_by = models.ForeignKey(
-        "auth.User", models.SET_NULL, related_name="terms", null=True, blank=True
+        "auth.User", models.CASCADE, related_name="terms", null=True, blank=True
     )
 
     objects = TermQuerySet.as_manager()


### PR DESCRIPTION
If we didn't modify the ForeignKey constraint on the Comment, Action Log etc, django admin ui shows these entities on the confirmation page. Thus marked it as Null.