### PR TITLE
Fix bug 1674173: Add support for non-ASCII characters in mentions

### DIFF
--- a/frontend/src/core/comments/components/AddComment.js
+++ b/frontend/src/core/comments/components/AddComment.js
@@ -339,7 +339,8 @@ export default function AddComment(props: Props) {
             const beforeRange = before && Editor.range(editor, before, start);
             const beforeText =
                 beforeRange && Editor.string(editor, beforeRange);
-            const beforeMatch = beforeText && beforeText.match(/^@(\w+)$/);
+            // Unicode property escapes allow for matching non-ASCII characters
+            const beforeMatch = beforeText && beforeText.match(/^@((\p{L}|\p{N}|\p{P})+)$/u);
             const after = Editor.after(editor, start);
             const afterRange = Editor.range(editor, start, after);
             const afterText = Editor.string(editor, afterRange);

--- a/frontend/src/core/comments/components/AddComment.js
+++ b/frontend/src/core/comments/components/AddComment.js
@@ -340,7 +340,8 @@ export default function AddComment(props: Props) {
             const beforeText =
                 beforeRange && Editor.string(editor, beforeRange);
             // Unicode property escapes allow for matching non-ASCII characters
-            const beforeMatch = beforeText && beforeText.match(/^@((\p{L}|\p{N}|\p{P})+)$/u);
+            const beforeMatch =
+                beforeText && beforeText.match(/^@((\p{L}|\p{N}|\p{P})+)$/u);
             const after = Editor.after(editor, start);
             const afterRange = Editor.range(editor, start, after);
             const afterText = Editor.string(editor, afterRange);


### PR DESCRIPTION
One should be able to mention people with fancy names like `@théo` or `@matjaž`.