### PR TITLE
Fix Bug 1624370 -  Rich Editor crash

### DIFF
--- a/frontend/src/modules/fluenteditor/components/RichEditor.js
+++ b/frontend/src/modules/fluenteditor/components/RichEditor.js
@@ -76,20 +76,23 @@ export default class RichEditor extends React.Component<Props> {
         this.props.sendTranslation(ignoreWarnings, fluentString, message);
     };
 
-    updateUnsavedChanges = (
-        translation?: Translation,
-        initial?: Translation,
-    ) => {
+    updateUnsavedChanges = () => {
         const props = this.props;
 
-        this.props.updateUnsavedChanges(
-            !translation
-                ? props.editor.translation
-                : fluent.serializer.serializeEntry(translation),
-            !initial
-                ? props.editor.initialTranslation
-                : fluent.serializer.serializeEntry(initial),
-        );
+        let translation = props.editor.translation;
+        let initial = props.editor.initialTranslation;
+
+        // If we're switching from or to a simple editor, we will not be able
+        // to serialize the current or initial translation
+        try {
+            translation = fluent.serializer.serializeEntry(translation);
+        } catch (e) {}
+
+        try {
+            initial = fluent.serializer.serializeEntry(initial);
+        } catch (e) {}
+
+        props.updateUnsavedChanges(translation, initial);
     };
 
     render() {

--- a/frontend/src/modules/fluenteditor/components/RichEditor.js
+++ b/frontend/src/modules/fluenteditor/components/RichEditor.js
@@ -82,17 +82,13 @@ export default class RichEditor extends React.Component<Props> {
     ) => {
         const props = this.props;
 
-        if (!translation) {
-            translation = props.editor.translation;
-        }
-
-        if (!initial) {
-            initial = props.editor.initialTranslation;
-        }
-
         this.props.updateUnsavedChanges(
-            fluent.serializer.serializeEntry(translation),
-            fluent.serializer.serializeEntry(initial),
+            !translation
+                ? props.editor.translation
+                : fluent.serializer.serializeEntry(translation),
+            !initial
+                ? props.editor.initialTranslation
+                : fluent.serializer.serializeEntry(initial),
         );
     };
 

--- a/frontend/src/modules/fluenteditor/components/RichEditor.js
+++ b/frontend/src/modules/fluenteditor/components/RichEditor.js
@@ -86,11 +86,15 @@ export default class RichEditor extends React.Component<Props> {
         // to serialize the current or initial translation
         try {
             translation = fluent.serializer.serializeEntry(translation);
-        } catch (e) {}
+        } catch (e) {
+            // Catch error with serialization
+        }
 
         try {
             initial = fluent.serializer.serializeEntry(initial);
-        } catch (e) {}
+        } catch (e) {
+            // Catch error with serialization
+        }
 
         props.updateUnsavedChanges(translation, initial);
     };

--- a/frontend/src/modules/fluenteditor/components/RichTranslationForm.js
+++ b/frontend/src/modules/fluenteditor/components/RichTranslationForm.js
@@ -75,9 +75,7 @@ export default class RichTranslationForm extends React.Component<EditorProps> {
 
         // Walks the tree and unify all simple elements into just one.
         const message = fluent.flattenMessage(editor.translation);
-        if (message.equals(editor.translation)) {
-            this.props.updateTranslation(message, true);
-        }
+        this.props.updateTranslation(message, true);
 
         this.focusInput(true);
     }
@@ -132,12 +130,10 @@ export default class RichTranslationForm extends React.Component<EditorProps> {
         if (!translation.equals(prevEditor.translation)) {
             // Walks the tree and unify all simple elements into just one.
             const message = fluent.flattenMessage(translation);
-            if (message.equals(translation)) {
-                this.props.updateTranslation(
-                    message,
-                    editor.changeSource !== 'internal',
-                );
-            }
+            this.props.updateTranslation(
+                message,
+                editor.changeSource !== 'internal',
+            );
         }
 
         // Close failed checks popup when content of the editor changes,

--- a/frontend/src/modules/fluenteditor/components/RichTranslationForm.js
+++ b/frontend/src/modules/fluenteditor/components/RichTranslationForm.js
@@ -75,7 +75,9 @@ export default class RichTranslationForm extends React.Component<EditorProps> {
 
         // Walks the tree and unify all simple elements into just one.
         const message = fluent.flattenMessage(editor.translation);
-        this.props.updateTranslation(message, true);
+        if (message.equals(editor.translation)) {
+            this.props.updateTranslation(message, true);
+        }
 
         this.focusInput(true);
     }
@@ -130,10 +132,12 @@ export default class RichTranslationForm extends React.Component<EditorProps> {
         if (!translation.equals(prevEditor.translation)) {
             // Walks the tree and unify all simple elements into just one.
             const message = fluent.flattenMessage(translation);
-            this.props.updateTranslation(
-                message,
-                editor.changeSource !== 'internal',
-            );
+            if (message.equals(translation)) {
+                this.props.updateTranslation(
+                    message,
+                    editor.changeSource !== 'internal',
+                );
+            }
         }
 
         // Close failed checks popup when content of the editor changes,


### PR DESCRIPTION
When transitioning from a translation that is open in a simple editor to a suggestion that is open in a rich editor the app would crash. The problem happened when trying to serialize a translation that is already serialized

To fix this I am only sending the data to be serialized if it is updated.