### PR TITLE
Fix bug 1632206: Preserve whitespace in submitted translations

### DIFF
--- a/pontoon/translations/forms.py
+++ b/pontoon/translations/forms.py
@@ -54,3 +54,6 @@ class CreateTranslationForm(forms.Form):
         if self.cleaned_data["plural_form"] == "-1":
             return None
         return self.cleaned_data["plural_form"]
+
+    def clean_translation(self):
+        return self.data.get("translation", "")

--- a/pontoon/translations/tests/test_forms.py
+++ b/pontoon/translations/tests/test_forms.py
@@ -107,3 +107,18 @@ def test_create_translation_form_clean_paths(entity_a, locale_a):
     )
     assert form.is_valid()
     assert form.cleaned_data["paths"] == ["a/d.ext", "foo/bar"]
+
+
+@pytest.mark.django_db
+def test_create_translation_form_clean_translation(entity_a, locale_a):
+    form = CreateTranslationForm(
+        {
+            "entity": entity_a.pk,
+            "translation": " salut ",
+            "locale": locale_a.code,
+            "plural_form": "-1",
+            "original": "hello",
+        }
+    )
+    assert form.is_valid()
+    assert form.cleaned_data["translation"] == " salut "


### PR DESCRIPTION
Add custom validation, which does not strip whitespace from the translation field.