### PR TITLE
Bug 1627655: Remove django-nose dependency

### DIFF
--- a/pontoon/base/tests/__init__.py
+++ b/pontoon/base/tests/__init__.py
@@ -13,7 +13,6 @@ from django.template.defaultfilters import slugify
 from django.test import TestCase as BaseTestCase, Client as BaseClient
 
 import factory
-from django_nose.tools import assert_equal
 from factory import LazyAttribute, Sequence, SubFactory, SelfAttribute
 from factory.django import DjangoModelFactory
 from mock import patch
@@ -207,8 +206,8 @@ def assert_redirects(response, expected_url, status_code=302, host=None, secure=
     """
     if host is None:
         host = "{}://{}".format("https" if secure else "http", host or "testserver")
-    assert_equal(response.status_code, status_code)
-    assert_equal(response["Location"], host + expected_url)
+    assert response.status_code == status_code
+    assert response["Location"] == host + expected_url
 
 
 def assert_attributes_equal(original, **expected_attrs):
@@ -221,14 +220,10 @@ def assert_attributes_equal(original, **expected_attrs):
 
     for key, value in expected_attrs.items():
         original_value = getattr(original, key)
-        assert_equal(
-            original_value,
-            value,
-            (
-                "Attribute `{key}` does not match: {original_value} != {value}".format(
-                    key=key, original_value=original_value, value=value
-                )
-            ),
+        assert (
+            original_value == value
+        ), "Attribute `{key}` does not match: {original_value} != {value}".format(
+            key=key, original_value=original_value, value=value
         )
 
 
@@ -309,7 +304,7 @@ def assert_json(response, expected_obj):
     """
     Checks if response contains a expected json object.
     """
-    assert_equal(json.loads(response.content), expected_obj)
+    assert json.loads(response.content) == expected_obj
 
 
 @contextmanager

--- a/pontoon/contributors/tests/test_views.py
+++ b/pontoon/contributors/tests/test_views.py
@@ -12,7 +12,7 @@ from six.moves import range
 from django.http import HttpResponse
 from django.urls import reverse
 from django.utils.timezone import now, make_aware
-from django_nose.tools import assert_equal, assert_true, assert_code, assert_contains
+from pytest_django.asserts import assertContains
 
 from pontoon.base.models import User
 from pontoon.base.tests import (
@@ -43,29 +43,29 @@ class ContributorProfileTests(UserTestCase):
     def test_invalid_first_name(self):
         response = self.client.post(self.url, {"first_name": '<aa>"\'"'})
 
-        assert_contains(response, "Enter a valid value.")
+        assertContains(response, "Enter a valid value.")
 
     def test_invalid_email(self):
         response = self.client.post(self.url, {"email": "usermail"})
 
-        assert_contains(response, "Enter a valid email address.")
+        assertContains(response, "Enter a valid email address.")
 
     def test_missing_profile_fields(self):
         response = self.client.post(self.url, {})
 
-        assert_contains(response, "This field is required.", count=2)
+        assertContains(response, "This field is required.", count=2)
 
     def test_valid_first_name(self):
         response = self.client.post(
             self.url, {"first_name": "contributor", "email": self.user.email}
         )
 
-        assert_contains(response, "Settings saved.")
+        assertContains(response, "Settings saved.")
 
     def test_user_locales_order(self):
         locale1, locale2, locale3 = LocaleFactory.create_batch(3)
         response = self.client.get(self.url)
-        assert_equal(response.status_code, 200)
+        assert response.status_code == 200
 
         response = self.client.post(
             "/settings/",
@@ -76,11 +76,12 @@ class ContributorProfileTests(UserTestCase):
             },
         )
 
-        assert_equal(response.status_code, 200)
-        assert_equal(
-            list(User.objects.get(pk=self.user.pk).profile.sorted_locales),
-            [locale2, locale1, locale3],
-        )
+        assert response.status_code == 200
+        assert list(User.objects.get(pk=self.user.pk).profile.sorted_locales) == [
+            locale2,
+            locale1,
+            locale3,
+        ]
         # Test if you can clear all locales
         response = self.client.post(
             "/settings/",
@@ -90,8 +91,8 @@ class ContributorProfileTests(UserTestCase):
                 "locales_order": "",
             },
         )
-        assert_equal(response.status_code, 200)
-        assert_equal(list(User.objects.get(pk=self.user.pk).profile.sorted_locales), [])
+        assert response.status_code == 200
+        assert list(User.objects.get(pk=self.user.pk).profile.sorted_locales) == []
 
         # Test if form handles duplicated locales
         response = self.client.post(
@@ -102,11 +103,11 @@ class ContributorProfileTests(UserTestCase):
                 "locales_order": commajoin(locale1.pk, locale2.pk, locale2.pk,),
             },
         )
-        assert_equal(response.status_code, 200)
-        assert_equal(
-            list(User.objects.get(pk=self.user.pk).profile.sorted_locales),
-            [locale1, locale2],
-        )
+        assert response.status_code, 200
+        assert list(User.objects.get(pk=self.user.pk).profile.sorted_locales) == [
+            locale1,
+            locale2,
+        ]
 
 
 class ContributorProfileViewTests(UserTestCase):
@@ -123,25 +124,25 @@ class ContributorProfileViewTests(UserTestCase):
         """Users should be able to retrieve contributor's profile by its username."""
         self.client.get("/contributors/{}/".format(self.user.username))
 
-        assert_equal(self.mock_render.call_args[0][2]["contributor"], self.user)
+        assert self.mock_render.call_args[0][2]["contributor"] == self.user
 
     def test_contributor_profile_by_email(self):
         """Check if we can access contributor profile by its email."""
         self.client.get("/contributors/{}/".format(self.user.email))
 
-        assert_equal(self.mock_render.call_args[0][2]["contributor"], self.user)
+        assert self.mock_render.call_args[0][2]["contributor"] == self.user
 
     def test_logged_user_profile(self):
         """Logged user should be able to re"""
         self.client.get("/profile/")
 
-        assert_equal(self.mock_render.call_args[0][2]["contributor"], self.user)
+        assert self.mock_render.call_args[0][2]["contributor"] == self.user
 
     def test_unlogged_user_profile(self):
         """Unlogged users shouldn't have access to edit any profile."""
         self.client.logout()
 
-        assert_equal(self.client.get("/profile/")["Location"], "/403")
+        assert self.client.get("/profile/")["Location"] == "/403"
 
 
 class ContributorTimelineViewTests(UserTestCase):
@@ -181,31 +182,28 @@ class ContributorTimelineViewTests(UserTestCase):
         """Backend should return events filtered by page number requested by user."""
         self.client.get("/contributors/{}/timeline/?page=2".format(self.user.username))
 
-        assert_equal(
-            self.mock_render.call_args[0][2]["events"],
-            [
-                {
-                    "date": dt,
-                    "type": "translation",
-                    "count": count,
-                    "project": self.project,
-                    "translation": translations[0][0],
-                }
-                for (dt, count), translations in list(self.translations.items())[10:20]
-            ],
-        )
+        assert self.mock_render.call_args[0][2]["events"] == [
+            {
+                "date": dt,
+                "type": "translation",
+                "count": count,
+                "project": self.project,
+                "translation": translations[0][0],
+            }
+            for (dt, count), translations in list(self.translations.items())[10:20]
+        ]
 
     def test_timeline_invalid_page(self):
         """Backend should return 404 error when user requests an invalid/empty page."""
-        resp = self.client.get(
+        response = self.client.get(
             "/contributors/{}/timeline/?page=45".format(self.user.username)
         )
-        assert_code(resp, 404)
+        assert response.status_code == 404
 
-        resp = self.client.get(
+        response = self.client.get(
             "/contributors/{}/timeline/?page=-aa45".format(self.user.username)
         )
-        assert_code(resp, 404)
+        assert response.status_code == 404
 
     def test_non_active_contributor(self):
         """Test if backend is able return events for a user without contributions."""
@@ -213,19 +211,18 @@ class ContributorTimelineViewTests(UserTestCase):
         self.client.get(
             "/contributors/{}/timeline/".format(nonactive_contributor.username)
         )
-        assert_equal(
-            self.mock_render.call_args[0][2]["events"],
-            [{"date": nonactive_contributor.date_joined, "type": "join"}],
-        )
+        assert self.mock_render.call_args[0][2]["events"] == [
+            {"date": nonactive_contributor.date_joined, "type": "join"}
+        ]
 
     def test_timeline_join(self):
         """Last page of results should include informations about the when user joined pontoon."""
         self.client.get("/contributors/{}/timeline/?page=3".format(self.user.username))
 
-        assert_equal(
-            self.mock_render.call_args[0][2]["events"][-1],
-            {"date": self.user.date_joined, "type": "join"},
-        )
+        assert self.mock_render.call_args[0][2]["events"][-1] == {
+            "date": self.user.date_joined,
+            "type": "join",
+        }
 
 
 class ContributorsTests(TestCase):
@@ -249,8 +246,8 @@ class ContributorsTests(TestCase):
         Calling the top contributors should result in period being None.
         """
         self.client.get("/contributors/")
-        assert_true(self.mock_render.call_args[0][0]["period"] is None)
-        assert_true(self.mock_users_with_translations_counts.call_args[0][0] is None)
+        assert self.mock_render.call_args[0][0]["period"] is None
+        assert self.mock_users_with_translations_counts.call_args[0][0] is None
 
     def test_invalid_period(self):
         """
@@ -258,13 +255,13 @@ class ContributorsTests(TestCase):
         """
         # If period parameter is invalid value
         self.client.get("/contributors/?period=invalidperiod")
-        assert_true(self.mock_render.call_args[0][0]["period"] is None)
-        assert_true(self.mock_users_with_translations_counts.call_args[0][0] is None)
+        assert self.mock_render.call_args[0][0]["period"] is None
+        assert self.mock_users_with_translations_counts.call_args[0][0] is None
 
         # Period shouldn't be negative integer
         self.client.get("/contributors/?period=-6")
-        assert_true(self.mock_render.call_args[0][0]["period"] is None)
-        assert_true(self.mock_users_with_translations_counts.call_args[0][0] is None)
+        assert self.mock_render.call_args[0][0]["period"] is None
+        assert self.mock_users_with_translations_counts.call_args[0][0] is None
 
     def test_given_period(self):
         """
@@ -276,8 +273,7 @@ class ContributorsTests(TestCase):
             return_value=aware_datetime(2015, 7, 5),
         ):
             self.client.get("/contributors/?period=6")
-            assert_equal(self.mock_render.call_args[0][0]["period"], 6)
-            assert_equal(
-                self.mock_users_with_translations_counts.call_args[0][0],
-                aware_datetime(2015, 1, 5),
-            )
+            assert self.mock_render.call_args[0][0]["period"] == 6
+            assert self.mock_users_with_translations_counts.call_args[0][
+                0
+            ] == aware_datetime(2015, 1, 5)

--- a/pontoon/db/tests/test_lookups.py
+++ b/pontoon/db/tests/test_lookups.py
@@ -1,10 +1,6 @@
 from __future__ import absolute_import
 
-from nose.tools import raises
-from django_nose.tools import (
-    assert_equal,
-    assert_true,
-)
+import pytest
 
 from pontoon.db import IContainsCollate  # noqa
 from pontoon.base.models import Entity
@@ -26,18 +22,18 @@ class TestIContainsCollationLookup(TestCase):
         query_sql = entities.query.sql_with_params()[0]
 
         # Force evaluation of query on the real database.
-        assert_equal(entities.count(), 10)
-        assert_true("COLLATE" not in query_sql)
+        assert entities.count() == 10
+        assert "COLLATE" not in query_sql
 
-    @raises(ValueError)
     def test_arguments_are_in_tuple(self):
         """Check if lookup validates missing collation properly."""
-        Entity.objects.filter(string__icontains_collate="st")
+        with pytest.raises(ValueError):
+            Entity.objects.filter(string__icontains_collate="st")
 
-    @raises(ValueError)
     def test_invalid_number_of_arguments(self):
         """Validate a number of arguments."""
-        Entity.objects.filter(string__icontains_collate=("qwertyuiop", "a", "b"))
+        with pytest.raises(ValueError):
+            Entity.objects.filter(string__icontains_collate=("qwertyuiop", "a", "b"))
 
     def test_collation_query(self):
         """Check if collate is applied to a given lookup."""
@@ -45,10 +41,8 @@ class TestIContainsCollationLookup(TestCase):
         query_sql = entities.query.sql_with_params()[0]
 
         # Force evaluation of query on the real database.
-        assert_equal(entities.count(), 10)
-        assert_true(
-            query_sql.endswith(
-                'WHERE UPPER("base_entity"."string"::text COLLATE "C") '
-                'LIKE UPPER(%s COLLATE "C")'
-            )
+        assert entities.count() == 10
+        assert query_sql.endswith(
+            'WHERE UPPER("base_entity"."string"::text COLLATE "C") '
+            'LIKE UPPER(%s COLLATE "C")'
         )

--- a/pontoon/projects/tests/test_views.py
+++ b/pontoon/projects/tests/test_views.py
@@ -3,11 +3,6 @@ from __future__ import absolute_import
 from django.http import HttpResponse
 from django.shortcuts import render
 
-from django_nose.tools import (
-    assert_equal,
-    assert_code,
-)
-
 from mock import patch
 
 from pontoon.base.tests import (
@@ -24,7 +19,8 @@ class ProjectTests(ViewTestCase):
         """
         Checks if view is returning error when project slug is invalid.
         """
-        assert_code(self.client.get("/projects/project_doesnt_exist/"), 404)
+        response = self.client.get("/projects/project_doesnt_exist/")
+        assert response.status_code == 404
 
     def test_project_view(self):
         """
@@ -35,7 +31,7 @@ class ProjectTests(ViewTestCase):
 
         with patch("pontoon.projects.views.render", wraps=render) as mock_render:
             self.client.get("/projects/{}/".format(project.slug))
-            assert_equal(mock_render.call_args[0][2]["project"], project)
+            assert mock_render.call_args[0][2]["project"] == project
 
 
 class ProjectContributorsTests(ViewTestCase):
@@ -43,9 +39,8 @@ class ProjectContributorsTests(ViewTestCase):
         """
         Checks if view handles invalid project.
         """
-        assert_code(
-            self.client.get("/projects/project_doesnt_exist/contributors/"), 404
-        )
+        response = self.client.get("/projects/project_doesnt_exist/contributors/")
+        assert response.status_code == 404
 
     def test_project_top_contributors(self):
         """
@@ -71,18 +66,16 @@ class ProjectContributorsTests(ViewTestCase):
                 "/projects/{}/ajax/contributors/".format(first_project.slug),
                 HTTP_X_REQUESTED_WITH="XMLHttpRequest",
             )
-            assert_equal(mock_render.call_args[0][0]["project"], first_project)
-            assert_equal(
-                list(mock_render.call_args[0][0]["contributors"]),
-                [first_project_contributor],
-            )
+            assert mock_render.call_args[0][0]["project"] == first_project
+            assert list(mock_render.call_args[0][0]["contributors"]) == [
+                first_project_contributor
+            ]
 
             self.client.get(
                 "/projects/{}/ajax/contributors/".format(second_project.slug),
                 HTTP_X_REQUESTED_WITH="XMLHttpRequest",
             )
-            assert_equal(mock_render.call_args[0][0]["project"], second_project)
-            assert_equal(
-                list(mock_render.call_args[0][0]["contributors"]),
-                [second_project_contributor],
-            )
+            assert mock_render.call_args[0][0]["project"] == second_project
+            assert list(mock_render.call_args[0][0]["contributors"]) == [
+                second_project_contributor
+            ]

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -154,7 +154,6 @@ INSTALLED_APPS = (
     "django.contrib.sites",
     # Third-party apps, patches, fixes
     "django_jinja",
-    "django_nose",
     "pipeline",
     "session_csrf",
     "guardian",
@@ -595,17 +594,6 @@ if os.environ.get("DJANGO_SQL_LOG", False):
         "level": "DEBUG",
         "handlers": ["console"],
     }
-
-# Tests
-TEST_RUNNER = "django_nose.NoseTestSuiteRunner"
-NOSE_ARGS = [
-    "--logging-filter=-factory,-django.db,-raygun4py",
-    "--logging-clear-handlers",
-]
-
-# Disable nose-progressive on CI due to ugly output.
-if not os.environ.get("CI", False):
-    NOSE_ARGS.append("--with-progressive")
 
 # General auth settings
 LOGIN_URL = "/"

--- a/pontoon/sync/tests/formats/__init__.py
+++ b/pontoon/sync/tests/formats/__init__.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-from django_nose.tools import assert_equal
-
 from pontoon.base.tests import (
     assert_attributes_equal,
     create_tempfile,
@@ -85,9 +83,7 @@ class FormatTestsMixin(object):
         )
 
         if self.supports_source:
-            assert_equal(
-                resource.translations[translation_index].source, [("file.py", "1")]
-            )
+            assert resource.translations[translation_index].source == [("file.py", "1")]
 
         if self.supports_source_string:
             assert_attributes_equal(

--- a/pontoon/sync/tests/formats/test_compare_locales.py
+++ b/pontoon/sync/tests/formats/test_compare_locales.py
@@ -6,12 +6,7 @@ import tempfile
 
 from textwrap import dedent
 
-from django_nose.tools import (
-    assert_equal,
-    assert_false,
-    assert_raises,
-    assert_true,
-)
+import pytest
 
 from pontoon.base.tests import (
     create_named_tempfile,
@@ -62,7 +57,7 @@ class CompareLocalesResourceTests(TestCase):
         raise a ParseError.
         """
         path = self.get_invalid_file_path()
-        with assert_raises(ParseError):
+        with pytest.raises(ParseError):
             compare_locales.CompareLocalesResource(path, source_resource=None)
 
     def test_init_missing_resource(self):
@@ -71,7 +66,7 @@ class CompareLocalesResourceTests(TestCase):
         given, raise a ParseError.
         """
         path = self.get_nonexistant_file_path()
-        with assert_raises(ParseError):
+        with pytest.raises(ParseError):
             compare_locales.CompareLocalesResource(path, source_resource=None)
 
     def test_init_missing_resource_with_source(self):
@@ -82,9 +77,8 @@ class CompareLocalesResourceTests(TestCase):
         path = self.get_nonexistant_file_path()
         translated_resource = self.get_nonexistant_file_resource(path)
 
-        assert_equal(len(translated_resource.translations), 1)
-        translation = translated_resource.translations[0]
-        assert_equal(translation.strings, {})
+        assert len(translated_resource.translations) == 1
+        assert translated_resource.translations[0].strings == {}
 
     def test_save_create_dirs(self):
         """
@@ -96,9 +90,9 @@ class CompareLocalesResourceTests(TestCase):
 
         translated_resource.translations[0].strings = {None: "New Translated String"}
 
-        assert_false(os.path.exists(path))
+        assert not os.path.exists(path)
         translated_resource.save(LocaleFactory.create())
-        assert_true(os.path.exists(path))
+        assert os.path.exists(path)
 
 
 BASE_ANDROID_XML_FILE = """<?xml version="1.0" encoding="utf-8"?>

--- a/pontoon/sync/tests/formats/test_ftl.py
+++ b/pontoon/sync/tests/formats/test_ftl.py
@@ -6,12 +6,7 @@ import tempfile
 
 from textwrap import dedent
 
-from django_nose.tools import (
-    assert_equal,
-    assert_false,
-    assert_raises,
-    assert_true,
-)
+import pytest
 from pontoon.base.tests import (
     assert_attributes_equal,
     create_named_tempfile,
@@ -52,7 +47,7 @@ class FTLResourceTests(FormatTestsMixin, TestCase):
         given, raise a IOError.
         """
         path = self.get_nonexistant_file_path()
-        with assert_raises(IOError):
+        with pytest.raises(IOError):
             ftl.FTLResource(path, locale=None, source_resource=None)
 
     def test_init_missing_resource_with_source(self):
@@ -63,9 +58,8 @@ class FTLResourceTests(FormatTestsMixin, TestCase):
         path = self.get_nonexistant_file_path()
         translated_resource = self.get_nonexistant_file_resource(path)
 
-        assert_equal(len(translated_resource.translations), 1)
-        translation = translated_resource.translations[0]
-        assert_equal(translation.strings, {})
+        assert len(translated_resource.translations) == 1
+        assert translated_resource.translations[0].strings == {}
 
     def test_save_create_dirs(self):
         """
@@ -77,9 +71,9 @@ class FTLResourceTests(FormatTestsMixin, TestCase):
 
         translated_resource.translations[0].strings = {None: "New Translated String"}
 
-        assert_false(os.path.exists(path))
+        assert not os.path.exists(path)
         translated_resource.save(LocaleFactory.create())
-        assert_true(os.path.exists(path))
+        assert os.path.exists(path)
 
     def test_parse_with_source_path(self):
         contents = "text = Arise, awake and do not stop until the goal is reached."
@@ -88,10 +82,10 @@ class FTLResourceTests(FormatTestsMixin, TestCase):
         )
         path = self.get_nonexistant_file_path()
         obj = ftl.parse(path, source_path=source_path, locale=None)
-        assert_equal(obj.path, path)
-        assert_equal(obj.locale, None)
-        assert_equal(obj.source_resource.path, source_path)
-        assert_equal(obj.source_resource.locale, None)
+        assert obj.path == path
+        assert obj.locale is None
+        assert obj.source_resource.path == source_path
+        assert obj.source_resource.locale is None
 
     def test_parse_with_no_source_path(self):
         contents = "text = Arise, awake and do not stop until the goal is reached."
@@ -99,9 +93,9 @@ class FTLResourceTests(FormatTestsMixin, TestCase):
             contents, prefix="strings", suffix=".ftl", directory=self.tempdir,
         )
         obj = ftl.parse(path, source_path=None, locale=None)
-        assert_equal(obj.path, path)
-        assert_equal(obj.source_resource, None)
-        assert_equal(obj.locale, None)
+        assert obj.path == path
+        assert obj.source_resource is None
+        assert obj.locale is None
 
 
 BASE_FTL_FILE = """

--- a/pontoon/sync/tests/formats/test_lang.py
+++ b/pontoon/sync/tests/formats/test_lang.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import os.path
 from textwrap import dedent
 
-from django_nose.tools import assert_equal, assert_raises
+import pytest
 
 from pontoon.base.tests import assert_attributes_equal, TestCase
 from pontoon.sync.exceptions import ParseError
@@ -91,7 +91,7 @@ class LangTests(FormatTestsMixin, TestCase):
         """
         current_dir = os.path.dirname(__file__)
         resource = lang.parse(os.path.join(current_dir, "bom.lang"))
-        assert_equal(len(resource.translations), 1)
+        assert len(resource.translations) == 1
         assert_attributes_equal(
             resource.translations[0],
             source_string="Source String",
@@ -116,16 +116,16 @@ class LangTests(FormatTestsMixin, TestCase):
             )
         )
 
-        assert_equal(resource.children[1].content, "1 hash")
-        assert_equal(resource.children[2].content, "2 hash")
-        assert_equal(resource.children[3].content, "3 hash")
-        assert_equal(resource.translations[0].comments, ["1 hash", "2 hash", "3 hash"])
+        assert resource.children[1].content == "1 hash"
+        assert resource.children[2].content == "2 hash"
+        assert resource.children[3].content == "3 hash"
+        assert resource.translations[0].comments == ["1 hash", "2 hash", "3 hash"]
 
     def test_parse_eof(self):
         """Langfiles do not need to end in a newline."""
         path, resource = self.parse_string(";Source\nTranslation")
-        assert_equal(resource.translations[0].source_string, "Source")
-        assert_equal(resource.translations[0].strings, {None: "Translation"})
+        assert resource.translations[0].source_string == "Source"
+        assert resource.translations[0].strings == {None: "Translation"}
 
     def test_preserve_comment_hashes(self):
         """
@@ -158,7 +158,7 @@ class LangTests(FormatTestsMixin, TestCase):
         If an entity has an empty translation, parse should raise a
         ParseError.
         """
-        with assert_raises(ParseError):
+        with pytest.raises(ParseError):
             self.parse_string(
                 dedent(
                     """

--- a/pontoon/sync/tests/formats/test_silme.py
+++ b/pontoon/sync/tests/formats/test_silme.py
@@ -4,7 +4,7 @@ import os.path
 import tempfile
 from textwrap import dedent
 
-from django_nose.tools import assert_equal, assert_raises, assert_true
+import pytest
 from silme.format.dtd import FormatParser as DTDParser
 
 from pontoon.base.tests import (
@@ -24,7 +24,7 @@ class SilmeResourceTests(TestCase):
         is given, raise an IOError.
         """
         path = os.path.join(tempfile.mkdtemp(), "does", "not", "exist.dtd")
-        with assert_raises(IOError):
+        with pytest.raises(IOError):
             silme.SilmeResource(DTDParser, path, source_resource=None)
 
     def create_nonexistant_resource(self, path):
@@ -47,9 +47,8 @@ class SilmeResourceTests(TestCase):
         path = os.path.join(tempfile.mkdtemp(), "does", "not", "exist.dtd")
         translated_resource = self.create_nonexistant_resource(path)
 
-        assert_equal(len(translated_resource.translations), 1)
-        translation = translated_resource.translations[0]
-        assert_equal(translation.strings, {})
+        assert len(translated_resource.translations) == 1
+        assert translated_resource.translations[0].strings == {}
 
     def test_save_create_dirs(self):
         """
@@ -62,7 +61,7 @@ class SilmeResourceTests(TestCase):
         translated_resource.translations[0].strings = {None: "New Translated String"}
         translated_resource.save(LocaleFactory.create())
 
-        assert_true(os.path.exists(path))
+        assert os.path.exists(path)
 
 
 BASE_DTD_FILE = """
@@ -786,7 +785,7 @@ class IncTests(FormatTestsMixin, TestCase):
         )
 
         path, resource = self.parse_string(input_string)
-        assert_equal(len(resource.translations), 2)
+        assert len(resource.translations) == 2
         assert_attributes_equal(
             resource.translations[1],
             key="MOZ_LANGPACK_CONTRIBUTORS",
@@ -814,7 +813,7 @@ class IncTests(FormatTestsMixin, TestCase):
         )
 
         path, resource = self.parse_string(input_string, source_string=source_string)
-        assert_equal(len(resource.translations), 2)
+        assert len(resource.translations) == 2
         assert_attributes_equal(
             resource.translations[1],
             key="MOZ_LANGPACK_CONTRIBUTORS",

--- a/pontoon/sync/tests/test_checks.py
+++ b/pontoon/sync/tests/test_checks.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import
 
 from mock import patch, PropertyMock
 
-from django_nose.tools import assert_equal
-
 from pontoon.base.utils import aware_datetime
 from pontoon.base.tests import TranslationFactory
 from pontoon.checks.models import (
@@ -32,9 +30,9 @@ class TestChangesetTranslationsChecks(FakeCheckoutTestCase):
     def test_bulk_check_translations_no_translations(self):
         self.mock_changed_translations.return_value = []
 
-        assert_equal(self.changeset.bulk_check_translations(), set())
-        assert_equal(Error.objects.count(), 0)
-        assert_equal(Warning.objects.count(), 0)
+        assert self.changeset.bulk_check_translations() == set()
+        assert not Error.objects.exists()
+        assert not Warning.objects.exists()
 
     def test_bulk_check_valid_translations(self):
         translation1, translation2 = TranslationFactory.create_batch(
@@ -49,12 +47,12 @@ class TestChangesetTranslationsChecks(FakeCheckoutTestCase):
             translation1,
             translation2,
         ]
-        assert_equal(
-            self.changeset.bulk_check_translations(),
-            {translation1.pk, translation2.pk},
-        )
-        assert_equal(Error.objects.count(), 0)
-        assert_equal(Warning.objects.count(), 0)
+        assert self.changeset.bulk_check_translations() == {
+            translation1.pk,
+            translation2.pk,
+        }
+        assert not Error.objects.exists()
+        assert not Warning.objects.exists()
 
     def test_bulk_check_invalid_translations(self):
         """
@@ -83,13 +81,13 @@ class TestChangesetTranslationsChecks(FakeCheckoutTestCase):
 
         valid_translations = self.changeset.bulk_check_translations()
 
-        assert_equal(valid_translations, {valid_translation.pk})
+        assert valid_translations == {valid_translation.pk}
 
         (error,) = Error.objects.all()
 
-        assert_equal(error.library, "p")
-        assert_equal(error.message, "Newline characters are not allowed")
-        assert_equal(error.translation, invalid_translation)
+        assert error.library == "p"
+        assert error.message == "Newline characters are not allowed"
+        assert error.translation == invalid_translation
 
         self.changeset.translations_to_update = {
             valid_translation.pk: valid_translation
@@ -97,5 +95,5 @@ class TestChangesetTranslationsChecks(FakeCheckoutTestCase):
 
         self.changeset.bulk_create_translation_memory_entries(valid_translations)
 
-        assert_equal(invalid_translation.memory_entries.count(), 0)
-        assert_equal(valid_translation.memory_entries.count(), 1)
+        assert not invalid_translation.memory_entries.exists()
+        assert valid_translation.memory_entries.count() == 1

--- a/pontoon/sync/tests/test_core.py
+++ b/pontoon/sync/tests/test_core.py
@@ -2,13 +2,7 @@ from __future__ import absolute_import
 
 import os.path
 
-from django_nose.tools import (
-    assert_equal,
-    assert_false,
-    assert_not_equal,
-    assert_raises,
-    assert_true,
-)
+import pytest
 from mock import ANY, Mock, patch, PropertyMock, MagicMock
 
 from pontoon.base.models import (
@@ -47,7 +41,7 @@ class UpdateEntityTests(FakeCheckoutTestCase):
         If both the db_entity and vcs_entity are None, raise a
         CommandError, as that should never happen.
         """
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             self.call_update_entities([("key", None, None)])
 
     def test_obsolete(self):
@@ -86,8 +80,8 @@ class UpdateTranslationsTests(FakeCheckoutTestCase):
                 ("both", None, None),
             ]
         )
-        assert_false(self.changeset.update_vcs_entity.called)
-        assert_false(self.changeset.update_db_entity.called)
+        assert not self.changeset.update_vcs_entity.called
+        assert not self.changeset.update_db_entity.called
 
     def test_no_translation(self):
         """If no translation exists for a specific locale, skip it."""
@@ -98,8 +92,8 @@ class UpdateTranslationsTests(FakeCheckoutTestCase):
         self.call_update_translations(
             [("key", self.main_db_entity, self.main_vcs_entity)]
         )
-        assert_false(self.changeset.update_vcs_entity.called)
-        assert_false(self.changeset.update_db_entity.called)
+        assert not self.changeset.update_vcs_entity.called
+        assert not self.changeset.update_db_entity.called
 
     def test_db_changed(self):
         """
@@ -142,14 +136,12 @@ class UpdateResourcesTests(FakeCheckoutTestCase):
 
         update_resources(self.db_project, self.vcs_project)
         self.main_db_resource.refresh_from_db()
-        assert_equal(
-            self.main_db_resource.total_strings, len(self.main_vcs_resource.entities)
+        assert self.main_db_resource.total_strings == len(
+            self.main_vcs_resource.entities
         )
 
         other_db_resource = Resource.objects.get(path=self.other_vcs_resource.path)
-        assert_equal(
-            other_db_resource.total_strings, len(self.other_vcs_resource.entities)
-        )
+        assert other_db_resource.total_strings == len(self.other_vcs_resource.entities)
 
 
 class UpdateTranslatedResourcesTests(FakeCheckoutTestCase):
@@ -169,8 +161,8 @@ class UpdateTranslatedResourcesTests(FakeCheckoutTestCase):
         update_translated_resources(
             self.db_project, self.vcs_project, self.translated_locale,
         )
-        assert_false(update_translated_resources_with_config_mock.called)
-        assert_true(update_translated_resources_without_config_mock.called)
+        assert not update_translated_resources_with_config_mock.called
+        assert update_translated_resources_without_config_mock.called
 
         # Reset called value
         update_translated_resources_with_config_mock.called = False
@@ -181,8 +173,8 @@ class UpdateTranslatedResourcesTests(FakeCheckoutTestCase):
         update_translated_resources(
             self.db_project, self.vcs_project, self.translated_locale,
         )
-        assert_true(update_translated_resources_with_config_mock.called)
-        assert_false(update_translated_resources_without_config_mock.called)
+        assert update_translated_resources_with_config_mock.called
+        assert not update_translated_resources_without_config_mock.called
 
     def test_project_configuration_basic(self):
         """
@@ -198,18 +190,13 @@ class UpdateTranslatedResourcesTests(FakeCheckoutTestCase):
                     self.db_project, self.vcs_project, self.translated_locale,
                 )
 
-                assert_true(
-                    TranslatedResource.objects.filter(
-                        resource=self.other_db_resource, locale=self.translated_locale,
-                    ).exists()
-                )
+                assert TranslatedResource.objects.filter(
+                    resource=self.other_db_resource, locale=self.translated_locale,
+                ).exists()
 
-                assert_false(
-                    TranslatedResource.objects.filter(
-                        resource=self.missing_db_resource,
-                        locale=self.translated_locale,
-                    ).exists()
-                )
+                assert not TranslatedResource.objects.filter(
+                    resource=self.missing_db_resource, locale=self.translated_locale,
+                ).exists()
 
     def test_no_project_configuration_basic(self):
         """
@@ -220,23 +207,17 @@ class UpdateTranslatedResourcesTests(FakeCheckoutTestCase):
             self.db_project, self.vcs_project, self.translated_locale,
         )
 
-        assert_true(
-            TranslatedResource.objects.filter(
-                resource=self.main_db_resource, locale=self.translated_locale
-            ).exists()
-        )
+        assert TranslatedResource.objects.filter(
+            resource=self.main_db_resource, locale=self.translated_locale
+        ).exists()
 
-        assert_true(
-            TranslatedResource.objects.filter(
-                resource=self.other_db_resource, locale=self.translated_locale
-            ).exists()
-        )
+        assert TranslatedResource.objects.filter(
+            resource=self.other_db_resource, locale=self.translated_locale
+        ).exists()
 
-        assert_false(
-            TranslatedResource.objects.filter(
-                resource=self.missing_db_resource, locale=self.translated_locale
-            ).exists()
-        )
+        assert not TranslatedResource.objects.filter(
+            resource=self.missing_db_resource, locale=self.translated_locale
+        ).exists()
 
     def test_no_project_configuration_asymmetric(self):
         """
@@ -252,23 +233,17 @@ class UpdateTranslatedResourcesTests(FakeCheckoutTestCase):
                 self.db_project, self.vcs_project, self.translated_locale,
             )
 
-            assert_true(
-                TranslatedResource.objects.filter(
-                    resource=self.main_db_resource, locale=self.translated_locale
-                ).exists()
-            )
+            assert TranslatedResource.objects.filter(
+                resource=self.main_db_resource, locale=self.translated_locale
+            ).exists()
 
-            assert_true(
-                TranslatedResource.objects.filter(
-                    resource=self.other_db_resource, locale=self.translated_locale
-                ).exists()
-            )
+            assert TranslatedResource.objects.filter(
+                resource=self.other_db_resource, locale=self.translated_locale
+            ).exists()
 
-            assert_true(
-                TranslatedResource.objects.filter(
-                    resource=self.missing_db_resource, locale=self.translated_locale
-                ).exists()
-            )
+            assert TranslatedResource.objects.filter(
+                resource=self.missing_db_resource, locale=self.translated_locale
+            ).exists()
 
     def test_no_project_configuration_extra_locales(self):
         """
@@ -279,29 +254,21 @@ class UpdateTranslatedResourcesTests(FakeCheckoutTestCase):
             self.db_project, self.vcs_project, self.translated_locale,
         )
 
-        assert_true(
-            TranslatedResource.objects.filter(
-                resource=self.main_db_resource, locale=self.translated_locale
-            ).exists()
-        )
+        assert TranslatedResource.objects.filter(
+            resource=self.main_db_resource, locale=self.translated_locale
+        ).exists()
 
-        assert_true(
-            TranslatedResource.objects.filter(
-                resource=self.other_db_resource, locale=self.translated_locale
-            ).exists()
-        )
+        assert TranslatedResource.objects.filter(
+            resource=self.other_db_resource, locale=self.translated_locale
+        ).exists()
 
-        assert_false(
-            TranslatedResource.objects.filter(
-                resource=self.main_db_resource, locale=self.inactive_locale
-            ).exists()
-        )
+        assert not TranslatedResource.objects.filter(
+            resource=self.main_db_resource, locale=self.inactive_locale
+        ).exists()
 
-        assert_false(
-            TranslatedResource.objects.filter(
-                resource=self.other_db_resource, locale=self.inactive_locale
-            ).exists()
-        )
+        assert not TranslatedResource.objects.filter(
+            resource=self.other_db_resource, locale=self.inactive_locale
+        ).exists()
 
 
 class EntityKeyTests(FakeCheckoutTestCase):
@@ -310,10 +277,9 @@ class EntityKeyTests(FakeCheckoutTestCase):
         Entities with the same string from different resources must not get the
         same key from entity_key.
         """
-        assert_not_equal(
-            entity_key(self.main_vcs_resource.entities["Common String"]),
-            entity_key(self.other_vcs_resource.entities["Common String"]),
-        )
+        assert entity_key(
+            self.main_vcs_resource.entities["Common String"]
+        ) != entity_key(self.other_vcs_resource.entities["Common String"])
 
 
 class CommitChangesTests(FakeCheckoutTestCase):
@@ -364,7 +330,7 @@ class CommitChangesTests(FakeCheckoutTestCase):
             os.path.join(FAKE_CHECKOUT_PATH, self.translated_locale.code),
         )
         commit_message = self.repository.commit.mock_calls[0][1][0]
-        assert_equal(commit_message.count(author.display_name_and_email), 1)
+        assert commit_message.count(author.display_name_and_email) == 1
 
     def test_no_authors(self):
         """
@@ -383,8 +349,8 @@ class CommitChangesTests(FakeCheckoutTestCase):
             os.path.join(FAKE_CHECKOUT_PATH, self.translated_locale.code),
         )
         user = self.mock_repo_commit.call_args[0][1]
-        assert_equal(user.first_name, "Pontoon")
-        assert_equal(user.email, "pontoon@example.com")
+        assert user.first_name == "Pontoon"
+        assert user.email == "pontoon@example.com"
 
 
 class PullChangesTests(FakeCheckoutTestCase):
@@ -403,7 +369,7 @@ class PullChangesTests(FakeCheckoutTestCase):
         self.mock_repo_pull.return_value = {"single_locale": "asdf"}
 
         has_changed, _ = pull_locale_repo_changes(self.db_project, self.locales)
-        assert_true(has_changed)
+        assert has_changed
 
     def test_unsure_changes(self):
         """
@@ -415,7 +381,7 @@ class PullChangesTests(FakeCheckoutTestCase):
         self.repository.save()
 
         has_changed, _ = pull_locale_repo_changes(self.db_project, self.locales)
-        assert_true(has_changed)
+        assert has_changed
 
     def test_unchanged(self):
         """
@@ -428,4 +394,4 @@ class PullChangesTests(FakeCheckoutTestCase):
         has_changed, _ = pull_locale_repo_changes(
             self.db_project, locales=self.db_project.locales.all()
         )
-        assert_false(has_changed)
+        assert not has_changed

--- a/pontoon/sync/tests/test_models.py
+++ b/pontoon/sync/tests/test_models.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-from django_nose.tools import assert_equal, assert_false, assert_is_none, assert_true
-
 from pontoon.base.tests import ProjectFactory, RepositoryFactory, TestCase
 from pontoon.base.utils import aware_datetime
 from pontoon.sync.models import ProjectSyncLog
@@ -21,7 +19,7 @@ class SyncLogTests(TestCase):
         repo = RepositoryFactory.create()
         ProjectSyncLogFactory.create(sync_log=sync_log, project__repositories=[repo])
 
-        assert_is_none(sync_log.end_time)
+        assert sync_log.end_time is None
 
     def test_end_time(self):
         """
@@ -35,7 +33,7 @@ class SyncLogTests(TestCase):
             project_sync_log__sync_log=sync_log, end_time=aware_datetime(2015, 1, 2)
         )
 
