### PR TITLE
Fix Bug 1679709 - Clicking on each machinery search result adds the text to the editor

### DIFF
--- a/frontend/src/modules/machinery/components/Machinery.js
+++ b/frontend/src/modules/machinery/components/Machinery.js
@@ -113,6 +113,7 @@ export default class Machinery extends React.Component<Props> {
                             <Translation
                                 sourceString={machinery.sourceString}
                                 translation={translation}
+                                entity={machinery.entity}
                                 addTextToEditorTranslation={
                                     addTextToEditorTranslation
                                 }

--- a/frontend/src/modules/machinery/components/Translation.js
+++ b/frontend/src/modules/machinery/components/Translation.js
@@ -59,11 +59,14 @@ export default function Translation(props: Props) {
         // added to the editor instead of replacing the editor content
         if (!entity) {
             addTextToEditorTranslation(translation.translation);
-        } else if (typeof editorContent !== 'string') {
-            // This is a Fluent Message, thus we are in the RichEditor.
-            // Handle machinery differently.
+        }
+        // This is a Fluent Message, thus we are in the RichEditor.
+        // Handle machinery differently.
+        else if (typeof editorContent !== 'string') {
             addTextToEditorTranslation(translation.translation, 'machinery');
-        } else {
+        }
+        // By default replace editor content
+        else {
             updateEditorTranslation(translation.translation, 'machinery');
         }
         updateMachinerySources(translation.sources, translation.translation);

--- a/frontend/src/modules/machinery/components/Translation.js
+++ b/frontend/src/modules/machinery/components/Translation.js
@@ -55,6 +55,8 @@ export default function Translation(props: Props) {
             return;
         }
 
+        // If there is no entity then it is a search term and it is
+        // added to the editor instead of replacing the editor content
         if (!entity) {
             addTextToEditorTranslation(translation.translation);
         } else if (typeof editorContent !== 'string') {

--- a/frontend/src/modules/machinery/components/Translation.js
+++ b/frontend/src/modules/machinery/components/Translation.js
@@ -16,6 +16,7 @@ import type { MachineryTranslation, SourceType } from 'core/api';
 type Props = {|
     sourceString: string,
     translation: MachineryTranslation,
+    entity: ?number,
     addTextToEditorTranslation: (string, ?string) => void,
     updateEditorTranslation: (string, string) => void,
     updateMachinerySources: (Array<SourceType>, string) => void,
@@ -35,6 +36,7 @@ export default function Translation(props: Props) {
         updateMachinerySources,
         sourceString,
         translation,
+        entity,
     } = props;
 
     const editorContent = useSelector((state) => state.editor.translation);
@@ -53,7 +55,9 @@ export default function Translation(props: Props) {
             return;
         }
 
-        if (typeof editorContent !== 'string') {
+        if (!entity) {
+            addTextToEditorTranslation(translation.translation);
+        } else if (typeof editorContent !== 'string') {
             // This is a Fluent Message, thus we are in the RichEditor.
             // Handle machinery differently.
             addTextToEditorTranslation(translation.translation, 'machinery');
@@ -64,6 +68,7 @@ export default function Translation(props: Props) {
     }, [
         isReadOnlyEditor,
         translation,
+        entity,
         editorContent,
         addTextToEditorTranslation,
         updateEditorTranslation,

--- a/frontend/src/modules/machinery/components/Translation.test.js
+++ b/frontend/src/modules/machinery/components/Translation.test.js
@@ -19,13 +19,20 @@ const DEFAULT_TRANSLATION = {
     translation: 'Un cheval, un cheval ! Mon royaume pour un cheval !',
 };
 
-function createTranslation(translation, updateMachinerySources) {
+function createTranslation(
+    translation,
+    updateMachinerySources,
+    updateEditorTranslation,
+    addTextToEditorTranslation,
+    entity?,
+) {
     const store = createReduxStore();
     const wrapper = mountComponentWithStore(Translation, store, {
         translation,
         updateMachinerySources,
-        updateEditorTranslation: sinon.mock(),
-        addTextToEditorTranslation: sinon.mock(),
+        updateEditorTranslation,
+        addTextToEditorTranslation,
+        entity,
     });
 
     createDefaultUser(store);
@@ -77,7 +84,14 @@ describe('<Translation>', () => {
 
     it('calls updateMachinerySources when clicking a translation', () => {
         const machineryMock = sinon.stub();
-        const wrapper = createTranslation(DEFAULT_TRANSLATION, machineryMock);
+        const updateEditorTranslationMock = sinon.spy();
+        const addTextToEditorTranslationMock = sinon.spy();
+        const wrapper = createTranslation(
+            DEFAULT_TRANSLATION,
+            machineryMock,
+            updateEditorTranslationMock,
+            addTextToEditorTranslationMock,
+        );
 
         expect(machineryMock.calledOnce).toBeFalsy();
         expect(wrapper.find('li.translation')).toHaveLength(1);
@@ -88,6 +102,51 @@ describe('<Translation>', () => {
             machineryMock.calledWith(
                 DEFAULT_TRANSLATION.sources,
                 DEFAULT_TRANSLATION.translation,
+            ),
+        ).toBeTruthy();
+    });
+
+    it('calls addTextToEditorTranslation when clicking on a search term', () => {
+        const machineryMock = sinon.stub();
+        const updateEditorTranslationMock = sinon.spy();
+        const addTextToEditorTranslationMock = sinon.spy();
+        const wrapper = createTranslation(
+            DEFAULT_TRANSLATION,
+            machineryMock,
+            updateEditorTranslationMock,
+            addTextToEditorTranslationMock,
+        );
+
+        expect(addTextToEditorTranslationMock.called).toBeFalsy();
+        wrapper.find('li.translation').simulate('click');
+        expect(addTextToEditorTranslationMock.called).toBeTruthy();
+        expect(
+            addTextToEditorTranslationMock.calledWith(
+                DEFAULT_TRANSLATION.translation,
+            ),
+        ).toBeTruthy();
+    });
+
+    it('calls updateEditorTranslation when an entity is present', () => {
+        const machineryMock = sinon.stub();
+        const entity = 770;
+        const updateEditorTranslationMock = sinon.spy();
+        const addTextToEditorTranslationMock = sinon.spy();
+        const wrapper = createTranslation(
+            DEFAULT_TRANSLATION,
+            machineryMock,
+            updateEditorTranslationMock,
+            addTextToEditorTranslationMock,
+            entity,
+        );
+
+        expect(updateEditorTranslationMock.called).toBeFalsy();
+        wrapper.find('li.translation').simulate('click');
+        expect(updateEditorTranslationMock.called).toBeTruthy();
+        expect(
+            updateEditorTranslationMock.calledWith(
+                DEFAULT_TRANSLATION.translation,
+                'machinery',
             ),
         ).toBeTruthy();
     });


### PR DESCRIPTION
Currently when searching within the Machinery tab, the results will replace the contents of the editor when clicked on.  As per the [concordance search spec](https://github.com/mozilla/pontoon/blob/master/specs/0106-concordance-search.md), the search results should just be added instead.  This patch makes that change.