### PR TITLE
Fix bug 1678462 - Use new enumeration types

### DIFF
--- a/pontoon/actionlog/models.py
+++ b/pontoon/actionlog/models.py
@@ -3,24 +3,23 @@ from django.db import models
 
 
 class ActionLog(models.Model):
-    ACTIONS_TYPES = (
+    class ActionType(models.TextChoices):
         # A translation has been created.
-        ("translation:created", "Translation created"),
+        TRANSLATION_CREATED = "translation:created", "Translation created"
         # A translation has been deleted.
-        ("translation:deleted", "Translation deleted"),
+        TRANSLATION_DELETED = "translation:deleted", "Translation deleted"
         # A translation has been approved.
-        ("translation:approved", "Translation approved"),
+        TRANSLATION_APPROVED = "translation:approved", "Translation approved"
         # A translation has been unapproved.
-        ("translation:unapproved", "Translation unapproved"),
+        TRANSLATION_UNAPPROVED = "translation:unapproved", "Translation unapproved"
         # A translation has been rejected.
-        ("translation:rejected", "Translation rejected"),
+        TRANSLATION_REJECTED = "translation:rejected", "Translation rejected"
         # A translation has been unrejected.
-        ("translation:unrejected", "Translation unrejected"),
+        TRANSLATION_UNREJECTED = "translation:unrejected", "Translation unrejected"
         # A comment has been added.
-        ("comment:added", "Comment added"),
-    )
+        COMMENT_ADDED = "comment:added", "Comment added"
 
