### PR TITLE
Fix bug 1668362: Use text cursor on search box icon

### DIFF
--- a/frontend/src/modules/machinery/components/Machinery.css
+++ b/frontend/src/modules/machinery/components/Machinery.css
@@ -15,6 +15,7 @@
 
 .machinery > .search-wrapper > label {
     color: #aaaaaa;
+    cursor: text;
     font-size: 17px;
     left: auto;
     position: absolute;

--- a/frontend/src/modules/search/components/SearchBox.css
+++ b/frontend/src/modules/search/components/SearchBox.css
@@ -33,6 +33,7 @@
 
 .search-box > label {
     color: #aaaaaa;
+    cursor: text;
     font-size: 17px;
     left: auto;
     position: absolute;


### PR DESCRIPTION
This patch changes the cursor on the search box magnifier icon from cursor to text in order to prevent users from thinking the icon acts as a button.

The patch can be tested on stage:
https://mozilla-pontoon-staging.herokuapp.com/sl/firefox/all-resources/?string=74127