### PR TITLE
Fix Bug 1679654 - Add ability to reset machinery search field

### DIFF
--- a/frontend/src/modules/machinery/components/Machinery.css
+++ b/frontend/src/modules/machinery/components/Machinery.css
@@ -23,6 +23,12 @@
     top: 16px;
 }
 
+.machinery > .search-wrapper > label > button {
+    background-color: transparent;
+    border: none;
+    color: #aaaaaa;
+}
+
 .machinery > .search-wrapper input[type='search'] {
     background: #333941;
     border: none;

--- a/frontend/src/modules/machinery/components/Machinery.css
+++ b/frontend/src/modules/machinery/components/Machinery.css
@@ -27,6 +27,7 @@
     background-color: transparent;
     border: none;
     color: #aaaaaa;
+    padding: 0 4px;
 }
 
 .machinery > .search-wrapper input[type='search'] {

--- a/frontend/src/modules/machinery/components/Machinery.js
+++ b/frontend/src/modules/machinery/components/Machinery.js
@@ -55,7 +55,6 @@ export default class Machinery extends React.Component<Props> {
     }
 
     handleResetSearch = () => {
-        this.searchInput.current.value = '';
         this.props.searchMachinery('');
     };
 
@@ -82,18 +81,16 @@ export default class Machinery extends React.Component<Props> {
         return (
             <section className='machinery'>
                 <div className='search-wrapper clearfix'>
-                    {showResetButton ? (
-                        <label htmlFor='machinery-search'>
+                    <label htmlFor='machinery-search'>
+                        {showResetButton ? (
                             <button
                                 className='fa fa-times'
                                 onClick={this.handleResetSearch}
                             ></button>
-                        </label>
-                    ) : (
-                        <label htmlFor='machinery-search'>
+                        ) : (
                             <div className='fa fa-search'></div>
-                        </label>
-                    )}
+                        )}
+                    </label>
                     <form onSubmit={this.submitForm}>
                         <Localized
                             id='machinery-Machinery--search-placeholder'

--- a/frontend/src/modules/machinery/components/Machinery.js
+++ b/frontend/src/modules/machinery/components/Machinery.js
@@ -54,7 +54,7 @@ export default class Machinery extends React.Component<Props> {
         }
     }
 
-    handleResetSearch = (event: SyntheticMouseEvent<>) => {
+    handleResetSearch = () => {
         this.searchInput.current.value = '';
         this.props.searchMachinery('');
     };

--- a/frontend/src/modules/machinery/components/Machinery.js
+++ b/frontend/src/modules/machinery/components/Machinery.js
@@ -55,9 +55,8 @@ export default class Machinery extends React.Component<Props> {
     }
 
     handleResetSearch = (event: SyntheticMouseEvent<>) => {
-        event.preventDefault();
         this.searchInput.current.value = '';
-        this.props.searchMachinery(this.searchInput.current.value);
+        this.props.searchMachinery('');
     };
 
     submitForm = (event: SyntheticKeyboardEvent<>) => {

--- a/frontend/src/modules/machinery/components/Machinery.js
+++ b/frontend/src/modules/machinery/components/Machinery.js
@@ -54,6 +54,12 @@ export default class Machinery extends React.Component<Props> {
         }
     }
 
+    handleResetSearch = (event: SyntheticMouseEvent<>) => {
+        event.preventDefault();
+        this.searchInput.current.value = '';
+        this.props.searchMachinery(this.searchInput.current.value);
+    };
+
     submitForm = (event: SyntheticKeyboardEvent<>) => {
         event.preventDefault();
         this.props.searchMachinery(this.searchInput.current.value);
@@ -75,9 +81,19 @@ export default class Machinery extends React.Component<Props> {
         return (
             <section className='machinery'>
                 <div className='search-wrapper clearfix'>
-                    <label htmlFor='machinery-search'>
-                        <div className='fa fa-search'></div>
-                    </label>
+                    {!this.searchInput.current ||
+                    this.searchInput.current.value === '' ? (
+                        <label htmlFor='machinery-search'>
+                            <div className='fa fa-search'></div>
+                        </label>
+                    ) : (
+                        <label htmlFor='machinery-search'>
+                            <button
+                                className='fa fa-times'
+                                onClick={this.handleResetSearch}
+                            ></button>
+                        </label>
+                    )}
                     <form onSubmit={this.submitForm}>
                         <Localized
                             id='machinery-Machinery--search-placeholder'

--- a/frontend/src/modules/machinery/components/Machinery.js
+++ b/frontend/src/modules/machinery/components/Machinery.js
@@ -77,20 +77,21 @@ export default class Machinery extends React.Component<Props> {
             return null;
         }
 
+        const showResetButton = !machinery.entity && machinery.sourceString;
+
         return (
             <section className='machinery'>
                 <div className='search-wrapper clearfix'>
-                    {!this.searchInput.current ||
-                    this.searchInput.current.value === '' ? (
-                        <label htmlFor='machinery-search'>
-                            <div className='fa fa-search'></div>
-                        </label>
-                    ) : (
+                    {showResetButton ? (
                         <label htmlFor='machinery-search'>
                             <button
                                 className='fa fa-times'
                                 onClick={this.handleResetSearch}
                             ></button>
+                        </label>
+                    ) : (
+                        <label htmlFor='machinery-search'>
+                            <div className='fa fa-search'></div>
                         </label>
                     )}
                     <form onSubmit={this.submitForm}>

--- a/frontend/src/modules/machinery/components/Machinery.test.js
+++ b/frontend/src/modules/machinery/components/Machinery.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 
 import Machinery from './Machinery';
 
@@ -44,5 +44,17 @@ describe('<Machinery>', () => {
         );
 
         expect(wrapper.type()).toBeNull();
+    });
+
+    it('renders a reset button if a source string is present', () => {
+        const machinery = {
+            translations: [],
+            sourceString: 'test',
+        };
+        const wrapper = mount(
+            <Machinery machinery={machinery} locale={LOCALE} />,
+        );
+
+        expect(wrapper.find('button')).toHaveLength(1);
     });
 });


### PR DESCRIPTION
The ability to reset the Machinery Search input to its original state is not currently intuitive (user must clear the input and hit enter). 

This PR follows the [specification for Concordance Search](https://github.com/mozilla/pontoon/blob/master/specs/0106-concordance-search.md) and switches the 'search' icon to a 'close' button (`x`) when a search is made. When the 'close' button is clicked the search input will be cleared and returned to its original state.

This does not currently work for the FTL files due to [Bug 1676750](https://bugzilla.mozilla.org/show_bug.cgi?id=1676750). The input is cleared but the original state is not restored.