### PR TITLE
Fix bug 1614588: Make Save/Suggest/Approve spinner appear again

### DIFF
--- a/frontend/src/core/editor/components/EditorMainAction.js
+++ b/frontend/src/core/editor/components/EditorMainAction.js
@@ -106,7 +106,11 @@ export default function EditorMainAction(props: Props) {
     }
 
     return (
-        <Localized id={btn.id} attrs={{ title: true }} glyph={btn.glyph}>
+        <Localized
+            id={btn.id}
+            attrs={{ title: true }}
+            elems={{ glyph: btn.glyph }}
+        >
             <button
                 className={btn.className}
                 onClick={btn.action}


### PR DESCRIPTION
Seems like we forgot to port this node to the new react-fluent syntax.