### PR TITLE
Fix bug 1684086: Prevent resource path overflow in resource menu

### DIFF
--- a/frontend/src/core/resource/components/ResourceItem.css
+++ b/frontend/src/core/resource/components/ResourceItem.css
@@ -8,3 +8,11 @@
     background: #3f4752;
     color: #fff;
 }
+
+.resource-menu .menu li a .path {
+    display: inline-block;
+    max-width: 550px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}

--- a/frontend/src/core/resource/components/ResourceItem.js
+++ b/frontend/src/core/resource/components/ResourceItem.js
@@ -28,7 +28,7 @@ export default function ResourceItem(props: Props) {
                 href={`/${parameters.locale}/${parameters.project}/${resource.path}/`}
                 onClick={navigateToPath}
             >
-                <span>{resource.path}</span>
+                <span className='path'>{resource.path}</span>
                 <ResourcePercent resource={resource} />
             </a>
         </li>

--- a/frontend/src/core/resource/components/ResourceItem.js
+++ b/frontend/src/core/resource/components/ResourceItem.js
@@ -28,7 +28,9 @@ export default function ResourceItem(props: Props) {
                 href={`/${parameters.locale}/${parameters.project}/${resource.path}/`}
                 onClick={navigateToPath}
             >
-                <span className='path'>{resource.path}</span>
+                <span className='path' title={resource.path}>
+                    {resource.path}
+                </span>
                 <ResourcePercent resource={resource} />
             </a>
         </li>


### PR DESCRIPTION
Before:
<img width="620" alt="Screenshot 2020-12-23 at 20 30 47" src="https://user-images.githubusercontent.com/626716/103031554-562d8c00-455e-11eb-888a-b452016e228b.png">

After:
<img width="620" alt="Screenshot 2020-12-23 at 20 37 37" src="https://user-images.githubusercontent.com/626716/103031753-bae8e680-455e-11eb-963b-e66e6eb60c28.png">


I was also thinking about adding `direction:rtl`, which adds ellipsis at the beginning. But it seemed even more confusing.