### PR TITLE
Fix bug 1672713: Remove django-session-csrf dependency

### DIFF
--- a/pontoon/base/admin.py
+++ b/pontoon/base/admin.py
@@ -2,11 +2,8 @@ import uuid
 
 from django.contrib import admin
 from django.contrib.auth import get_user_model
-from django.contrib.auth.admin import (
-    UserAdmin as AuthUserAdmin,
-    GroupAdmin,
-)
-from django.contrib.auth.models import User, Group
+from django.contrib.auth.admin import UserAdmin as AuthUserAdmin
+from django.contrib.auth.models import User
 from django.forms.models import ModelForm
 from django.forms import ChoiceField
 from django.urls import reverse
@@ -366,8 +363,8 @@ class UserRoleLogActionAdmin(admin.ModelAdmin):
     performed_by_email.allow_tags = True
 
 
+admin.site.unregister(User)
 admin.site.register(User, UserAdmin)
-admin.site.register(Group, GroupAdmin)
 admin.site.register(models.Locale, LocaleAdmin)
 admin.site.register(models.Project, ProjectAdmin)
 admin.site.register(models.Resource, ResourceAdmin)

--- a/pontoon/base/apps.py
+++ b/pontoon/base/apps.py
@@ -1,20 +1,12 @@
 from django.apps import AppConfig
-from django.contrib import admin
-from django.contrib.admin.sites import AdminSite
-
-import session_csrf
-from session_csrf import anonymous_csrf
 
 
 class BaseConfig(AppConfig):
     name = "pontoon.base"
     verbose_name = "Base"
 
-    _has_patched = False
-
     def ready(self):
         super(BaseConfig, self).ready()
-        self.monkeypatch()
 
         # Load celery app so celery.shared_task uses it for executing
         # tasks.
@@ -22,26 +14,3 @@ class BaseConfig(AppConfig):
 
         # Load and register signals.
         from pontoon.base import signals  # NOQA
-
-    def monkeypatch(self):
-        # Only patch once, ever.
-        if BaseConfig._has_patched:
-            return
-
-        # Monkey-patch Django's csrf_protect decorator to use
-        # session-based CSRF tokens:
-        session_csrf.monkeypatch()
-        admin.site = SessionCsrfAdminSite()
-
-        BaseConfig._has_patched = True
-
-
-class SessionCsrfAdminSite(AdminSite):
-    """Custom admin site that handles login with session_csrf."""
-
-    def login(self, request, extra_context=None):
-        @anonymous_csrf
-        def call_parent_login(request, extra_context):
-            return super(SessionCsrfAdminSite, self).login(request, extra_context)
-
-        return call_parent_login(request, extra_context)

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -153,7 +153,6 @@ INSTALLED_APPS = (
     # Third-party apps, patches, fixes
     "django_jinja",
     "pipeline",
-    "session_csrf",
     "guardian",
     "corsheaders",
     "allauth",
@@ -181,7 +180,7 @@ MIDDLEWARE = (
     "django.middleware.common.CommonMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
-    "session_csrf.CsrfMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "csp.middleware.CSPMiddleware",
@@ -193,7 +192,6 @@ CONTEXT_PROCESSORS = (
     "django.template.context_processors.debug",
     "django.template.context_processors.media",
     "django.template.context_processors.request",
-    "session_csrf.context_processor",
     "django.contrib.messages.context_processors.messages",
     "pontoon.base.context_processors.globals",
 )
@@ -600,8 +598,8 @@ LOGIN_REDIRECT_URL_FAILURE = "/"
 # everything.
 ENGAGE_ROBOTS = False
 
-# Always generate a CSRF token for anonymous users.
-ANON_ALWAYS = True
+# Store the CSRF token in the user's session instead of in a cookie.
+CSRF_USE_SESSIONS = True
 
 # Set X-Frame-Options to DENY by default on all responses.
 X_FRAME_OPTIONS = "DENY"

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -72,9 +72,6 @@ django-partial-index==0.5.2 \
 django-pipeline==1.7.0 \
     --hash=sha256:0ded22b974e3d627c27fc490ef5b23fcdcf0cdb00b704d628b5ca6d0b010d6fe \
     --hash=sha256:f7da70f00aa4baea3e0811f88927a116425deee05871fa2bfd2f8247f42d8847
-django-session-csrf==0.7.1 \
-    --hash=sha256:e17177e6e2e6518ec7ce6693ad10a5c747f8571d09f4cfa9082599334421605d \
-    --hash=sha256:ff8c10e30d312c77fc6a6db7710e22b9383e28c03b7fe958876ca96f39aa6cf2
 django-webpack-loader==0.5.0 \
     --hash=sha256:0a8536e36a30d719018cd4c5da6e9d2377771134e713c14e617bb484b4f0acce
 factory-boy==2.5.2 \


### PR DESCRIPTION
The package is natively replaced by Django. We use CSRF_USE_SESSIONS to force Django to save the CSRF  tokens in the session instead of in a cookie. We also get rid of the patching of the AppConfig and AdminSite.

The changes to the admin site were needed because after deleting the `SessionCsrfAdminSite`, Django complained about the re-registering of the `User`. I fixed this as suggested in the [Django docs](https://docs.djangoproject.com/en/3.1/topics/auth/customizing/#extending-the-existing-user-model), and I also removed the redundant Group/GroupAdmin registration.