### PR TITLE
Add link to Slate docs to Frontend ReadMe documentation

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -261,3 +261,4 @@ You can read [more about pseudo-localization on Wikipedia](https://en.wikipedia.
 - [reselect](https://github.com/reduxjs/reselect)
 - [ReactTimeAgo](https://github.com/catamphetamine/react-time-ago)
 - [react-tabs](https://github.com/reactjs/react-tabs)
+- [Slate](https://docs.slatejs.org/)


### PR DESCRIPTION
It felt more appropriate to add this to the `Tools documentation` section at the end of the ReadMe, but let me know if you think it needs to also be in the `Tools` table at the top