-        assert_equal(sync_log.end_time, aware_datetime(2015, 1, 2))
+        assert sync_log.end_time == aware_datetime(2015, 1, 2)
 
     def test_end_time_skipped(self):
         """Include skipped repos in finding the latest end time."""
@@ -50,7 +48,7 @@ class SyncLogTests(TestCase):
             sync_log=sync_log, skipped=True, skipped_end_time=aware_datetime(2015, 1, 4)
         )
 
-        assert_equal(sync_log.end_time, aware_datetime(2015, 1, 4))
+        assert sync_log.end_time == aware_datetime(2015, 1, 4)
 
     def test_finished(self):
         sync_log = SyncLogFactory.create()
@@ -62,7 +60,7 @@ class SyncLogTests(TestCase):
         )
 
         # Sync isn't finished until all repos are finished.
-        assert_false(sync_log.finished)
+        assert not sync_log.finished
 
         repo_log = RepositorySyncLogFactory.create(
             repository=repo,
@@ -71,13 +69,13 @@ class SyncLogTests(TestCase):
             end_time=None,
         )
         del sync_log.finished
-        assert_false(sync_log.finished)
+        assert not sync_log.finished
 
         repo_log.end_time = aware_datetime(2015, 1, 2)
         repo_log.save()
 
         del sync_log.finished
