### PR TITLE
Fix bug 1676857: Add template for writing specifications

### DIFF
--- a/specs/0000-template.md
+++ b/specs/0000-template.md
@@ -28,4 +28,3 @@ Feel free to add additional sections as needed. Common examples include (and are
 - **Out of scope:** In describing a feature scope it's sometimes helpful to explaining what doesn't fit in.
 
 Note that you are welcome to use all features of the [Markdown](https://guides.github.com/features/mastering-markdown/) syntax in formatting your specification.
-

--- a/specs/0000-template.md
+++ b/specs/0000-template.md
@@ -25,6 +25,6 @@ Feel free to add additional sections as needed. Common examples include (and are
 - **Mockup(s):** Sometimes it's easier to explain the UI with a screenshot or a drawing.
 - **Algorithm:** Explain parts of the feature with pseudocode (or Python or JS code).
 - **Roles:** Provide details on how the feature impacts different user roles?
-- **Out of scope:** In describing a feature scope it's sometimes helpful to explaining what doesn't fit in.
+- **Out of scope:** In describing a feature scope it's sometimes helpful to explain what doesn't fit in.
 
 Note that you are welcome to use all features of the [Markdown](https://guides.github.com/features/mastering-markdown/) syntax in formatting your specification.

--- a/specs/0000-template.md
+++ b/specs/0000-template.md
@@ -1,0 +1,31 @@
+- Feature Name: Name Of The Feature
+- Created: YYYY-MM-DD
+- Associated Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=BUG-ID
+
+# Summary
+
+A short, usually 1 sentence description of the feature being specified.
+
+# Motivation
+
+Explain the rationale for developing the new feature — what value does it provide to the user and/or what problem does it solve.
+
+# Feature explanation
+
+A general explanation of a feature written from the perspective of the end user. Define user interface and user interactions precisely enough for developers to be able to start coding.
+
+This section also provides a concise technical specification, but keep in mind that once the specification is approved, bugs will be filed with all implementation details.
+
+Note that we use present simple tense across the entire specification.
+
+# Optional sections
+
+Feel free to add additional sections as needed. Common examples include (and are not limited to):
+
+- **Mockup(s):** Sometimes it's easier to explain the UI with a screenshot or a drawing.
+- **Algorithm:** Explain parts of the feature with pseudocode (or Python or JS code).
+- **Roles:** Provide details on how the feature impacts different user roles?
+- **Out of scope:** In describing a feature scope it's sometimes helpful to explaining what doesn't fit in.
+
+Note that you are welcome to use all features of the [Markdown](https://guides.github.com/features/mastering-markdown/) syntax in formatting your specification.
+

--- a/specs/0000-template.md
+++ b/specs/0000-template.md
@@ -24,7 +24,9 @@ Feel free to add additional sections as needed. Common examples include (and are
 
 - **Mockup(s):** Sometimes it's easier to explain the UI with a screenshot or a drawing.
 - **Algorithm:** Explain parts of the feature with pseudocode (or Python or JS code).
-- **Roles:** Provide details on how the feature impacts different user roles?
+- **Roles:** Provide details on how the feature impacts different user roles.
 - **Out of scope:** In describing a feature scope it's sometimes helpful to explain what doesn't fit in.
 
 Note that you are welcome to use all features of the [Markdown](https://guides.github.com/features/mastering-markdown/) syntax in formatting your specification.
+
+*Save the file as ABCD-feature-name.md, where ABCD is the spec number. The spec number is determined by increasing the spec with the highest number by one (including specs under review). If your specification includes any auxiliary files such as mockups, save them in the subdirectory called ABCD. There are no constraints on the auxiliary file names.*


### PR DESCRIPTION
This patch adds a template for writing specifications, which must be used when submitting a feature specification for Pontoon. It builds upon specifications that have landed so far.

It's also the last step before we can mark [Specification Process](https://wiki.mozilla.org/L10n:Pontoon_Roadmap#Specification_Process) as done on our Roadmap.

We'll include more details about the process of writing specifications in the [Development Process](https://wiki.mozilla.org/L10n:Pontoon_Roadmap#Development_Process) document.

@adngdb Would you be able to review this?