### PR TITLE
Bug 1567400: Git commit as VCS_SYNC user, not translation author

### DIFF
--- a/pontoon/sync/vcs/repositories.py
+++ b/pontoon/sync/vcs/repositories.py
@@ -154,9 +154,9 @@ class CommitToGit(CommitToRepository):
         git_cmd = [
             "git",
             "-c",
-            f"user.name={user.first_name}",
+            f"user.name={settings.VCS_SYNC_NAME}",
             "-c",
-            f"user.email={user.email}",
+            f"user.email={settings.VCS_SYNC_EMAIL}",
         ]
 
         # Add new and remove missing paths


### PR DESCRIPTION
@jotes I misled you into this change, which I believe should be reverted. We should keep "Pontoon" as committer, and only use translation author as author.