-        assert_true(sync_log.finished)
+        assert sync_log.finished
 
 
 class ProjectSyncLogTests(TestCase):
@@ -85,7 +83,7 @@ class ProjectSyncLogTests(TestCase):
         """If a sync is unfinished, it's end_time is None."""
         repo = RepositoryFactory.create()
         project_sync_log = ProjectSyncLogFactory.create(project__repositories=[repo])
-        assert_is_none(project_sync_log.end_time)
+        assert project_sync_log.end_time is None
 
     def test_end_time(self):
         """
@@ -101,7 +99,7 @@ class ProjectSyncLogTests(TestCase):
             end_time=aware_datetime(2015, 1, 1),
         )
 
-        assert_equal(project_sync_log.end_time, aware_datetime(2015, 1, 1))
+        assert project_sync_log.end_time == aware_datetime(2015, 1, 1)
 
     def test_end_time_skipped(self):
         """
@@ -113,7 +111,7 @@ class ProjectSyncLogTests(TestCase):
             skipped=True,
             skipped_end_time=aware_datetime(2015, 1, 1),
         )
-        assert_equal(project_sync_log.end_time, aware_datetime(2015, 1, 1))
+        assert project_sync_log.end_time == aware_datetime(2015, 1, 1)
 
     def test_status(self):
         repo = RepositoryFactory.create()
