### PR TITLE
Fix bug 1658420: Enable downloads of Terminology in TBX 2008 (v2) format

### DIFF
--- a/pontoon/base/utils.py
+++ b/pontoon/base/utils.py
@@ -502,7 +502,7 @@ def build_translation_memory_file(creation_date, locale_code, entries):
             }
         )
 
-    yield (u"\n\t</body>" u"\n</tmx>")
+    yield (u"\n\t</body>" u"\n</tmx>\n")
 
 
 def get_m2m_changes(current_qs, new_qs):

--- a/pontoon/terminology/urls.py
+++ b/pontoon/terminology/urls.py
@@ -7,14 +7,12 @@ from . import views
 urlpatterns = [
     # AJAX: Retrieve terms for given Entity and Locale
     url(r"^get-terms/", views.get_terms, name="pontoon.terms.get"),
-
     # AJAX: Download terminology in TBX 2.0
     url(
         r"^(?P<locale>.+)\.v2\.tbx$",
         views.download_terminology_tbx_v2,
         name="pontoon.terminology.download.tbx.v2",
     ),
-
     # AJAX: Download terminology in TBX 3.0
     url(
         r"^(?P<locale>.+)\.tbx$",

--- a/pontoon/terminology/urls.py
+++ b/pontoon/terminology/urls.py
@@ -10,13 +10,13 @@ urlpatterns = [
     # AJAX: Download terminology in TBX 2.0
     url(
         r"^(?P<locale>.+)\.v2\.tbx$",
-        views.download_terminology_tbx_v2,
+        views.DownloadTerminologyViewV2.as_view(),
         name="pontoon.terminology.download.tbx.v2",
     ),
     # AJAX: Download terminology in TBX 3.0
     url(
         r"^(?P<locale>.+)\.tbx$",
-        views.download_terminology_tbx_v3,
+        views.DownloadTerminologyViewV3.as_view(),
         name="pontoon.terminology.download.tbx.v3",
     ),
 ]

--- a/pontoon/terminology/urls.py
+++ b/pontoon/terminology/urls.py
@@ -7,10 +7,18 @@ from . import views
 urlpatterns = [
     # AJAX: Retrieve terms for given Entity and Locale
     url(r"^get-terms/", views.get_terms, name="pontoon.terms.get"),
-    # AJAX: Download terminology
+
+    # AJAX: Download terminology in TBX 2.0
+    url(
+        r"^(?P<locale>.+)\.v2\.tbx$",
+        views.download_terminology_tbx_v2,
+        name="pontoon.terminology.download.tbx.v2",
+    ),
+
+    # AJAX: Download terminology in TBX 3.0
     url(
         r"^(?P<locale>.+)\.tbx$",
-        views.download_terminology,
-        name="pontoon.download_tbx",
+        views.download_terminology_tbx_v3,
+        name="pontoon.terminology.download.tbx.v3",
     ),
 ]

--- a/pontoon/terminology/utils.py
+++ b/pontoon/terminology/utils.py
@@ -13,7 +13,7 @@ def build_tbx_v2_file(term_translations, locale):
     yield (
         u'<?xml version="1.0" encoding="UTF-8"?>'
         u'\n<!DOCTYPE martif SYSTEM "TBXcoreStructV02.dtd">'
-        u'\n<martif type="TBX" xml:lang="en">'
+        u'\n<martif type="TBX" xml:lang="en-US">'
         u"\n\t<martifHeader>"
         u"\n\t\t<fileDesc>"
         u"\n\t\t\t<titleStmt>"
@@ -35,7 +35,8 @@ def build_tbx_v2_file(term_translations, locale):
         term = translation.term
         yield (
             u'\n\t\t\t<termEntry id="c%(id)s">'
-            u'\n\t\t\t\t<langSec xml:lang="en-US">'
+            u'\n\t\t\t\t<descrip type="context">%(usage)s</descrip>'
+            u'\n\t\t\t\t<langSet xml:lang="en-US">'
             u"\n\t\t\t\t\t<ntig>"
             u"\n\t\t\t\t\t\t<termGrp>"
             u"\n\t\t\t\t\t\t\t<term>%(term)s</term>"
@@ -44,16 +45,15 @@ def build_tbx_v2_file(term_translations, locale):
             u"\n\t\t\t\t\t</ntig>"
             u"\n\t\t\t\t\t<descripGrp>"
             u'\n\t\t\t\t\t\t<descrip type="definition">%(definition)s</descrip>'
-            u'\n\t\t\t\t\t\t<descrip type="context">%(usage)s</descrip>'
             u"\n\t\t\t\t\t</descripGrp>"
-            u"\n\t\t\t\t</langSec>"
-            u"\n\t\t\t\t<langSec xml:lang=%(locale)s>"
+            u"\n\t\t\t\t</langSet>"
+            u"\n\t\t\t\t<langSet xml:lang=%(locale)s>"
             u"\n\t\t\t\t\t<ntig>"
             u"\n\t\t\t\t\t\t<termGrp>"
             u"\n\t\t\t\t\t\t\t<term>%(translation)s</term>"
             u"\n\t\t\t\t\t\t</termGrp>"
             u"\n\t\t\t\t\t</ntig>"
-            u"\n\t\t\t\t</langSec>"
+            u"\n\t\t\t\t</langSet>"
             u"\n\t\t\t</termEntry>"
             % {
                 "id": term.pk,
@@ -66,7 +66,7 @@ def build_tbx_v2_file(term_translations, locale):
             }
         )
 
-    yield (u"\n\t\t</body>" u"\n\t</text>" u"\n</tbx>\n")
+    yield (u"\n\t\t</body>" u"\n\t</text>" u"\n</martif>\n")
 
 
 def build_tbx_v3_file(term_translations, locale):

--- a/pontoon/terminology/utils.py
+++ b/pontoon/terminology/utils.py
@@ -3,8 +3,76 @@ from __future__ import absolute_import
 from xml.sax.saxutils import escape, quoteattr
 
 
-def build_terminology_file(term_translations, locale):
+def build_tbx_v2_file(term_translations, locale):
     """
+    Generates contents of the TBX 2008 (v2) file (TBX-Default dialect):
+
+    TBX files could contain large amount of entries and it's impossible to render all the data with
+    django templates. Rendering a string in memory is a lot faster.
+    """
+    yield (
+        u'<?xml version="1.0" encoding="UTF-8"?>'
+        u'\n<!DOCTYPE martif SYSTEM "TBXcoreStructV02.dtd">'
+        u'\n<martif type="TBX" xml:lang="en">'
+        u"\n\t<martifHeader>"
+        u"\n\t\t<fileDesc>"
+        u"\n\t\t\t<titleStmt>"
+        u"\n\t\t\t\t<title>Mozilla Terms</title>"
+        u"\n\t\t\t</titleStmt>"
+        u"\n\t\t\t<sourceDesc>"
+        u"\n\t\t\t\t<p>from a Mozilla termbase</p>"
+        u"\n\t\t\t</sourceDesc>"
+        u"\n\t\t</fileDesc>"
+        u"\n\t\t<encodingDesc>"
+        u'\n\t\t\t<p type="XCSURI">TBXXCSV02.xcs</p>'
+        u"\n\t\t</encodingDesc>"
+        u"\n\t</martifHeader>"
+        u"\n\t<text>"
+        u"\n\t\t<body>"
+    )
+
+    for translation in term_translations:
+        term = translation.term
+        yield (
+            u'\n\t\t\t<termEntry id="c%(id)s">'
+            u'\n\t\t\t\t<langSec xml:lang="en-US">'
+            u"\n\t\t\t\t\t<ntig>"
+            u"\n\t\t\t\t\t\t<termGrp>"
+            u"\n\t\t\t\t\t\t\t<term>%(term)s</term>"
+            u'\n\t\t\t\t\t\t\t<termNote type="partOfSpeech">%(part_of_speech)s</termNote>'
+            u"\n\t\t\t\t\t\t</termGrp>"
+            u"\n\t\t\t\t\t</ntig>"
+            u"\n\t\t\t\t\t<descripGrp>"
+            u'\n\t\t\t\t\t\t<descrip type="definition">%(definition)s</descrip>'
+            u'\n\t\t\t\t\t\t<descrip type="context">%(usage)s</descrip>'
+            u"\n\t\t\t\t\t</descripGrp>"
+            u"\n\t\t\t\t</langSec>"
+            u"\n\t\t\t\t<langSec xml:lang=%(locale)s>"
+            u"\n\t\t\t\t\t<ntig>"
+            u"\n\t\t\t\t\t\t<termGrp>"
+            u"\n\t\t\t\t\t\t\t<term>%(translation)s</term>"
+            u"\n\t\t\t\t\t\t</termGrp>"
+            u"\n\t\t\t\t\t</ntig>"
+            u"\n\t\t\t\t</langSec>"
+            u"\n\t\t\t</termEntry>"
+            % {
+                "id": term.pk,
+                "term": escape(term.text),
+                "part_of_speech": escape(term.part_of_speech),
+                "definition": escape(term.definition),
+                "usage": escape(term.usage),
+                "locale": quoteattr(locale),
+                "translation": escape(translation.text),
+            }
+        )
+
+    yield (u"\n\t\t</body>" u"\n\t</text>" u"\n</tbx>")
+
+
+def build_tbx_v3_file(term_translations, locale):
+    """
+    Generates contents of the TBX v3 file (TBX-Basic dialect, DCT style):
+
     TBX files could contain large amount of entries and it's impossible to render all the data with
     django templates. Rendering a string in memory is a lot faster.
     """

--- a/pontoon/terminology/utils.py
+++ b/pontoon/terminology/utils.py
@@ -66,7 +66,7 @@ def build_tbx_v2_file(term_translations, locale):
             }
         )
 
-    yield (u"\n\t\t</body>" u"\n\t</text>" u"\n</tbx>")
+    yield (u"\n\t\t</body>" u"\n\t</text>" u"\n</tbx>\n")
 
 
 def build_tbx_v3_file(term_translations, locale):
@@ -129,4 +129,4 @@ def build_tbx_v3_file(term_translations, locale):
             }
         )
 
