### PR TITLE
Fix Bug 1666199 Unify download URL schema

### DIFF
--- a/frontend/src/core/user/components/UserMenu.js
+++ b/frontend/src/core/user/components/UserMenu.js
@@ -130,7 +130,7 @@ export class UserMenuBase extends React.Component<Props, State> {
                                 }}
                             >
                                 <a
-                                    href={`/${locale}/${project}/${locale}.${project}.tmx`}
+                                    href={`/translation-memory/${locale}.${project}.tmx`}
                                 >
                                     {
                                         '<glyph></glyph>Download Translation Memory'
@@ -150,7 +150,7 @@ export class UserMenuBase extends React.Component<Props, State> {
                                     }}
                                 >
                                     <a
-                                        href={`/download/?code=${locale}&slug=${project}&part=${resource}`}
+                                        href={`/translations/?code=${locale}&slug=${project}&part=${resource}`}
                                     >
                                         {'<glyph></glyph>Download Translations'}
                                     </a>

--- a/pontoon/base/templates/widgets/heading_info.html
+++ b/pontoon/base/templates/widgets/heading_info.html
@@ -142,7 +142,7 @@
               <a href="/terminology/{{ locale }}.tbx">Download Terminology</a>
           </li>
           <li>
-              <a href="/{{ locale }}/{{ project }}/{{ locale }}.{{ project }}.tmx">Download Translation Memory</a>
+              <a href="/translation-memory/{{ locale }}.{{ project }}.tmx">Download Translation Memory</a>
           </li>
       </ul>
   </div>

--- a/pontoon/base/tests/views/test_tmx.py
+++ b/pontoon/base/tests/views/test_tmx.py
@@ -7,6 +7,8 @@ from datetime import datetime
 import pytest
 from lxml import etree
 
+from django.urls import reverse
+
 from pontoon.base.utils import build_translation_memory_file
 
 
@@ -28,11 +30,10 @@ def _check_xml(xml_content, expected_xml=None, dtd_path=None):
 @pytest.mark.django_db
 def test_view_tmx_locale_file_dl(client, entity_a, locale_a):
     """By download the data."""
-    response = client.get(
-        "/{locale}/{project}/{locale}.{project}.tmx".format(
-            locale=locale_a.code, project=entity_a.resource.project.slug,
-        )
+    url = reverse(
+        "pontoon.download_tmx", args=(locale_a.code, entity_a.resource.project.slug,)
     )
+    response = client.get(url)
     assert response.status_code == 200
     _check_xml(b"".join(response.streaming_content))
 
@@ -40,18 +41,12 @@ def test_view_tmx_locale_file_dl(client, entity_a, locale_a):
 @pytest.mark.django_db
 def test_view_tmx_bad_params(client, entity_a, locale_a, settings_debug):
     """Validate locale code and don't return data."""
-    response = client.get(
-        "/{locale}/{project}/{locale}.{project}.tmx".format(
-            locale="invalidlocale", project="invalidproject",
-        )
-    )
+    url = reverse("pontoon.download_tmx", args=("invalidlocale", "invalidproject",))
+    response = client.get(url)
     assert response.status_code == 404
 
-    response = client.get(
-        "/{locale}/{project}/{locale}.{project}.tmx".format(
-            locale=locale_a, project="invalidproject",
-        )
-    )
+    url = reverse("pontoon.download_tmx", args=(locale_a, "invalidproject",))
+    response = client.get(url)
     assert response.status_code == 404
 
 

--- a/pontoon/base/urls.py
+++ b/pontoon/base/urls.py
@@ -56,7 +56,7 @@ urlpatterns = [
     ),
     # Download translation memory
     url(
-        r"^translation-memory/(?P<filename>.+)\.tmx$",
+        r"^translation-memory/(?P<locale>[A-Za-z0-9\-\@\.]+)\.(?P<slug>[\w-]+)\.tmx$",
         views.download_translation_memory,
         name="pontoon.download_tmx",
     ),

--- a/pontoon/base/urls.py
+++ b/pontoon/base/urls.py
@@ -78,7 +78,11 @@ urlpatterns = [
         views.get_translations_from_other_locales,
         name="pontoon.other_locales",
     ),
-    url(r"^translations/", views.translations, name="pontoon.translations"),
+    url(
+        r"^translations/",
+        views.download_translations,
+        name="pontoon.download.translations",
+    ),
     url(r"^upload/", views.upload, name="pontoon.upload"),
     url(r"^user-data/", views.user_data, name="pontoon.user_data"),
 ]

--- a/pontoon/base/urls.py
+++ b/pontoon/base/urls.py
@@ -56,7 +56,7 @@ urlpatterns = [
     ),
     # Download translation memory
     url(
-        r"^(?P<locale>[A-Za-z0-9\-\@\.]+)/(?P<slug>[\w-]+)/(?P<filename>.+)\.tmx$",
+        r"^translation-memory/(?P<filename>.+)\.tmx$",
         views.download_translation_memory,
         name="pontoon.download_tmx",
     ),
@@ -78,7 +78,7 @@ urlpatterns = [
         views.get_translations_from_other_locales,
         name="pontoon.other_locales",
     ),
-    url(r"^download/", views.download, name="pontoon.download"),
+    url(r"^translations/", views.translations, name="pontoon.translations"),
     url(r"^upload/", views.upload, name="pontoon.upload"),
     url(r"^user-data/", views.user_data, name="pontoon.user_data"),
 ]

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -691,7 +691,7 @@ def perform_checks(request):
 
 
 @transaction.atomic
-def download(request):
+def translations(request):
     """Download translated resource."""
     try:
         slug = request.GET["slug"]
@@ -755,7 +755,15 @@ def upload(request):
 
 
 @condition(etag_func=None)
-def download_translation_memory(request, locale, slug, filename):
+def download_translation_memory(request, filename):
+
+    vars = filename.split(".")
+    try:
+        locale = vars[0]
+        slug = vars[1]
+    except len(var) != 2:
+        raise Http404
+
     locale = get_object_or_404(Locale, code=locale)
 
     if slug.lower() == "all-projects":

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -691,7 +691,7 @@ def perform_checks(request):
 
 
 @transaction.atomic
-def translations(request):
+def download_translations(request):
     """Download translated resource."""
     try:
         slug = request.GET["slug"]

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -755,15 +755,7 @@ def upload(request):
 
 
 @condition(etag_func=None)
-def download_translation_memory(request, filename):
-
-    vars = filename.split(".")
-    try:
-        locale = vars[0]
-        slug = vars[1]
-    except len(var) != 2:
-        raise Http404
-
+def download_translation_memory(request, locale, slug):
     locale = get_object_or_404(Locale, code=locale)
 
     if slug.lower() == "all-projects":


### PR DESCRIPTION
1)Changed the url for translation memory (line 133)  in UserMenu.js file
2)Changed the url for translations (line 153)  in UserMenu.js file
3)Removed the parameters locale and slug passed in the url for
  downloading translation memory (line 59)  in pontoon/base/ urls.py
4)Modified the view download_translation_memory in pontoon/base/views.py
  to accept only 2 parameters i.e. request and filename and introduced a
  new variable vars to extract locale and slug using split function.
5)Changed the view name download in pontoon/base/views.py to translations
  (line 694) and changed the urls,name corresponding to it in
  pontoon/base/ urls.py (line 81)