### PR TITLE
Bug 1627655: Update django-pipeline dependency

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -176,11 +176,6 @@ swapper==1.1.2 \
   --hash=sha256:4c094929675559d34ff555bfdd7ae56aa22ed828d55e8850599fadb36ca822fc \
   --hash=sha256:a0abc7427214be9815480c4c57ddc351f3cf062240a96d57adbec36cc3fb1677
 
-# >=2.1.3 django-pipeline
-futures==3.0.4 \
-    --hash=sha256:4e860d18d866ff6c5f2804ebcbb16415f4f29cf57efea919178b809cf99326b6 \
-    --hash=sha256:19485d83f7bd2151c0aeaf88fbba3ee50dadfb222ffc3b66a344ef4952b782a3
-
 # >=2.1.7,<3 graphene-django
 graphene==2.1.8 \
     --hash=sha256:09165f03e1591b76bf57b133482db9be6dac72c74b0a628d3c93182af9c5a896 \

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -69,9 +69,9 @@ django-notifications-hq==1.6.0 \
 django-partial-index==0.5.2 \
     --hash=sha256:1eae3c5274b7729e92b33bf06abe95b55288c2718904384907e18f88c3d82155 \
     --hash=sha256:8a805b52971a58cb78c925dbb976fecf59c662a1c767846061444a2587247804
-django-pipeline==1.7.0 \
-    --hash=sha256:0ded22b974e3d627c27fc490ef5b23fcdcf0cdb00b704d628b5ca6d0b010d6fe \
-    --hash=sha256:f7da70f00aa4baea3e0811f88927a116425deee05871fa2bfd2f8247f42d8847
+django-pipeline==2.0.5 \
+    --hash=sha256:6c7bd5c2a922ddb7e989a1c5a6852f3a8bffcf6e14d9f228261c8ba04b5b79a7 \
+    --hash=sha256:7bf3d304c655ca20f77d66a4f4f3511a7b2f317768110967828aa5088806d4ce
 django-webpack-loader==0.5.0 \
     --hash=sha256:0a8536e36a30d719018cd4c5da6e9d2377771134e713c14e617bb484b4f0acce
 graphene-django==2.13.0 \


### PR DESCRIPTION
The new version supports Django 3.1, and futures is not a dependency any more.

I'm not sure how to properly test this locally, so this should probably be tested in staging.