### PR TITLE
Remove backports.csv dependency

### DIFF
--- a/pontoon/administration/views.py
+++ b/pontoon/administration/views.py
@@ -1,6 +1,5 @@
+import csv
 import logging
-
-from backports import csv
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
@@ -284,7 +283,7 @@ def _get_project_strings_csv(project, entities, output):
 
     :arg Project project: the project from which to take strings
     :arg list entities: the list of all entities of the project
-    :arg buffer output: a buffer to which the CSV writed will send its data
+    :arg buffer output: a buffer to which the CSV writer will send its data
 
     :returns: the same output object with the CSV data
 
@@ -300,12 +299,10 @@ def _get_project_strings_csv(project, entities, output):
     for translation in translations:
         all_data[translation.entity.id][translation.locale.code] = translation.string
 
-    writer = csv.writer(output)
     headers = ["source"] + [x.code for x in locales]
-    writer.writerow(headers)
-    for string in all_data.values():
-        row = [string.get(key, "") for key in headers]
-        writer.writerow(row)
+    writer = csv.DictWriter(output, fieldnames=headers)
+    writer.writeheader()
+    writer.writerows(all_data.values())
 
     return output
 

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -21,9 +21,6 @@
 # ----------------------------------------------------------------------------------
 -c constraints.txt
 
-backports.csv==1.0.5 \
-    --hash=sha256:d3b0cefaaca92be3d2d4ceec140827cae1d871da7fff5db70697d72328357d65 \
-    --hash=sha256:8c421385cbc6042ba90c68c871c5afc13672acaf91e1508546d6cda6725ebfc6
 bleach==3.1.4 \
     --hash=sha256:cc8da25076a1fe56c3ac63671e2194458e0c4d9c7becfd52ca251650d517903c \
     --hash=sha256:e78e426105ac07026ba098f04de8abe9b6e3e98b5befbf89b51a5ef0a4292b03


### PR DESCRIPTION
All CSV features we use are natively supported by Python. In particular, the DictWriter takes care of missing row entries and treats them as an empty string.