### PR TITLE
Title missing in Terms panel and popup

### DIFF
--- a/frontend/src/core/api/types.js
+++ b/frontend/src/core/api/types.js
@@ -64,6 +64,7 @@ export type UsersList = {|
  * Term entry with translation.
  */
 export type TermType = {|
+    +title: string,
     +text: string,
     +partOfSpeech: string,
     +definition: string,

--- a/frontend/src/core/term/components/Term.js
+++ b/frontend/src/core/term/components/Term.js
@@ -57,6 +57,7 @@ export default function Term(props: Props) {
             onClick={() => copyTermIntoEditor(term.translation)}
         >
             <header>
+                <span className='text'>{term.title}</span>
                 <span className='text'>{term.text}</span>
                 <span className='part-of-speech'>{term.partOfSpeech}</span>
                 <a

--- a/frontend/src/core/term/components/Term.test.js
+++ b/frontend/src/core/term/components/Term.test.js
@@ -6,6 +6,7 @@ import Term from './Term';
 
 describe('<Term>', () => {
     const TERM = {
+        title: 'title',
         text: 'text',
         partOfSpeech: 'partOfSpeech',
         definition: 'definition',
@@ -32,6 +33,7 @@ describe('<Term>', () => {
         const wrapper = shallow(<Term term={TERM} />);
 
         expect(wrapper.find('li')).toHaveLength(1);
+        expect(wrapper.find('.title')).toHaveLength('title');
         expect(wrapper.find('.text').text()).toEqual('text');
         expect(wrapper.find('.part-of-speech').text()).toEqual('partOfSpeech');
         expect(wrapper.find('.definition').text()).toEqual('definition');

--- a/pontoon/terminology/views.py
+++ b/pontoon/terminology/views.py
@@ -28,6 +28,7 @@ def get_terms(request):
 
     for term in Term.objects.for_string(source_string):
         data = {
+            "title": term.title,
             "text": term.text,
             "part_of_speech": term.part_of_speech,
             "definition": term.definition,

--- a/pontoon/test/factories.py
+++ b/pontoon/test/factories.py
@@ -194,6 +194,7 @@ class TagFactory(DjangoModelFactory):
 
 
 class TermFactory(DjangoModelFactory):
+    title = "title"
     text = Sequence(lambda n: "Term {0}".format(n))
     definition = "definition"
     part_of_speech = "part_of_speech"


### PR DESCRIPTION
# Fixed Bugs: Bug 1679565 
## Bug Name : Title missing in Terms panel and popup
**_(BUGZILLA)_**
### Explanation: I had added title string into term panel and added in python files also.