@@ -122,7 +120,7 @@ class ProjectSyncLogTests(TestCase):
         )
 
         # Repos aren't finished, status should be in-progress.
-        assert_equal(project_sync_log.status, ProjectSyncLog.IN_PROGRESS)
+        assert project_sync_log.status == ProjectSyncLog.IN_PROGRESS
 
         # Once repo is finished, status should be synced.
         RepositorySyncLogFactory.create(
@@ -134,21 +132,21 @@ class ProjectSyncLogTests(TestCase):
 
         del project_sync_log.finished
         del project_sync_log.status
-        assert_equal(project_sync_log.status, ProjectSyncLog.SYNCED)
+        assert project_sync_log.status == ProjectSyncLog.SYNCED
 
         # Skipped projects are just "skipped".
         skipped_log = ProjectSyncLogFactory.create(
             project__repositories=[repo], skipped=True,
         )
 
-        assert_equal(skipped_log.status, ProjectSyncLog.SKIPPED)
+        assert skipped_log.status == ProjectSyncLog.SKIPPED
 
     def test_finished(self):
         repo = RepositoryFactory.create()
         project_sync_log = ProjectSyncLogFactory.create(project__repositories=[repo])
 
         # Sync isn't finished until all repos are finished.
-        assert_false(project_sync_log.finished)
+        assert not project_sync_log.finished
 
         repo_log = RepositorySyncLogFactory.create(
             repository=repo,
@@ -158,27 +156,27 @@ class ProjectSyncLogTests(TestCase):
         )
 
         del project_sync_log.finished
-        assert_false(project_sync_log.finished)
+        assert not project_sync_log.finished
 
         repo_log.end_time = aware_datetime(2015, 1, 2)
         repo_log.save()
 
         del project_sync_log.finished
-        assert_true(project_sync_log.finished)
+        assert project_sync_log.finished
 
     def test_finished_skipped(self):
         """A skipped log is considered finished."""
         skipped_log = ProjectSyncLogFactory.create(skipped=True)
-        assert_true(skipped_log.finished)
+        assert skipped_log.finished
 
 
 class RepositorySyncLogTests(TestCase):
     def test_finished(self):
         log = RepositorySyncLogFactory.create(end_time=None)
-        assert_false(log.finished)
+        assert not log.finished
 
         log.end_time = aware_datetime(2015, 1, 1)
         log.save()
 
         del log.finished
-        assert_true(log.finished)
+        assert log.finished

--- a/pontoon/sync/tests/test_sync_projects.py
+++ b/pontoon/sync/tests/test_sync_projects.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from django.core.management.base import CommandError
 
-from django_nose.tools import assert_equal, assert_false, assert_raises
+import pytest
 from mock import ANY, patch, PropertyMock
 from six import StringIO
 
@@ -76,7 +76,7 @@ class CommandTests(TestCase):
         If no projects are found that match the given slugs, raise a
         CommandError.
         """
-        with assert_raises(CommandError):
+        with pytest.raises(CommandError):
             self.execute_command(projects="does-not-exist")
 
     def test_invalid_slugs(self):
@@ -91,9 +91,9 @@ class CommandTests(TestCase):
             handle_project.pk, ANY, no_pull=False, no_commit=False, force=False,
         )
 
-        assert_equal(
-            self.command.stderr.getvalue(),
-            "Couldn't find projects with following slugs: aaa, bbb",
+        assert (
+            self.command.stderr.getvalue()
+            == "Couldn't find projects with following slugs: aaa, bbb"
         )
 
     def test_cant_commit(self):
@@ -106,7 +106,7 @@ class CommandTests(TestCase):
             can_commit.return_value = False
 
             self.execute_command(projects=project.slug)
-            assert_false(self.mock_sync_project.delay.called)
+            assert not self.mock_sync_project.delay.called
 
     def test_options(self):
         project = ProjectFactory.create()
@@ -117,7 +117,7 @@ class CommandTests(TestCase):
 
     def test_sync_log(self):
         """Create a new sync log when command is run."""
-        assert_false(SyncLog.objects.exists())
+        assert not SyncLog.objects.exists()
 
         ProjectFactory.create()
         with patch.object(sync_projects, "timezone") as mock_timezone:
@@ -125,4 +125,4 @@ class CommandTests(TestCase):
             self.execute_command()
 
         sync_log = SyncLog.objects.all()[0]
-        assert_equal(sync_log.start_time, aware_datetime(2015, 1, 1))
+        assert sync_log.start_time == aware_datetime(2015, 1, 1)

--- a/pontoon/sync/tests/test_vcs.py
+++ b/pontoon/sync/tests/test_vcs.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 from textwrap import dedent
 
-from django_nose.tools import assert_equal, assert_true
 from mock import patch
 
 from pontoon.sync.vcs.repositories import VCSRepository
@@ -21,9 +20,10 @@ class VCSRepositoryTests(TestCase):
             "pontoon.sync.vcs.repositories.log"
         ) as mock_log:
             mock_execute.return_value = 1, "output", "stderr"
-            assert_equal(
-                repo.execute("command", cwd="working_dir", log_errors=True),
-                (1, "output", "stderr"),
+            assert repo.execute("command", cwd="working_dir", log_errors=True) == (
+                1,
+                "output",
+                "stderr",
             )
             mock_log.error.assert_called_with(
                 CONTAINS("stderr", "command", "working_dir")
@@ -61,34 +61,36 @@ class VCSChangedFilesTests(object):
             self.vcsrepository, "execute", side_effect=self.execute_success
         ) as mock_execute:
             changed_files = self.vcsrepository.get_changed_files("/path", "1")
-            assert_true(mock_execute.called)
-            assert_equal(
-                changed_files, ["changed_file1.properties", "changed_file2.properties"]
-            )
+            assert mock_execute.called
+            assert changed_files == [
+                "changed_file1.properties",
+                "changed_file2.properties",
+            ]
 
     def test_changed_files_error(self):
         with patch.object(
             self.vcsrepository, "execute", side_effect=self.execute_failure
         ) as mock_execute:
-            assert_equal(self.vcsrepository.get_changed_files("path", "1"), [])
-            assert_true(mock_execute.called)
+            assert self.vcsrepository.get_changed_files("path", "1") == []
+            assert mock_execute.called
 
     def test_removed_files(self):
         with patch.object(
             self.vcsrepository, "execute", side_effect=self.execute_success
         ) as mock_execute:
             removed_files = self.vcsrepository.get_removed_files("/path", "1")
-            assert_true(mock_execute.called)
-            assert_equal(
-                removed_files, ["removed_file1.properties", "removed_file2.properties"]
-            )
+            assert mock_execute.called
+            assert removed_files == [
+                "removed_file1.properties",
+                "removed_file2.properties",
+            ]
 
     def test_removed_files_error(self):
         with patch.object(
             self.vcsrepository, "execute", side_effect=self.execute_failure
         ) as mock_execute:
-            assert_equal(self.vcsrepository.get_removed_files("path", "1"), [])
-            assert_true(mock_execute.called)
+            assert self.vcsrepository.get_removed_files("path", "1") == []
+            assert mock_execute.called
 
 
 class GitChangedFilesTest(VCSChangedFilesTests, TestCase):

--- a/pontoon/sync/tests/test_vcs_models.py
+++ b/pontoon/sync/tests/test_vcs_models.py
@@ -7,11 +7,6 @@ from http.client import HTTPException
 
 import scandir
 
-from django_nose.tools import (
-    assert_equal,
-    assert_false,
-    assert_true,
-)
 from mock import Mock, patch, PropertyMock
 
 from pontoon.base.models import (
@@ -103,10 +98,10 @@ class VCSProjectTests(VCSTestCase):
                 return_value=["/root/foo.po", "/root/meh/bar.po"]
             )
 
-            assert_equal(
-                list(self.vcs_project.relative_resource_paths()),
-                ["foo.po", "meh/bar.po"],
-            )
+            assert list(self.vcs_project.relative_resource_paths()) == [
+                "foo.po",
+                "meh/bar.po",
+            ]
 
     def test_relative_resource_paths_pot(self):
         """
@@ -124,10 +119,10 @@ class VCSProjectTests(VCSTestCase):
                 return_value=["/root/foo.pot", "/root/meh/bar.pot"]
             )
 
