### PR TITLE
Bug 1627655: Remove django-bulk-update dependency

### DIFF
--- a/pontoon/base/migrations/0001_squashed_0154_auto_20200206_1736.py
+++ b/pontoon/base/migrations/0001_squashed_0154_auto_20200206_1736.py
@@ -13,7 +13,6 @@ import partial_index
 
 import pontoon.db.migrations
 
-from bulk_update.helper import bulk_update
 from django.conf import settings
 from django.db import connection, migrations, models, ProgrammingError
 
@@ -1499,7 +1498,9 @@ def migration_0081_add_locale_data(apps, schema_editor):
         except KeyError:
             pass
     if locales:
-        bulk_update(locales)
+        Locale.objects.bulk_update(
+            locales, fields=["script", "direction", "population"]
+        )
 
 
 def migration_0081_remove_locale_data(apps, schema_editor):
@@ -1510,7 +1511,9 @@ def migration_0081_remove_locale_data(apps, schema_editor):
         l.direction = "ltr"
         l.population = 0
     if locales:
-        bulk_update(locales)
+        Locale.objects.bulk_update(
+            locales, fields=["script", "direction", "population"]
+        )
 
 
 def migration_0089_create_pm_groups(apps, schema_editor):
@@ -1557,9 +1560,8 @@ def migration_0098_migrate_locales(apps, schema_editor):
     ):
         if pontoon_code in locale_map:
             locale_map[pontoon_code].ms_terminology_code = ms_code
-    bulk_update(
-        list(locale_map.values()),
-        update_fields=["ms_translator_code", "ms_terminology_code"],
+    Locale.objects.bulk_update(
+        list(locale_map.values()), fields=["ms_translator_code", "ms_terminology_code"],
     )
 
 
@@ -1661,7 +1663,9 @@ def migration_0134_populate_google_translate_code(apps, schema_editor):
     ) in MIGRATION_0134_PONTOON_TO_GOOGLE_TRANSLATE_MAP:
         if pontoon_code in locale_map:
             locale_map[pontoon_code].google_translate_code = google_translate_code
-    bulk_update(list(locale_map.values()), update_fields=["google_translate_code"])
+    Locale.objects.bulk_update(
+        list(locale_map.values()), fields=["google_translate_code"]
+    )
 
 
 def migration_0146_add_pretranslation_users(apps, schema_editor):
@@ -1692,7 +1696,7 @@ def migration_0153_add_word_count(apps, schema_editor):
     for e in Entity.objects.all():
         e.word_count = get_word_count(e.string)
         entities.append(e)
-    bulk_update(entities, update_fields=["word_count"], batch_size=1000)
+    Entity.objects.bulk_update(entities, fields=["word_count"], batch_size=1000)
 
 
 def migration_0153_reset_word_count(apps, schema_editor):

--- a/pontoon/base/tests/managers/test_entity.py
+++ b/pontoon/base/tests/managers/test_entity.py
@@ -990,9 +990,9 @@ def test_mgr_bulk_update(get_word_count_mock, admin, resource_a, locale_a):
     testEntitiesQuerySet = Entity.for_project_locale(
         admin, resource_a.project, locale_a
     )
-    updated_count = testEntitiesQuerySet.bulk_update(
+    testEntitiesQuerySet.bulk_update(
         objs,
-        update_fields=[
+        fields=[
             "resource",
             "string",
             "string_plural",
@@ -1006,4 +1006,3 @@ def test_mgr_bulk_update(get_word_count_mock, admin, resource_a, locale_a):
     )
 
     assert get_word_count_mock.call_count == 4
-    assert updated_count == len(objs)

--- a/pontoon/sync/changeset.py
+++ b/pontoon/sync/changeset.py
@@ -1,6 +1,5 @@
 import logging
 
-from bulk_update.helper import bulk_update
 from collections import defaultdict
 from django.contrib.auth.models import User
 from django.db import connection
@@ -436,9 +435,9 @@ class ChangeSet(object):
 
     def bulk_update_entities(self):
         if len(self.entities_to_update) > 0:
-            bulk_update(
+            Entity.objects.bulk_update(
                 self.entities_to_update,
-                update_fields=[
+                fields=[
                     "resource",
                     "string",
                     "string_plural",
@@ -465,9 +464,9 @@ class ChangeSet(object):
 
     def bulk_update_translations(self):
         if len(self.translations_to_update) > 0:
-            bulk_update(
+            Translation.objects.bulk_update(
                 list(self.translations_to_update.values()),
-                update_fields=[
+                fields=[
                     "entity",
                     "locale",
                     "string",

--- a/pontoon/sync/management/commands/import_pootle.py
+++ b/pontoon/sync/management/commands/import_pootle.py
@@ -1,4 +1,3 @@
-from bulk_update.helper import bulk_update
 from collections import Counter
 from datetime import datetime
 from django.contrib.auth.models import User
@@ -131,7 +130,7 @@ class Command(BaseCommand):
                 )
 
         if users:
-            bulk_update(users)
+            User.objects.bulk_update(users)
 
         for t in translations:
             try:
@@ -157,7 +156,7 @@ class Command(BaseCommand):
             t.approved_date = dateObj
 
         if translations:
-            bulk_update(translations)
+            Translation.objects.bulk_update(translations)
 
         missing_users = Counter(missing_users_list)
         for missing_user in missing_users.keys():

--- a/pontoon/sync/models.py
+++ b/pontoon/sync/models.py
@@ -1,7 +1,5 @@
 import logging
 
-from bulk_update.helper import bulk_update
-
 from django.urls import reverse
 from django.db import models
 from django.db.models import F, Max, Sum
@@ -76,7 +74,9 @@ class SyncLog(BaseLog):
                 )
             )
 
-        bulk_update(translated_resources, update_fields=["total_strings"])
+        TranslatedResource.objects.bulk_update(
+            translated_resources, fields=["total_strings"]
+        )
 
         # total_strings missmatch in ProjectLocales within the same project
         for p in Project.objects.available():

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -46,9 +46,6 @@ django-allauth==0.42.0 \
     --hash=sha256:f17209410b7f87da0a84639fd79d3771b596a6d3fc1a8e48ce50dabc7f441d30
 django-bmemcached==0.2.3 \
     --hash=sha256:c9e4f5ca17417a26354e7d6a8899e44e34d541e8731ea0d987f2bf5a04df351a
-django-bulk-update==2.2.0 \
-    --hash=sha256:49a403392ae05ea872494d74fb3dfa3515f8df5c07cc277c3dc94724c0ee6985 \
-    --hash=sha256:5ab7ce8a65eac26d19143cc189c0f041d5c03b9d1b290ca240dc4f3d6aaeb337
 django-cors-headers==3.5.0 \
     --hash=sha256:9322255c296d5f75089571f29e520c83ff9693df17aa3cf9f6a4bea7c6740169 \
     --hash=sha256:db82b2840f667d47872ae3e4a4e0a0d72fbecb42779b8aa233fa8bb965f7836a


### PR DESCRIPTION
The package has not been updated for 3 years, and is not tested on current Django versions. Thus, we use the Django-native `bulk_update` method instead.

The Django-native method, as opposed to the package method, does not return the number of updated objects, so I got rid of that in the single test where it was used. Also, I adjusted the `EntityQuerySet.bulk_update` method to not throw a `DeprecationWarning`, and take care of the word count.