-    action_type = models.CharField(max_length=50, choices=ACTIONS_TYPES)
+    action_type = models.CharField(max_length=50, choices=ActionType.choices)
     created_at = models.DateTimeField(auto_now_add=True)
     performed_by = models.ForeignKey(
         "auth.User", models.SET_NULL, related_name="actions", null=True
@@ -36,7 +35,7 @@ class ActionLog(models.Model):
     locale = models.ForeignKey("base.Locale", models.CASCADE, blank=True, null=True,)
 
     def validate_action_type_choice(self):
-        valid_types = [t[0] for t in self.ACTIONS_TYPES]
+        valid_types = self.ActionType.values
         if self.action_type not in valid_types:
             raise ValidationError(
                 'Action type "{}" is not one of the permitted values: {}'.format(
@@ -45,29 +44,27 @@ class ActionLog(models.Model):
             )
 
     def validate_foreign_keys_per_action(self):
-        if self.action_type == "translation:deleted" and (
+        if self.action_type == self.ActionType.TRANSLATION_DELETED and (
             self.translation or not self.entity or not self.locale
         ):
             raise ValidationError(
-                'For action type "translation:deleted", `entity` and `locale` are required'
+                f'For action type "{self.action_type}", `entity` and `locale` are required'
             )
 
-        if self.action_type == "comment:added" and not (
+        if self.action_type == self.ActionType.COMMENT_ADDED and not (
             (self.translation and not self.locale and not self.entity)
             or (not self.translation and self.locale and self.entity)
         ):
             raise ValidationError(
-                'For action type "comment:added", either `translation` or `entity` and `locale` are required'
+                f'For action type "{self.action_type}", either `translation` or `entity` and `locale` are required'
             )
 
         if (
-            self.action_type != "translation:deleted"
-            and self.action_type != "comment:added"
+            self.action_type != self.ActionType.TRANSLATION_DELETED
+            and self.action_type != self.ActionType.COMMENT_ADDED
         ) and (not self.translation or self.entity or self.locale):
             raise ValidationError(
-                'For action type "{}", only `translation` is accepted'.format(
-                    self.action_type
-                )
+                f'For action type "{self.action_type}", only `translation` is accepted'
             )
 
     def save(self, *args, **kwargs):

--- a/pontoon/actionlog/tests/test_models.py
+++ b/pontoon/actionlog/tests/test_models.py
@@ -10,15 +10,19 @@ from pontoon.actionlog.models import ActionLog
 def test_log_action_missing_arg(user_a, entity_a, locale_a):
     # No translation nor (entity and locale) pair.
     with pytest.raises(ValidationError):
-        utils.log_action("translation:created", user_a)
+        utils.log_action(ActionLog.ActionType.TRANSLATION_CREATED, user_a)
 
     # Missing locale.
     with pytest.raises(ValidationError):
-        utils.log_action("translation:deleted", user_a, entity=entity_a)
+        utils.log_action(
+            ActionLog.ActionType.TRANSLATION_DELETED, user_a, entity=entity_a
+        )
 
     # Missing entity.
     with pytest.raises(ValidationError):
-        utils.log_action("translation:deleted", user_a, locale=locale_a)
+        utils.log_action(
+            ActionLog.ActionType.TRANSLATION_DELETED, user_a, locale=locale_a
+        )
 
 
 @pytest.mark.django_db
@@ -35,7 +39,7 @@ def test_log_action_deleted_wrong_keys(user_a, translation_a):
     # We send the wrong parameters for the "deleted" action.
     with pytest.raises(ValidationError):
         utils.log_action(
-            "translation:deleted", user_a, translation=translation_a,
+            ActionLog.ActionType.TRANSLATION_DELETED, user_a, translation=translation_a,
         )
 
 
@@ -44,29 +48,35 @@ def test_log_action_non_deleted_wrong_keys(user_a, entity_a, locale_a):
     # We send the wrong parameters for a non-"deleted" action.
     with pytest.raises(ValidationError):
         utils.log_action(
-            "translation:approved", user_a, entity=entity_a, locale=locale_a,
+            ActionLog.ActionType.TRANSLATION_APPROVED,
+            user_a,
+            entity=entity_a,
+            locale=locale_a,
         )
 
 
 @pytest.mark.django_db
 def test_log_action_valid_with_translation(user_a, translation_a):
     utils.log_action(
-        "translation:created", user_a, translation=translation_a,
+        ActionLog.ActionType.TRANSLATION_CREATED, user_a, translation=translation_a,
     )
 
     log = ActionLog.objects.filter(performed_by=user_a, translation=translation_a)
     assert len(log) == 1
-    assert log[0].action_type == "translation:created"
+    assert log[0].action_type == ActionLog.ActionType.TRANSLATION_CREATED
 
 
 @pytest.mark.django_db
 def test_log_action_valid_with_entity_locale(user_a, entity_a, locale_a):
     utils.log_action(
-        "translation:deleted", user_a, entity=entity_a, locale=locale_a,
+        ActionLog.ActionType.TRANSLATION_DELETED,
+        user_a,
+        entity=entity_a,
+        locale=locale_a,
     )
 
     log = ActionLog.objects.filter(
         performed_by=user_a, entity=entity_a, locale=locale_a,
     )
     assert len(log) == 1
-    assert log[0].action_type == "translation:deleted"
+    assert log[0].action_type == ActionLog.ActionType.TRANSLATION_DELETED

--- a/pontoon/actionlog/utils.py
+++ b/pontoon/actionlog/utils.py
@@ -8,7 +8,7 @@ def log_action(
 
     :arg string action:
         The type of action that was performed.
-        See models.ActionLog.ACTIONS_TYPES for choices.
+        See models.ActionLog.ActionType for choices.
     :arg User user: The User who performed the action.
     :arg Translation translation: The Translation the action was performed on.
     :arg Entity entity:

--- a/pontoon/administration/tests/test_views.py
+++ b/pontoon/administration/tests/test_views.py
@@ -25,7 +25,9 @@ from pontoon.test.factories import (
 
 @pytest.mark.django_db
 def test_manage_project_strings(client):
-    project = ProjectFactory.create(data_source="database", repositories=[])
+    project = ProjectFactory.create(
+        data_source=Project.DataSource.DATABASE, repositories=[]
+    )
     url = reverse("pontoon.admin.project.strings", args=(project.slug,))
 
     # Test with anonymous user.
@@ -65,7 +67,7 @@ def test_manage_project_strings_bad_request(client_superuser):
 @pytest.mark.django_db
 def test_manage_project_strings_new(admin, client_superuser, locale_a):
     project = ProjectFactory.create(
-        data_source="database", repositories=[], locales=[locale_a],
+        data_source=Project.DataSource.DATABASE, repositories=[], locales=[locale_a],
     )
     url = reverse("pontoon.admin.project.strings", args=(project.slug,))
 
@@ -108,7 +110,7 @@ def test_manage_project_strings_new(admin, client_superuser, locale_a):
 @pytest.mark.django_db
 def test_manage_project_strings_existing_resource(client_superuser, locale_a):
     project = ProjectFactory.create(
-        data_source="database", repositories=[], locales=[locale_a],
+        data_source=Project.DataSource.DATABASE, repositories=[], locales=[locale_a],
     )
     ResourceFactory.create(
         path="not_database", project=project,
@@ -143,7 +145,7 @@ def test_manage_project_strings_translated_resource(client_superuser):
         LocaleFactory.create(code="gs", name="Geonosian"),
     ]
     project = ProjectFactory.create(
-        data_source="database", locales=locales, repositories=[]
+        data_source=Project.DataSource.DATABASE, locales=locales, repositories=[]
     )
     locales_count = len(locales)
     _create_or_update_translated_resources(project, locales)
@@ -190,7 +192,9 @@ def test_manage_project_strings_translated_resource(client_superuser):
 def test_manage_project_strings_new_all_empty(client_superuser):
     """Test that sending empty data doesn't create empty strings in the database.
     """
-    project = ProjectFactory.create(data_source="database", repositories=[])
+    project = ProjectFactory.create(
+        data_source=Project.DataSource.DATABASE, repositories=[]
+    )
     url = reverse("pontoon.admin.project.strings", args=(project.slug,))
 
     # Test sending an empty batch of strings.
@@ -205,7 +209,9 @@ def test_manage_project_strings_new_all_empty(client_superuser):
 
 @pytest.mark.django_db
 def test_manage_project_strings_list(client_superuser):
-    project = ProjectFactory.create(data_source="database", repositories=[])
+    project = ProjectFactory.create(
+        data_source=Project.DataSource.DATABASE, repositories=[]
+    )
     resource = ResourceFactory.create(project=project)
     nb_entities = 2
     entities = EntityFactory.create_batch(nb_entities, resource=resource)
@@ -278,7 +284,9 @@ def test_manage_project_strings_download_csv(client_superuser):
     locale_kl = LocaleFactory.create(code="kl", name="Klingon")
     locale_gs = LocaleFactory.create(code="gs", name="Geonosian")
     project = ProjectFactory.create(
-        data_source="database", locales=[locale_kl, locale_gs], repositories=[]
+        data_source=Project.DataSource.DATABASE,
+        locales=[locale_kl, locale_gs],
+        repositories=[],
     )
 
     url = reverse("pontoon.admin.project.strings", args=(project.slug,))
@@ -367,7 +375,7 @@ def test_project_add_locale(client_superuser):
     locale_kl = LocaleFactory.create(code="kl", name="Klingon")
     locale_gs = LocaleFactory.create(code="gs", name="Geonosian")
     project = ProjectFactory.create(
-        data_source="database", locales=[locale_kl], repositories=[],
+        data_source=Project.DataSource.DATABASE, locales=[locale_kl], repositories=[],
     )
     _create_or_update_translated_resources(project, [locale_kl])
 

--- a/pontoon/administration/views.py
+++ b/pontoon/administration/views.py
@@ -181,7 +181,7 @@ def manage_project(request, slug=None, template="admin_project.html"):
                     tag_formset.save()
 
                 # If the data source is database and there are new strings, save them.
-                if project.data_source == "database":
+                if project.data_source == Project.DataSource.DATABASE:
                     _save_new_strings(project, request.POST.get("new_strings", ""))
                     _create_or_update_translated_resources(project, locales)
 
@@ -406,7 +406,7 @@ def manage_project_strings(request, slug=None):
     except Project.DoesNotExist:
         raise Http404
 
-    if project.data_source != "database":
+    if project.data_source != Project.DataSource.DATABASE:
         return HttpResponseForbidden(
             "Project %s's strings come from a repository, managing strings is forbidden."
             % project.name

--- a/pontoon/api/tests/test_schema.py
+++ b/pontoon/api/tests/test_schema.py
@@ -35,7 +35,7 @@ def test_projects(client):
 
     response = client.get("/graphql", body, HTTP_ACCEPT="application/json")
 
-    ProjectFactory.create(visibility="private")
+    ProjectFactory.create(visibility=Project.Visibility.PRIVATE)
     assert response.status_code == 200
     assert response.json() == {
         "data": {
@@ -50,7 +50,7 @@ def test_projects(client):
 
 @pytest.fixture()
 def regular_projects(locale_a):
-    return ProjectFactory.create_batch(3, visibility="public") + list(
+    return ProjectFactory.create_batch(3, visibility=Project.Visibility.PUBLIC) + list(
         Project.objects.filter(slug__in=["terminology"])
     )
 
@@ -69,7 +69,7 @@ def system_projects(locale_a):
 
 @pytest.fixture()
 def private_projects():
-    return ProjectFactory.create_batch(3, visibility="private")
+    return ProjectFactory.create_batch(3, visibility=Project.Visibility.PRIVATE)
 
 
 @pytest.mark.django_db

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -951,7 +951,7 @@ class Locale(AggregatedStats):
         TranslatedResource.objects.filter(
             resource__project__disabled=False,
             resource__project__system_project=False,
-            resource__project__visibility="public",
+            resource__project__visibility=Project.Visibility.PUBLIC,
             locale=self,
         ).aggregate_stats(self)
 
@@ -1151,7 +1151,7 @@ class ProjectQuerySet(models.QuerySet):
         if user.is_superuser:
             return self
 
-        return self.filter(visibility="public")
+        return self.filter(visibility=Project.Visibility.PUBLIC)
 
     def available(self):
         """
@@ -1271,12 +1271,12 @@ class Project(AggregatedStats):
     """,
     )
 
-    VISIBILITY_TYPES = (
-        ("private", "Private"),
-        ("public", "Public"),
-    )
+    class Visibility(models.TextChoices):
+        PRIVATE = "private", "Private"
+        PUBLIC = "public", "Public"
+
     visibility = models.CharField(
-        max_length=20, default=VISIBILITY_TYPES[0][0], choices=VISIBILITY_TYPES,
+        max_length=20, default=Visibility.PRIVATE, choices=Visibility.choices,
     )
 
     # Website for in place localization
@@ -1622,7 +1622,7 @@ class ProjectLocaleQuerySet(models.QuerySet):
         if user.is_superuser:
             return self
 
-        return self.filter(project__visibility="public",)
+        return self.filter(project__visibility=Project.Visibility.PUBLIC,)
 
     def visible(self):
         """
@@ -3045,7 +3045,9 @@ class Translation(DirtyFieldsMixin, models.Model):
         CAIGHDEAN = "caighdean", "Caighdean"
 
     machinery_sources = ArrayField(
-        models.CharField(max_length=30, choices=Source.choices), default=list, blank=True,
+        models.CharField(max_length=30, choices=Source.choices),
+        default=list,
+        blank=True,
     )
 
     objects = TranslationQuerySet.as_manager()
@@ -3504,7 +3506,7 @@ class TranslatedResourceQuerySet(models.QuerySet):
         if project.slug == "all-projects":
             translated_resources = translated_resources.filter(
                 resource__project__system_project=False,
-                resource__project__visibility="public",
+                resource__project__visibility=Project.Visibility.PUBLIC,
             )
         else:
             translated_resources = translated_resources.filter(

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -41,6 +41,7 @@ from django.utils.functional import cached_property
 from guardian.shortcuts import get_objects_for_user
 from jsonfield import JSONField
 
+from pontoon.actionlog.models import ActionLog
 from pontoon.actionlog.utils import log_action
 from pontoon.base import utils
 from pontoon.base.templatetags.helpers import as_simple_translation
@@ -3166,7 +3167,7 @@ class Translation(DirtyFieldsMixin, models.Model):
             # Log that all those translations are rejected.
             for t in approved_translations:
                 log_action(
-                    "translation:rejected",
+                    ActionLog.ActionType.TRANSLATION_REJECTED,
                     self.approved_user or self.user,
                     translation=t,
                 )

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -1208,13 +1208,12 @@ class ProjectQuerySet(models.QuerySet):
         return AggregatedStats.get_top_instances(self)
 
 
-PRIORITY_CHOICES = (
-    (1, "Lowest"),
-    (2, "Low"),
-    (3, "Normal"),
-    (4, "High"),
-    (5, "Highest"),
-)
+class Priority(models.IntegerChoices):
+    LOWEST = 1, "Lowest"
+    LOW = 2, "Low"
+    NORMAL = 3, "Normal"
+    HIGH = 4, "High"
+    HIGHEST = 5, "Highest"
 
 
 class Project(AggregatedStats):
@@ -1306,7 +1305,7 @@ class Project(AggregatedStats):
     # Project info
     info = models.TextField("Project info", blank=True)
     deadline = models.DateField(blank=True, null=True)
-    priority = models.IntegerField(choices=PRIORITY_CHOICES, default=1)
+    priority = models.IntegerField(choices=Priority.choices, default=Priority.LOWEST)
     contact = models.ForeignKey(
         User,
         models.SET_NULL,

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -3037,7 +3037,7 @@ class Translation(DirtyFieldsMixin, models.Model):
     )
     unrejected_date = models.DateTimeField(null=True, blank=True)
 
-    class Source(models.TextChoices):
+    class MachinerySource(models.TextChoices):
         TRANSLATION_MEMORY = "translation-memory", "Translation Memory"
         GOOGLE_TRANSLATE = "google-translate", "Google Translate"
         MICROSOFT_TRANSLATOR = "microsoft-translator", "Microsoft Translator"
@@ -3047,7 +3047,7 @@ class Translation(DirtyFieldsMixin, models.Model):
         CAIGHDEAN = "caighdean", "Caighdean"
 
     machinery_sources = ArrayField(
-        models.CharField(max_length=30, choices=Source.choices),
+        models.CharField(max_length=30, choices=MachinerySource.choices),
         default=list,
         blank=True,
     )

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -744,14 +744,14 @@ class Locale(AggregatedStats):
     )
 
     # Writing direction
-    DIRECTION = (
-        ("ltr", "left-to-right"),
-        ("rtl", "right-to-left"),
-    )
+    class Direction(models.TextChoices):
+        LEFT_TO_RIGHT = "ltr", "left-to-right"
+        RIGHT_TO_LEFT = "rtl", "right-to-left"
+
     direction = models.CharField(
         max_length=3,
-        default="ltr",
-        choices=DIRECTION,
+        default=Direction.LEFT_TO_RIGHT,
+        choices=Direction.choices,
         help_text="""
         Writing direction of the script. Set to "right-to-left" if "rtl" value
         for the locale script is set to "YES" in

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -1171,7 +1171,7 @@ class ProjectQuerySet(models.QuerySet):
         """
         Projects that can be force-synced are not disabled and use repository as their data source type.
         """
-        return self.filter(disabled=False, data_source="repository")
+        return self.filter(disabled=False, data_source=Project.DataSource.REPOSITORY)
 
     def syncable(self):
         """
@@ -1221,10 +1221,12 @@ class Project(AggregatedStats):
     slug = models.SlugField(unique=True)
     locales = models.ManyToManyField(Locale, through="ProjectLocale")
 
+    class DataSource(models.TextChoices):
+        REPOSITORY = "repository", "Repository"
+        DATABASE = "database", "Database"
+
     data_source = models.CharField(
-        max_length=255,
-        default="repository",
-        choices=(("repository", "Repository"), ("database", "Database"),),
+        max_length=255, default=DataSource.REPOSITORY, choices=DataSource.choices,
     )
     can_be_requested = models.BooleanField(
         default=True,

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -388,14 +388,13 @@ class PermissionChangelog(models.Model):
     """
 
     # Managers can perform various action on a user.
-    ACTIONS_TYPES = (
+    class ActionType(models.TextChoices):
         # User has been added to a group (e.g. translators, managers).
-        ("added", "Added"),
+        ADDED = "added", "Added"
         # User has been removed from a group (e.g. translators, managers).
-        ("removed", "Removed"),
-    )
+        REMOVED = "removed", "Removed"
 
-    action_type = models.CharField(max_length=20, choices=ACTIONS_TYPES)
+    action_type = models.CharField(max_length=20, choices=ActionType.choices)
     performed_by = models.ForeignKey(
         User, models.SET_NULL, null=True, related_name="changed_permissions_log"
     )

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -2035,46 +2035,46 @@ class Resource(models.Model):
     date_obsoleted = models.DateTimeField(null=True, blank=True)
 
     # Format
-    FORMAT_CHOICES = (
-        ("dtd", "dtd"),
-        ("ftl", "ftl"),
-        ("inc", "inc"),
-        ("ini", "ini"),
-        ("json", "json"),
-        ("lang", "lang"),
-        ("po", "po"),
-        ("properties", "properties"),
-        ("xlf", "xliff"),
-        ("xliff", "xliff"),
-        ("xml", "xml"),
-    )
+    class Format(models.TextChoices):
+        DTD = "dtd", "dtd"
+        FTL = "ftl", "ftl"
+        INC = "inc", "inc"
+        INI = "ini", "ini"
+        JSON = "json", "json"
+        LANG = "lang", "lang"
+        PO = "po", "po"
+        PROPERTIES = "properties", "properties"
+        XLF = "xlf", "xliff"
+        XLIFF = "xliff", "xliff"
+        XML = "xml", "xml"
+
     format = models.CharField(
-        "Format", max_length=20, blank=True, choices=FORMAT_CHOICES
+        "Format", max_length=20, blank=True, choices=Format.choices
     )
 
     deadline = models.DateField(blank=True, null=True)
 
     SOURCE_EXTENSIONS = ["pot"]  # Extensions of source-only formats.
-    ALLOWED_EXTENSIONS = [f[0] for f in FORMAT_CHOICES] + SOURCE_EXTENSIONS
+    ALLOWED_EXTENSIONS = Format.values + SOURCE_EXTENSIONS
 
-    ASYMMETRIC_FORMATS = (
-        "dtd",
-        "ftl",
-        "inc",
-        "ini",
-        "json",
-        "properties",
-        "xml",
-    )
+    ASYMMETRIC_FORMATS = {
+        Format.DTD,
+        Format.FTL,
+        Format.INC,
+        Format.INI,
+        Format.JSON,
+        Format.PROPERTIES,
+        Format.XML,
+    }
 
     # Formats that allow empty translations
-    EMPTY_TRANSLATION_FORMATS = (
-        "dtd",
-        "inc",
-        "ini",
-        "properties",
-        "xml",
-    )
+    EMPTY_TRANSLATION_FORMATS = {
+        Format.DTD,
+        Format.INC,
+        Format.INI,
+        Format.PROPERTIES,
+        Format.XML,
+    }
 
     objects = ResourceQuerySet.as_manager()
 
@@ -3127,7 +3127,7 @@ class Translation(DirtyFieldsMixin, models.Model):
     def tm_source(self):
         source = self.entity.string
 
-        if self.entity.resource.format == "ftl":
+        if self.entity.resource.format == Resource.Format.FTL:
             return as_simple_translation(source)
 
         return source
@@ -3136,7 +3136,7 @@ class Translation(DirtyFieldsMixin, models.Model):
     def tm_target(self):
         target = self.string
 
-        if self.entity.resource.format == "ftl":
+        if self.entity.resource.format == Resource.Format.FTL:
             return as_simple_translation(target)
 
         return target

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -3035,18 +3035,17 @@ class Translation(DirtyFieldsMixin, models.Model):
     )
     unrejected_date = models.DateTimeField(null=True, blank=True)
 
-    SOURCE_TYPES = (
-        ("translation-memory", "Translation Memory"),
-        ("google-translate", "Google Translate"),
-        ("microsoft-translator", "Microsoft Translator"),
-        ("systran-translate", "Systran Translate"),
-        ("microsoft-terminology", "Microsoft"),
-        ("transvision", "Mozilla"),
-        ("caighdean", "Caighdean"),
-    )
+    class Source(models.TextChoices):
+        TRANSLATION_MEMORY = "translation-memory", "Translation Memory"
+        GOOGLE_TRANSLATE = "google-translate", "Google Translate"
+        MICROSOFT_TRANSLATOR = "microsoft-translator", "Microsoft Translator"
+        SYSTRAN_TRANSLATE = "systran-translate", "Systran Translate"
+        MICROSOFT_TERMINOLOGY = "microsoft-terminology", "Microsoft"
+        TRANSVISION = "transvision", "Mozilla"
+        CAIGHDEAN = "caighdean", "Caighdean"
 
     machinery_sources = ArrayField(
-        models.CharField(max_length=30, choices=SOURCE_TYPES), default=list, blank=True,
+        models.CharField(max_length=30, choices=Source.choices), default=list, blank=True,
     )
 
     objects = TranslationQuerySet.as_manager()
@@ -3119,9 +3118,7 @@ class Translation(DirtyFieldsMixin, models.Model):
         """
         Returns the corresponding comma-separated machinery_sources values
         """
-        choices = dict(self.SOURCE_TYPES)
-        result = [choices[key] for key in self.machinery_sources]
-
+        result = [self.Source(source).label for source in self.machinery_sources]
         return ", ".join(result)
 
     @property

--- a/pontoon/base/tests/__init__.py
+++ b/pontoon/base/tests/__init__.py
@@ -115,7 +115,7 @@ class RepositoryFactory(DjangoModelFactory):
 class ResourceFactory(DjangoModelFactory):
     project = SubFactory(ProjectFactory)
     path = Sequence(lambda n: "/fake/path{0}.po".format(n))
-    format = "po"
+    format = Resource.Format.PO
     total_strings = 1
 
     class Meta:

--- a/pontoon/base/tests/__init__.py
+++ b/pontoon/base/tests/__init__.py
@@ -105,7 +105,7 @@ class ProjectFactory(DjangoModelFactory):
 
 class RepositoryFactory(DjangoModelFactory):
     project = SubFactory(ProjectFactory)
-    type = "git"
+    type = Repository.Type.GIT
     url = Sequence(lambda n: "https://example.com/url_{0}.git".format(n))
 
     class Meta:

--- a/pontoon/base/tests/forms/test_permission_log.py
+++ b/pontoon/base/tests/forms/test_permission_log.py
@@ -43,11 +43,19 @@ def test_locale_perms_form_log(
     changelog_entry0, changelog_entry1 = PermissionChangelog.objects.all()
 
     assert_permissionchangelog(
-        changelog_entry0, "added", user_a, user_c, locale_a.translators_group,
+        changelog_entry0,
+        PermissionChangelog.ActionType.ADDED,
+        user_a,
+        user_c,
+        locale_a.translators_group,
     )
 
     assert_permissionchangelog(
-        changelog_entry1, "added", user_a, user_b, locale_a.managers_group,
+        changelog_entry1,
+        PermissionChangelog.ActionType.ADDED,
+        user_a,
+        user_b,
+        locale_a.managers_group,
     )
 
     # Remove items from groups
@@ -61,11 +69,19 @@ def test_locale_perms_form_log(
     changelog_entry3, changelog_entry2 = PermissionChangelog.objects.order_by("-pk")[:2]
 
     assert_permissionchangelog(
-        changelog_entry2, "removed", user_a, user_c, locale_a.translators_group,
+        changelog_entry2,
+        PermissionChangelog.ActionType.REMOVED,
+        user_a,
+        user_c,
+        locale_a.translators_group,
     )
 
     assert_permissionchangelog(
-        changelog_entry3, "removed", user_a, user_b, locale_a.managers_group,
+        changelog_entry3,
+        PermissionChangelog.ActionType.REMOVED,
+        user_a,
+        user_b,
+        locale_a.managers_group,
     )
 
 
@@ -84,7 +100,11 @@ def test_project_locale_perms_form_log(
     (changelog_entry0,) = PermissionChangelog.objects.all()
 
     assert_permissionchangelog(
-        changelog_entry0, "added", user_a, user_c, locale_a.translators_group,
+        changelog_entry0,
+        PermissionChangelog.ActionType.ADDED,
+        user_a,
+        user_c,
+        locale_a.translators_group,
     )
 
     # Remove items from groups
@@ -98,5 +118,9 @@ def test_project_locale_perms_form_log(
     (changelog_entry1,) = PermissionChangelog.objects.order_by("-pk")[:1]
 
     assert_permissionchangelog(
-        changelog_entry1, "removed", user_a, user_c, locale_a.translators_group,
+        changelog_entry1,
+        PermissionChangelog.ActionType.REMOVED,
+        user_a,
+        user_c,
+        locale_a.translators_group,
     )

--- a/pontoon/base/tests/managers/test_project.py
+++ b/pontoon/base/tests/managers/test_project.py
@@ -5,7 +5,7 @@ from pontoon.base.models import Project, ProjectLocale
 
 @pytest.fixture
 def public_project():
-    yield ProjectFactory.create(visibility="public")
+    yield ProjectFactory.create(visibility=Project.Visibility.PUBLIC)
 
 
 @pytest.fixture
@@ -15,7 +15,7 @@ def private_project():
 
 @pytest.fixture
 def public_project_locale():
-    yield ProjectLocaleFactory.create(project__visibility="public")
+    yield ProjectLocaleFactory.create(project__visibility=Project.Visibility.PUBLIC)
 
 
 @pytest.fixture

--- a/pontoon/base/tests/models/conftest.py
+++ b/pontoon/base/tests/models/conftest.py
@@ -10,12 +10,6 @@ from pontoon.test.factories import (
 
 
 @pytest.fixture
-def repo_file(project_a):
-    """Repo (file) 0"""
-    return RepositoryFactory.create(type="file", project=project_a, url="repo_file0",)
-
-
-@pytest.fixture
 def repo_git(project_a):
     """Repo (git) 0"""
     return RepositoryFactory.create(type="git", project=project_a, url="repo_git0",)

--- a/pontoon/base/tests/models/test_project.py
+++ b/pontoon/base/tests/models/test_project.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 from django.contrib.auth.models import AnonymousUser
 
-from pontoon.base.models import ProjectLocale, Project
+from pontoon.base.models import ProjectLocale, Project, Repository
 from pontoon.test.factories import (
     ChangedEntityLocaleFactory,
     EntityFactory,
@@ -26,22 +26,12 @@ def test_project_commit_no_repos(project_a):
 
 
 @pytest.mark.django_db
-def test_project_commit_false(project_a, repo_file):
-    """
-    can_commit should be False if there are no repo xthat can be
-    committed to.
-    """
-    assert project_a.repositories.first().type == "file"
-    assert not project_a.can_commit
-
-
-@pytest.mark.django_db
 def test_project_commit_true(project_a, repo_git):
     """
     can_commit should be True if there is a repo that can be
     committed to.
     """
-    assert project_a.repositories.first().type == "git"
+    assert project_a.repositories.first().type == Repository.Type.GIT
     assert project_a.can_commit
 
 
@@ -57,8 +47,8 @@ def test_project_type_multi_repos(project_a, repo_git, repo_hg):
     If a project has repos, return the type of the repo created
     first.
     """
-    assert project_a.repositories.first().type == "git"
-    assert project_a.repository_type == "git"
+    assert project_a.repositories.first().type == Repository.Type.GIT
+    assert project_a.repository_type == Repository.Type.GIT
 
 
 @pytest.mark.django_db

--- a/pontoon/base/tests/models/test_project.py
+++ b/pontoon/base/tests/models/test_project.py
@@ -137,7 +137,7 @@ def public_project():
 
 @pytest.fixture
 def private_project():
-    yield ProjectFactory.create(visibility="private")
+    yield ProjectFactory.create(visibility=Project.Visibility.PRIVATE)
 
 
 @pytest.mark.parametrize(

--- a/pontoon/base/tests/models/test_repository.py
+++ b/pontoon/base/tests/models/test_repository.py
@@ -2,24 +2,8 @@ import os
 from unittest.mock import call, patch, Mock
 
 import pytest
-from urllib.parse import urlparse
 
 from pontoon.test.factories import ProjectLocaleFactory
-
-
-@pytest.mark.django_db
-def test_repo_checkout_path(repo_file, settings):
-    """checkout_path should be determined by the repo URL."""
-    # im a bit unclear about the mix of os.path and urlparse here
-    # how would this work on windows <> linux ?
-    assert repo_file.checkout_path == os.path.join(
-        *[repo_file.project.checkout_path] + urlparse(repo_file.url).path.split("/")
-    )
-    settings.MEDIA_ROOT = "/media/root"
-    assert repo_file.checkout_path == os.path.join(
-        *[repo_file.project.checkout_path] + urlparse(repo_file.url).path.split("/")
-    )
-    assert repo_file.project.checkout_path.startswith("/media/root")
 
 
 @pytest.mark.django_db
@@ -123,8 +107,10 @@ def test_repo_url_for_path_no_match(repo_git, locale_a, settings):
 
 @pytest.mark.django_db
 def test_repo_pull(repo_git):
-    with patch("pontoon.base.models.update_from_vcs") as m_update_from_vcs, patch(
-        "pontoon.base.models.get_revision"
+    with patch(
+        "pontoon.sync.vcs.repositories.update_from_vcs"
+    ) as m_update_from_vcs, patch(
+        "pontoon.sync.vcs.repositories.get_revision"
     ) as m_get_revision:
         repo_git.url = "https://example.com"
         m_get_revision.return_value = "asdf"
@@ -148,8 +134,8 @@ def test_repo_pull_multi_locale(project_locale_a, repo_git, locale_b):
         project=repo_git.project, locale=locale_b,
     )
 
-    with patch("pontoon.base.models.update_from_vcs") as m_update_from_vcs:
-        with patch("pontoon.base.models.get_revision") as m_get_revision:
+    with patch("pontoon.sync.vcs.repositories.update_from_vcs") as m_update_from_vcs:
+        with patch("pontoon.sync.vcs.repositories.get_revision") as m_get_revision:
             repo_git.url = "https://example.com/{locale_code}/"
             repo_git.locale_url = lambda locale: "https://example.com/%s" % locale.code
             repo_git.locale_checkout_path = lambda locale: "/media/%s" % locale.code
@@ -181,7 +167,7 @@ def test_repo_pull_multi_locale(project_locale_a, repo_git, locale_b):
 def test_repo_commit(repo_git):
     repo_git.url = "https://example.com"
 
-    with patch("pontoon.base.models.commit_to_vcs") as m:
+    with patch("pontoon.sync.vcs.repositories.commit_to_vcs") as m:
         repo_git.commit("message", "author", "path")
         assert m.call_args[0] == (
             "git",
@@ -203,7 +189,7 @@ def test_repo_commit_multi_locale(repo_git):
 
     repo_git.url_for_path = Mock(return_value="https://example.com/for_path")
 
-    with patch("pontoon.base.models.commit_to_vcs") as m:
+    with patch("pontoon.sync.vcs.repositories.commit_to_vcs") as m:
         repo_git.commit("message", "author", "path")
         assert m.call_args[0] == (
             "git",

--- a/pontoon/base/tests/models/test_repository.py
+++ b/pontoon/base/tests/models/test_repository.py
@@ -1,9 +1,25 @@
 import os
 from unittest.mock import call, patch, Mock
+from urllib.parse import urlparse
 
 import pytest
 
 from pontoon.test.factories import ProjectLocaleFactory
+
+
+@pytest.mark.django_db
+def test_repo_checkout_path(repo_git, settings):
+    """checkout_path should be determined by the repo URL."""
+    # im a bit unclear about the mix of os.path and urlparse here
+    # how would this work on windows <> linux ?
+    assert repo_git.checkout_path == os.path.join(
+        *[repo_git.project.checkout_path] + urlparse(repo_git.url).path.split("/")
+    )
+    settings.MEDIA_ROOT = "/media/root"
+    assert repo_git.checkout_path == os.path.join(
+        *[repo_git.project.checkout_path] + urlparse(repo_git.url).path.split("/")
+    )
+    assert repo_git.project.checkout_path.startswith("/media/root")
 
 
 @pytest.mark.django_db

--- a/pontoon/base/tests/models/test_stats.py
+++ b/pontoon/base/tests/models/test_stats.py
@@ -6,19 +6,24 @@ from pontoon.base.models import TranslatedResource
 from pontoon.checks.models import (
     Error,
     Warning,
+    FailedCheck,
 )
 
 
 @pytest.fixture
 def translation_with_error(translation_a):
-    Error.objects.create(translation=translation_a, library="p", message="error")
+    Error.objects.create(
+        translation=translation_a, library=FailedCheck.Library.PONTOON, message="error"
+    )
     return translation_a
 
 
 @pytest.fixture
 def translation_with_warning(translation_a):
     Warning.objects.create(
-        translation=translation_a, library="p", message="warning",
+        translation=translation_a,
+        library=FailedCheck.Library.PONTOON,
+        message="warning",
     )
     return translation_a
 

--- a/pontoon/base/tests/test_admin.py
+++ b/pontoon/base/tests/test_admin.py
@@ -99,7 +99,11 @@ def test_user_admin_form_log_add_groups(
     (changelog_entry0,) = PermissionChangelog.objects.all()
 
     assert_permissionchangelog(
-        changelog_entry0, "added", user_a, user_b, locale_c.managers_group,
+        changelog_entry0,
+        PermissionChangelog.ActionType.ADDED,
+        user_a,
+        user_b,
+        locale_c.managers_group,
     )
 
 
@@ -122,5 +126,9 @@ def test_user_admin_form_log_removed_groups(
     (changelog_entry0,) = PermissionChangelog.objects.all()
 
     assert_permissionchangelog(
-        changelog_entry0, "removed", user_a, user_b, locale_c.managers_group,
+        changelog_entry0,
+        PermissionChangelog.ActionType.REMOVED,
+        user_a,
+        user_b,
+        locale_c.managers_group,
     )

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -29,6 +29,7 @@ from django.views.generic.edit import FormView
 
 from notifications.signals import notify
 
+from pontoon.actionlog.models import ActionLog
 from pontoon.actionlog.utils import log_action
 from pontoon.base import forms
 from pontoon.base import utils
@@ -625,12 +626,14 @@ def add_comment(request):
     # Translation comment
     if translation:
         c = Comment(author=user, translation=translation, content=comment)
-        log_action("comment:added", user, translation=translation)
+        log_action(ActionLog.ActionType.COMMENT_ADDED, user, translation=translation)
 
     # Team comment
     else:
         c = Comment(author=user, entity=entity, locale=locale, content=comment)
-        log_action("comment:added", user, entity=entity, locale=locale)
+        log_action(
+            ActionLog.ActionType.COMMENT_ADDED, user, entity=entity, locale=locale
+        )
 
     c.save()
 

--- a/pontoon/batch/actions.py
+++ b/pontoon/batch/actions.py
@@ -66,7 +66,11 @@ def approve_translations(form, user, translations, locale):
 
     # Log approving actions
     actions_to_log = [
-        ActionLog(action_type="translation:approved", performed_by=user, translation=t,)
+        ActionLog(
+            action_type=ActionLog.ActionType.TRANSLATION_APPROVED,
+            performed_by=user,
+            translation=t,
+        )
         for t in translations
     ]
     ActionLog.objects.bulk_create(actions_to_log)
@@ -115,7 +119,11 @@ def reject_translations(form, user, translations, locale):
 
     # Log rejecting actions
     actions_to_log = [
-        ActionLog(action_type="translation:rejected", performed_by=user, translation=t,)
+        ActionLog(
+            action_type=ActionLog.ActionType.TRANSLATION_REJECTED,
+            performed_by=user,
+            translation=t,
+        )
         for t in translations
     ]
     ActionLog.objects.bulk_create(actions_to_log)
@@ -167,7 +175,11 @@ def replace_translations(form, user, translations, locale):
 
     # Log rejecting actions
     actions_to_log = [
-        ActionLog(action_type="translation:rejected", performed_by=user, translation=t,)
+        ActionLog(
+            action_type=ActionLog.ActionType.TRANSLATION_REJECTED,
+            performed_by=user,
+            translation=t,
+        )
         for t in old_translations
     ]
     ActionLog.objects.bulk_create(actions_to_log)
@@ -189,7 +201,11 @@ def replace_translations(form, user, translations, locale):
 
     # Log creating actions
     actions_to_log = [
-        ActionLog(action_type="translation:created", performed_by=user, translation=t,)
+        ActionLog(
+            action_type=ActionLog.ActionType.TRANSLATION_CREATED,
+            performed_by=user,
+            translation=t,
+        )
         for t in changed_translations
     ]
     ActionLog.objects.bulk_create(actions_to_log)

--- a/pontoon/batch/utils.py
+++ b/pontoon/batch/utils.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 
 from django.utils import timezone
 
-from pontoon.base.models import Entity
+from pontoon.base.models import Entity, Resource
 from pontoon.checks import DB_FORMATS
 
 from pontoon.checks.libraries import run_checks
@@ -96,7 +96,7 @@ def find_and_replace(translations, find, replace, user):
         # Cache the old value to identify changed translations
         new_translation = deepcopy(translation)
 
-        if translation.entity.resource.format == "ftl":
+        if translation.entity.resource.format == Resource.Format.FTL:
             new_translation.string = ftl_find_and_replace(
                 translation.string, find, replace
             )

--- a/pontoon/checks/models.py
+++ b/pontoon/checks/models.py
@@ -10,11 +10,11 @@ class FailedCheck(models.Model):
     Severity of failed checks are expressed by subclasses of this model.
     """
 
-    library = models.CharField(
-        max_length=20,
-        choices=(("p", "pontoon"), ("cl", "compare-locales"),),
-        db_index=True,
-    )
+    class Library(models.TextChoices):
+        PONTOON = "p", "pontoon"
+        COMPARE_LOCALES = "cl", "compare-locales"
+
+    library = models.CharField(max_length=20, choices=Library.choices, db_index=True,)
     message = models.TextField()
 
     class Meta:

--- a/pontoon/checks/tests/test_libraries.py
+++ b/pontoon/checks/tests/test_libraries.py
@@ -3,6 +3,7 @@ from unittest.mock import patch, MagicMock, ANY
 
 import pytest
 
+from pontoon.base.models import Resource
 from pontoon.checks.libraries import run_checks
 
 
@@ -19,7 +20,7 @@ def entity_properties_mock():
     """
     mock = MagicMock()
     mock.resource.path = "file.properties"
-    mock.resource.format = "properties"
+    mock.resource.format = Resource.Format.PROPERTIES
     mock.resource.all.return_value = []
     mock.string = "Example string"
     mock.comment = ""
@@ -34,7 +35,7 @@ def entity_dtd_mock():
     """
     mock = MagicMock()
     mock.resource.path = "file.dtd"
-    mock.resource.format = "dtd"
+    mock.resource.format = Resource.Format.DTD
     mock.resource.all.return_value = []
     mock.string = "Example string"
     mock.key = "entity_dtd"
@@ -50,7 +51,7 @@ def entity_properties_plurals_mock():
     """
     mock = MagicMock()
     mock.resource.path = "file.properties"
-    mock.resource.format = "properties"
+    mock.resource.format = Resource.Format.PROPERTIES
     mock.resource.all.return_value = []
     mock.string = "Example string"
     mock.comment = "Localization_and_Plurals"
@@ -80,7 +81,7 @@ def entity_ftl_mock():
     """
     mock = MagicMock()
     mock.resource.path = "file.ftl"
-    mock.resource.format = "ftl"
+    mock.resource.format = Resource.Format.FTL
     mock.resource.all.return_value = []
     mock.string = dedent(
         """

--- a/pontoon/checks/tests/test_models.py
+++ b/pontoon/checks/tests/test_models.py
@@ -9,6 +9,7 @@ from pontoon.checks.utils import (
 from pontoon.checks.models import (
     Error,
     Warning,
+    FailedCheck,
 )
 
 
@@ -83,14 +84,14 @@ def test_save_failed_checks(translation_a):
 
     error1, error2 = Error.objects.order_by("message")
 
-    assert error1.library == "cl"
+    assert error1.library == FailedCheck.Library.COMPARE_LOCALES
     assert error1.message == "compare-locales error 1"
-    assert error2.library == "cl"
+    assert error2.library == FailedCheck.Library.COMPARE_LOCALES
     assert error2.message == "compare-locales error 2"
 
     (cl_warning,) = Warning.objects.order_by("library", "message")
 
-    assert cl_warning.library == "cl"
+    assert cl_warning.library == FailedCheck.Library.COMPARE_LOCALES
     assert cl_warning.message == "compare-locales warning 1"
 
 
@@ -130,17 +131,17 @@ def test_bulk_run_checks(
     p_error, cl_error = errors
 
     assert cl_warning.pk is not None
-    assert cl_warning.library == "cl"
+    assert cl_warning.library == FailedCheck.Library.COMPARE_LOCALES
     assert cl_warning.message == "unknown escape sequence, \\q"
     assert cl_warning.translation == translation_compare_locales_warning
 
     assert cl_error.pk is not None
-    assert cl_error.library == "cl"
+    assert cl_error.library == FailedCheck.Library.COMPARE_LOCALES
     assert cl_error.message == "Found single %"
     assert cl_error.translation == translation_compare_locales_error
 
     assert p_error.pk is not None
-    assert p_error.library == "p"
+    assert p_error.library == FailedCheck.Library.PONTOON
     assert p_error.message == "Empty translations are not allowed"
     assert p_error.translation == translation_pontoon_error
 
@@ -168,14 +169,14 @@ def test_get_failed_checks_db_objects(translation_a):
     (cl_warning,) = warnings
     cl_error, p_error = sorted(errors, key=lambda e: e.library)
 
-    assert cl_warning.library == "cl"
+    assert cl_warning.library == FailedCheck.Library.COMPARE_LOCALES
     assert cl_warning.message == "compare-locales warning 1"
     assert cl_warning.translation == translation_a
 
-    assert cl_error.library == "cl"
+    assert cl_error.library == FailedCheck.Library.COMPARE_LOCALES
     assert cl_error.message == "compare-locales error 1"
     assert cl_error.translation == translation_a
 
-    assert p_error.library == "p"
+    assert p_error.library == FailedCheck.Library.PONTOON
     assert p_error.message == "pontoon error 1"
     assert p_error.translation == translation_a

--- a/pontoon/checks/tests/test_models.py
+++ b/pontoon/checks/tests/test_models.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pontoon.base.models import Translation
+from pontoon.base.models import Translation, Resource
 from pontoon.checks.utils import (
     save_failed_checks,
     get_failed_checks_db_objects,
@@ -16,7 +16,7 @@ from pontoon.checks.models import (
 def translation_properties(translation_a):
     resource = translation_a.entity.resource
     resource.path = "test.properties"
-    resource.format = "properties"
+    resource.format = Resource.Format.PROPERTIES
     resource.save()
 
     yield translation_a
@@ -58,7 +58,7 @@ def translation_pontoon_error(translation_a):
 
     resource = translation.entity.resource
     resource.path = "test.po"
-    resource.format = "po"
+    resource.format = Resource.Format.PO
     resource.save()
 
     translation.string = ""

--- a/pontoon/projects/tests/test_views.py
+++ b/pontoon/projects/tests/test_views.py
@@ -4,6 +4,7 @@ import pytest
 from django.http import HttpResponse
 from django.shortcuts import render
 
+from pontoon.base.models import Project
 from pontoon.base.tests import (
     ProjectFactory,
     ResourceFactory,
@@ -27,7 +28,7 @@ def test_project_view(client):
     """
     Checks if project page is returned properly.
     """
-    project = ProjectFactory.create(visibility="public")
+    project = ProjectFactory.create(visibility=Project.Visibility.PUBLIC)
     ResourceFactory.create(project=project)
 
     with patch("pontoon.projects.views.render", wraps=render) as mock_render:
@@ -40,13 +41,13 @@ def test_project_top_contributors(client):
     """
     Tests if view returns top contributors specific for given project.
     """
-    first_project = ProjectFactory.create(visibility="public")
+    first_project = ProjectFactory.create(visibility=Project.Visibility.PUBLIC)
     ResourceFactory.create(project=first_project)
     first_project_contributor = TranslationFactory.create(
         entity__resource__project=first_project
     ).user
 
-    second_project = ProjectFactory.create(visibility="public")
+    second_project = ProjectFactory.create(visibility=Project.Visibility.PUBLIC)
     ResourceFactory.create(project=second_project)
     second_project_contributor = TranslationFactory.create(
         entity__resource__project=second_project

--- a/pontoon/sync/changeset.py
+++ b/pontoon/sync/changeset.py
@@ -282,7 +282,7 @@ class ChangeSet(object):
                 new_action = None
                 if not db_translation.approved and not vcs_translation.fuzzy:
                     new_action = ActionLog(
-                        action_type="translation:approved",
+                        action_type=ActionLog.ActionType.TRANSLATION_APPROVED,
                         performed_by=user or self.sync_user,
                         translation=db_translation,
                     )
@@ -337,7 +337,7 @@ class ChangeSet(object):
                 # because they were approved previously.
                 if not translation.fuzzy:
                     new_action = ActionLog(
-                        action_type="translation:rejected",
+                        action_type=ActionLog.ActionType.TRANSLATION_REJECTED,
                         performed_by=user or self.sync_user,
                         translation=translation,
                     )
@@ -346,7 +346,7 @@ class ChangeSet(object):
                     translation.rejected_date = self.now
                 else:
                     new_action = ActionLog(
-                        action_type="translation:unapproved",
+                        action_type=ActionLog.ActionType.TRANSLATION_UNAPPROVED,
                         performed_by=user or self.sync_user,
                         translation=translation,
                     )
@@ -455,7 +455,7 @@ class ChangeSet(object):
         for translation in self.translations_to_create:
             self.actions_to_log.append(
                 ActionLog(
-                    action_type="translation:created",
+                    action_type=ActionLog.ActionType.TRANSLATION_CREATED,
                     created_at=translation.date,
                     performed_by=translation.user or self.sync_user,
                     translation=translation,

--- a/pontoon/sync/tests/test_changeset.py
+++ b/pontoon/sync/tests/test_changeset.py
@@ -215,7 +215,8 @@ class ChangeSetTests(FakeCheckoutTestCase):
         )
 
         assert ActionLog.objects.filter(
-            action_type="translation:approved", translation=self.main_db_translation.pk,
+            action_type=ActionLog.ActionType.TRANSLATION_APPROVED,
+            translation=self.main_db_translation.pk,
         ).exists()
 
     def test_update_db_dont_approve_fuzzy(self):
@@ -255,7 +256,8 @@ class ChangeSetTests(FakeCheckoutTestCase):
         )
 
         assert ActionLog.objects.filter(
-            action_type="translation:created", translation=translation.pk,
+            action_type=ActionLog.ActionType.TRANSLATION_CREATED,
+            translation=translation.pk,
         ).exists()
 
     def test_update_db_unfuzzy_existing(self):
@@ -298,7 +300,8 @@ class ChangeSetTests(FakeCheckoutTestCase):
         )
 
         assert ActionLog.objects.filter(
-            action_type="translation:rejected", translation=self.main_db_translation.pk,
+            action_type=ActionLog.ActionType.TRANSLATION_REJECTED,
+            translation=self.main_db_translation.pk,
         ).exists()
 
         created_after_translation.refresh_from_db()
@@ -332,7 +335,7 @@ class ChangeSetTests(FakeCheckoutTestCase):
         )
 
         assert ActionLog.objects.filter(
-            action_type="translation:unapproved",
+            action_type=ActionLog.ActionType.TRANSLATION_UNAPPROVED,
             translation=self.main_db_translation.pk,
         ).exists()
 
@@ -369,7 +372,8 @@ class ChangeSetTests(FakeCheckoutTestCase):
         )
 
         assert ActionLog.objects.filter(
-            action_type="translation:rejected", translation=self.main_db_translation.pk,
+            action_type=ActionLog.ActionType.TRANSLATION_REJECTED,
+            translation=self.main_db_translation.pk,
         ).exists()
 
     def test_update_db_reject_approved_skip_fuzzy(self):

--- a/pontoon/sync/tests/test_checks.py
+++ b/pontoon/sync/tests/test_checks.py
@@ -5,6 +5,7 @@ from pontoon.base.tests import TranslationFactory
 from pontoon.checks.models import (
     Warning,
     Error,
+    FailedCheck,
 )
 from pontoon.sync.tests import FakeCheckoutTestCase
 
@@ -83,7 +84,7 @@ class TestChangesetTranslationsChecks(FakeCheckoutTestCase):
 
         (error,) = Error.objects.all()
 
-        assert error.library == "p"
+        assert error.library == FailedCheck.Library.PONTOON
         assert error.message == "Newline characters are not allowed"
         assert error.translation == invalid_translation
 

--- a/pontoon/sync/tests/test_sync_projects.py
+++ b/pontoon/sync/tests/test_sync_projects.py
@@ -50,8 +50,8 @@ class CommandTests(TestCase):
 
     def test_non_repository_projects(self):
         """Only sync projects with data_source=repository."""
-        ProjectFactory.create(data_source="database")
-        repo_project = ProjectFactory.create(data_source="repository")
+        ProjectFactory.create(data_source=Project.DataSource.DATABASE)
+        repo_project = ProjectFactory.create(data_source=Project.DataSource.REPOSITORY)
 
         self.execute_command()
         self.mock_sync_project.delay.assert_called_with(

--- a/pontoon/sync/tests/test_vcs.py
+++ b/pontoon/sync/tests/test_vcs.py
@@ -1,6 +1,7 @@
 from textwrap import dedent
 from unittest.mock import patch
 
+from pontoon.base.models import Repository
 from pontoon.sync.vcs.repositories import VCSRepository
 from pontoon.base.tests import CONTAINS, TestCase
 
@@ -11,7 +12,7 @@ class VCSRepositoryTests(TestCase):
         If the return code from execute is non-zero and log_errors is
         True, log an error message.
         """
-        repo = VCSRepository("/path")
+        repo = VCSRepository.for_type(Repository.Type.GIT, "/path")
 
         with patch("pontoon.sync.vcs.repositories.execute") as mock_execute, patch(
             "pontoon.sync.vcs.repositories.log"
@@ -91,7 +92,7 @@ class VCSChangedFilesTests(object):
 
 
 class GitChangedFilesTest(VCSChangedFilesTests, TestCase):
-    repository_type = "git"
+    repository_type = Repository.Type.GIT
     shell_output = dedent(
         """
         M changed_file1.properties
@@ -103,7 +104,7 @@ class GitChangedFilesTest(VCSChangedFilesTests, TestCase):
 
 
 class HgChangedFilesTest(VCSChangedFilesTests, TestCase):
-    repository_type = "hg"
+    repository_type = Repository.Type.HG
     shell_output = dedent(
         """
         M changed_file1.properties
@@ -115,7 +116,7 @@ class HgChangedFilesTest(VCSChangedFilesTests, TestCase):
 
 
 class SVNChangedFilesTest(VCSChangedFilesTests, TestCase):
-    repository_type = "svn"
+    repository_type = Repository.Type.SVN
     shell_output = dedent(
         """
         M changed_file1.properties

--- a/pontoon/tags/models.py
+++ b/pontoon/tags/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 
-from pontoon.base.models import PRIORITY_CHOICES, Project, Resource
+from pontoon.base.models import Priority, Project, Resource
 
 
 class TagQuerySet(models.QuerySet):
@@ -13,7 +13,7 @@ class Tag(models.Model):
     name = models.CharField(max_length=30)
     project = models.ForeignKey(Project, models.CASCADE, blank=True, null=True)
     resources = models.ManyToManyField(Resource)
-    priority = models.IntegerField(blank=True, null=True, choices=PRIORITY_CHOICES)
+    priority = models.IntegerField(blank=True, null=True, choices=Priority.choices)
 
     objects = TagQuerySet.as_manager()
 

--- a/pontoon/tags/tests/test_views.py
+++ b/pontoon/tags/tests/test_views.py
@@ -4,6 +4,7 @@ import pytest
 
 from django.urls import reverse
 
+from pontoon.base.models import Priority
 from pontoon.tags.utils import TaggedLocale, TagTool
 
 
@@ -120,7 +121,7 @@ def test_view_project_tag_locales(client, project_a, tag_a):
     response = client.get(url)
     assert response.status_code == 404
 
-    tag_a.priority = 3
+    tag_a.priority = Priority.NORMAL
     tag_a.save()
     response = client.get(url)
     assert response.status_code == 200
@@ -143,7 +144,7 @@ def test_view_project_tag_locales_ajax(client, project_a, project_locale_a, tag_
         "pontoon.tags.ajax.teams", kwargs=dict(project=project_a.slug, tag=tag_a.slug),
     )
     project_a.tag_set.add(tag_a)
-    tag_a.priority = 3
+    tag_a.priority = Priority.NORMAL
     tag_a.save()
     response = client.get(url, HTTP_X_REQUESTED_WITH="XMLHttpRequest")
 
@@ -168,7 +169,7 @@ def test_view_project_tag_locales_ajax(client, project_a, project_locale_a, tag_
 def test_view_project_tag_ajax(client, project_a, tag_a):
     url = reverse("pontoon.projects.ajax.tags", kwargs=dict(slug=project_a.slug),)
     project_a.tag_set.add(tag_a)
-    tag_a.priority = 3
+    tag_a.priority = Priority.NORMAL
     tag_a.save()
 
     response = client.get(url)

--- a/pontoon/teams/tests/test_utils.py
+++ b/pontoon/teams/tests/test_utils.py
@@ -36,10 +36,18 @@ def test_log_group_members_added(translators_group, user_a, assert_permissioncha
     changelog_entry0, changelog_entry1 = PermissionChangelog.objects.all()
 
     assert_permissionchangelog(
-        changelog_entry0, "added", user_a, member0, translators_group
+        changelog_entry0,
+        PermissionChangelog.ActionType.ADDED,
+        user_a,
+        member0,
+        translators_group,
     )
     assert_permissionchangelog(
-        changelog_entry1, "added", user_a, member2, translators_group
+        changelog_entry1,
+        PermissionChangelog.ActionType.ADDED,
+        user_a,
+        member2,
+        translators_group,
     )
 
 
@@ -55,10 +63,18 @@ def test_log_group_members_removed(
     changelog_entry0, changelog_entry1 = PermissionChangelog.objects.all()
 
     assert_permissionchangelog(
-        changelog_entry0, "removed", user_a, member0, translators_group
+        changelog_entry0,
+        PermissionChangelog.ActionType.REMOVED,
+        user_a,
+        member0,
+        translators_group,
     )
     assert_permissionchangelog(
-        changelog_entry1, "removed", user_a, member2, translators_group
+        changelog_entry1,
+        PermissionChangelog.ActionType.REMOVED,
+        user_a,
+        member2,
+        translators_group,
     )
 
 
@@ -73,11 +89,19 @@ def test_log_group_members_mixed(translators_group, user_a, assert_permissioncha
     changelog_entry0, changelog_entry1 = PermissionChangelog.objects.all()
 
     assert_permissionchangelog(
-        changelog_entry0, "added", user_a, member2, translators_group
+        changelog_entry0,
+        PermissionChangelog.ActionType.ADDED,
+        user_a,
+        member2,
+        translators_group,
     )
 
     assert_permissionchangelog(
-        changelog_entry1, "removed", user_a, member0, translators_group
+        changelog_entry1,
+        PermissionChangelog.ActionType.REMOVED,
+        user_a,
+        member0,
+        translators_group,
     )
 
 
@@ -99,8 +123,12 @@ def test_log_user_groups_added(
 
     changelog_entry0, changelog_entry1 = PermissionChangelog.objects.all()
 
-    assert_permissionchangelog(changelog_entry0, "added", user_a, user_b, group0)
-    assert_permissionchangelog(changelog_entry1, "added", user_a, user_b, group2)
+    assert_permissionchangelog(
+        changelog_entry0, PermissionChangelog.ActionType.ADDED, user_a, user_b, group0
+    )
+    assert_permissionchangelog(
+        changelog_entry1, PermissionChangelog.ActionType.ADDED, user_a, user_b, group2
+    )
 
 
 @pytest.mark.django_db
@@ -114,9 +142,13 @@ def test_log_user_groups_removed(
 
     changelog_entry0, changelog_entry1 = PermissionChangelog.objects.all()
 
-    assert_permissionchangelog(changelog_entry0, "removed", user_a, user_b, group0)
+    assert_permissionchangelog(
+        changelog_entry0, PermissionChangelog.ActionType.REMOVED, user_a, user_b, group0
+    )
 
-    assert_permissionchangelog(changelog_entry1, "removed", user_a, user_b, group2)
+    assert_permissionchangelog(
+        changelog_entry1, PermissionChangelog.ActionType.REMOVED, user_a, user_b, group2
+    )
 
 
 @pytest.mark.django_db
@@ -130,6 +162,10 @@ def test_log_user_groups_mixed(
     log_user_groups(user_a, user_b, (added_groups, removed_groups))
 
     changelog_entry0, changelog_entry1 = PermissionChangelog.objects.all()
-    assert_permissionchangelog(changelog_entry0, "added", user_a, user_b, group2)
+    assert_permissionchangelog(
+        changelog_entry0, PermissionChangelog.ActionType.ADDED, user_a, user_b, group2
+    )
 
-    assert_permissionchangelog(changelog_entry1, "removed", user_a, user_b, group0)
+    assert_permissionchangelog(
+        changelog_entry1, PermissionChangelog.ActionType.REMOVED, user_a, user_b, group0
+    )

--- a/pontoon/teams/utils.py
+++ b/pontoon/teams/utils.py
@@ -13,13 +13,19 @@ def log_user_groups(admin, user, changed_groups):
     add_groups, remove_groups = changed_groups
     log_entries = [
         PermissionChangelog(
-            action_type="added", performed_by=admin, performed_on=user, group=group,
+            action_type=PermissionChangelog.ActionType.ADDED,
+            performed_by=admin,
+            performed_on=user,
+            group=group,
         )
         for group in add_groups
     ]
     log_entries += [
         PermissionChangelog(
-            action_type="removed", performed_by=admin, performed_on=user, group=group,
+            action_type=PermissionChangelog.ActionType.REMOVED,
+            performed_by=admin,
+            performed_on=user,
+            group=group,
         )
         for group in remove_groups
     ]
@@ -38,14 +44,20 @@ def log_group_members(manager, group, changed_groups):
     add_users, remove_users = changed_groups
     log_entries = [
         PermissionChangelog(
-            action_type="added", performed_by=manager, performed_on=user, group=group,
+            action_type=PermissionChangelog.ActionType.ADDED,
+            performed_by=manager,
+            performed_on=user,
+            group=group,
         )
         for user in add_users
     ]
 
     log_entries += [
         PermissionChangelog(
-            action_type="removed", performed_by=manager, performed_on=user, group=group,
+            action_type=PermissionChangelog.ActionType.REMOVED,
+            performed_by=manager,
+            performed_on=user,
+            group=group,
         )
         for user in remove_users
     ]

--- a/pontoon/terminology/models.py
+++ b/pontoon/terminology/models.py
@@ -69,13 +69,15 @@ class Term(models.Model):
     usage = models.TextField(blank=True)
     notes = models.TextField(blank=True)
 
-    STATUSES = (
-        ("approved", "Approved"),
-        ("new", "New"),
-        ("obsolete", "Obsolete"),
-        ("review", "Review"),
+    class Status(models.TextChoices):
+        APPROVED = "approved", "Approved"
+        NEW = "new", "New"
+        OBSOLETE = "obsolete", "Obsolete"
+        REVIEW = "review", "Review"
+
+    status = models.CharField(
+        max_length=20, choices=Status.choices, null=True, blank=True
     )
-    status = models.CharField(max_length=20, choices=STATUSES, null=True, blank=True)
 
     case_sensitive = models.BooleanField(default=False)
     exact_match = models.BooleanField(default=False)

--- a/pontoon/terminology/models.py
+++ b/pontoon/terminology/models.py
@@ -57,13 +57,13 @@ class Term(models.Model):
     text = models.CharField(max_length=255)
     entity = models.OneToOneField("base.Entity", models.SET_NULL, null=True, blank=True)
 
-    PARTS_OF_SPEECH = (
-        ("adjective", "Adjective"),
-        ("adverb", "Adverb"),
-        ("noun", "Noun"),
-        ("verb", "Verb"),
-    )
-    part_of_speech = models.CharField(max_length=50, choices=PARTS_OF_SPEECH)
+    class PartOfSpeech(models.TextChoices):
+        ADJECTIVE = "adjective", "Adjective"
+        ADVERB = "adverb", "Adverb"
+        NOUN = "noun", "Noun"
+        VERB = "verb", "Verb"
+
+    part_of_speech = models.CharField(max_length=50, choices=PartOfSpeech.choices)
 
     definition = models.TextField(blank=True)
     usage = models.TextField(blank=True)

--- a/pontoon/terminology/tests/test_models.py
+++ b/pontoon/terminology/tests/test_models.py
@@ -107,12 +107,15 @@ def test_term_localizable(_):
 @patch("pontoon.terminology.models.update_terminology_project_stats")
 def test_term_entity_comment(_):
     term_a = TermFactory.create(
-        text="term", part_of_speech="noun", definition="definition",
+        text="term", part_of_speech=Term.PartOfSpeech.NOUN, definition="definition",
     )
     assert term_a.entity_comment() == "Noun. Definition."
 
     term_b = TermFactory.create(
-        text="term", part_of_speech="noun", definition="definition", usage="usage",
+        text="term",
+        part_of_speech=Term.PartOfSpeech.NOUN,
+        definition="definition",
+        usage="usage",
     )
     assert term_b.entity_comment() == "Noun. Definition. E.g. Usage."
 

--- a/pontoon/test/factories.py
+++ b/pontoon/test/factories.py
@@ -43,7 +43,7 @@ class ProjectFactory(DjangoModelFactory):
     name = Sequence(lambda n: "Project {0}".format(n))
     slug = LazyAttribute(lambda p: slugify(p.name))
     links = False
-    visibility = "public"
+    visibility = Project.Visibility.PUBLIC
 
     class Meta:
         model = Project

--- a/pontoon/test/factories.py
+++ b/pontoon/test/factories.py
@@ -86,7 +86,7 @@ class RepositoryFactory(DjangoModelFactory):
 class ResourceFactory(DjangoModelFactory):
     project = SubFactory(ProjectFactory)
     path = Sequence(lambda n: "/fake/path{0}.po".format(n))
-    format = "po"
+    format = Resource.Format.PO
     total_strings = 1
 
     class Meta:

--- a/pontoon/test/factories.py
+++ b/pontoon/test/factories.py
@@ -76,7 +76,7 @@ class ProjectLocaleFactory(DjangoModelFactory):
 
 class RepositoryFactory(DjangoModelFactory):
     project = SubFactory(ProjectFactory)
-    type = "git"
+    type = Repository.Type.GIT
     url = Sequence(lambda n: "https://example.com/url_{0}.git".format(n))
 
     class Meta:

--- a/pontoon/translations/tests/test_views.py
+++ b/pontoon/translations/tests/test_views.py
@@ -3,7 +3,7 @@ import pytest
 from django.urls import reverse
 
 from pontoon.base.models import Translation
-from pontoon.checks.models import Warning
+from pontoon.checks.models import Warning, FailedCheck
 from pontoon.test.factories import TranslationFactory
 
 
@@ -198,7 +198,7 @@ def test_run_checks_during_translation_update(
     (warning,) = Warning.objects.all()
 
     assert warning.translation_id == translation_pk
-    assert warning.library == "cl"
+    assert warning.library == FailedCheck.Library.COMPARE_LOCALES
     assert warning.message == "trailing argument 1 `s` missing"
 
 

--- a/pontoon/translations/views.py
+++ b/pontoon/translations/views.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 from django.utils.datastructures import MultiValueDictKeyError
 from django.views.decorators.http import require_POST
 
+from pontoon.actionlog.models import ActionLog
 from pontoon.actionlog.utils import log_action
 from pontoon.base import utils
 from pontoon.base.models import (
@@ -106,7 +107,7 @@ def create_translation(request):
 
     translation.save(failed_checks=failed_checks)
 
-    log_action("translation:created", user, translation=translation)
+    log_action(ActionLog.ActionType.TRANSLATION_CREATED, user, translation=translation)
 
     if translations:
         translation = entity.reset_active_translation(
@@ -166,7 +167,12 @@ def delete_translation(request):
 
     translation.delete()
 
-    log_action("translation:deleted", request.user, entity=entity, locale=locale)
+    log_action(
+        ActionLog.ActionType.TRANSLATION_DELETED,
+        request.user,
+        entity=entity,
+        locale=locale,
+    )
 
     return JsonResponse({"status": True})
 
@@ -241,7 +247,7 @@ def approve_translation(request):
 
     translation.approve(user)
 
-    log_action("translation:approved", user, translation=translation)
+    log_action(ActionLog.ActionType.TRANSLATION_APPROVED, user, translation=translation)
 
     active_translation = translation.entity.reset_active_translation(
         locale=locale, plural_form=translation.plural_form,
@@ -299,7 +305,11 @@ def unapprove_translation(request):
 
     translation.unapprove(request.user)
 
-    log_action("translation:unapproved", request.user, translation=translation)
+    log_action(
+        ActionLog.ActionType.TRANSLATION_UNAPPROVED,
+        request.user,
+        translation=translation,
+    )
 
     active_translation = translation.entity.reset_active_translation(
         locale=locale, plural_form=translation.plural_form,
@@ -363,7 +373,9 @@ def reject_translation(request):
 
     translation.reject(request.user)
 
-    log_action("translation:rejected", request.user, translation=translation)
+    log_action(
+        ActionLog.ActionType.TRANSLATION_REJECTED, request.user, translation=translation
+    )
 
     active_translation = translation.entity.reset_active_translation(
         locale=locale, plural_form=translation.plural_form,
@@ -421,7 +433,11 @@ def unreject_translation(request):
 
     translation.unreject(request.user)
 
-    log_action("translation:unrejected", request.user, translation=translation)
+    log_action(
+        ActionLog.ActionType.TRANSLATION_UNREJECTED,
+        request.user,
+        translation=translation,
+    )
 
     active_translation = translation.entity.reset_active_translation(
         locale=locale, plural_form=translation.plural_form,


### PR DESCRIPTION
We now use the new enumeration types wherever possible, in order to have more readable and maintainable code.

This is best reviewed per commit, as every commit introduces a single enum. The final commit (`Repository.Type`) includes some small drive-by refactoring, and it also introduced a cyclic dependency between `base/models.py` and `sync/vcs/repositories.py`. I solved it by making all imports in `base/models.py` local, but I am open to alternative solutions. At some point, some more refactoring of `sync/vcs/repositories.py` probably wouldn't hurt, 