### PR TITLE
Fix Bug 1673238: Interactive tour shows wrong elements for Machinery/Locales

### DIFF
--- a/frontend/public/static/locale/en-US/translate.ftl
+++ b/frontend/public/static/locale/en-US/translate.ftl
@@ -379,11 +379,19 @@ interactivetour-InteractiveTour--history-content =
 
 interactivetour-InteractiveTour--terms-title = Terms
 interactivetour-InteractiveTour--terms-content =
-    Test
+    The Terms panel contains any specialized words
+    found in the source string, along with their
+    definition, usage example, part of speech and
+    translation. By clicking on the term, its
+    translation gets inserted into the editor
 
 interactivetour-InteractiveTour--comments-title = Comments
 interactivetour-InteractiveTour--comments-content =
-    Test
+    In the Comments tab you can discuss how to
+    translate a string with your fellow team
+    members. It's also the place where you can
+    request more context about or report an issue in
+    the source string.
     
 interactivetour-InteractiveTour--machinery-title = Machinery
 interactivetour-InteractiveTour--machinery-content =

--- a/frontend/public/static/locale/en-US/translate.ftl
+++ b/frontend/public/static/locale/en-US/translate.ftl
@@ -379,19 +379,16 @@ interactivetour-InteractiveTour--history-content =
 
 interactivetour-InteractiveTour--terms-title = Terms
 interactivetour-InteractiveTour--terms-content =
-    The Terms panel contains any specialized words
-    found in the source string, along with their
-    definition, usage example, part of speech and
-    translation. By clicking on the term, its
-    translation gets inserted into the editor
+    The Terms panel contains specialized words (terms) found in the
+    source string, along with their definitions, usage examples, part
+    of speech and translations. By clicking on a term, its translation
+    gets inserted into the editor.
 
 interactivetour-InteractiveTour--comments-title = Comments
 interactivetour-InteractiveTour--comments-content =
-    In the Comments tab you can discuss how to
-    translate a string with your fellow team
-    members. It's also the place where you can
-    request more context about or report an issue in
-    the source string.
+    In the Comments tab you can discuss how to translate content with
+    your fellow team members. It’s also the place where you can request
+    more context about or report an issue in the source string.
     
 interactivetour-InteractiveTour--machinery-title = Machinery
 interactivetour-InteractiveTour--machinery-content =

--- a/frontend/public/static/locale/en-US/translate.ftl
+++ b/frontend/public/static/locale/en-US/translate.ftl
@@ -377,6 +377,14 @@ interactivetour-InteractiveTour--history-content =
     each entry indicate its review status (Approved, Rejected or
     Unreviewed).
 
+interactivetour-InteractiveTour--terms-title = Terms
+interactivetour-InteractiveTour--terms-content =
+    Test
+
+interactivetour-InteractiveTour--comments-title = Comments
+interactivetour-InteractiveTour--comments-content =
+    Test
+    
 interactivetour-InteractiveTour--machinery-title = Machinery
 interactivetour-InteractiveTour--machinery-content =
     The Machinery tab shows automated translation suggestions from

