### PR TITLE
Fix bug 1633149: Detect changes to translated resources on sync

### DIFF
--- a/pontoon/sync/tests/test_vcs_models.py
+++ b/pontoon/sync/tests/test_vcs_models.py
@@ -269,6 +269,7 @@ class VCSProjectTests(VCSTestCase):
         source resources within the source repository checkout path.
         """
         checkout_path_mock.return_value = PROJECT_CONFIG_CHECKOUT_PATH
+        self.vcs_project.db_project.configuration_file = "l10n.toml"
         self.vcs_project.configuration = VCSConfiguration(self.vcs_project)
 
         assert sorted(list(self.vcs_project.resource_paths_with_config())) == sorted(
@@ -427,10 +428,10 @@ class VCSConfigurationTests(VCSTestCase):
 
     def test_reference_path(self):
         absolute_l10n_path = os.path.join(
-            PROJECT_CONFIG_CHECKOUT_PATH, "values-fr/amo.pot",
+            PROJECT_CONFIG_CHECKOUT_PATH, "values-fr/amo.po",
         )
 
-        reference_path = os.path.join(PROJECT_CONFIG_CHECKOUT_PATH, "values/amo.po",)
+        reference_path = os.path.join(PROJECT_CONFIG_CHECKOUT_PATH, "values/amo.pot",)
 
         assert (
             self.vcs_project.configuration.reference_path(

--- a/pontoon/sync/tests/test_vcs_models.py
+++ b/pontoon/sync/tests/test_vcs_models.py
@@ -14,6 +14,7 @@ from pontoon.base.models import (
 )
 from pontoon.base.tests import (
     CONTAINS,
+    LocaleFactory,
     ProjectFactory,
     RepositoryFactory,
     ResourceFactory,
@@ -68,11 +69,60 @@ class VCSProjectTests(VCSTestCase):
         self.mock_checkout_path = checkout_path_patch.start()
         self.addCleanup(checkout_path_patch.stop)
 
+        self.locale = LocaleFactory.create(code="XY")
         self.project = ProjectFactory.create(
-            repositories__permalink="https://example.com/l10n/{locale_code}"
+            locales=[self.locale],
+            repositories__permalink="https://example.com/l10n/{locale_code}",
         )
         self.vcs_project = VCSProject(self.project)
         super(VCSProjectTests, self).setUp()
+
+    @patch.object(VCSProject, "source_directory_path", new_callable=PropertyMock)
+    def test_get_relevant_files_with_config(self, source_directory_path_mock):
+        """
+        Return relative reference paths and locales of paths found in project configuration.
+        """
+        source_directory_path_mock.return_value = ""
+        paths = ["locale/path/to/localizable_file.ftl"]
+        self.vcs_project.configuration = VCSConfiguration(self.vcs_project)
+
+        # Return empty dict if no reference path found for any of the paths
+        with patch(
+            "pontoon.sync.vcs.models.VCSConfiguration.reference_path",
+            return_value=None,
+        ):
+            files = self.vcs_project.get_relevant_files_with_config(paths)
+            assert files == {}
+
+        # Return empty dict if no reference path found for any of the paths
+        with patch(
+            "pontoon.sync.vcs.models.VCSConfiguration.reference_path",
+            return_value="reference/path/to/localizable_file.ftl",
+        ):
+            files = self.vcs_project.get_relevant_files_with_config(paths)
+            assert files == {"reference/path/to/localizable_file.ftl": [self.locale]}
+
+    def test_get_relevant_files_without_config(self):
+        """
+        Return relative paths and their locales if they start with locale repository paths.
+        """
+        paths = [
+            "locales/xy/path/to/localizable_file.ftl",
+            "some.random.file",
+            ".hidden_file",
+        ]
+
+        locale_path_locales = {
+            "locales/ab": "AB",
+            "locales/cd": "CD",
+            "locales/xy": "XY",
+        }
+
+        files = self.vcs_project.get_relevant_files_without_config(
+            paths, locale_path_locales
+        )
+
+        assert files == {"path/to/localizable_file.ftl": ["XY"]}
 
     def test_missing_permalink_prefix(self):
         """
