### PR TITLE
Bug 1417530 - Migrate Contributors unit-tests to Pytest.

### DIFF
--- a/pontoon/contributors/tests/test_views.py
+++ b/pontoon/contributors/tests/test_views.py
@@ -3,23 +3,19 @@ from datetime import (
     datetime,
     timedelta,
 )
-from random import randint
 from unittest.mock import patch
 
+import pytest
 from django.http import HttpResponse
 from django.urls import reverse
 from django.utils.timezone import now, make_aware
-from pytest_django.asserts import assertContains
 
 from pontoon.base.models import User
 from pontoon.base.tests import (
     LocaleFactory,
-    ProjectFactory,
     TranslationFactory,
-    TestCase,
     UserFactory,
 )
-from pontoon.base.tests.test_views import UserTestCase
 from pontoon.base.utils import aware_datetime
 from pontoon.contributors import views
 
@@ -32,245 +28,258 @@ def commajoin(*items):
     return ",".join(map(str, items))
 
 
-class ContributorProfileTests(UserTestCase):
-    """Tests related to the saving user profile."""
-
-    url = reverse("pontoon.contributors.settings")
-
-    def test_invalid_first_name(self):
-        response = self.client.post(self.url, {"first_name": '<aa>"\'"'})
-
-        assertContains(response, "Enter a valid value.")
-
-    def test_invalid_email(self):
-        response = self.client.post(self.url, {"email": "usermail"})
-
-        assertContains(response, "Enter a valid email address.")
-
-    def test_missing_profile_fields(self):
-        response = self.client.post(self.url, {})
-
-        assertContains(response, "This field is required.", count=2)
-
-    def test_valid_first_name(self):
-        response = self.client.post(
-            self.url, {"first_name": "contributor", "email": self.user.email}
-        )
-
-        assertContains(response, "Settings saved.")
-
-    def test_user_locales_order(self):
-        locale1, locale2, locale3 = LocaleFactory.create_batch(3)
-        response = self.client.get(self.url)
-        assert response.status_code == 200
-
-        response = self.client.post(
-            "/settings/",
-            {
-                "first_name": "contributor",
-                "email": self.user.email,
-                "locales_order": commajoin(locale2.pk, locale1.pk, locale3.pk,),
-            },
-        )
-
-        assert response.status_code == 200
-        assert list(User.objects.get(pk=self.user.pk).profile.sorted_locales) == [
-            locale2,
-            locale1,
-            locale3,
-        ]
-        # Test if you can clear all locales
-        response = self.client.post(
-            "/settings/",
-            {
-                "first_name": "contributor",
-                "email": self.user.email,
-                "locales_order": "",
-            },
-        )
-        assert response.status_code == 200
-        assert list(User.objects.get(pk=self.user.pk).profile.sorted_locales) == []
-
-        # Test if form handles duplicated locales
-        response = self.client.post(
-            "/settings/",
-            {
-                "first_name": "contributor",
-                "email": self.user.email,
-                "locales_order": commajoin(locale1.pk, locale2.pk, locale2.pk,),
-            },
-        )
-        assert response.status_code, 200
-        assert list(User.objects.get(pk=self.user.pk).profile.sorted_locales) == [
-            locale1,
-            locale2,
-        ]
+@pytest.fixture
+def settings_url():
+    return reverse("pontoon.contributors.settings")
 
 
-class ContributorProfileViewTests(UserTestCase):
-    def setUp(self):
-        super(ContributorProfileViewTests, self).setUp()
+@pytest.mark.django_db
+def test_profileform_invalid_first_name(member, settings_url):
+    response = member.client.post(settings_url, {"first_name": '<aa>"\'"'})
 
-        mock_render = patch(
-            "pontoon.contributors.views.render", return_value=HttpResponse("")
-        )
-        self.mock_render = mock_render.start()
-        self.addCleanup(mock_render.stop)
-
-    def test_contributor_profile_by_username(self):
-        """Users should be able to retrieve contributor's profile by its username."""
-        self.client.get("/contributors/{}/".format(self.user.username))
-
-        assert self.mock_render.call_args[0][2]["contributor"] == self.user
-
-    def test_contributor_profile_by_email(self):
-        """Check if we can access contributor profile by its email."""
-        self.client.get("/contributors/{}/".format(self.user.email))
-
-        assert self.mock_render.call_args[0][2]["contributor"] == self.user
-
-    def test_logged_user_profile(self):
-        """Logged user should be able to re"""
-        self.client.get("/profile/")
-
-        assert self.mock_render.call_args[0][2]["contributor"] == self.user
-
-    def test_unlogged_user_profile(self):
-        """Unlogged users shouldn't have access to edit any profile."""
-        self.client.logout()
-
-        assert self.client.get("/profile/")["Location"] == "/403"
+    assert b"Enter a valid value." in response.content
 
 
-class ContributorTimelineViewTests(UserTestCase):
-    """User timeline is a list of events created by a certain contributor."""
+@pytest.mark.django_db
+def test_profileform_invalid_email(member, settings_url):
+    response = member.client.post(settings_url, {"email": "usermail"})
 
