### PR TITLE
Fix bug 1633148: Support alternative file extenions on upload

### DIFF
--- a/pontoon/base/forms.py
+++ b/pontoon/base/forms.py
@@ -12,8 +12,8 @@ from pontoon.base.models import (
     User,
     UserProfile,
 )
+from pontoon.sync.formats import are_compatible_formats
 from pontoon.teams.utils import log_group_members
-from pontoon.sync.formats import SUPPORTED_FORMAT_PARSERS
 
 
 class HtmlField(forms.CharField):
@@ -65,16 +65,13 @@ class UploadFileForm(DownloadFileForm):
 
             # File format validation
             if part:
-                file_extension = os.path.splitext(uploadfile.name)[1].lower()
-                part_extension = os.path.splitext(part)[1].lower()
+                uploadfile_ext = os.path.splitext(uploadfile.name)[1].lower()
+                targetfile_ext = os.path.splitext(part)[1].lower()
 
-                # For now, skip if uploading file while using subpages
-                if (
-                    part_extension in SUPPORTED_FORMAT_PARSERS.keys()
-                    and part_extension != file_extension
-                ):
+                # Fail if upload and target file are incompatible
+                if not are_compatible_formats(uploadfile_ext, targetfile_ext):
                     message = "Upload failed. File format not supported. Use {supported}.".format(
-                        supported=part_extension
+                        supported=targetfile_ext
                     )
                     raise forms.ValidationError(message)
 

--- a/pontoon/base/forms.py
+++ b/pontoon/base/forms.py
@@ -1,9 +1,9 @@
-import os
-
 import bleach
 
 from django import forms
 from django.conf import settings
+
+from pathlib import Path
 
 from pontoon.base import utils
 from pontoon.base.models import (
@@ -65,8 +65,8 @@ class UploadFileForm(DownloadFileForm):
 
             # File format validation
             if part:
-                uploadfile_ext = os.path.splitext(uploadfile.name)[1].lower()
-                targetfile_ext = os.path.splitext(part)[1].lower()
+                uploadfile_ext = Path(uploadfile.name).suffix.lower()
+                targetfile_ext = Path(part).suffix.lower()
 
                 # Fail if upload and target file are incompatible
                 if not are_compatible_formats(uploadfile_ext, targetfile_ext):

--- a/pontoon/sync/formats/__init__.py
+++ b/pontoon/sync/formats/__init__.py
@@ -34,6 +34,22 @@ SUPPORTED_FORMAT_PARSERS = {
 }
 
 
+def are_compatible_formats(extension_a, extension_b):
+    """
+    Return True if given file extensions belong to the same file format.
+    We test that by comparing parsers used by each file extenion.
+    Note that some formats (e.g. Gettext, XLIFF) use multiple file extensions.
+    """
+    try:
+        return (
+            SUPPORTED_FORMAT_PARSERS[extension_a]
+            == SUPPORTED_FORMAT_PARSERS[extension_b]
+        )
+    # File extension not supported
+    except KeyError:
+        return False
+
+
 def parse(path, source_path=None, locale=None):
     """
     Parse the resource file at the given path and return a

--- a/pontoon/sync/tests/formats/test_formats.py
+++ b/pontoon/sync/tests/formats/test_formats.py
@@ -1,0 +1,22 @@
+from pontoon.base.tests import TestCase
+from pontoon.sync.formats import are_compatible_formats
+
+
+class CompareLocalesResourceTests(TestCase):
+    def test_are_compatible_formats(self):
+        """
+        Return True if both extensions use the same file parser.
+        """
+        # Same extension
+        assert are_compatible_formats(".dtd", ".dtd")
+        assert are_compatible_formats(".po", ".po")
+
+        # Same parser
+        assert are_compatible_formats(".po", ".pot")
+        assert are_compatible_formats(".xlf", ".xliff")
+
+        # Different parser
+        assert not are_compatible_formats(".ftl", ".json")
+
+        # Not supported file format
+        assert not are_compatible_formats(".something", ".else")


### PR DESCRIPTION
XLIFF file format supports .xliff and .xlf extensions. Previously, we only support the extension of the target file.

Also, due to bug 1530139, projects using TOML configuration files require Gettext files to use the .pot extension on upload, which are used for templates (source files). With this fix, .po (used for l10n files is also supported).