@@ -219,7 +269,6 @@ class VCSProjectTests(VCSTestCase):
         source resources within the source repository checkout path.
         """
         checkout_path_mock.return_value = PROJECT_CONFIG_CHECKOUT_PATH
-        self.vcs_project.db_project.configuration_file = "l10n.toml"
         self.vcs_project.configuration = VCSConfiguration(self.vcs_project)
 
         assert sorted(list(self.vcs_project.resource_paths_with_config())) == sorted(
@@ -374,6 +423,20 @@ class VCSConfigurationTests(VCSTestCase):
                 self.locale, absolute_resource_path,
             )
             == l10n_path
+        )
+
+    def test_reference_path(self):
+        absolute_l10n_path = os.path.join(
+            PROJECT_CONFIG_CHECKOUT_PATH, "values-fr/amo.pot",
+        )
+
+        reference_path = os.path.join(PROJECT_CONFIG_CHECKOUT_PATH, "values/amo.po",)
+
+        assert (
+            self.vcs_project.configuration.reference_path(
+                self.locale, absolute_l10n_path,
+            )
+            == reference_path
         )
 
     def test_locale_resources(self):

--- a/pontoon/sync/vcs/models.py
+++ b/pontoon/sync/vcs/models.py
@@ -265,21 +265,13 @@ class VCSProject(object):
                     )
                 )
 
-                # Find relevant changes in repository by matching changed
-                # paths against locale repository paths
-                locale_path_locales = self.locale_path_locales(repo.checkout_path)
-                locale_paths = locale_path_locales.keys()
-
-                for path in changed_files:
-                    if is_hidden(path):
-                        continue
-
-                    for locale_path in locale_paths:
-                        if path.startswith(locale_path):
-                            locale = locale_path_locales[locale_path]
-                            path = path[len(locale_path) :].lstrip(os.sep)
-                            files.setdefault(path, []).append(locale)
-                            break
+                # Include only relevant (localizable) files
+                if self.configuration:
+                    files = self.get_relevant_files_with_config(changed_files)
+                else:
+                    files = self.get_relevant_files_without_config(
+                        changed_files, self.locale_path_locales(repo.checkout_path)
+                    )
 
         log.info(
             "Changed files in {} repository, relevant for enabled locales: {}".format(
@@ -310,6 +302,49 @@ class VCSProject(object):
         )
         changed_files = set(self.changed_source_files[0])
         return changed_files.intersection(config_files)
+
+    def get_relevant_files_with_config(self, paths):
+        """
+        Check if given paths represent localizable files using project configuration.
+        Return a dict of relative reference paths of such paths and corresponding Locale
+        objects.
+        """
+        files = {}
+
+        for locale in self.db_project.locales.all():
+            for path in paths:
+                absolute_path = os.path.join(self.source_directory_path, path)
+                reference_path = self.configuration.reference_path(locale, absolute_path)
+
+                if reference_path:
+                    relative_reference_path = reference_path[
+                        len(self.source_directory_path) :
+                    ].lstrip(os.sep)
+                    files.setdefault(relative_reference_path, []).append(locale)
+
+        return files
+
+    def get_relevant_files_without_config(self, paths, locale_path_locales):
+        """
+        Check if given paths represent localizable files by matching them against locale
+        repository paths. Return a dict of relative reference paths of such paths and
+        corresponding Locale objects.
+        """
+        files = {}
+        locale_paths = locale_path_locales.keys()
+
+        for path in paths:
+            if is_hidden(path):
+                continue
+
+            for locale_path in locale_paths:
+                if path.startswith(locale_path):
+                    locale = locale_path_locales[locale_path]
+                    path = path[len(locale_path) :].lstrip(os.sep)
+                    files.setdefault(path, []).append(locale)
+                    break
+
+        return files
 
     def locale_path_locales(self, repo_checkout_path):
         """
@@ -664,6 +699,15 @@ class VCSConfiguration(object):
 
         m = project_files.match(reference_path)
         return m[0] if m is not None else None
+
+    def reference_path(self, locale, l10n_path):
+        """
+        Return reference path for the given locale and l10n path.
+        """
+        project_files = self.get_or_set_project_files(locale.code)
+
+        m = project_files.match(l10n_path)
+        return m[1] if m is not None else None
 
     def locale_resources(self, locale):
         """

--- a/pontoon/sync/vcs/models.py
+++ b/pontoon/sync/vcs/models.py
@@ -314,7 +314,9 @@ class VCSProject(object):
         for locale in self.db_project.locales.all():
             for path in paths:
                 absolute_path = os.path.join(self.source_directory_path, path)
-                reference_path = self.configuration.reference_path(locale, absolute_path)
+                reference_path = self.configuration.reference_path(
+                    locale, absolute_path
+                )
 
                 if reference_path:
                     relative_reference_path = reference_path[


### PR DESCRIPTION
When detecting changes to translated resources in VCS, we need to identify which of the changed paths belongs to a localizable resource (and ignore others).

The logic that does that makes assumptions about the file and folder structure which are not valid for projects using project configuration. Hence this patch adds a new logic for such projects, which makes use of the ProjectFiles matcher of the compare-locales library.

The logic also converts the changed paths to the canonical form for representing resources used across Pontoon codebase (reference path insted of l10n path) and assigns the list of changed locales to each path.

As a side effect, this patch also fixes [bug 1608045](https://bugzilla.mozilla.org/show_bug.cgi?id=1608045), which is another symptom of the very same problem.