### PR TITLE
Fix bug 1667765: Enable Sync button by default in production

### DIFF
--- a/docker/config/webapp.env.template
+++ b/docker/config/webapp.env.template
@@ -2,7 +2,6 @@ SECRET_KEY=insert_random_key
 DJANGO_DEV=True
 DJANGO_DEBUG=True
 DATABASE_URL=postgres://pontoon:asdf@postgresql/pontoon
-MANUAL_SYNC=True
 SESSION_COOKIE_SECURE=False
 SITE_URL=#SITE_URL#
 FXA_CLIENT_ID=2651b9211a44b7b2

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -752,7 +752,7 @@ except ValueError:
 
 SYNC_LOG_RETENTION = 90  # days
 
-MANUAL_SYNC = os.environ.get("MANUAL_SYNC", "False") != "False"
+MANUAL_SYNC = os.environ.get("MANUAL_SYNC", "True") != "False"
 
 # Celery
 


### PR DESCRIPTION
Sync button in Project Admin is not enabled by default on production instances (unlike in development instances), which is inconsistent with the [docs](https://mozilla-pontoon.readthedocs.io/en/latest/user/localizing-your-projects.html#adding-a-new-project-to-pontoon).