### PR TITLE
Send Systran code to server when retrieving profile owner

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -1074,6 +1074,9 @@ class Locale(AggregatedStats):
         if old is None or old.systran_translate_code == self.systran_translate_code:
             return
 
+        if not self.systran_translate_code:
+            return
+
         api_key = settings.SYSTRAN_TRANSLATE_API_KEY
         server = settings.SYSTRAN_TRANSLATE_SERVER
         profile_owner = settings.SYSTRAN_TRANSLATE_PROFILE_OWNER
@@ -1085,7 +1088,7 @@ class Locale(AggregatedStats):
         payload = {
             "key": api_key,
             "source": "en",
-            "target": self.code,
+            "target": self.systran_translate_code,
         }
 
         try:


### PR DESCRIPTION
We're sending the locale code instead of Systran code to the API when retrieving the profile owner. That means we don't get any matches for locales like `es-ES`, which use the `es` engine.