### PR TITLE
Authentication Error bug fix

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -13,6 +13,7 @@
 *.env.development.local
 *.env.test.local
 *.env.production.local
+*.html
 
 **/package.json*
 npm-debug.log*

--- a/pontoon/base/templates/django/socialaccount/authentication_error.html
+++ b/pontoon/base/templates/django/socialaccount/authentication_error.html
@@ -5,5 +5,5 @@
 {% block content %}
 <h1 id="title">Sign In Failure</h1>
 <h2 id="subtitle">An error occurred while attempting to sign in.</h2>
-<p id="action"><a href="{% provider_login_url %}">Try again</a></p>
+<p id="action"><a href="{{ provider_login_url }}">Try again</a></p>
 {% endblock %}


### PR DESCRIPTION
Working on [Bug 1669192](https://bugzilla.mozilla.org/show_bug.cgi?id=1669192) uncovered a syntax error within the `authentication_error.html` file that was causing the app to crash instead of showing the "Sign in Failure" page.

This patch fixes that error and also includes adding `*html`  to the `prettierignore` file so that those are not reformatted with Prettier.