### PR TITLE
Fix bug 1658420: Download terminology (.tbx)

### DIFF
--- a/frontend/public/static/locale/en-US/translate.ftl
+++ b/frontend/public/static/locale/en-US/translate.ftl
@@ -618,6 +618,7 @@ user-UserAvatar--alt-text = User Profile
 user-SignIn--sign-in = Sign in
 user-SignOut--sign-out = <glyph></glyph>Sign out
 
+user-UserMenu--download-terminology = <glyph></glyph>Download Terminology
 user-UserMenu--download-tm = <glyph></glyph>Download Translation Memory
 user-UserMenu--download-translations = <glyph></glyph>Download Translations
 user-UserMenu--upload-translations = <glyph></glyph>Upload Translations

--- a/frontend/src/core/user/components/UserMenu.js
+++ b/frontend/src/core/user/components/UserMenu.js
@@ -57,9 +57,6 @@ export class UserMenuBase extends React.Component<Props, State> {
         const project = parameters.project;
         const resource = parameters.resource;
 
-        const tmHref = `/${locale}/${project}/${locale}.${project}.tmx`;
-        const transHref = `/download/?code=${locale}&slug=${project}&part=${resource}`;
-
         const canDownload = (
             project !== 'all-projects' &&
             resource !== 'all-resources'
@@ -111,10 +108,21 @@ export class UserMenuBase extends React.Component<Props, State> {
 
                 <li>
                     <Localized
+                        id="user-UserMenu--download-terminology"
+                        elems={{ glyph: <i className="fa fa-cloud-download-alt fa-fw" /> }}
+                    >
+                        <a href={ `/terminology/${locale}.tbx` }>
+                            { '<glyph></glyph>Download Terminology' }
+                        </a>
+                    </Localized>
+                </li>
+
+                <li>
+                    <Localized
                         id="user-UserMenu--download-tm"
                         elems={{ glyph: <i className="fa fa-cloud-download-alt fa-fw" /> }}
                     >
-                        <a href={ tmHref }>
+                        <a href={ `/${locale}/${project}/${locale}.${project}.tmx` }>
                             { '<glyph></glyph>Download Translation Memory' }
                         </a>
                     </Localized>
@@ -126,7 +134,7 @@ export class UserMenuBase extends React.Component<Props, State> {
                         id="user-UserMenu--download-translations"
                         elems={{ glyph: <i className="fa fa-cloud-download-alt fa-fw" /> }}
                     >
-                        <a href={ transHref }>
+                        <a href={ `/download/?code=${locale}&slug=${project}&part=${resource}` }>
                             { '<glyph></glyph>Download Translations' }
                         </a>
                     </Localized>

--- a/pontoon/base/utils.py
+++ b/pontoon/base/utils.py
@@ -16,10 +16,7 @@ from guardian.decorators import permission_required as guardian_permission_requi
 from django.utils.text import slugify
 from six import BytesIO
 
-from xml.sax.saxutils import (
-    escape as xml_escape,
-    quoteattr,
-)
+from xml.sax.saxutils import escape, quoteattr
 
 from django.db.models import Prefetch
 from django.db.models.query import QuerySet
@@ -498,10 +495,10 @@ def build_translation_memory_file(creation_date, locale_code, entries):
             u"\n\t\t</tu>"
             % {
                 "tuid": quoteattr(tuid),
-                "source": xml_escape(source),
+                "source": escape(source),
                 "locale_code": quoteattr(locale_code),
-                "target": xml_escape(target),
-                "project_name": xml_escape(project_name),
+                "target": escape(target),
+                "project_name": escape(project_name),
             }
         )
 

--- a/pontoon/base/utils.py
+++ b/pontoon/base/utils.py
@@ -459,8 +459,7 @@ def convert_to_unix_time(my_datetime):
 def build_translation_memory_file(creation_date, locale_code, entries):
     """
     TMX files will contain large amount of entries and it's impossible to render all the data with
-    django templates.
-    Rendering of string in memory is a lot faster.
+    django templates. Rendering a string in memory is a lot faster.
     :arg datetime creation_date: when TMX file is being created.
     :arg str locale_code: code of a locale
     :arg list entries: A list which contains tuples with following items:
@@ -472,7 +471,7 @@ def build_translation_memory_file(creation_date, locale_code, entries):
                          * project_slug - slugified name of a project,
     """
     yield (
-        u'<?xml version="1.0" encoding="utf-8" ?>'
+        u'<?xml version="1.0" encoding="UTF-8"?>'
         u'\n<tmx version="1.4">'
         u"\n\t<header"
         u' adminlang="en-US"'

--- a/pontoon/terminology/urls.py
+++ b/pontoon/terminology/urls.py
@@ -7,4 +7,10 @@ from . import views
 urlpatterns = [
     # AJAX: Retrieve terms for given Entity and Locale
     url(r"^get-terms/", views.get_terms, name="pontoon.terms.get"),
+    # AJAX: Download terminology
+    url(
+        r"^(?P<locale>.+)\.tbx$",
+        views.download_terminology,
+        name="pontoon.download_tbx",
+    ),
 ]

--- a/pontoon/terminology/utils.py
+++ b/pontoon/terminology/utils.py
@@ -1,0 +1,62 @@
+from __future__ import absolute_import
+
+
+def build_terminology_file(term_translations, locale):
+    """
+    TBX files could contain large amount of entries and it's impossible to render all the data with
+    django templates. Rendering a string in memory is a lot faster.
+    """
+    yield (
+        u'<?xml version="1.0" encoding="UTF-8"?>'
+        u'\n<?xml-model href="https://raw.githubusercontent.com/LTAC-Global/TBX-Basic_dialect/master/DCA/TBXcoreStructV03_TBX-Basic_integrated.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>'
+        u'\n<?xml-model href="https://raw.githubusercontent.com/LTAC-Global/TBX-Basic_dialect/master/DCA/TBX-Basic_DCA.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>'
+        u'\n<tbx style="dca" type="TBX-Basic" xml:lang="en" xmlns="urn:iso:std:iso:30042:ed-2">'
+        u"\n\t<tbxHeader>"
+        u"\n\t\t<fileDesc>"
+        u"\n\t\t\t<titleStmt>"
+        u"\n\t\t\t\t<title>Mozilla Terms</title>"
+        u"\n\t\t\t</titleStmt>"
+        u"\n\t\t\t<sourceDesc>"
+        u"\n\t\t\t\t<p>from a Mozilla termbase</p>"
+        u"\n\t\t\t</sourceDesc>"
+        u"\n\t\t</fileDesc>"
+        u"\n\t\t<encodingDesc>"
+        u'\n\t\t\t<p type="XCSURI">TBXXCSV02.xcs</p>'
+        u"\n\t\t</encodingDesc>"
+        u"\n\t</tbxHeader>"
+        u"\n\t<text>"
+        u"\n\t\t<body>"
+    )
+
+    for translation in term_translations:
+        term = translation.term
+        yield (
+            u'\n\t\t\t<conceptEntry id="c%(id)s">'
+            u'\n\t\t\t\t<langSec xml:lang="en-US">'
+            u"\n\t\t\t\t\t<termSec>"
+            u"\n\t\t\t\t\t\t<term>%(term)s</term>"
+            u'\n\t\t\t\t\t\t<termNote type="partOfSpeech">%(part_of_speech)s</termNote>'
+            u"\n\t\t\t\t\t\t<descripGrp>"
+            u'\n\t\t\t\t\t\t\t<descrip type="definition">%(definition)s</descrip>'
+            u'\n\t\t\t\t\t\t\t<descrip type="context">%(usage)s</descrip>'
+            u"\n\t\t\t\t\t\t</descripGrp>"
+            u"\n\t\t\t\t\t</termSec>"
+            u"\n\t\t\t\t</langSec>"
+            u'\n\t\t\t\t<langSec xml:lang="%(locale)s">'
+            u"\n\t\t\t\t\t<termSec>"
+            u"\n\t\t\t\t\t\t<term>%(translation)s</term>"
+            u"\n\t\t\t\t\t</termSec>"
+            u"\n\t\t\t\t</langSec>"
+            u"\n\t\t\t</conceptEntry>"
+            % {
+                "id": term.pk,
+                "term": term.text,
+                "part_of_speech": term.part_of_speech,
+                "definition": term.definition,
+                "usage": term.usage,
+                "locale": locale,
+                "translation": translation.text,
+            }
+        )
+
+    yield (u"\n\t\t</body>" u"\n\t</text>" u"\n</tbx>")

--- a/pontoon/terminology/utils.py
+++ b/pontoon/terminology/utils.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from xml.sax.saxutils import escape, quoteattr
+
 
 def build_terminology_file(term_translations, locale):
     """
@@ -42,7 +44,7 @@ def build_terminology_file(term_translations, locale):
             u"\n\t\t\t\t\t\t</descripGrp>"
             u"\n\t\t\t\t\t</termSec>"
             u"\n\t\t\t\t</langSec>"
-            u'\n\t\t\t\t<langSec xml:lang="%(locale)s">'
+            u"\n\t\t\t\t<langSec xml:lang=%(locale)s>"
             u"\n\t\t\t\t\t<termSec>"
             u"\n\t\t\t\t\t\t<term>%(translation)s</term>"
             u"\n\t\t\t\t\t</termSec>"
@@ -50,12 +52,12 @@ def build_terminology_file(term_translations, locale):
             u"\n\t\t\t</conceptEntry>"
             % {
                 "id": term.pk,
-                "term": term.text,
-                "part_of_speech": term.part_of_speech,
-                "definition": term.definition,
-                "usage": term.usage,
-                "locale": locale,
-                "translation": translation.text,
+                "term": escape(term.text),
+                "part_of_speech": escape(term.part_of_speech),
+                "definition": escape(term.definition),
+                "usage": escape(term.usage),
+                "locale": quoteattr(locale),
+                "translation": escape(translation.text),
             }
         )
 

--- a/pontoon/terminology/views.py
+++ b/pontoon/terminology/views.py
@@ -1,12 +1,14 @@
 from __future__ import absolute_import
 
-from django.http import JsonResponse
+from django.http import JsonResponse, StreamingHttpResponse
 from django.shortcuts import get_object_or_404
 from django.utils.datastructures import MultiValueDictKeyError
+from django.views.decorators.http import condition
 
 from pontoon.base.models import Locale
 from pontoon.base.utils import require_AJAX
-from pontoon.terminology.models import Term
+from pontoon.terminology import utils
+from pontoon.terminology.models import Term, TermTranslation
 
 
 @require_AJAX
@@ -36,3 +38,20 @@ def get_terms(request):
         payload.append(data)
 
     return JsonResponse(payload, safe=False)
+
+
+@condition(etag_func=None)
+def download_terminology(request, locale):
+    locale = get_object_or_404(Locale, code=locale)
+
+    term_translations = TermTranslation.objects.filter(locale=locale).prefetch_related(
+        "term"
+    )
+    content = utils.build_terminology_file(term_translations, locale.code)
+
+    response = StreamingHttpResponse(content, content_type="text/xml")
+    response["Content-Disposition"] = 'attachment; filename="{locale}.tbx"'.format(
+        locale=locale.code
+    )
+
+    return response


### PR DESCRIPTION
The patch is deployed to stage:
https://mozilla-pontoon-staging.herokuapp.com/fr/firefox/all-resources/

To test, go to any translate page, click on the profile menu (top right) and select "Download Terminology". The .tbx file for the given locale will be downloaded.