--- a/frontend/src/modules/interactivetour/components/InteractiveTour.js
+++ b/frontend/src/modules/interactivetour/components/InteractiveTour.js
@@ -265,10 +265,11 @@ export class InteractiveTourBase extends React.Component<InternalProps, State> {
                         </Localized>
                         <Localized id='interactivetour-InteractiveTour--terms-content'>
                             <p>
-                                The Terms panel contains specialized words (terms) found in the
-                                source string, along with their definitions, usage examples, part
-                                of speech and translations. By clicking on a term, its translation
-                                gets inserted into the editor.
+                                The Terms panel contains specialized words
+                                (terms) found in the source string, along with
+                                their definitions, usage examples, part of
+                                speech and translations. By clicking on a term,
+                                its translation gets inserted into the editor.
                             </p>
                         </Localized>
                     </div>
@@ -287,9 +288,11 @@ export class InteractiveTourBase extends React.Component<InternalProps, State> {
                         </Localized>
                         <Localized id='interactivetour-InteractiveTour--comments-content'>
                             <p>
-                                In the Comments tab you can discuss how to translate content with
-                                your fellow team members. It’s also the place where you can request
-                                more context about or report an issue in the source string.
+                                In the Comments tab you can discuss how to
+                                translate content with your fellow team members.
+                                It’s also the place where you can request more
+                                context about or report an issue in the source
+                                string.
                             </p>
                         </Localized>
                     </div>

--- a/frontend/src/modules/interactivetour/components/InteractiveTour.js
+++ b/frontend/src/modules/interactivetour/components/InteractiveTour.js
@@ -265,11 +265,10 @@ export class InteractiveTourBase extends React.Component<InternalProps, State> {
                         </Localized>
                         <Localized id='interactivetour-InteractiveTour--terms-content'>
                             <p>
-                                The Terms panel contains any specialized words
-                                found in the source string, along with their
-                                definition, usage example, part of speech and
-                                translation. By clicking on the term, its
-                                translation gets inserted into the editor
+                                The Terms panel contains specialized words (terms) found in the
+                                source string, along with their definitions, usage examples, part
+                                of speech and translations. By clicking on a term, its translation
+                                gets inserted into the editor.
                             </p>
                         </Localized>
                     </div>
@@ -288,11 +287,9 @@ export class InteractiveTourBase extends React.Component<InternalProps, State> {
                         </Localized>
                         <Localized id='interactivetour-InteractiveTour--comments-content'>
                             <p>
-                                In the Comments tab you can discuss how to
-                                translate a string with your fellow team
-                                members. It's also the place where you can
-                                request more context about or report an issue in
-                                the source string.
+                                In the Comments tab you can discuss how to translate content with
+                                your fellow team members. It’s also the place where you can request
+                                more context about or report an issue in the source string.
                             </p>
                         </Localized>
                     </div>

--- a/frontend/src/modules/interactivetour/components/InteractiveTour.js
+++ b/frontend/src/modules/interactivetour/components/InteractiveTour.js
@@ -264,7 +264,13 @@ export class InteractiveTourBase extends React.Component<InternalProps, State> {
                             <h3>Terms</h3>
                         </Localized>
                         <Localized id='interactivetour-InteractiveTour--terms-content'>
-                            <p>Test</p>
+                            <p>
+                                The Terms panel contains any specialized words
+                                found in the source string, along with their
+                                definition, usage example, part of speech and
+                                translation. By clicking on the term, its
+                                translation gets inserted into the editor
+                            </p>
                         </Localized>
                     </div>
                 ),
@@ -281,7 +287,13 @@ export class InteractiveTourBase extends React.Component<InternalProps, State> {
                             <h3>Comments</h3>
                         </Localized>
                         <Localized id='interactivetour-InteractiveTour--comments-content'>
-                            <p>Test</p>
+                            <p>
+                                In the Comments tab you can discuss how to
+                                translate a string with your fellow team
+                                members. It's also the place where you can
+                                request more context about or report an issue in
+                                the source string.
+                            </p>
                         </Localized>
                     </div>
                 ),

--- a/frontend/src/modules/interactivetour/components/InteractiveTour.js
+++ b/frontend/src/modules/interactivetour/components/InteractiveTour.js
@@ -256,7 +256,42 @@ export class InteractiveTourBase extends React.Component<InternalProps, State> {
                 ),
             },
             {
-                selector: '#app > .panel-content .entity-details .react-tabs',
+                selector:
+                    '#app > .panel-content .entity-details .third-column .top .react-tabs',
+                content: (
+                    <div>
+                        <Localized id='interactivetour-InteractiveTour--terms-title'>
+                            <h3>Terms</h3>
+                        </Localized>
+                        <Localized id='interactivetour-InteractiveTour--terms-content'>
+                            <p>Test</p>
+                        </Localized>
+                    </div>
+                ),
+                action: (node) => {
+                    node.querySelector('#react-tabs-0').click();
+                },
+            },
+            {
+                selector:
+                    '#app > .panel-content .entity-details .third-column .top .react-tabs',
+                content: (
+                    <div>
+                        <Localized id='interactivetour-InteractiveTour--comments-title'>
+                            <h3>Comments</h3>
+                        </Localized>
+                        <Localized id='interactivetour-InteractiveTour--comments-content'>
+                            <p>Test</p>
+                        </Localized>
+                    </div>
+                ),
+                action: (node) => {
+                    node.querySelector('#react-tabs-2').click();
+                },
+            },
+            {
+                selector:
+                    '#app > .panel-content .entity-details .third-column .bottom .react-tabs',
                 content: (
                     <div>
                         <Localized id='interactivetour-InteractiveTour--machinery-title'>
@@ -274,11 +309,12 @@ export class InteractiveTourBase extends React.Component<InternalProps, State> {
                     </div>
                 ),
                 action: (node) => {
-                    node.querySelector('#react-tabs-0').click();
+                    node.querySelector('#react-tabs-4').click();
                 },
             },
             {
-                selector: '#app > .panel-content .entity-details .react-tabs',
+                selector:
+                    '#app > .panel-content .entity-details .third-column .bottom .react-tabs',
                 content: (
                     <div>
                         <Localized id='interactivetour-InteractiveTour--locales-title'>
@@ -296,7 +332,7 @@ export class InteractiveTourBase extends React.Component<InternalProps, State> {
                     </div>
                 ),
                 action: (node) => {
-                    node.querySelector('#react-tabs-2').click();
+                    node.querySelector('#react-tabs-6').click();
                 },
             },
             {


### PR DESCRIPTION
Addressing bug 1673238: Fixed interactive tour, added two tabs for comments and terms that point to the comments and terms sections. Pointed the machinery and locales tabs to the machinery and locales section. I was not sure what description I should put for the comments and terms tabs in the interactive tour.