### PR TITLE
Fix bug 1676751: Make sure Machinery search matches results

### DIFF
--- a/frontend/src/modules/machinery/components/Machinery.js
+++ b/frontend/src/modules/machinery/components/Machinery.js
@@ -35,6 +35,25 @@ export default class Machinery extends React.Component<Props> {
         this.searchInput = React.createRef();
     }
 
+    componentDidMount() {
+        const { machinery } = this.props;
+
+        // Restore custom input in search field,
+        // e.g. when switching from Locales tab back to Machinery
+        if (!machinery.entity && machinery.sourceString) {
+            this.searchInput.current.value = machinery.sourceString;
+        }
+    }
+
+    componentDidUpdate(prevProps: Props) {
+        const { machinery } = this.props;
+
+        // Clear search field after switching to a different entity
+        if (machinery.entity && !prevProps.machinery.entity) {
+            this.searchInput.current.value = '';
+        }
+    }
+
     submitForm = (event: SyntheticKeyboardEvent<>) => {
         event.preventDefault();
         this.props.searchMachinery(this.searchInput.current.value);

--- a/frontend/src/modules/machinery/components/Machinery.test.js
+++ b/frontend/src/modules/machinery/components/Machinery.test.js
@@ -38,7 +38,11 @@ describe('<Machinery>', () => {
     });
 
     it('returns null if there is no locale', () => {
-        const wrapper = shallow(<Machinery locale={null} />);
+        const machinery = {};
+        const wrapper = shallow(
+            <Machinery machinery={machinery} locale={null} />,
+        );
+
         expect(wrapper.type()).toBeNull();
     });
 });


### PR DESCRIPTION
This patch fixes two similar bugs which caused inconsistencies between what is displayed in the Machinery search field and Machinery results.

1. Clear search field after switching to a different entity.
1. Restore custom input in search field, e.g. when switching from Locales tab back to Machinery.