### PR TITLE
Keep a new line before commit message trailers

### DIFF
--- a/pontoon/sync/templates/sync/commit_message.jinja
+++ b/pontoon/sync/templates/sync/commit_message.jinja
@@ -1,6 +1,5 @@
 Pontoon: Update {{ locale.name }} ({{ locale.code }}) localization of {{ project.name }}
-
-{%- if authors %}
+{% if authors %}
 {% for author in authors -%}
 Co-authored-by: {{ author.display_name_and_email|safe }}
 {% endfor %}


### PR DESCRIPTION
By convention, a new line is used before git commit message trailers (such as 'Co-authored-by').

Currently the commit message template explicitly removes newlines. This change keeps a single newline before the 'Co-authored-by' trailer.

This changes commit messages from

```
My commit message
Co-authored-by: Example 1
Co-authored-by: Example 2
```

to


```
My commit message

Co-authored-by: Example 1
Co-authored-by: Example 2
```