### PR TITLE
Fix bug 1676927: Enable force sync for projects with sync disabled

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -1138,14 +1138,17 @@ class ProjectQuerySet(models.QuerySet):
         """
         return self.available().filter(system_project=False)
 
+    def force_syncable(self):
+        """
+        Projects that can be force-synced are not disabled and use repository as their data source type.
+        """
+        return self.filter(disabled=False, data_source="repository")
+
     def syncable(self):
         """
-        Syncable projects are not disabled, don't have sync disabled and use
-        repository as their data source type.
+        Syncable projects are same as force-syncable, but must not have sync disabled.
         """
-        return self.filter(
-            disabled=False, sync_disabled=False, data_source="repository",
-        )
+        return self.force_syncable().filter(sync_disabled=False)
 
     def prefetch_project_locale(self, locale):
         """

--- a/pontoon/sync/management/commands/sync_projects.py
+++ b/pontoon/sync/management/commands/sync_projects.py
@@ -49,7 +49,11 @@ class Command(BaseCommand):
         """
         sync_log = SyncLog.objects.create(start_time=timezone.now())
 
-        projects = Project.objects.syncable()
+        if options["force"]:
+            projects = Project.objects.force_syncable()
+        else:
+            projects = Project.objects.syncable()
+
         slugs = (
             options["projects"].split(",")
             if "projects" in options and options["projects"]
@@ -59,14 +63,14 @@ class Command(BaseCommand):
             projects = projects.filter(slug__in=slugs)
 
         if len(projects) < 1:
-            raise CommandError("No matching projects found.")
+            raise CommandError("No matching projects to sync found.")
 
         if slugs and len(projects) != len(slugs):
             invalid_slugs = sorted(
                 set(slugs).difference(set(projects.values_list("slug", flat=True)))
             )
             self.stderr.write(
-                "Couldn't find projects with following slugs: {}".format(
+                "Couldn't find projects to sync with following slugs: {}".format(
                     ", ".join(invalid_slugs)
                 )
             )

--- a/pontoon/sync/tests/test_sync_projects.py
+++ b/pontoon/sync/tests/test_sync_projects.py
@@ -92,7 +92,7 @@ class CommandTests(TestCase):
 
         assert (
             self.command.stderr.getvalue()
-            == "Couldn't find projects with following slugs: aaa, bbb"
+            == "Couldn't find projects to sync with following slugs: aaa, bbb"
         )
 
     def test_cant_commit(self):


### PR DESCRIPTION
This patch ignores the `sync_disabled` flag on force-sync and makes error messages clearer.

@jotes Could you help with the review, pretty please?