### PR TITLE
Fix 1417530 - Convert the api tests from Unittest to Pytest.

### DIFF
--- a/pontoon/api/tests/test_schema.py
+++ b/pontoon/api/tests/test_schema.py
@@ -2,147 +2,154 @@ from __future__ import absolute_import
 
 import sys
 
-from django.test import TestCase
+import pytest
 
 
-class TestCyclicQueries(TestCase):
-    def setUp(self):
-        # graphql-core's ExecutionContext.report_error uses sys.excepthook to
-        # print error stack traces. According to Python docs this hooks can be
-        # safely customized:
-        #
-        #     The handling of such top-level exceptions can be customized by
-        #     assigning another three-argument function to sys.excepthook.
-        #
-        # Cf. https://docs.python.org/2/library/sys.html#sys.excepthook
-        self.excepthook_orig = sys.excepthook
-        sys.excepthook = lambda *x: None
+@pytest.fixture
+def setup_excepthook():
+    # graphql-core's ExecutionContext.report_error uses sys.excepthook to
+    # print error stack traces. According to Python docs this hooks can be
+    # safely customized:
+    #
+    #     The handling of such top-level exceptions can be customized by
+    #     assigning another three-argument function to sys.excepthook.
+    #
+    # Cf. https://docs.python.org/2/library/sys.html#sys.excepthook
+    excepthook_orig = sys.excepthook
+    sys.excepthook = lambda *x: None
+    yield
+    sys.excepthook = excepthook_orig
 
-    def tearDown(self):
-        sys.excepthook = self.excepthook_orig
 
-    def test_projects(self):
-        body = {
-            "query": """{
-                projects(includeSystem: true) {
-                    name
-                }
-            }"""
+@pytest.mark.django_db
+def test_projects(client):
+    body = {
+        "query": """{
+            projects(includeSystem: true) {
+                name
+            }
+        }"""
+    }
+
+    response = client.get("/graphql", body, HTTP_ACCEPT="application/json")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "data": {
+            "projects": [
+                {"name": "Pontoon Intro"},
+                {"name": "Terminology"},
+                {"name": "Tutorial"},
+            ]
         }
+    }
 
-        response = self.client.get("/graphql", body, HTTP_ACCEPT="application/json")
 
