### PR TITLE
Fix Bug 1647124 - RTL support in comments

### DIFF
--- a/frontend/src/core/comments/components/Comment.js
+++ b/frontend/src/core/comments/components/Comment.js
@@ -39,36 +39,34 @@ export default function Comment(props: Props) {
                 imageUrl={comment.userGravatarUrlSmall}
             />
             <div className='container'>
-                <div className='content' dir='auto'>
-                    <div>
-                        <a
-                            className='comment-author'
-                            href={`/contributors/${comment.username}`}
-                            target='_blank'
-                            rel='noopener noreferrer'
-                            onClick={(e: SyntheticMouseEvent<>) =>
-                                e.stopPropagation()
-                            }
-                        >
-                            {comment.author}
-                        </a>
-                        <Linkify
-                            properties={{
-                                target: '_blank',
-                                rel: 'noopener noreferrer',
-                            }}
-                        >
-                            {/* We can safely use parse with comment.content as it is
-                             * sanitized when coming from the DB. See:
-                             *   - pontoon.base.forms.AddCommentForm(}
-                             *   - pontoon.base.forms.HtmlField()
-                             */}
-                            {parse(comment.content)}
-                        </Linkify>
-                        {!comment.pinned ? null : (
-                            <div className='fa fa-thumbtack comment-pin'></div>
-                        )}
-                    </div>
+                <div className='content'>
+                    <a
+                        className='comment-author'
+                        href={`/contributors/${comment.username}`}
+                        target='_blank'
+                        rel='noopener noreferrer'
+                        onClick={(e: SyntheticMouseEvent<>) =>
+                            e.stopPropagation()
+                        }
+                    >
+                        {comment.author}
+                    </a>
+                    <Linkify
+                        properties={{
+                            target: '_blank',
+                            rel: 'noopener noreferrer',
+                        }}
+                    >
+                        {/* We can safely use parse with comment.content as it is
+                         * sanitized when coming from the DB. See:
+                         *   - pontoon.base.forms.AddCommentForm(}
+                         *   - pontoon.base.forms.HtmlField()
+                         */}
+                        <div dir='auto'>{parse(comment.content)}</div>
+                    </Linkify>
+                    {!comment.pinned ? null : (
+                        <div className='fa fa-thumbtack comment-pin'></div>
+                    )}
                 </div>
                 <div className='info'>
                     <ReactTimeAgo

--- a/frontend/src/core/comments/components/Comment.js
+++ b/frontend/src/core/comments/components/Comment.js
@@ -40,33 +40,35 @@ export default function Comment(props: Props) {
             />
             <div className='container'>
                 <div className='content'>
-                    <a
-                        className='comment-author'
-                        href={`/contributors/${comment.username}`}
-                        target='_blank'
-                        rel='noopener noreferrer'
-                        onClick={(e: SyntheticMouseEvent<>) =>
-                            e.stopPropagation()
-                        }
-                    >
-                        {comment.author}
-                    </a>
-                    <Linkify
-                        properties={{
-                            target: '_blank',
-                            rel: 'noopener noreferrer',
-                        }}
-                    >
-                        {/* We can safely use parse with comment.content as it is
-                         * sanitized when coming from the DB. See:
-                         *   - pontoon.base.forms.AddCommentForm(}
-                         *   - pontoon.base.forms.HtmlField()
-                         */}
-                        <div dir='auto'>{parse(comment.content)}</div>
-                    </Linkify>
-                    {!comment.pinned ? null : (
-                        <div className='fa fa-thumbtack comment-pin'></div>
-                    )}
+                    <div>
+                        <a
+                            className='comment-author'
+                            href={`/contributors/${comment.username}`}
+                            target='_blank'
+                            rel='noopener noreferrer'
+                            onClick={(e: SyntheticMouseEvent<>) =>
+                                e.stopPropagation()
+                            }
+                        >
+                            {comment.author}
+                        </a>
+                        <Linkify
+                            properties={{
+                                target: '_blank',
+                                rel: 'noopener noreferrer',
+                            }}
+                        >
+                            {/* We can safely use parse with comment.content as it is
+                             * sanitized when coming from the DB. See:
+                             *   - pontoon.base.forms.AddCommentForm(}
+                             *   - pontoon.base.forms.HtmlField()
+                             */}
+                            <span dir='auto'>{parse(comment.content)}</span>
+                        </Linkify>
+                        {!comment.pinned ? null : (
+                            <div className='fa fa-thumbtack comment-pin'></div>
+                        )}
+                    </div>
                 </div>
                 <div className='info'>
                     <ReactTimeAgo

--- a/frontend/src/core/comments/components/Comment.test.js
+++ b/frontend/src/core/comments/components/Comment.test.js
@@ -38,10 +38,8 @@ describe('<Comment>', () => {
         );
 
         // Comments are hidden in a Linkify component.
-        const content = wrapper
-            .find('Linkify')
-            .map((item) => item.props().children);
-        expect(content).toContain(
+        const content = wrapper.find('Linkify').find('div').text();
+        expect(content).toEqual(
             "What I hear when I'm being yelled at is people caring loudly at me.",
         );
     });

--- a/frontend/src/core/comments/components/Comment.test.js
+++ b/frontend/src/core/comments/components/Comment.test.js
@@ -38,7 +38,7 @@ describe('<Comment>', () => {
         );
 
         // Comments are hidden in a Linkify component.
-        const content = wrapper.find('Linkify').find('div').text();
+        const content = wrapper.find('Linkify').find('span').text();
         expect(content).toEqual(
             "What I hear when I'm being yelled at is people caring loudly at me.",
         );


### PR DESCRIPTION
The comment editor handled the RTL text properly but, when the comment displayed it miss-ordered the sentence if English letters were inside the arab/kurdish setence.

It appears that having the direction set in the parent div caused the direction to be set by the first element, which is the username/email.  I've moved the attribute `dir: auto` from the parent div to a div that directly wraps the comment.

I've not been able to test that this picks up the correct direction with `auto`, but it does display correctly when directly set to the `rtl` value.