### PR TITLE
Fix Bug 1669192 - Unable to authorize with GitHub

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -45,8 +45,8 @@ Django==2.2.13 \
 django-ace==1.0.5 \
     --hash=sha256:1334f08b4c5548e8ab13b25787e6a3f49dfe5fc92bb3a3d845b5b42fa0e1aff6 \
     --hash=sha256:a2616b0265bdc1f839cc905c77243f779d82c00f3fddf58d23c08eb07e91e189
-django-allauth==0.41.0 \
-    --hash=sha256:7ab91485b80d231da191d5c7999ba93170ef1bf14ab6487d886598a1ad03e1d8
+django-allauth==0.42.0 \
+    --hash=sha256:f17209410b7f87da0a84639fd79d3771b596a6d3fc1a8e48ce50dabc7f441d30
 django-bmemcached==0.2.3 \
     --hash=sha256:c9e4f5ca17417a26354e7d6a8899e44e34d541e8731ea0d987f2bf5a04df351a
 django-bulk-update==2.2.0 \


### PR DESCRIPTION
Using GitHub to authenticate a signin was causing an error. The authentication would complete on GitHub but when redirected to Pontoon an error occurred.

In looking into this it was discovered that GitHub changed the way it handles authentication from using query params to using headers instead. The django-allauth package was updated with this change in v0.42.0.

Pontoon was still using v0.41.0 and updating to v0.42.0 fixes the issue.