### PR TITLE
Fix bug 1678452: Fix Django deprecation warnings

### DIFF
--- a/frontend/src/core/api/locale.js
+++ b/frontend/src/core/api/locale.js
@@ -35,6 +35,6 @@ export default class LocaleAPI extends APIBase {
         const headers = new Headers();
         headers.append('X-Requested-With', 'XMLHttpRequest');
 
-        return await this.fetch('/graphql/', 'GET', payload, headers);
+        return await this.fetch('/graphql', 'GET', payload, headers);
     }
 }

--- a/frontend/src/core/api/project.js
+++ b/frontend/src/core/api/project.js
@@ -23,6 +23,6 @@ export default class ProjectAPI extends APIBase {
         const headers = new Headers();
         headers.append('X-Requested-With', 'XMLHttpRequest');
 
-        return await this.fetch('/graphql/', 'GET', payload, headers);
+        return await this.fetch('/graphql', 'GET', payload, headers);
     }
 }

--- a/pontoon/administration/urls.py
+++ b/pontoon/administration/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import include, path
 
 from . import views
 
@@ -7,37 +7,41 @@ import pontoon.tags.admin.views as tags_admin_views
 
 urlpatterns = [
     # Admin Home
-    url(r"^$", views.admin, name="pontoon.admin"),
+    path("", views.admin, name="pontoon.admin"),
     # AJAX view: Project tags
-    url(
-        r"^projects/(?P<project>[\w-]+)/ajax/tag/(?P<tag>[\w-]+)/$",
+    path(
+        "projects/<slug:project>/ajax/tag/<slug:tag>/",
         tags_admin_views.ProjectTagAdminAjaxView.as_view(),
         name="pontoon.admin.project.ajax.tag",
     ),
     # Add new project
-    url(r"^projects/$", views.manage_project, name="pontoon.admin.project.new"),
-    # Sync project
-    url(
-        r"^projects/(?P<slug>[\w-]+)/sync/$",
-        views.manually_sync_project,
-        name="pontoon.project.sync",
-    ),
-    # Sync project
-    url(
-        r"^projects/(?P<slug>[\w-]+)/strings/$",
-        views.manage_project_strings,
-        name="pontoon.admin.project.strings",
-    ),
-    # Pretranslate project
-    url(
-        r"^projects/(?P<slug>[\w-]+)/pretranslate/$",
-        views.manually_pretranslate_project,
-        name="pontoon.project.sync",
-    ),
-    # Edit project
-    url(
-        r"^projects/(?P<slug>.+)/$", views.manage_project, name="pontoon.admin.project"
+    path("projects/", views.manage_project, name="pontoon.admin.project.new"),
+    # Project-related views
+    path(
+        "projects/<slug:slug>/",
+        include(
+            [
+                # Sync project
+                path(
+                    "sync/", views.manually_sync_project, name="pontoon.project.sync",
+                ),
+                # Project strings
+                path(
+                    "strings/",
+                    views.manage_project_strings,
+                    name="pontoon.admin.project.strings",
+                ),
+                # Pretranslate project
+                path(
+                    "pretranslate/",
+                    views.manually_pretranslate_project,
+                    name="pontoon.project.sync",
+                ),
+                # Edit project
+                path("", views.manage_project, name="pontoon.admin.project"),
+            ]
+        ),
     ),
     # Get slug
-    url(r"^get-slug/$", views.get_slug, name="pontoon.admin.get_slug"),
+    path("get-slug/", views.get_slug, name="pontoon.admin.get_slug"),
 ]

--- a/pontoon/administration/views.py
+++ b/pontoon/administration/views.py
@@ -21,7 +21,7 @@ from pontoon.administration.forms import (
     TagInlineFormSet,
 )
 from pontoon.base import utils
-from pontoon.base.utils import require_AJAX
+from pontoon.base.utils import require_AJAX, is_ajax
 from pontoon.base.models import (
     Entity,
     Locale,
@@ -61,7 +61,7 @@ def get_slug(request):
         log.error("Insufficient privileges.")
         return HttpResponse("error")
 
-    if not request.is_ajax():
+    if not is_ajax(request):
         log.error("Non-AJAX request")
         return HttpResponse("error")
 

--- a/pontoon/allauth_urls.py
+++ b/pontoon/allauth_urls.py
@@ -5,7 +5,7 @@ views and don't allow user to tamper with the state of an account.
 """
 import importlib
 
-from django.conf.urls import url
+from django.urls import path
 from django.conf import settings
 from django.contrib.auth import views
 
@@ -14,25 +14,23 @@ from allauth.socialaccount import views as socialaccount_views, providers
 
 if settings.AUTHENTICATION_METHOD == "django":
     urlpatterns = [
-        url(r"^standalone-login/$", views.LoginView.as_view(), name="standalone_login"),
-        url(
-            r"^standalone-logout/$",
-            views.LogoutView.as_view(),
-            name="standalone_logout",
+        path("standalone-login/", views.LoginView.as_view(), name="standalone_login"),
+        path(
+            "standalone-logout/", views.LogoutView.as_view(), name="standalone_logout",
         ),
     ]
 else:
     urlpatterns = [
-        url(r"^login/$", account_views.login, name="account_login"),
-        url(r"^logout/$", account_views.logout, name="account_logout"),
-        url(r"^inactive/$", account_views.account_inactive, name="account_inactive"),
-        url(
-            "^social/login/cancelled/$",
+        path("login/", account_views.login, name="account_login"),
+        path("logout/", account_views.logout, name="account_logout"),
+        path("inactive/", account_views.account_inactive, name="account_inactive"),
+        path(
+            "social/login/cancelled/",
             socialaccount_views.login_cancelled,
             name="socialaccount_login_cancelled",
         ),
-        url(
-            "^social/login/error/$",
+        path(
+            "social/login/error/",
             socialaccount_views.login_error,
             name="socialaccount_login_error",
         ),

--- a/pontoon/api/urls.py
+++ b/pontoon/api/urls.py
@@ -1,7 +1,7 @@
 from csp.decorators import csp_exempt
 from graphene_django.views import GraphQLView
 
-from django.conf.urls import url
+from django.urls import path
 from django.views.decorators.csrf import csrf_exempt
 
 from pontoon.api.schema import schema
@@ -10,8 +10,8 @@ from pontoon.settings import DEV
 
 urlpatterns = [
     # GraphQL endpoint. In DEV mode it serves the GraphiQL IDE if accessed with Accept: text/html
-    url(
-        r"^graphql",
+    path(
+        "graphql",
         csp_exempt(csrf_exempt(GraphQLView.as_view(schema=schema, graphiql=DEV))),
     ),
 ]

--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -16,7 +16,7 @@ from django.contrib.humanize.templatetags import humanize
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.serializers.json import DjangoJSONEncoder
 from django.urls import reverse
-from django.utils.http import is_safe_url
+from django.utils.http import url_has_allowed_host_and_scheme
 
 
 register = template.Library()
@@ -34,7 +34,7 @@ def url(viewname, *args, **kwargs):
 def return_url(request):
     """Get an url of the previous page."""
     url = request.POST.get("return_url", request.META.get("HTTP_REFERER", "/"))
-    if not is_safe_url(url, settings.ALLOWED_HOSTS):
+    if not url_has_allowed_host_and_scheme(url, settings.ALLOWED_HOSTS):
         return settings.SITE_URL
     return url
 

--- a/pontoon/base/urls.py
+++ b/pontoon/base/urls.py
@@ -1,86 +1,81 @@
-from django.conf.urls import url
+from django.urls import path
 from django.views.generic import RedirectView, TemplateView
 
 from . import views
 
 urlpatterns = [
     # Terms
-    url(
-        r"^terms/$",
+    path(
+        "terms/",
         TemplateView.as_view(template_name="terms.html"),
         name="pontoon.terms",
     ),
     # TRANSLATE URLs
     # Legacy: Translate project's page
-    url(
-        r"^locale/(?P<locale>[A-Za-z0-9\-\@\.]+)/project/(?P<slug>.+)"
-        + "/page/(?P<page>.+)/$",
+    path(
+        "<locale:locale>/project/<slug:slug>/page/<path:page>/",
         RedirectView.as_view(url="/%(locale)s/%(slug)s/%(page)s/", permanent=True),
     ),
     # Legacy: Translate project
-    url(
-        r"^locale/(?P<locale>[A-Za-z0-9\-\@\.]+)/project/(?P<slug>.+)/$",
+    path(
+        "locale/<locale:locale>/project/<slug:slug>/",
         RedirectView.as_view(url="/%(locale)s/%(slug)s/", permanent=True),
     ),
     # AJAX: Get locale details
-    url(
-        r"^teams/(?P<locale>[A-Za-z0-9\-\@\.]+)/projects/$",
+    path(
+        "teams/<locale:locale>/projects/",
         views.locale_projects,
         name="pontoon.locale.projects",
     ),
     # AJAX: Get locale stats used in All Resources part
-    url(
-        r"^teams/(?P<locale>[A-Za-z0-9\-\@\.]+)/stats/$",
-        views.locale_stats,
-        name="pontoon.locale.stats",
+    path(
+        "teams/<locale:locale>/stats/", views.locale_stats, name="pontoon.locale.stats",
     ),
     # AJAX: Get locale-project pages/paths with stats
-    url(
-        r"^(?P<locale>[A-Za-z0-9\-\@\.]+)/(?P<slug>[\w-]+)/parts/$",
+    path(
+        "<locale:locale>/<slug:slug>/parts/",
         views.locale_project_parts,
         name="pontoon.locale.project.parts",
     ),
     # AJAX: Get authors and time range data
-    url(
-        r"^(?P<locale>[A-Za-z0-9\-\@\.]+)/(?P<slug>[\w-]+)/(?P<part>.+)/authors-and-time-range/$",
+    path(
+        "<locale:locale>/<slug:slug>/<path:part>/authors-and-time-range/",
         views.authors_and_time_range,
         name="pontoon.authors.and.time.range",
     ),
     # Locale-agnostic links
-    url(
-        r"^projects/(?P<slug>[\w-]+)/(?P<part>.+)/$",
+    path(
+        "projects/<slug:slug>/<path:part>/",
         views.translate_locale_agnostic,
         name="pontoon.translate.locale.agnostic",
     ),
     # Download translation memory
-    url(
-        r"^translation-memory/(?P<locale>[A-Za-z0-9\-\@\.]+)\.(?P<slug>[\w-]+)\.tmx$",
+    path(
+        "translation-memory/<locale:locale>.<slug:slug>.tmx",
         views.download_translation_memory,
         name="pontoon.download_tmx",
     ),
     # AJAX
-    url(r"^get-entities/", views.entities, name="pontoon.entities"),
-    url(r"^get-users/", views.get_users, name="pontoon.get_users"),
-    url(r"^perform-checks/", views.perform_checks, name="pontoon.perform.checks"),
-    url(r"^get-history/", views.get_translation_history, name="pontoon.get_history"),
-    url(
-        r"^get-team-comments/",
-        views.get_team_comments,
-        name="pontoon.get_team_comments",
+    path("get-entities/", views.entities, name="pontoon.entities"),
+    path("get-users/", views.get_users, name="pontoon.get_users"),
+    path("perform-checks/", views.perform_checks, name="pontoon.perform.checks"),
+    path("get-history/", views.get_translation_history, name="pontoon.get_history"),
+    path(
+        "get-team-comments/", views.get_team_comments, name="pontoon.get_team_comments",
     ),
-    url(r"^add-comment/", views.add_comment, name="pontoon.add_comment",),
-    url(r"^pin-comment/", views.pin_comment, name="pontoon.pin_comment",),
-    url(r"^unpin-comment/", views.unpin_comment, name="pontoon.unpin_comment",),
-    url(
-        r"^other-locales/",
+    path("add-comment/", views.add_comment, name="pontoon.add_comment",),
+    path("pin-comment/", views.pin_comment, name="pontoon.pin_comment",),
+    path("unpin-comment/", views.unpin_comment, name="pontoon.unpin_comment",),
+    path(
+        "other-locales/",
         views.get_translations_from_other_locales,
         name="pontoon.other_locales",
     ),
-    url(
-        r"^translations/",
+    path(
+        "translations/",
         views.download_translations,
         name="pontoon.download.translations",
     ),
-    url(r"^upload/", views.upload, name="pontoon.upload"),
-    url(r"^user-data/", views.user_data, name="pontoon.user_data"),
+    path("upload/", views.upload, name="pontoon.upload"),
+    path("user-data/", views.user_data, name="pontoon.user_data"),
 ]

--- a/pontoon/base/utils.py
+++ b/pontoon/base/utils.py
@@ -94,6 +94,13 @@ def get_object_or_none(model, *args, **kwargs):
         return None
 
 
+def is_ajax(request):
+    """
+    Checks whether the given request is an AJAX request.
+    """
+    return request.headers.get("x-requested-with") == "XMLHttpRequest"
+
+
 def require_AJAX(f):
     """
     AJAX request required decorator
@@ -101,7 +108,7 @@ def require_AJAX(f):
 
     @functools.wraps(f)  # Required by New Relic
     def wrap(request, *args, **kwargs):
-        if not request.is_ajax():
+        if not is_ajax(request):
             return HttpResponseBadRequest("Bad Request: Request must be AJAX")
         return f(request, *args, **kwargs)
 

--- a/pontoon/batch/urls.py
+++ b/pontoon/batch/urls.py
@@ -1,11 +1,11 @@
-from django.conf.urls import url
+from django.urls import path
 
 from . import views
 
 
 urlpatterns = [
-    url(
-        r"^batch-edit-translations/",
+    path(
+        "batch-edit-translations/",
         views.batch_edit_translations,
         name="pontoon.batch.edit.translations",
     ),

--- a/pontoon/contributors/urls.py
+++ b/pontoon/contributors/urls.py
@@ -1,69 +1,80 @@
-from django.conf.urls import url
+from django.urls import path, register_converter
+from django.urls.converters import StringConverter
 from django.views.generic import RedirectView
 
 from . import views
 
+
+class EmailConverter(StringConverter):
+    regex = r"[\w.%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4}"
+
+
+class UsernameConverter(StringConverter):
+    regex = r"[\w.@+-]+"
+
+
+register_converter(EmailConverter, "email")
+register_converter(UsernameConverter, "username")
+
 urlpatterns = [
     # Legacy: Redirect to /contributors/email
-    url(
-        r"^contributor/(?P<email>[\w.%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})/$",
+    path(
+        "contributor/<email:email>/",
         RedirectView.as_view(url="/contributors/%(email)s/", permanent=True),
     ),
     # List contributors
-    url(
-        r"^contributors/$",
-        views.ContributorsView.as_view(),
-        name="pontoon.contributors",
+    path(
+        "contributors/", views.ContributorsView.as_view(), name="pontoon.contributors",
     ),
     # Contributor profile by email
-    url(
-        r"^contributors/(?P<email>[\w.%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})/$",
+    path(
+        "contributors/<email:email>/",
         views.contributor_email,
         name="pontoon.contributors.contributor.email",
     ),
     # Contributor timeline
-    url(
-        r"^contributors/(?P<username>[\w.@+-]+)/timeline/$",
+    path(
+        "contributors/<username:username>/timeline/",
         views.contributor_timeline,
         name="pontoon.contributors.contributor.timeline",
     ),
     # Contributor profile by username
-    url(
-        r"^contributors/(?P<username>[\w.@+-]+)/$",
+    path(
+        "contributors/<username:username>/",
         views.contributor_username,
         name="pontoon.contributors.contributor.username",
     ),
     # Current user's profile
-    url(r"^profile/$", views.profile, name="pontoon.contributors.profile"),
+    path("profile/", views.profile, name="pontoon.contributors.profile"),
     # Current user's settings
-    url(r"^settings/$", views.settings, name="pontoon.contributors.settings"),
+    path("settings/", views.settings, name="pontoon.contributors.settings"),
     # Current user's notifications
-    url(
-        r"^notifications/$",
+    path(
+        "notifications/",
         views.notifications,
         name="pontoon.contributors.notifications",
     ),
     # Mark current user's notifications as read
-    url(
-        r"^notifications/mark-all-as-read/$",
+    path(
+        "notifications/mark-all-as-read/",
         views.mark_all_notifications_as_read,
         name="pontoon.contributors.notifications.mark.all.as.read",
     ),
-    # API: Toogle user profile attribute
-    url(
-        r"^api/v1/user/(?P<username>[\w.@+-]+)/$",
+    # API: Toggle user profile attribute
+    path(
+        "api/v1/user/<username:username>/",
         views.toggle_user_profile_attribute,
         name="pontoon.contributors.toggle_user_profile_attribute",
     ),
     # AJAX
-    url(
-        r"^save-custom-homepage/$",
+    path(
+        "save-custom-homepage/",
         views.save_custom_homepage,
         name="pontoon.contributors.save_custom_homepage",
     ),
     # AJAX: Save preferred source locale
-    url(
-        r"^save-preferred-source-locale/$",
+    path(
+        "save-preferred-source-locale/",
         views.save_preferred_source_locale,
         name="pontoon.contributors.save_preferred_source_locale",
     ),

--- a/pontoon/homepage/urls.py
+++ b/pontoon/homepage/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import url
+from django.urls import path
 
 from . import views
 
 urlpatterns = [
     # Homepage
-    url(r"^$", views.homepage, name="pontoon.homepage"),
+    path("", views.homepage, name="pontoon.homepage"),
 ]

--- a/pontoon/in_context/urls.py
+++ b/pontoon/in_context/urls.py
@@ -1,14 +1,14 @@
-from django.conf.urls import url
+from django.urls import path
 from django.views.generic import RedirectView
 
 from . import views
 
 urlpatterns = [
     # In-context demo
-    url(r"^in-context/$", views.in_context, name="pontoon.in_context",),
+    path("in-context/", views.in_context, name="pontoon.in_context",),
     # Legacy: Redirect to /in-context
-    url(
-        r"^intro/$",
+    path(
+        "intro/",
         RedirectView.as_view(pattern_name="pontoon.in_context", permanent=True),
     ),
 ]

--- a/pontoon/localizations/urls.py
+++ b/pontoon/localizations/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import include, path, re_path
 
 from pontoon.projects import views as projects_views
 from pontoon.teams import views as teams_views
@@ -6,62 +6,71 @@ from pontoon.teams import views as teams_views
 from . import views
 
 urlpatterns = [
-    # Localization page
-    url(
-        r"^(?P<code>[A-Za-z0-9\-\@\.]+)/(?P<slug>[\w-]+)/$",
-        views.localization,
-        name="pontoon.localizations.localization",
-    ),
-    # Localization tags
-    url(
-        r"^(?P<code>[A-Za-z0-9\-\@\.]+)/(?P<slug>[\w-]+)/tags/$",
-        views.localization,
-        name="pontoon.localizations.tags",
-    ),
-    # Localization contributors
-    url(
-        r"^(?P<code>[A-Za-z0-9\-\@\.]+)/(?P<slug>[\w-]+)/contributors/$",
-        views.localization,
-        name="pontoon.localizations.contributors",
-    ),
-    # Project info
-    url(
-        r"^(?P<code>[A-Za-z0-9\-\@\.]+)/(?P<slug>[\w-]+)/project-info/$",
-        views.localization,
-        name="pontoon.localizations.project-info",
-    ),
-    # Team info
-    url(
-        r"^(?P<code>[A-Za-z0-9\-\@\.]+)/(?P<slug>[\w-]+)/team-info/$",
-        views.localization,
-        name="pontoon.localizations.team-info",
-    ),
-    # AJAX view: Localization resources
-    url(
-        r"^(?P<code>[A-Za-z0-9\-\@\.]+)/(?P<slug>[\w-]+)/ajax/$",
-        views.ajax_resources,
-        name="pontoon.localizations.ajax.resources",
-    ),
-    # AJAX view: Localization tags
-    url(
-        r"^(?P<code>[A-Za-z0-9\-\@\.]+)/(?P<slug>[\w-]+)/ajax/tags/$",
-        views.ajax_tags,
-        name="pontoon.localizations.ajax.tags",
-    ),
-    # AJAX view: Localization contributors
-    url(
-        r"^(?P<code>[A-Za-z0-9\-\@\.]+)/(?P<slug>[\w-]+)/ajax/contributors/$",
-        views.LocalizationContributorsView.as_view(),
-        name="pontoon.localizations.ajax.contributors",
+    path(
+        "<locale:code>/<slug:slug>/",
+        include(
+            [
+                # Localization page
+                path(
+                    "", views.localization, name="pontoon.localizations.localization",
+                ),
+                # Localization tags
+                path("tags/", views.localization, name="pontoon.localizations.tags",),
+                # Localization contributors
+                path(
+                    "contributors/",
+                    views.localization,
+                    name="pontoon.localizations.contributors",
+                ),
+                # Project info
+                path(
+                    "project-info/",
+                    views.localization,
+                    name="pontoon.localizations.project-info",
+                ),
+                # Team info
+                path(
+                    "team-info/",
+                    views.localization,
+                    name="pontoon.localizations.team-info",
+                ),
+                # AJAX views
+                path(
+                    "ajax/",
+                    include(
+                        [
+                            # Localization resources
+                            path(
+                                "",
+                                views.ajax_resources,
+                                name="pontoon.localizations.ajax.resources",
+                            ),
+                            # Localization tags
+                            path(
+                                "tags/",
+                                views.ajax_tags,
+                                name="pontoon.localizations.ajax.tags",
+                            ),
+                            # Localization contributors
+                            path(
+                                "contributors/",
+                                views.LocalizationContributorsView.as_view(),
+                                name="pontoon.localizations.ajax.contributors",
+                            ),
+                        ]
+                    ),
+                ),
+            ]
+        ),
     ),
     # AJAX view: Project info
-    url(
+    re_path(
         r"^[A-Za-z0-9\-\@\.]+/(?P<slug>[\w-]+)/ajax/project-info/$",
         projects_views.ajax_info,
         name="pontoon.localizations.ajax.project-info",
     ),
     # AJAX view: Team info
-    url(
+    re_path(
         r"^(?P<locale>[A-Za-z0-9\-\@\.]+)/[\w-]+/ajax/team-info/$",
         teams_views.ajax_info,
         name="pontoon.localizations.ajax.team-info",

--- a/pontoon/machinery/urls.py
+++ b/pontoon/machinery/urls.py
@@ -1,44 +1,40 @@
-from django.conf.urls import url
+from django.urls import path
 from django.views.generic import RedirectView
 
 from . import views
 
 urlpatterns = [
     # Machinery Metasearch
-    url(r"^machinery/$", views.machinery, name="pontoon.machinery"),
+    path("machinery/", views.machinery, name="pontoon.machinery"),
     # Legacy: Redirect to /machinery
-    url(
-        r"^search/$",
+    path(
+        "search/",
         RedirectView.as_view(pattern_name="pontoon.machinery", permanent=True),
     ),
-    url(
-        r"^terminology/$",
+    path(
+        "terminology/",
         RedirectView.as_view(pattern_name="pontoon.machinery", permanent=True),
     ),
     # AJAX
-    url(
-        r"^translation-memory/$",
+    path(
+        "translation-memory/",
         views.translation_memory,
         name="pontoon.translation_memory",
     ),
-    url(
-        r"^google-translate/$", views.google_translate, name="pontoon.google_translate"
-    ),
-    url(
-        r"^microsoft-translator/$",
+    path("google-translate/", views.google_translate, name="pontoon.google_translate"),
+    path(
+        "microsoft-translator/",
         views.microsoft_translator,
         name="pontoon.microsoft_translator",
     ),
-    url(
-        r"^systran-translate/$",
-        views.systran_translate,
-        name="pontoon.systran_translate",
+    path(
+        "systran-translate/", views.systran_translate, name="pontoon.systran_translate",
     ),
-    url(r"^caighdean/$", views.caighdean, name="pontoon.caighdean"),
-    url(
-        r"^microsoft-terminology/$",
+    path("caighdean/", views.caighdean, name="pontoon.caighdean"),
+    path(
+        "microsoft-terminology/",
         views.microsoft_terminology,
         name="pontoon.microsoft_terminology",
     ),
-    url(r"^transvision/$", views.transvision, name="pontoon.transvision"),
+    path("transvision/", views.transvision, name="pontoon.transvision"),
 ]

--- a/pontoon/projects/urls.py
+++ b/pontoon/projects/urls.py
@@ -1,74 +1,80 @@
-from django.conf.urls import url
+from django.urls import include, path
 from django.views.generic import RedirectView
 
 from . import views
 
 urlpatterns = [
     # Legacy: Redirect to /projects
-    url(r"^project/$", RedirectView.as_view(url="/projects/", permanent=True)),
+    path("project/", RedirectView.as_view(url="/projects/", permanent=True)),
     # Legacy: Redirect to /projects/slug
-    url(
-        r"^project/(?P<slug>[\w-]+)/$",
+    path(
+        "project/<slug:slug>/",
         RedirectView.as_view(url="/projects/%(slug)s/", permanent=True),
     ),
     # Active projects
-    url(r"^projects/$", views.projects, name="pontoon.projects"),
-    # Project page
-    url(
-        r"^projects/(?P<slug>[\w-]+)/$", views.project, name="pontoon.projects.project"
-    ),
-    # Project tags
-    url(
-        r"^projects/(?P<slug>[\w-]+)/tags/$",
-        views.project,
-        name="pontoon.projects.tags",
-    ),
-    # Project contributors
-    url(
-        r"^projects/(?P<slug>[\w-]+)/contributors/$",
-        views.project,
-        name="pontoon.projects.contributors",
-    ),
-    # Project info
-    url(
-        r"^projects/(?P<slug>[\w-]+)/info/$",
-        views.project,
-        name="pontoon.projects.info",
-    ),
-    # Project notifications
-    url(
-        r"^projects/(?P<slug>[\w-]+)/notifications/$",
-        views.project,
-        name="pontoon.projects.notifications",
-    ),
-    # AJAX view: Project teams
-    url(
-        r"^projects/(?P<slug>[\w-]+)/ajax/$",
-        views.ajax_teams,
-        name="pontoon.projects.ajax.teams",
-    ),
-    # AJAX view: Project tags
-    url(
-        r"^projects/(?P<slug>[\w-]+)/ajax/tags/$",
-        views.ajax_tags,
-        name="pontoon.projects.ajax.tags",
-    ),
-    # AJAX view: Project contributors
-    url(
-        r"^projects/(?P<slug>[\w-]+)/ajax/contributors/$",
-        views.ProjectContributorsView.as_view(),
-        name="pontoon.projects.ajax.contributors",
-    ),
-    # AJAX view: Project info
-    url(
-        r"^projects/(?P<slug>[\w-]+)/ajax/info/$",
-        views.ajax_info,
-        name="pontoon.projects.ajax.info",
-    ),
-    # AJAX view: Project notifications
-    url(
-        r"^projects/(?P<slug>[\w-]+)/ajax/notifications/$",
-        views.ajax_notifications,
-        name="pontoon.projects.ajax.notifications",
+    path("projects/", views.projects, name="pontoon.projects"),
+    # Project-related views
+    path(
+        "projects/<slug:slug>/",
+        include(
+            [
+                # Project page
+                path("", views.project, name="pontoon.projects.project"),
+                # Project tags
+                path("tags/", views.project, name="pontoon.projects.tags",),
+                # Project contributors
+                path(
+                    "contributors/",
+                    views.project,
+                    name="pontoon.projects.contributors",
+                ),
+                # Project info
+                path("info/", views.project, name="pontoon.projects.info",),
+                # Project notifications
+                path(
+                    "notifications/",
+                    views.project,
+                    name="pontoon.projects.notifications",
+                ),
+                # AJAX views
+                path(
+                    "ajax/",
+                    include(
+                        [
+                            # Project teams
+                            path(
+                                "",
+                                views.ajax_teams,
+                                name="pontoon.projects.ajax.teams",
+                            ),
+                            # Project tags
+                            path(
+                                r"tags/",
+                                views.ajax_tags,
+                                name="pontoon.projects.ajax.tags",
+                            ),
+                            # Project contributors
+                            path(
+                                "contributors/",
+                                views.ProjectContributorsView.as_view(),
+                                name="pontoon.projects.ajax.contributors",
+                            ),
+                            # Project info
+                            path(
+                                "info/",
+                                views.ajax_info,
+                                name="pontoon.projects.ajax.info",
+                            ),
+                            # Project notifications
+                            path(
+                                "notifications/",
+                                views.ajax_notifications,
+                                name="pontoon.projects.ajax.notifications",
+                            ),
+                        ]
+                    ),
+                ),
+            ]
+        ),
     ),
 ]

--- a/pontoon/sync/urls.py
+++ b/pontoon/sync/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import path
 from django.views.generic import RedirectView
 
 from pontoon.sync import views
@@ -6,13 +6,13 @@ from pontoon.sync import views
 
 urlpatterns = [
     # Redirect until we use it for something more meaningful
-    url(
-        r"^sync/$",
+    path(
+        "sync/",
         RedirectView.as_view(pattern_name="pontoon.sync.logs.list", permanent=True),
     ),
-    url(r"^sync/log/$", views.sync_log_list, name="pontoon.sync.logs.list"),
-    url(
-        r"^sync/log/(?P<sync_log_pk>\d+)/",
+    path("sync/log/", views.sync_log_list, name="pontoon.sync.logs.list"),
+    path(
+        "sync/log/<int:sync_log_pk>/",
         views.sync_log_details,
         name="pontoon.sync.logs.details",
     ),

--- a/pontoon/tags/urls.py
+++ b/pontoon/tags/urls.py
@@ -1,18 +1,18 @@
-from django.conf.urls import url
+from django.urls import path
 
 from . import views
 
 
 urlpatterns = [
     # Project tag page
-    url(
-        r"^projects/(?P<project>[\w-]+)/tags/(?P<tag>[\w-]+)/$",
+    path(
+        "projects/<slug:project>/tags/<slug:tag>/",
         views.ProjectTagView.as_view(),
         name="pontoon.tags.project.tag",
     ),
     # AJAX view: Project tag teams
-    url(
-        r"^projects/(?P<project>[\w-]+)/ajax/tags/(?P<tag>[\w-]+)/$",
+    path(
+        "projects/<slug:project>/ajax/tags/<slug:tag>/",
         views.ProjectTagView.as_view(),
         name="pontoon.tags.ajax.teams",
     ),

--- a/pontoon/tags/views.py
+++ b/pontoon/tags/views.py
@@ -2,6 +2,7 @@ from django.http import Http404
 
 from .utils import TagsTool
 from pontoon.base.models import Project
+from pontoon.base.utils import is_ajax
 
 from django.views.generic import DetailView
 
@@ -19,7 +20,7 @@ class ProjectTagView(DetailView):
         return super().get_queryset().visible_for(self.request.user)
 
     def get(self, request, *args, **kwargs):
-        if request.is_ajax():
+        if is_ajax(request):
             return self.get_AJAX(request, *args, **kwargs)
         return super(ProjectTagView, self).get(request, *args, **kwargs)
 
@@ -35,7 +36,7 @@ class ProjectTagView(DetailView):
         except IndexError:
             raise Http404
 
-        if self.request.is_ajax():
+        if is_ajax(self.request):
             return dict(project=self.object, locales=list(tag.iter_locales()), tag=tag,)
 
         return dict(project=self.object, tag=tag)

--- a/pontoon/teams/urls.py
+++ b/pontoon/teams/urls.py
@@ -1,78 +1,84 @@
-from django.conf.urls import url
+from django.urls import include, path
 from django.views.generic import RedirectView
 
 from . import views
 
+
 urlpatterns = [
     # Localization teams
-    url(r"^teams/$", views.teams, name="pontoon.teams"),
+    path("teams/", views.teams, name="pontoon.teams"),
     # AJAX: Request team to be added to Pontoon
-    url(r"^teams/request/$", views.request_item, name="pontoon.teams.request.locale"),
+    path("teams/request/", views.request_item, name="pontoon.teams.request.locale"),
     # Redirect to a team page
-    url(
-        r"^teams/(?P<locale>[A-Za-z0-9\-\@\.]+)/$",
+    path(
+        "teams/<locale:locale>/",
         RedirectView.as_view(url="/%(locale)s/", permanent=True),
     ),
-    # Team contributors
-    url(
-        r"^(?P<locale>[A-Za-z0-9\-\@\.]+)/contributors/$",
-        views.team,
-        name="pontoon.teams.contributors",
-    ),
-    # Team bugs
-    url(
-        r"^(?P<locale>[A-Za-z0-9\-\@\.]+)/bugs/$", views.team, name="pontoon.teams.bugs"
-    ),
-    # Team info
-    url(
-        r"^(?P<locale>[A-Za-z0-9\-\@\.]+)/info/$", views.team, name="pontoon.teams.info"
-    ),
-    # Team permissions
-    url(
-        r"^(?P<locale>[A-Za-z0-9\-\@\.]+)/permissions/$",
-        views.team,
-        name="pontoon.teams.permissions",
-    ),
-    # Legacy url for permissions management
-    url(
-        r"^(?P<locale>[A-Za-z0-9\-\@\.]+)/manage/$",
-        RedirectView.as_view(url="/%(locale)s/permissions/", permanent=True),
-        name="pontoon.teams.manage",
-    ),
-    # AJAX view: Team projects
-    url(
-        r"^(?P<locale>[A-Za-z0-9\-\@\.]+)/ajax/$",
-        views.ajax_projects,
-        name="pontoon.teams.ajax.projects",
-    ),
-    # AJAX view: Team contributors
-    url(
-        r"^(?P<code>[A-Za-z0-9\-\@\.]+)/ajax/contributors/$",
-        views.LocaleContributorsView.as_view(),
-        name="pontoon.teams.ajax.contributors",
-    ),
-    # AJAX view: Team info
-    url(
-        r"^(?P<locale>[A-Za-z0-9\-\@\.]+)/ajax/info/$",
-        views.ajax_info,
-        name="pontoon.teams.ajax.info",
-    ),
-    # AJAX view: Update team info
-    url(
-        r"^(?P<locale>[A-Za-z0-9\-\@\.]+)/ajax/update-info/$",
-        views.ajax_update_info,
-        name="pontoon.teams.ajax.update-info",
-    ),
-    # AJAX view: Team permissions
-    url(
-        r"^(?P<locale>[A-Za-z0-9\-\@\.]+)/ajax/permissions/$",
-        views.ajax_permissions,
-        name="pontoon.teams.ajax.permissions",
-    ),
-    # AJAX: Request projects to be added to locale
-    url(
-        r"^(?P<locale>[A-Za-z0-9\-\@\.]+)/request/$",
-        views.request_item,
-        name="pontoon.teams.request.projects",
+    path(
+        "<locale:locale>/",
+        include(
+            [
+                # Team contributors
+                path("contributors/", views.team, name="pontoon.teams.contributors",),
+                # Team bugs
+                path("bugs/", views.team, name="pontoon.teams.bugs",),
+                # Team info
+                path("info/", views.team, name="pontoon.teams.info",),
+                # Team permissions
+                path("permissions/", views.team, name="pontoon.teams.permissions",),
+                # Legacy url for permissions management
+                path(
+                    "manage/",
+                    RedirectView.as_view(
+                        url="/%(locale)s/permissions/", permanent=True
+                    ),
+                    name="pontoon.teams.manage",
+                ),
+                # AJAX views
+                path(
+                    "ajax/",
+                    include(
+                        [
+                            # Team projects
+                            path(
+                                "",
+                                views.ajax_projects,
+                                name="pontoon.teams.ajax.projects",
+                            ),
+                            # Team contributors
+                            path(
+                                "contributors/",
+                                views.LocaleContributorsView.as_view(),
+                                name="pontoon.teams.ajax.contributors",
+                            ),
+                            # Team info
+                            path(
+                                "info/",
+                                views.ajax_info,
+                                name="pontoon.teams.ajax.info",
+                            ),
+                            # Update team info
+                            path(
+                                "update-info/",
+                                views.ajax_update_info,
+                                name="pontoon.teams.ajax.update-info",
+                            ),
+                            # Team permissions
+                            path(
+                                "permissions/",
+                                views.ajax_permissions,
+                                name="pontoon.teams.ajax.permissions",
+                            ),
+                        ]
+                    ),
+                ),
+                # AJAX: Request projects to be added to locale
+                path(
+                    "request/",
+                    views.request_item,
+                    name="pontoon.teams.request.projects",
+                ),
+            ]
+        ),
     ),
 ]

--- a/pontoon/teams/views.py
+++ b/pontoon/teams/views.py
@@ -282,7 +282,7 @@ class LocaleContributorsView(ContributorsMixin, DetailView):
     template_name = "teams/includes/contributors.html"
     model = Locale
     slug_field = "code"
-    slug_url_kwarg = "code"
+    slug_url_kwarg = "locale"
 
     def get_context_object_name(self, obj):
         return "locale"

--- a/pontoon/terminology/urls.py
+++ b/pontoon/terminology/urls.py
@@ -1,19 +1,19 @@
-from django.conf.urls import url
+from django.urls import path
 
 from . import views
 
 urlpatterns = [
     # AJAX: Retrieve terms for given Entity and Locale
-    url(r"^get-terms/", views.get_terms, name="pontoon.terms.get"),
+    path("get-terms/", views.get_terms, name="pontoon.terms.get"),
     # AJAX: Download terminology in TBX 2.0
-    url(
-        r"^(?P<locale>.+)\.v2\.tbx$",
+    path(
+        "<locale:locale>.v2.tbx",
         views.DownloadTerminologyViewV2.as_view(),
         name="pontoon.terminology.download.tbx.v2",
     ),
     # AJAX: Download terminology in TBX 3.0
-    url(
-        r"^(?P<locale>.+)\.tbx$",
+    path(
+        "<locale:locale>.tbx",
         views.DownloadTerminologyViewV3.as_view(),
         name="pontoon.terminology.download.tbx.v3",
     ),

--- a/pontoon/tour/urls.py
+++ b/pontoon/tour/urls.py
@@ -1,10 +1,10 @@
-from django.conf.urls import url
+from django.urls import path
 
 from . import views
 
 urlpatterns = [
-    url(
-        r"^update-tour-status/",
+    path(
+        "update-tour-status/",
         views.update_tour_status,
         name="pontoon.update_tour_status",
     ),

--- a/pontoon/translate/urls.py
+++ b/pontoon/translate/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls import url
+from django.urls import path, re_path
 from django.views.generic import RedirectView
 
 from . import views
@@ -12,20 +12,16 @@ RESOURCE_PART = r"(?P<resource>.+)"
 
 urlpatterns = [
     # For backwards compatibility, redirect old `translate/` URLs.
-    url(
-        r"^translate/{locale}/{project}/{resource}/$".format(
-            locale=LOCALE_PART, project=PROJECT_PART, resource=RESOURCE_PART,
-        ),
+    path(
+        "translate/<locale:locale>/<slug:project>/<path:resource>/",
         RedirectView.as_view(
             url="/%(locale)s/%(project)s/%(resource)s/",
             query_string=True,
             permanent=False,
         ),
     ),
-    url(
-        r"^{locale}/{project}/{resource}/$".format(
-            locale=LOCALE_PART, project=PROJECT_PART, resource=RESOURCE_PART,
-        ),
+    path(
+        "<locale:locale>/<slug:project>/<path:resource>/",
         views.translate,
         name="pontoon.translate",
     ),
@@ -43,6 +39,6 @@ urlpatterns = [
 # automatically done when running with `make run`.
 if settings.DEV:
     urlpatterns += [
-        url(r"^static/(?P<path>.*)$", views.static_serve_dev,),
-        url(r"^sockjs-node/.*$", views.translate,),
+        path("static/<path:path>", views.static_serve_dev,),
+        re_path(r"^sockjs-node/.*$", views.translate,),
     ]

--- a/pontoon/translations/urls.py
+++ b/pontoon/translations/urls.py
@@ -1,21 +1,19 @@
-from django.conf.urls import url
+from django.urls import path
 
 from . import views
 
 
 urlpatterns = [
-    url(r"^create/$", views.create_translation, name="pontoon.translations.create",),
-    url(r"^delete/$", views.delete_translation, name="pontoon.translations.delete",),
-    url(r"^approve/$", views.approve_translation, name="pontoon.translations.approve",),
-    url(
-        r"^unapprove/$",
+    path("create/", views.create_translation, name="pontoon.translations.create",),
+    path("delete/", views.delete_translation, name="pontoon.translations.delete",),
+    path("approve/", views.approve_translation, name="pontoon.translations.approve",),
+    path(
+        "unapprove/",
         views.unapprove_translation,
         name="pontoon.translations.unapprove",
     ),
-    url(r"^reject/$", views.reject_translation, name="pontoon.translations.reject",),
-    url(
-        r"^unreject/$",
-        views.unreject_translation,
-        name="pontoon.translations.unreject",
+    path("reject/", views.reject_translation, name="pontoon.translations.reject",),
+    path(
+        "unreject/", views.unreject_translation, name="pontoon.translations.unreject",
     ),
 ]

--- a/pontoon/urls.py
+++ b/pontoon/urls.py
@@ -1,10 +1,17 @@
-from django.conf.urls import include, url
+from django.urls import include, path, register_converter
+from django.urls.converters import StringConverter
 from django.contrib import admin
 from django.contrib.auth import logout
 from django.views.generic import RedirectView, TemplateView
 
 from pontoon.teams.views import team
 
+
+class LocaleConverter(StringConverter):
+    regex = r"[A-Za-z0-9\-\@\.]+"
+
+
+register_converter(LocaleConverter, "locale")
 
 pontoon_js_view = TemplateView.as_view(
     template_name="js/pontoon.js", content_type="text/javascript"
@@ -13,101 +20,101 @@ pontoon_js_view = TemplateView.as_view(
 
 urlpatterns = [
     # Legacy: Locale redirect for compatibility with i18n ready URL scheme
-    url(r"^en-US(?P<url>.+)$", RedirectView.as_view(url="%(url)s", permanent=True)),
+    path("en-US<path:url>", RedirectView.as_view(url="%(url)s", permanent=True)),
     # Redirect legacy Aurora projects
-    url(
-        r"^projects/firefox-aurora/(?P<url>.*)$",
+    path(
+        "projects/firefox-aurora/<path:url>",
         RedirectView.as_view(url="/projects/firefox/%(url)s", permanent=True),
     ),
-    url(
-        r"^projects/firefox-for-android-aurora/(?P<url>.*)$",
+    path(
+        "projects/firefox-for-android-aurora/<path:url>",
         RedirectView.as_view(
             url="/projects/firefox-for-android/%(url)s", permanent=True
         ),
     ),
-    url(
-        r"^projects/thunderbird-aurora/(?P<url>.*)$",
+    path(
+        "projects/thunderbird-aurora/<path:url>",
         RedirectView.as_view(url="/projects/thunderbird/%(url)s", permanent=True),
     ),
-    url(
-        r"^projects/lightning-aurora/(?P<url>.*)$",
+    path(
+        "projects/lightning-aurora/<path:url>",
         RedirectView.as_view(url="/projects/lightning/%(url)s", permanent=True),
     ),
-    url(
-        r"^projects/seamonkey-aurora/(?P<url>.*)$",
+    path(
+        "projects/seamonkey-aurora/<path:url>",
         RedirectView.as_view(url="/projects/seamonkey/%(url)s", permanent=True),
     ),
-    url(
-        r"^(?P<locale>[A-Za-z0-9\-\@\.]+)/firefox-aurora/(?P<url>.*)$",
+    path(
+        "<locale:locale>/firefox-aurora/<path:url>",
         RedirectView.as_view(url="/%(locale)s/firefox/%(url)s", permanent=True),
     ),
-    url(
-        r"^(?P<locale>[A-Za-z0-9\-\@\.]+)/firefox-for-android-aurora/(?P<url>.*)$",
+    path(
+        "<locale:locale>/firefox-for-android-aurora/<path:url>",
         RedirectView.as_view(
             url="/%(locale)s/firefox-for-android/%(url)s", permanent=True
         ),
     ),
-    url(
-        r"^(?P<locale>[A-Za-z0-9\-\@\.]+)/thunderbird-aurora/(?P<url>.*)$",
+    path(
+        "<locale:locale>/thunderbird-aurora/<path:url>",
         RedirectView.as_view(url="/%(locale)s/thunderbird/%(url)s", permanent=True),
     ),
-    url(
-        r"^(?P<locale>[A-Za-z0-9\-\@\.]+)/lightning-aurora/(?P<url>.*)$",
+    path(
+        "<locale:locale>/lightning-aurora/<path:url>",
         RedirectView.as_view(url="/%(locale)s/lightning/%(url)s", permanent=True),
     ),
-    url(
-        r"^(?P<locale>[A-Za-z0-9\-\@\.]+)/seamonkey-aurora/(?P<url>.*)$",
+    path(
+        "<locale:locale>/seamonkey-aurora/<path:url>",
         RedirectView.as_view(url="/%(locale)s/seamonkey/%(url)s", permanent=True),
     ),
     # Accounts
-    url(r"^accounts/", include("pontoon.allauth_urls")),
+    path("accounts/", include("pontoon.allauth_urls")),
     # Admin
-    url(r"^admin/", include("pontoon.administration.urls")),
+    path("admin/", include("pontoon.administration.urls")),
     # Django admin
-    url(r"^a/", admin.site.urls),
+    path("a/", admin.site.urls),
     # Logout
-    url(r"^signout/$", logout, {"next_page": "/"}, name="signout"),
+    path("signout/", logout, {"next_page": "/"}, name="signout"),
     # Error pages
-    url(r"^403/$", TemplateView.as_view(template_name="403.html")),
-    url(r"^404/$", TemplateView.as_view(template_name="404.html")),
-    url(r"^500/$", TemplateView.as_view(template_name="500.html")),
+    path("403/", TemplateView.as_view(template_name="403.html")),
+    path("404/", TemplateView.as_view(template_name="404.html")),
+    path("500/", TemplateView.as_view(template_name="500.html")),
     # Robots.txt
-    url(
-        r"^robots.txt$",
+    path(
+        "robots.txt",
         TemplateView.as_view(template_name="robots.txt", content_type="text/plain"),
     ),
     # contribute.json
-    url(
-        r"^contribute.json$",
+    path(
+        "contribute.json",
         TemplateView.as_view(
             template_name="contribute.json", content_type="text/plain"
         ),
     ),
     # Favicon
-    url(
-        r"^favicon\.ico$",
+    path(
+        "favicon.ico",
         RedirectView.as_view(url="/static/img/favicon.ico", permanent=True),
     ),
     # Include script
-    url(r"^pontoon\.js$", pontoon_js_view),
-    url(r"^static/js/pontoon\.js$", pontoon_js_view),
+    path("pontoon.js", pontoon_js_view),
+    path("static/js/pontoon.js", pontoon_js_view),
     # Include URL configurations from installed apps
-    url(r"^terminology/", include("pontoon.terminology.urls")),
-    url(r"^translations/", include("pontoon.translations.urls")),
-    url(r"", include("pontoon.teams.urls")),
-    url(r"", include("pontoon.tour.urls")),
-    url(r"", include("pontoon.tags.urls")),
-    url(r"", include("pontoon.sync.urls")),
-    url(r"", include("pontoon.projects.urls")),
-    url(r"", include("pontoon.machinery.urls")),
-    url(r"", include("pontoon.contributors.urls")),
-    url(r"", include("pontoon.localizations.urls")),
-    url(r"", include("pontoon.base.urls")),
-    url(r"", include("pontoon.translate.urls")),
-    url(r"", include("pontoon.batch.urls")),
-    url(r"", include("pontoon.api.urls")),
-    url(r"", include("pontoon.homepage.urls")),
-    url(r"", include("pontoon.in_context.urls")),
+    path("terminology/", include("pontoon.terminology.urls")),
+    path("translations/", include("pontoon.translations.urls")),
+    path("", include("pontoon.teams.urls")),
+    path("", include("pontoon.tour.urls")),
+    path("", include("pontoon.tags.urls")),
+    path("", include("pontoon.sync.urls")),
+    path("", include("pontoon.projects.urls")),
+    path("", include("pontoon.machinery.urls")),
+    path("", include("pontoon.contributors.urls")),
+    path("", include("pontoon.localizations.urls")),
+    path("", include("pontoon.base.urls")),
+    path("", include("pontoon.translate.urls")),
+    path("", include("pontoon.batch.urls")),
+    path("", include("pontoon.api.urls")),
+    path("", include("pontoon.homepage.urls")),
+    path("", include("pontoon.in_context.urls")),
     # Team page: Must be at the end
-    url(r"^(?P<locale>[A-Za-z0-9\-\@\.]+)/$", team, name="pontoon.teams.team"),
+    path("<locale:locale>/", team, name="pontoon.teams.team"),
 ]


### PR DESCRIPTION
This fixes all Django deprecation warnings caused by our code. It is split up into 3 commits, which you can review individually.

The largest change concerns all `urls.py` files. The previously used `django.conf.urls.url` is deprecated, and almost all of our regex uses are now replaced by explicit path strings. In the process, I greatly simplified the regex usage.

Note that the previous GraphQL regex made the API available at any URL starting with `/graphql` (including `/graphql/`), but now it is only exactly that URL.