-        self.assertEqual(response.status_code, 200)
-        self.assertJSONEqual(
-            response.content,
-            {
-                "data": {
-                    "projects": [
-                        {"name": "Pontoon Intro"},
-                        {"name": "Terminology"},
-                        {"name": "Tutorial"},
-                    ]
+@pytest.mark.django_db
+def test_project_localizations(client):
+    body = {
+        "query": """{
+            project(slug: "pontoon-intro") {
+                localizations {
+                    locale {
+                        name
+                    }
                 }
-            },
-        )
+            }
+        }"""
+    }
 
-    def test_project_localizations(self):
-        body = {
-            "query": """{
-                project(slug: "pontoon-intro") {
-                    localizations {
-                        locale {
-                            name
+    response = client.get("/graphql", body, HTTP_ACCEPT="application/json")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "data": {"project": {"localizations": [{"locale": {"name": "English"}}]}}
+    }
+
+
+@pytest.mark.django_db
+def test_projects_localizations_cyclic(client):
+    body = {
+        "query": """{
+            projects {
+                localizations {
+                    locale {
+                        localizations {
+                            totalStrings
                         }
                     }
                 }
-            }"""
-        }
+            }
+        }"""
+    }
 
-        response = self.client.get("/graphql", body, HTTP_ACCEPT="application/json")
+    response = client.get("/graphql", body, HTTP_ACCEPT="application/json")
 
-        self.assertEqual(response.status_code, 200)
-        self.assertJSONEqual(
-            response.content,
-            {"data": {"project": {"localizations": [{"locale": {"name": "English"}}]}}},
-        )
+    assert response.status_code == 200
+    assert b"Cyclic queries are forbidden" in response.content
 
-    def test_projects_localizations_cyclic(self):
-        body = {
-            "query": """{
-                projects {
-                    localizations {
-                        locale {
-                            localizations {
-                                totalStrings
-                            }
+
+@pytest.mark.django_db
+def test_project_localizations_cyclic(client):
+    body = {
+        "query": """{
+            project(slug: "pontoon-intro") {
+                localizations {
+                    locale {
+                        localizations {
+                            totalStrings
                         }
                     }
                 }
-            }"""
-        }
+            }
+        }"""
+    }
 
-        response = self.client.get("/graphql", body, HTTP_ACCEPT="application/json")
+    response = client.get("/graphql", body, HTTP_ACCEPT="application/json")
 
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "Cyclic queries are forbidden")
+    assert response.status_code == 200
+    assert b"Cyclic queries are forbidden" in response.content
 
-    def test_project_localizations_cyclic(self):
-        body = {
-            "query": """{
-                project(slug: "pontoon-intro") {
-                    localizations {
-                        locale {
-                            localizations {
-                                totalStrings
-                            }
+
+@pytest.mark.django_db
+def test_locales_localizations_cyclic(client):
+    body = {
+        "query": """{
+            locales {
+                localizations {
+                    project {
+                        localizations {
+                            totalStrings
                         }
                     }
                 }
-            }"""
-        }
+            }
+        }"""
+    }
 
-        response = self.client.get("/graphql", body, HTTP_ACCEPT="application/json")
+    response = client.get("/graphql", body, HTTP_ACCEPT="application/json")
 
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "Cyclic queries are forbidden")
+    assert response.status_code == 200
+    assert b"Cyclic queries are forbidden" in response.content
 
-    def test_locales_localizations_cyclic(self):
-        body = {
-            "query": """{
-                locales {
-                    localizations {
-                        project {
-                            localizations {
-                                totalStrings
-                            }
+
+@pytest.mark.django_db
+def test_locale_localizations_cyclic(client):
+    body = {
+        "query": """{
+            locale(code: "en-US") {
+                localizations {
+                    project {
+                        localizations {
+                            totalStrings
                         }
                     }
                 }
-            }"""
-        }
+            }
+        }"""
+    }
 
-        response = self.client.get("/graphql", body, HTTP_ACCEPT="application/json")
+    response = client.get("/graphql", body, HTTP_ACCEPT="application/json")
 
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "Cyclic queries are forbidden")
-
-    def test_locale_localizations_cyclic(self):
-        body = {
-            "query": """{
-                locale(code: "en-US") {
-                    localizations {
-                        project {
-                            localizations {
-                                totalStrings
-                            }
-                        }
-                    }
-                }
-            }"""
-        }
-
-        response = self.client.get("/graphql", body, HTTP_ACCEPT="application/json")
-
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "Cyclic queries are forbidden")
+    assert response.status_code == 200
+    assert b"Cyclic queries are forbidden" in response.content

--- a/pontoon/api/tests/test_util.py
+++ b/pontoon/api/tests/test_util.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-import unittest
 from graphql import Source, parse as parse_source
 
 from pontoon.api.util import get_fields
@@ -26,217 +25,207 @@ def parse_graphql_query(query):
     return document.definitions
 
 
-class TestUtil(unittest.TestCase):
-    def test_get_fields_one(self):
-        input = """
-            query {
-                projects {
-                    name
-                }
+def test_get_fields_one():
+    input = """
+        query {
+            projects {
+                name
             }
-        """
+        }
+    """
 
-        (query,) = parse_graphql_query(input)
-        info = MockResolveInfo(query)
+    (query,) = parse_graphql_query(input)
+    info = MockResolveInfo(query)
 
-        self.assertEqual(get_fields(info), ["projects", "projects.name"])
+    assert get_fields(info) == ["projects", "projects.name"]
 
-    def test_get_fields_many(self):
-        input = """
-            query {
-                projects {
-                    name
-                    slug
-                }
+
+def test_get_fields_many():
+    input = """
+        query {
+            projects {
+                name
+                slug
             }
-        """
+        }
+    """
 
-        (query,) = parse_graphql_query(input)
-        info = MockResolveInfo(query)
+    (query,) = parse_graphql_query(input)
+    info = MockResolveInfo(query)
 
-        self.assertEqual(
-            get_fields(info), ["projects", "projects.name", "projects.slug"]
-        )
+    assert get_fields(info) == ["projects", "projects.name", "projects.slug"]
 
-    def test_get_fields_fragment(self):
-        input = """
-            query {
-                projects {
-                    name
-                    slug
-                    ...stats
-                }
+
+def test_get_fields_fragment():
+    input = """
+        query {
+            projects {
+                name
+                slug
+                ...stats
             }
+        }
 
-            fragment stats on Project {
-                totalStrings
-                missingStrings
-            }
-        """
+        fragment stats on Project {
+            totalStrings
+            missingStrings
+        }
+    """
 
-        query, frag = parse_graphql_query(input)
-        info = MockResolveInfo(query, {"stats": frag})
+    query, frag = parse_graphql_query(input)
+    info = MockResolveInfo(query, {"stats": frag})
 
-        self.assertEqual(
-            get_fields(info),
-            [
-                "projects",
-                "projects.name",
-                "projects.slug",
-                "projects.totalStrings",
-                "projects.missingStrings",
-            ],
-        )
+    assert get_fields(info) == [
+        "projects",
+        "projects.name",
+        "projects.slug",
+        "projects.totalStrings",
+        "projects.missingStrings",
+    ]
 
-    def test_get_fields_cyclic(self):
-        input = """
-            query {
-                projects {
-                    name
-                    slug
-                    localizations {
-                        locale {
-                            localizations {
-                                totalStrings
-                            }
-                        }
-                    }
-                }
-            }
-        """
 
-        (query,) = parse_graphql_query(input)
-        info = MockResolveInfo(query)
-
-        self.assertEqual(
-            get_fields(info),
-            [
-                "projects",
-                "projects.name",
-                "projects.slug",
-                "projects.localizations",
-                "projects.localizations.locale",
-                "projects.localizations.locale.localizations",
-                "projects.localizations.locale.localizations.totalStrings",
-            ],
-        )
-
-    def test_get_fields_cyclic_with_fragment(self):
-        input = """
-            query {
-                projects {
-                    name
-                    slug
-                    localizations {
-                        locale {
-                            localizations {
-                                ...stats
-                            }
-                        }
-                    }
-                }
-            }
-
-            fragment stats on ProjectLocale {
-                totalStrings
-                missingStrings
-            }
-        """
-
-        query, frag = parse_graphql_query(input)
-        info = MockResolveInfo(query, {"stats": frag})
-
-        self.assertEqual(
-            get_fields(info),
-            [
-                "projects",
-                "projects.name",
-                "projects.slug",
-                "projects.localizations",
-                "projects.localizations.locale",
-                "projects.localizations.locale.localizations",
-                "projects.localizations.locale.localizations.totalStrings",
-                "projects.localizations.locale.localizations.missingStrings",
-            ],
-        )
-
-    def test_get_fields_cyclic_in_fragment(self):
-        input = """
-            query {
-                projects {
-                    name
-                    slug
-                    localizations {
-                        locale {
-                            ...localizations
-                        }
-                    }
-                }
-            }
-
-            fragment localizations on Locale {
+def test_get_fields_cyclic():
+    input = """
+        query {
+            projects {
+                name
+                slug
                 localizations {
-                    totalStrings
-                    missingStrings
+                    locale {
+                        localizations {
+                            totalStrings
+                        }
+                    }
                 }
             }
-        """
+        }
+    """
 
-        query, frag = parse_graphql_query(input)
-        info = MockResolveInfo(query, {"localizations": frag})
+    (query,) = parse_graphql_query(input)
+    info = MockResolveInfo(query)
 
-        self.assertEqual(
-            get_fields(info),
-            [
-                "projects",
-                "projects.name",
-                "projects.slug",
-                "projects.localizations",
-                "projects.localizations.locale",
-                "projects.localizations.locale.localizations",
-                "projects.localizations.locale.localizations.totalStrings",
-                "projects.localizations.locale.localizations.missingStrings",
-            ],
-        )
+    assert get_fields(info) == [
+        "projects",
+        "projects.name",
+        "projects.slug",
+        "projects.localizations",
+        "projects.localizations.locale",
+        "projects.localizations.locale.localizations",
+        "projects.localizations.locale.localizations.totalStrings",
+    ]
 
-    def test_get_fields_two_queries(self):
-        input = """
-            query {
-                projects {
-                    name
+
+def test_get_fields_cyclic_with_fragment():
+    input = """
+        query {
+            projects {
+                name
+                slug
+                localizations {
+                    locale {
+                        localizations {
+                            ...stats
+                        }
+                    }
                 }
             }
+        }
 
-            query {
-                locales {
-                    name
+        fragment stats on ProjectLocale {
+            totalStrings
+            missingStrings
+        }
+    """
+
+    query, frag = parse_graphql_query(input)
+    info = MockResolveInfo(query, {"stats": frag})
+
+    assert get_fields(info) == [
+        "projects",
+        "projects.name",
+        "projects.slug",
+        "projects.localizations",
+        "projects.localizations.locale",
+        "projects.localizations.locale.localizations",
+        "projects.localizations.locale.localizations.totalStrings",
+        "projects.localizations.locale.localizations.missingStrings",
+    ]
+
+
+def test_get_fields_cyclic_in_fragment():
+    input = """
+        query {
+            projects {
+                name
+                slug
+                localizations {
+                    locale {
+                        ...localizations
+                    }
                 }
             }
-        """
+        }
 
-        query1, query2 = parse_graphql_query(input)
-
-        info1 = MockResolveInfo(query1)
-        self.assertEqual(get_fields(info1), ["projects", "projects.name"])
-
-        info2 = MockResolveInfo(query2)
-        self.assertEqual(get_fields(info2), ["locales", "locales.name"])
-
-    def test_get_fields_two_fields(self):
-        input = """
-            query {
-                projects {
-                    name
-                }
-                locales {
-                    name
-                }
+        fragment localizations on Locale {
+            localizations {
+                totalStrings
+                missingStrings
             }
-        """
+        }
+    """
 
-        (query,) = parse_graphql_query(input)
-        info = MockResolveInfo(query)
+    query, frag = parse_graphql_query(input)
+    info = MockResolveInfo(query, {"localizations": frag})
 
-        self.assertEqual(
-            get_fields(info), ["projects", "projects.name", "locales", "locales.name"]
-        )
+    assert get_fields(info) == [
+        "projects",
+        "projects.name",
+        "projects.slug",
+        "projects.localizations",
+        "projects.localizations.locale",
+        "projects.localizations.locale.localizations",
+        "projects.localizations.locale.localizations.totalStrings",
+        "projects.localizations.locale.localizations.missingStrings",
+    ]
+
+
+def test_get_fields_two_queries():
+    input = """
+        query {
+            projects {
+                name
+            }
+        }
+
+        query {
+            locales {
+                name
+            }
+        }
+    """
+
+    query1, query2 = parse_graphql_query(input)
+
+    info1 = MockResolveInfo(query1)
+    assert get_fields(info1) == ["projects", "projects.name"]
+
+    info2 = MockResolveInfo(query2)
+    assert get_fields(info2) == ["locales", "locales.name"]
+
+
+def test_get_fields_two_fields():
+    input = """
+        query {
+            projects {
+                name
+            }
+            locales {
+                name
+            }
+        }
+    """
+
+    (query,) = parse_graphql_query(input)
+    info = MockResolveInfo(query)
+
+    assert get_fields(info) == ["projects", "projects.name", "locales", "locales.name"]


### PR DESCRIPTION
I didn't want to reinvent the wheel in #1682. There's no need for parametrization in Unittest when it's available in Pytest OOTB.