### PR TITLE
Fix bug 1681293: Make sure editor is reset on keyboard navigation

### DIFF
--- a/frontend/src/modules/entitydetails/components/EntityDetails.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.js
@@ -239,13 +239,13 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
                 this.props.unsavedChangesExist,
                 this.props.unsavedChangesIgnored,
                 () => {
-                    dispatch(editor.actions.reset());
                     dispatch(
                         navigation.actions.updateEntity(
                             router,
                             nextEntity.pk.toString(),
                         ),
                     );
+                    dispatch(editor.actions.reset());
                 },
             ),
         );
@@ -259,13 +259,13 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
                 this.props.unsavedChangesExist,
                 this.props.unsavedChangesIgnored,
                 () => {
-                    dispatch(editor.actions.reset());
                     dispatch(
                         navigation.actions.updateEntity(
                             router,
                             previousEntity.pk.toString(),
                         ),
                     );
+                    dispatch(editor.actions.reset());
                 },
             ),
         );


### PR DESCRIPTION
I found two other places where it looks like we should change the order. But I haven't changed it, because I wasn't able to produce any issues.

https://github.com/mozilla/pontoon/blob/master/frontend/src/modules/entitieslist/components/EntitiesList.js#L219
https://github.com/mozilla/pontoon/blob/master/frontend/src/modules/search/components/SearchBox.js#L379