### PR TITLE
Fix Metadata CSS regression caused by bug 1611510

### DIFF
--- a/frontend/src/modules/entitydetails/components/Metadata.css
+++ b/frontend/src/modules/entitydetails/components/Metadata.css
@@ -25,7 +25,7 @@
     text-transform: uppercase;
 }
 
-.metadata p a {
+.metadata div a {
     color: #7bc876;
     text-decoration: none;
 }
@@ -34,7 +34,7 @@
     display: inline-block;
 }
 
-.metadata p .divider {
+.metadata div .divider {
     font-style: normal;
     font-weight: 100;
     margin: 0 3px;


### PR DESCRIPTION
While reviewing #1676, I've noticed that links aren't green anymore and that the divider lost spacing:
https://pontoon.mozilla.org/sl/firefox/all-resources/?string=74127

In #1684 we changed the element name, but didn't update affected CSS.