### PR TITLE
Bug 1627655: Update django-cors-headers

### DIFF
--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -763,7 +763,7 @@ CELERY_ACCEPT_CONTENT = ["pickle"]
 # For the sake of integration with other sites,
 # some of javascript files (e.g. pontoon.js)
 # require Access-Control-Allow-Origin header to be set as '*'.
-CORS_ORIGIN_ALLOW_ALL = True
+CORS_ALLOW_ALL_ORIGINS = True
 CORS_URLS_REGEX = r"^/(pontoon\.js|graphql/?)$"
 
 SOCIALACCOUNT_ENABLED = True

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -49,9 +49,9 @@ django-bmemcached==0.2.3 \
 django-bulk-update==2.2.0 \
     --hash=sha256:49a403392ae05ea872494d74fb3dfa3515f8df5c07cc277c3dc94724c0ee6985 \
     --hash=sha256:5ab7ce8a65eac26d19143cc189c0f041d5c03b9d1b290ca240dc4f3d6aaeb337
-django-cors-headers==3.2.1 \
-    --hash=sha256:a5960addecc04527ab26617e51b8ed42f0adab4594b24bb0f3c33e2bd3857c3f \
-    --hash=sha256:a785b5f446f6635810776d9f5f5d23e6a2a2f728ea982648370afaf0dfdf2627
+django-cors-headers==3.5.0 \
+    --hash=sha256:9322255c296d5f75089571f29e520c83ff9693df17aa3cf9f6a4bea7c6740169 \
+    --hash=sha256:db82b2840f667d47872ae3e4a4e0a0d72fbecb42779b8aa233fa8bb965f7836a
 django_csp==3.4 \
     --hash=sha256:096b634430d8ea81c3d9f216f87be890f3a975c17bb9a4631f6a1619ac09c91e \
     --hash=sha256:04c0ccd4e1339e8f6af48c55c3347dc996fde2d22d79e8bf2f6b7a920412e408


### PR DESCRIPTION
The new version supports Django 3.1. The CORS_ORIGIN_ALLOW_ALL setting was renamed to CORS_ALLOW_ALL_ORIGINS.