-    def setUp(self):
-        """
-        We setup a sample contributor with random set of translations.
-        """
-        super(ContributorTimelineViewTests, self).setUp()
-        self.project = ProjectFactory.create()
-        self.translations = OrderedDict()
+    assert b"Enter a valid email address." in response.content
 
-        for i in range(26):
-            date = make_aware(datetime(2016, 12, 1) - timedelta(days=i))
-            translations_count = randint(1, 3)
-            self.translations.setdefault((date, translations_count), []).append(
-                sorted(
-                    TranslationFactory.create_batch(
-                        translations_count,
-                        date=date,
-                        user=self.user,
-                        entity__resource__project=self.project,
-                    ),
-                    key=lambda t: t.pk,
-                    reverse=True,
-                )
+
+@pytest.mark.django_db
+def test_profileform_missing_profile_fields(member, settings_url):
+    response = member.client.post(settings_url, {})
+
+    assert response.content.count(b"This field is required.") == 2
+
+
+@pytest.mark.django_db
+def test_profileform_valid_first_name(member, settings_url):
+    response = member.client.post(
+        settings_url, {"first_name": "contributor", "email": member.user.email}
+    )
+
+    assert b"Settings saved." in response.content
+
+
+@pytest.mark.django_db
+def test_profileform_user_locales_order(member, settings_url):
+    locale1, locale2, locale3 = LocaleFactory.create_batch(3)
+    response = member.client.get(settings_url)
+    assert response.status_code == 200
+
+    response = member.client.post(
+        "/settings/",
+        {
+            "first_name": "contributor",
+            "email": member.user.email,
+            "locales_order": commajoin(locale2.pk, locale1.pk, locale3.pk,),
+        },
+    )
+
+    assert response.status_code == 200
+    assert list(User.objects.get(pk=member.user.pk).profile.sorted_locales) == [
+        locale2,
+        locale1,
+        locale3,
+    ]
+    # Test if you can clear all locales
+    response = member.client.post(
+        "/settings/",
+        {"first_name": "contributor", "email": member.user.email, "locales_order": ""},
+    )
+    assert response.status_code == 200
+    assert list(User.objects.get(pk=member.user.pk).profile.sorted_locales) == []
+
+    # Test if form handles duplicated locales
+    response = member.client.post(
+        "/settings/",
+        {
+            "first_name": "contributor",
+            "email": member.user.email,
+            "locales_order": commajoin(locale1.pk, locale2.pk, locale2.pk,),
+        },
+    )
+    assert response.status_code, 200
+    assert list(User.objects.get(pk=member.user.pk).profile.sorted_locales) == [
+        locale1,
+        locale2,
+    ]
+
+
+@pytest.fixture
+def mock_profile_render():
+    with patch(
+        "pontoon.contributors.views.render", return_value=HttpResponse("")
+    ) as render:
+        yield render
+
+
+@pytest.mark.django_db
+def test_profile_view_contributor_profile_by_username(member, mock_profile_render):
+    """Users should be able to retrieve contributor's profile by its username."""
+    member.client.get("/contributors/{}/".format(member.user.username))
+
+    assert mock_profile_render.call_args[0][2]["contributor"] == member.user
+
+
+@pytest.mark.django_db
+def test_profile_view_contributor_profile_by_email(member, mock_profile_render):
+    """Check if we can access contributor profile by its email."""
+    member.client.get("/contributors/{}/".format(member.user.email))
+
+    assert mock_profile_render.call_args[0][2]["contributor"] == member.user
+
+
+@pytest.mark.django_db
+def test_profile_view_logged_user_profile(member, mock_profile_render):
+    """Logged users should be able view their profiles"""
+    member.client.get("/profile/")
+
+    assert mock_profile_render.call_args[0][2]["contributor"] == member.user
+
+
+@pytest.mark.django_db
+def test_profile_view_unlogged_user_profile(member):
+    """Unlogged users shouldn't have access to edit any profile."""
+    member.client.logout()
+
+    assert member.client.get("/profile/")["Location"] == "/403"
+
+
+@pytest.fixture()
+def contributor_translations(settings, user_a, project_a):
+    """
+    Setup a sample contributor with random set of translations.
+    """
+    translations = OrderedDict()
+    for i in range(6):
+        date = make_aware(datetime(2016, 12, 1) - timedelta(days=i))
+        translations_count = 2
+        translations.setdefault((date, translations_count), []).append(
+            sorted(
+                TranslationFactory.create_batch(
+                    translations_count,
+                    date=date,
+                    user=user_a,
+                    entity__resource__project=project_a,
+                ),
+                key=lambda t: t.pk,
+                reverse=True,
             )
-
-        mock_render = patch(
-            "pontoon.contributors.views.render", return_value=HttpResponse("")
         )
-        self.mock_render = mock_render.start()
-        self.addCleanup(mock_render.stop)
+    settings.CONTRIBUTORS_TIMELINE_EVENTS_PER_PAGE = 2
+    yield translations
 
-    def test_timeline(self):
-        """Backend should return events filtered by page number requested by user."""
-        self.client.get("/contributors/{}/timeline/?page=2".format(self.user.username))
 
-        assert self.mock_render.call_args[0][2]["events"] == [
-            {
-                "date": dt,
-                "type": "translation",
-                "count": count,
-                "project": self.project,
-                "translation": translations[0][0],
-            }
-            for (dt, count), translations in list(self.translations.items())[10:20]
-        ]
-
-    def test_timeline_invalid_page(self):
-        """Backend should return 404 error when user requests an invalid/empty page."""
-        response = self.client.get(
-            "/contributors/{}/timeline/?page=45".format(self.user.username)
-        )
-        assert response.status_code == 404
-
-        response = self.client.get(
-            "/contributors/{}/timeline/?page=-aa45".format(self.user.username)
-        )
-        assert response.status_code == 404
-
-    def test_non_active_contributor(self):
-        """Test if backend is able return events for a user without contributions."""
-        nonactive_contributor = UserFactory.create()
-        self.client.get(
-            "/contributors/{}/timeline/".format(nonactive_contributor.username)
-        )
-        assert self.mock_render.call_args[0][2]["events"] == [
-            {"date": nonactive_contributor.date_joined, "type": "join"}
-        ]
-
-    def test_timeline_join(self):
-        """Last page of results should include informations about the when user joined pontoon."""
-        self.client.get("/contributors/{}/timeline/?page=3".format(self.user.username))
-
-        assert self.mock_render.call_args[0][2]["events"][-1] == {
-            "date": self.user.date_joined,
-            "type": "join",
+@pytest.mark.django_db
+def test_timeline(
+    contributor_translations, client, project_a, mock_profile_render, user_a
+):
+    """Backend should return events filtered by page number requested by user."""
+    client.get("/contributors/{}/timeline/?page=2".format(user_a.username))
+    assert mock_profile_render.call_args[0][2]["events"] == [
+        {
+            "date": dt,
+            "type": "translation",
+            "count": count,
+            "project": project_a,
+            "translation": translations[0][0],
         }
+        for (dt, count), translations in list(contributor_translations.items())[2:4]
+    ]
 
 
-class ContributorsTests(TestCase):
-    def setUp(self):
-        mock_render = patch.object(
-            views.ContributorsView, "render_to_response", return_value=HttpResponse("")
+@pytest.mark.django_db
+def test_timeline_invalid_page(contributor_translations, client, user_a):
+    """Backend should return 404 error when user requests an invalid/empty page."""
+    response = client.get("/contributors/{}/timeline/?page=45".format(user_a.username))
+    assert response.status_code == 404
+
+    response = client.get(
+        "/contributors/{}/timeline/?page=-aa45".format(user_a.username)
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_timeline_non_active_contributor(
+    contributor_translations, client, mock_profile_render
+):
+    """Test if backend is able return events for a user without contributions."""
+    nonactive_contributor = UserFactory.create()
+    client.get("/contributors/{}/timeline/".format(nonactive_contributor.username))
+    assert mock_profile_render.call_args[0][2]["events"] == [
+        {"date": nonactive_contributor.date_joined, "type": "join"}
+    ]
+
+
+@pytest.mark.django_db
+def test_timeline_join(client, contributor_translations, mock_profile_render, user_a):
+    """Last page of results should include informations about the when user joined pontoon."""
+    client.get("/contributors/{}/timeline/?page=3".format(user_a.username))
+
+    assert mock_profile_render.call_args[0][2]["events"][-1] == {
+        "date": user_a.date_joined,
+        "type": "join",
+    }
+
+
+@pytest.fixture
+def mock_contributors_render():
+    with patch.object(
+        views.ContributorsView, "render_to_response", return_value=HttpResponse("")
+    ) as mock:
+        yield mock
+
+
+@pytest.fixture
+def mock_users_translations_counts():
+    with patch("pontoon.contributors.views.users_with_translations_counts") as mock:
+        yield mock
+
+
+@pytest.mark.django_db
+def test_default_period(
+    member, mock_contributors_render, mock_users_translations_counts
+):
+    """
+    Calling the top contributors should result in period being None.
+    """
+    member.client.get("/contributors/")
+    assert mock_contributors_render.call_args[0][0]["period"] is None
+    assert mock_users_translations_counts.call_args[0][0] is None
+
+
+@pytest.mark.django_db
+def test_invalid_period(
+    member, mock_contributors_render, mock_users_translations_counts
+):
+    """
+    Checks how view handles invalid period, it result in period being None - displays all data.
+    """
+    # If period parameter is invalid value
+    member.client.get("/contributors/?period=invalidperiod")
+    assert mock_contributors_render.call_args[0][0]["period"] is None
+    assert mock_users_translations_counts.call_args[0][0] is None
+
+    # Period shouldn't be negative integer
+    member.client.get("/contributors/?period=-6")
+    assert mock_contributors_render.call_args[0][0]["period"] is None
+    assert mock_users_translations_counts.call_args[0][0] is None
+
+
+@pytest.mark.django_db
+def test_given_period(member, mock_contributors_render, mock_users_translations_counts):
+    """
+    Checks if view sets and returns data for right period.
+    """
+    with patch(
+        "django.utils.timezone.now", wraps=now, return_value=aware_datetime(2015, 7, 5),
+    ):
+        member.client.get("/contributors/?period=6")
+        assert mock_contributors_render.call_args[0][0]["period"] == 6
+        assert mock_users_translations_counts.call_args[0][0] == aware_datetime(
+            2015, 1, 5
         )
-        self.mock_render = mock_render.start()
-        self.addCleanup(mock_render.stop)
-
-        mock_users_with_translations_counts = patch(
-            "pontoon.contributors.views.users_with_translations_counts"
-        )
-        self.mock_users_with_translations_counts = (
-            mock_users_with_translations_counts.start()
-        )
-        self.addCleanup(mock_users_with_translations_counts.stop)
-
-    def test_default_period(self):
-        """
-        Calling the top contributors should result in period being None.
-        """
-        self.client.get("/contributors/")
-        assert self.mock_render.call_args[0][0]["period"] is None
-        assert self.mock_users_with_translations_counts.call_args[0][0] is None
-
-    def test_invalid_period(self):
-        """
-        Checks how view handles invalid period, it result in period being None - displays all data.
-        """
-        # If period parameter is invalid value
-        self.client.get("/contributors/?period=invalidperiod")
-        assert self.mock_render.call_args[0][0]["period"] is None
-        assert self.mock_users_with_translations_counts.call_args[0][0] is None
-
-        # Period shouldn't be negative integer
-        self.client.get("/contributors/?period=-6")
-        assert self.mock_render.call_args[0][0]["period"] is None
-        assert self.mock_users_with_translations_counts.call_args[0][0] is None
-
-    def test_given_period(self):
-        """
-        Checks if view sets and returns data for right period.
-        """
-        with patch(
-            "django.utils.timezone.now",
-            wraps=now,
-            return_value=aware_datetime(2015, 7, 5),
-        ):
-            self.client.get("/contributors/?period=6")
-            assert self.mock_render.call_args[0][0]["period"] == 6
-            assert self.mock_users_with_translations_counts.call_args[0][
-                0
-            ] == aware_datetime(2015, 1, 5)

--- a/pontoon/contributors/views.py
+++ b/pontoon/contributors/views.py
@@ -1,6 +1,7 @@
 import json
 
 from dateutil.relativedelta import relativedelta
+from django.conf import settings as django_settings
 from django.contrib import messages
 from django.contrib.auth import logout
 from django.contrib.auth.decorators import login_required
@@ -63,8 +64,9 @@ def contributor_timeline(request, username):
     counts_by_day = contributor_translations.values("day").annotate(count=Count("id"))
 
     try:
-        events_paginator = Paginator(counts_by_day, 10)
-        timeline_events = []
+        events_paginator = Paginator(
+            counts_by_day, django_settings.CONTRIBUTORS_TIMELINE_EVENTS_PER_PAGE
+        )
 
         timeline_events = map_translations_to_events(
             events_paginator.page(page).object_list, contributor_translations

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -828,3 +828,6 @@ DJANGO_NOTIFICATIONS_CONFIG = {
 
 # Maximum number of read notifications to display in the notifications menu
 NOTIFICATIONS_MAX_COUNT = 7
+
+# Number of events displayed on the Contributor's timeline per page.
+CONTRIBUTORS_TIMELINE_EVENTS_PER_PAGE = 10


### PR DESCRIPTION
Misc:
* Improve the performance of Contributors tests - achieved by decreasing the number of objects produced by the test fixtures.
* Introduce a new configuration option to set the page size of the events on the Contributor's timeline.

@mathjazz r? The execution time of the tests in this module dropped from ~30s to ~10s. 