### PR TITLE
Remove more unused templatetags helpers

### DIFF
--- a/pontoon/base/tests/test_helpers.py
+++ b/pontoon/base/tests/test_helpers.py
@@ -87,7 +87,7 @@ def test_helper_to_json():
         "a": "foo",
         "b": aware_datetime(2015, 1, 1),
     }
-    string = '{"a": "foo", "b": "2015-01-01T00:00:00+00:00"}'
+    string = '{"a": "foo", "b": "2015-01-01T00:00:00Z"}'
     assert to_json(obj) == string
 
 


### PR DESCRIPTION
As a follow-up to #1704, I removed some more helpers.
The DjangoJSONEncoder already supports datetime and Promise objects, and thisyear+naturalday were unused.
The previous encoder also handled QuerySet objects, but I couldn't find any place where this is actually used.