-            assert_equal(
-                list(self.vcs_project.relative_resource_paths()),
-                ["foo.po", "meh/bar.po"],
-            )
+            assert list(self.vcs_project.relative_resource_paths()) == [
+                "foo.po",
+                "meh/bar.po",
+            ]
 
     def test_source_directory_with_config(self):
         """
@@ -136,9 +131,9 @@ class VCSProjectTests(VCSTestCase):
         """
         self.vcs_project.configuration = Mock(return_value=[True])
 
-        assert_equal(
-            self.vcs_project.source_directory_path,
-            self.vcs_project.db_project.source_repository.checkout_path,
+        assert (
+            self.vcs_project.source_directory_path
+            == self.vcs_project.db_project.source_repository.checkout_path
         )
 
     def test_source_directory_path_no_resource(self):
@@ -149,9 +144,8 @@ class VCSProjectTests(VCSTestCase):
         checkout_path = os.path.join(TEST_CHECKOUT_PATH, "no_resources_test")
         self.mock_checkout_path.return_value = checkout_path
 
-        assert_equal(
-            self.vcs_project.source_directory_path,
-            os.path.join(checkout_path, "real_resources", "templates"),
+        assert self.vcs_project.source_directory_path == os.path.join(
+            checkout_path, "real_resources", "templates"
         )
 
     def test_source_directory_scoring_templates(self):
@@ -162,9 +156,8 @@ class VCSProjectTests(VCSTestCase):
         checkout_path = os.path.join(TEST_CHECKOUT_PATH, "scoring_templates_test")
         self.mock_checkout_path.return_value = checkout_path
 
-        assert_equal(
-            self.vcs_project.source_directory_path,
-            os.path.join(checkout_path, "templates"),
+        assert self.vcs_project.source_directory_path == os.path.join(
+            checkout_path, "templates"
         )
 
     def test_source_directory_scoring_en_US(self):
@@ -175,8 +168,8 @@ class VCSProjectTests(VCSTestCase):
         checkout_path = os.path.join(TEST_CHECKOUT_PATH, "scoring_en_US_test")
         self.mock_checkout_path.return_value = checkout_path
 
-        assert_equal(
-            self.vcs_project.source_directory_path, os.path.join(checkout_path, "en-US")
+        assert self.vcs_project.source_directory_path == os.path.join(
+            checkout_path, "en-US"
         )
 
     def test_source_directory_scoring_source_files(self):
@@ -187,10 +180,9 @@ class VCSProjectTests(VCSTestCase):
         checkout_path = os.path.join(TEST_CHECKOUT_PATH, "scoring_source_files_test")
         self.mock_checkout_path.return_value = checkout_path
 
-        assert_equal(
-            self.vcs_project.source_directory_path,
-            os.path.join(checkout_path, "en"),  # en has pot files in it
-        )
+        assert self.vcs_project.source_directory_path == os.path.join(
+            checkout_path, "en"
+        )  # en has pot files in it
 
     def test_resources_parse_error(self):
         """
@@ -219,7 +211,7 @@ class VCSProjectTests(VCSTestCase):
         ):
             MockVCSResource.side_effect = vcs_resource_constructor
 
-            assert_equal(self.vcs_project.resources, {"success": "successful resource"})
+            assert self.vcs_project.resources == {"success": "successful resource"}
             mock_log.error.assert_called_with(CONTAINS("failure", "error message"))
 
     @patch.object(Repository, "checkout_path", new_callable=PropertyMock)
@@ -232,23 +224,17 @@ class VCSProjectTests(VCSTestCase):
         self.vcs_project.db_project.configuration_file = "l10n.toml"
         self.vcs_project.configuration = VCSConfiguration(self.vcs_project)
 
-        assert_equal(
-            sorted(list(self.vcs_project.resource_paths_with_config())),
-            sorted(
-                [
-                    os.path.join(PROJECT_CONFIG_CHECKOUT_PATH, "values/amo.pot"),
-                    os.path.join(
-                        PROJECT_CONFIG_CHECKOUT_PATH, "values/strings.properties"
-                    ),
-                    os.path.join(
-                        PROJECT_CONFIG_CHECKOUT_PATH, "values/strings_child.properties"
-                    ),
-                    os.path.join(
-                        PROJECT_CONFIG_CHECKOUT_PATH,
-                        "values/strings_reality.properties",
-                    ),
-                ]
-            ),
+        assert sorted(list(self.vcs_project.resource_paths_with_config())) == sorted(
+            [
+                os.path.join(PROJECT_CONFIG_CHECKOUT_PATH, "values/amo.pot"),
+                os.path.join(PROJECT_CONFIG_CHECKOUT_PATH, "values/strings.properties"),
+                os.path.join(
+                    PROJECT_CONFIG_CHECKOUT_PATH, "values/strings_child.properties"
+                ),
+                os.path.join(
+                    PROJECT_CONFIG_CHECKOUT_PATH, "values/strings_reality.properties",
+                ),
+            ]
         )
 
     @patch.object(VCSProject, "source_directory_path", new_callable=PropertyMock)
@@ -272,10 +258,9 @@ class VCSProjectTests(VCSTestCase):
                 ("/root", [], ["foo.pot", "region.properties"])
             ]
 
-            assert_equal(
-                list(self.vcs_project.resource_paths_without_config()),
-                [os.path.join("/root", "foo.pot")],
-            )
+            assert list(self.vcs_project.resource_paths_without_config()) == [
+                os.path.join("/root", "foo.pot")
+            ]
 
     @patch.object(VCSProject, "source_directory_path", new_callable=PropertyMock)
     def test_resource_paths_without_config_exclude_hidden(
@@ -294,10 +279,9 @@ class VCSProjectTests(VCSTestCase):
             wraps=scandir,
             return_value=hidden_paths,
         ):
-            assert_equal(
-                list(self.vcs_project.resource_paths_without_config()),
-                ["/root/templates/foo.pot"],
-            )
+            assert list(self.vcs_project.resource_paths_without_config()) == [
+                "/root/templates/foo.pot"
+            ]
 
 
 class VCSConfigurationTests(VCSTestCase):
@@ -341,50 +325,44 @@ class VCSConfigurationTests(VCSTestCase):
         config = self.vcs_project.configuration.parsed_configuration
         locale_code = "new-locale-code"
 
-        assert_false(locale_code in config.all_locales)
+        assert locale_code not in config.all_locales
 
         self.vcs_project.configuration.add_locale(locale_code)
 
-        assert_true(locale_code in config.locales)
+        assert locale_code in config.locales
 
     def test_get_or_set_project_files_reference(self):
         self.vcs_project.configuration.add_locale = Mock()
         locale_code = None
 
-        assert_equal(
-            self.vcs_project.configuration.get_or_set_project_files(
-                locale_code,
-            ).locale,
-            locale_code,
+        assert (
+            self.vcs_project.configuration.get_or_set_project_files(locale_code,).locale
+            == locale_code
         )
 
-        assert_false(self.vcs_project.configuration.add_locale.called)
+        assert not self.vcs_project.configuration.add_locale.called
 
     def test_get_or_set_project_files_l10n(self):
         self.vcs_project.configuration.add_locale = Mock()
         locale_code = self.locale.code
 
-        assert_equal(
-            self.vcs_project.configuration.get_or_set_project_files(
-                locale_code,
-            ).locale,
-            locale_code,
+        assert (
+            self.vcs_project.configuration.get_or_set_project_files(locale_code,).locale
+            == locale_code
         )
 
-        assert_false(self.vcs_project.configuration.add_locale.called)
+        assert not self.vcs_project.configuration.add_locale.called
 
     def test_get_or_set_project_files_new_locale(self):
         self.vcs_project.configuration.add_locale = Mock()
         locale_code = "new-locale-code"
 
-        assert_equal(
-            self.vcs_project.configuration.get_or_set_project_files(
-                locale_code,
-            ).locale,
-            locale_code,
+        assert (
+            self.vcs_project.configuration.get_or_set_project_files(locale_code,).locale
+            == locale_code
         )
 
-        assert_true(self.vcs_project.configuration.add_locale.called)
+        assert self.vcs_project.configuration.add_locale.called
 
     def test_l10n_path(self):
         absolute_resource_path = os.path.join(
@@ -393,26 +371,23 @@ class VCSConfigurationTests(VCSTestCase):
 
         l10n_path = os.path.join(PROJECT_CONFIG_CHECKOUT_PATH, "values-fr/amo.po",)
 
-        assert_equal(
+        assert (
             self.vcs_project.configuration.l10n_path(
                 self.locale, absolute_resource_path,
-            ),
-            l10n_path,
+            )
+            == l10n_path
         )
 
     def test_locale_resources(self):
-        assert_equal(
-            sorted(
-                self.vcs_project.configuration.locale_resources(self.locale),
-                key=lambda r: r.path,
-            ),
-            [
-                self.resource_amo,
-                self.resource_strings,
-                self.resource_strings_child,
-                self.resource_strings_reality,
-            ],
-        )
+        assert sorted(
+            self.vcs_project.configuration.locale_resources(self.locale),
+            key=lambda r: r.path,
+        ) == [
+            self.resource_amo,
+            self.resource_strings,
+            self.resource_strings_child,
+            self.resource_strings_reality,
+        ]
 
 
 class GrandFatheredVCSConfigurationTest(VCSConfigurationTests):
@@ -422,18 +397,15 @@ class GrandFatheredVCSConfigurationTest(VCSConfigurationTests):
 
     def test_locale_resources(self):
         # no resource_strings, excluded for `fr`
-        assert_equal(
-            sorted(
-                self.vcs_project.configuration.locale_resources(self.locale),
-                key=lambda r: r.path,
-            ),
-            [
-                self.resource_amo,
-                # self.resource_strings,
-                self.resource_strings_child,
-                self.resource_strings_reality,
-            ],
-        )
+        assert sorted(
+            self.vcs_project.configuration.locale_resources(self.locale),
+            key=lambda r: r.path,
+        ) == [
+            self.resource_amo,
+            # self.resource_strings,
+            self.resource_strings_child,
+            self.resource_strings_reality,
+        ]
 
 
 def setUpResource(self):
@@ -465,9 +437,8 @@ class VCSConfigurationFullLocaleTests(VCSTestCase):
     def test_vcs_resource(self):
         self.vcs_project.configuration.add_locale(self.locale.code)
         r = VCSResource(self.vcs_project, "values/strings.properties", [self.locale])
-        assert_equal(
-            r.files[self.locale].path,
-            os.path.join(PROJECT_CONFIG_CHECKOUT_PATH, "values-fr/strings.properties"),
+        assert r.files[self.locale].path == os.path.join(
+            PROJECT_CONFIG_CHECKOUT_PATH, "values-fr/strings.properties"
         )
 
     def test_vcs_resource_path(self):
@@ -475,11 +446,8 @@ class VCSConfigurationFullLocaleTests(VCSTestCase):
         r = VCSResource(
             self.vcs_project, "values/strings_reality.properties", [self.locale]
         )
-        assert_equal(
-            r.files[self.locale].path,
-            os.path.join(
-                PROJECT_CONFIG_CHECKOUT_PATH, "values-fr/strings_reality.properties"
-            ),
+        assert r.files[self.locale].path == os.path.join(
+            PROJECT_CONFIG_CHECKOUT_PATH, "values-fr/strings_reality.properties"
         )
 
     def test_vcs_resource_child(self):
@@ -487,11 +455,8 @@ class VCSConfigurationFullLocaleTests(VCSTestCase):
         r = VCSResource(
             self.vcs_project, "values/strings_child.properties", [self.locale]
         )
-        assert_equal(
-            r.files[self.locale].path,
-            os.path.join(
-                PROJECT_CONFIG_CHECKOUT_PATH, "values-fr/strings_child.properties"
-            ),
+        assert r.files[self.locale].path == os.path.join(
+            PROJECT_CONFIG_CHECKOUT_PATH, "values-fr/strings_child.properties"
         )
 
 
@@ -504,9 +469,8 @@ class VCSConfigurationPartialLocaleTests(VCSTestCase):
     def test_vcs_resource(self):
         self.vcs_project.configuration.add_locale(self.locale.code)
         r = VCSResource(self.vcs_project, "values/strings.properties", [self.locale])
-        assert_equal(
-            r.files[self.locale].path,
-            os.path.join(PROJECT_CONFIG_CHECKOUT_PATH, "values-sl/strings.properties"),
+        assert r.files[self.locale].path == os.path.join(
+            PROJECT_CONFIG_CHECKOUT_PATH, "values-sl/strings.properties"
         )
 
     def test_vcs_resource_path(self):
@@ -514,14 +478,14 @@ class VCSConfigurationPartialLocaleTests(VCSTestCase):
         r = VCSResource(
             self.vcs_project, "values/strings_reality.properties", [self.locale]
         )
-        assert_equal(r.files, {})
+        assert r.files == {}
 
     def test_vcs_resource_child(self):
         self.vcs_project.configuration.add_locale(self.locale.code)
         r = VCSResource(
             self.vcs_project, "values/strings_child.properties", [self.locale]
         )
-        assert_equal(r.files, {})
+        assert r.files == {}
 
 
 class VCSEntityTests(VCSTestCase):
@@ -535,9 +499,9 @@ class VCSEntityTests(VCSTestCase):
         entity = VCSEntityFactory()
         entity.translations = {"empty": empty_translation, "full": full_translation}
 
-        assert_false(entity.has_translation_for("missing"))
-        assert_true(entity.has_translation_for("empty"))
-        assert_true(entity.has_translation_for("full"))
+        assert not entity.has_translation_for("missing")
+        assert entity.has_translation_for("empty")
+        assert entity.has_translation_for("full")
 
 
 class DownloadTOMLParserTests(TestCase):

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -166,13 +166,6 @@ Jinja2==2.11.1 \
 MarkupSafe==0.23 \
     --hash=sha256:a4ec1aff59b95a14b45eb2e23761a0179e98319da5a7eb76b56ea8cdc7b871c3
 
-# >=1.2.1 django-nose
-# >=1.2.1 nose-progressive
-nose==1.3.6 \
-    --hash=sha256:4772ab5189229392d16c70ba7b8bb66b5d3c18076694c55347afb98c950b283c \
-    --hash=sha256:e19b4f8a495681c367ab56c3c04f8bef30ddd7907ddfd9bee663a3f3286762b6 \
-    --hash=sha256:f61e0909a743eed37b1207e38a8e7b4a2fe0a82185e36f2be252ef1b3f901758
-
 # >=3.1.0 django-notifications-hq
 django-model-utils==4.0.0 \
     --hash=sha256:9cf882e5b604421b62dbe57ad2b18464dc9c8f963fc3f9831badccae66c1139c \
@@ -343,10 +336,6 @@ packaging==17.1 \
 # >=2.0.2 packaging
 pyparsing==2.2.0 \
     --hash=sha256:fee43f17a9c4087e7ed1605bd6df994c6173c1e977d7ade7b651292fab2bd010
-
-# >=1.3,<2.0 nose-progressive
-blessings==1.6 \
-    --hash=sha256:edc5713061f10966048bf6b40d9a514b381e0ba849c64e034c4ef6c1847d3007
 
 # pydocstyle
 snowballstemmer==1.2.1 \

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -68,8 +68,6 @@ django_guardian==1.4.9 \
 django-jinja==2.6.0 \
     --hash=sha256:4e3e97d7b40669926a9517eb4522cd98dce2e32dcba908aad156810b74744148 \
     --hash=sha256:7459985c25ddb6584c6bab345761c8c5557713448e6fbb322af1b6dd7f5512bd
-django-nose==1.4.4 \
-    --hash=sha256:ea24863cd7278aa503af4e693fc639cc86f6ab5cc79fd36dafe17d4f5d8ea114
 django-notifications-hq==1.6.0 \
     --hash=sha256:debeb71b7076b08487b40bf07664d1cc43b9977c4480bbc969b30236dda7a461 \
     --hash=sha256:dfc6f8bd4034ceae91143bc3802ddfb6e276eaec90e63dd23e2584c052561576

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -33,9 +33,6 @@ hashin==0.13.2 \
     --hash=sha256:4aaa2890d63e0eff9e1038e8a602eccbfe2eb90aa8177ff2b2db018815e2be95 \
     --hash=sha256:a166442889c1cedf0f909956e6ca1c4b39c28d121a9b22dc90b4b44b1d \
     --hash=sha256:40c51ea166442889c1cedf0f909956e6ca1c4b39c28d121a9b22dc90b4b44b1d
-nose-progressive==1.5.1 \
-    --hash=sha256:44bd41344c1cc1de434a72764ed47fdbbbdbcf03c7801114c0433cd6c696cb55 \
-    --hash=sha256:aac01f33c8446407b3c5e6f2185d5b09f5f3e6cb773f1db2df99efce5a70b81b
 django-extensions==2.2.8 \
     --hash=sha256:1a03c4e8bade575f8c2be6c76456f8a2be3f9b02ab9f47d3535afa9562dc0493 \
     --hash=sha256:2699cc1d6fb4bd393c0b5832fea4bc685f2ace5800b3c9ff222b2080f161ac04


### PR DESCRIPTION
The package doesn't officially support Django >=3.0, and `nose` is not maintained anymore. All usages were replaced by appropriate `pytest` equivalents.

I deleted the `TEST_RUNNER` definition in the settings. We could change it to run `pytest` instead when calling `./manage.py test` (see instructions [here](https://pytest-django.readthedocs.io/en/latest/faq.html#how-can-i-use-manage-py-test-with-pytest-django)), but I don't think that's worth it since we use the `pytest` command directly.