-    yield (u"\n\t\t</body>" u"\n\t</text>" u"\n</tbx>")
+    yield (u"\n\t\t</body>" u"\n\t</text>" u"\n</tbx>\n")

--- a/pontoon/terminology/views.py
+++ b/pontoon/terminology/views.py
@@ -41,13 +41,30 @@ def get_terms(request):
 
 
 @condition(etag_func=None)
-def download_terminology(request, locale):
+def download_terminology_tbx_v2(request, locale):
     locale = get_object_or_404(Locale, code=locale)
 
     term_translations = TermTranslation.objects.filter(locale=locale).prefetch_related(
         "term"
     )
-    content = utils.build_terminology_file(term_translations, locale.code)
+    content = utils.build_tbx_v2_file(term_translations, locale.code)
+
+    response = StreamingHttpResponse(content, content_type="text/xml")
+    response["Content-Disposition"] = 'attachment; filename="{locale}.v2.tbx"'.format(
+        locale=locale.code
+    )
+
+    return response
+
+
+@condition(etag_func=None)
+def download_terminology_tbx_v3(request, locale):
+    locale = get_object_or_404(Locale, code=locale)
+
+    term_translations = TermTranslation.objects.filter(locale=locale).prefetch_related(
+        "term"
+    )
+    content = utils.build_tbx_v3_file(term_translations, locale.code)
 
     response = StreamingHttpResponse(content, content_type="text/xml")
     response["Content-Disposition"] = 'attachment; filename="{locale}.tbx"'.format(

--- a/pontoon/terminology/views.py
+++ b/pontoon/terminology/views.py
@@ -3,7 +3,9 @@ from __future__ import absolute_import
 from django.http import JsonResponse, StreamingHttpResponse
 from django.shortcuts import get_object_or_404
 from django.utils.datastructures import MultiValueDictKeyError
+from django.utils.decorators import method_decorator
 from django.views.decorators.http import condition
+from django.views.generic import ListView
 
 from pontoon.base.models import Locale
 from pontoon.base.utils import require_AJAX
@@ -40,35 +42,25 @@ def get_terms(request):
     return JsonResponse(payload, safe=False)
 
 
-@condition(etag_func=None)
-def download_terminology_tbx_v2(request, locale):
-    locale = get_object_or_404(Locale, code=locale)
+@method_decorator(condition(etag_func=None), name="dispatch")
+class DownloadTerminologyViewV2(ListView):
+    def get_tbx_file_content(self, term_translations, locale_code):
+        return utils.build_tbx_v2_file(term_translations, locale_code)
 
-    term_translations = TermTranslation.objects.filter(locale=locale).prefetch_related(
-        "term"
-    )
-    content = utils.build_tbx_v2_file(term_translations, locale.code)
+    def dispatch(self, request, locale, *args, **kwargs):
+        locale = get_object_or_404(Locale, code=locale)
+        term_translations = TermTranslation.objects.filter(
+            locale=locale
+        ).prefetch_related("term")
+        content = self.get_tbx_file_content(term_translations, locale.code)
 
-    response = StreamingHttpResponse(content, content_type="text/xml")
-    response["Content-Disposition"] = 'attachment; filename="{locale}.v2.tbx"'.format(
-        locale=locale.code
-    )
+        response = StreamingHttpResponse(content, content_type="text/xml")
+        response["Content-Disposition"] = 'attachment; filename="{locale}.tbx"'.format(
+            locale=locale.code
+        )
+        return response
 
-    return response
 
-
-@condition(etag_func=None)
-def download_terminology_tbx_v3(request, locale):
-    locale = get_object_or_404(Locale, code=locale)
-
-    term_translations = TermTranslation.objects.filter(locale=locale).prefetch_related(
-        "term"
-    )
-    content = utils.build_tbx_v3_file(term_translations, locale.code)
-
-    response = StreamingHttpResponse(content, content_type="text/xml")
-    response["Content-Disposition"] = 'attachment; filename="{locale}.tbx"'.format(
-        locale=locale.code
-    )
-
-    return response
+class DownloadTerminologyViewV3(DownloadTerminologyViewV2):
+    def get_tbx_file_content(self, term_translations, locale_code):
+        return utils.build_tbx_v3_file(term_translations, locale_code)


### PR DESCRIPTION
We're adding the ability to download Terminology in the legacy TBX 2.0 format (URL-only).