### PR TITLE
Update README clarifying chat channel scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ If you want to go further, you can:
 * See Mozilla's Pontoon servers:
     * [Staging](https://mozilla-pontoon-staging.herokuapp.com/)
     * [Production](https://pontoon.mozilla.org/)
-* Get in touch with us on [chat.mozilla.org](https://chat.mozilla.org/#/room/#pontoon:mozilla.org) _(**Please note:** This channel is dedicated exclusively for discussing Pontoon's development. Questions about third-party deployment, syntax of localizable resources, general support, etc; are better suited for [our discourse forum](https://discourse.mozilla.org/c/pontoon/)_.
+* For discussing Pontoon's development, get in touch with us on [chat.mozilla.org](https://chat.mozilla.org/#/room/#pontoon:mozilla.org)
+* For feedback, support, and 3rd party deployments, check out [Discourse](https://discourse.mozilla.org/c/pontoon/)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ If you want to go further, you can:
 * See Mozilla's Pontoon servers:
     * [Staging](https://mozilla-pontoon-staging.herokuapp.com/)
     * [Production](https://pontoon.mozilla.org/)
-* Get in touch with us on [chat.mozilla.org](https://chat.mozilla.org/#/room/#pontoon:mozilla.org).
+* Get in touch with us on [chat.mozilla.org](https://chat.mozilla.org/#/room/#pontoon:mozilla.org) _(**Please note:** This channel is dedicated exclusively for discussing Pontoon's development. Questions about third-party deployment, syntax of localizable resources, general support, etc; are better suited for [our discourse forum](https://discourse.mozilla.org/c/pontoon/)_.
 
 ## License
 


### PR DESCRIPTION
Many end-users who enter Pontoon's chat channel, probably do so by obtaining the link here _(as I did! :raised_eyebrow: )_
This helps to guide users to the right place for discussing their questions.

*Thanks to @flodolo,  for pointing that out.*