### PR TITLE
Fix Bug 1675438 - Poorly wrapped text in comment

### DIFF
--- a/frontend/src/core/comments/components/AddComment.css
+++ b/frontend/src/core/comments/components/AddComment.css
@@ -17,6 +17,7 @@
     margin: auto;
     overflow: auto;
     padding: 7px;
+    word-break: break-word;
 }
 
 .comments-list .add-comment .comment-editor .mention-element {

--- a/frontend/src/core/comments/components/AddComment.css
+++ b/frontend/src/core/comments/components/AddComment.css
@@ -17,7 +17,6 @@
     margin: auto;
     overflow: auto;
     padding: 7px;
-    word-break: break-all;
 }
 
 .comments-list .add-comment .comment-editor .mention-element {


### PR DESCRIPTION
When adding a comment if the text extended beyond the end of the line it would split the word and continue on the next line. This was being caused by the `word-break` property that was originally set when the comment input was a textarea. With the switch to the Slate editor this is no longer needed and long text now wraps to the next line without breaking.