### PR TITLE
Fix bug 1686369: implement Tab shortcut for 'Locales' tab

### DIFF
--- a/frontend/src/core/editor/actions.js
+++ b/frontend/src/core/editor/actions.js
@@ -20,12 +20,12 @@ export const END_UPDATE_TRANSLATION: 'editor/END_UPDATE_TRANSLATION' =
 export const RESET_EDITOR: 'editor/RESET_EDITOR' = 'editor/RESET_EDITOR';
 export const RESET_FAILED_CHECKS: 'editor/RESET_FAILED_CHECKS' =
     'editor/RESET_FAILED_CHECKS';
-export const RESET_HELPER_INDEX: 'editor/RESET_HELPER_INDEX' =
-    'editor/RESET_HELPER_INDEX';
+export const RESET_HELPER_ELEMENT_INDEX: 'editor/RESET_HELPER_ELEMENT_INDEX' =
+    'editor/RESET_HELPER_ELEMENT_INDEX';
 export const RESET_SELECTION: 'editor/RESET_SELECTION' =
     'editor/RESET_SELECTION';
-export const SELECT_HELPER_INDEX: 'editor/SELECT_HELPER_INDEX' =
-    'editor/SELECT_HELPER_INDEX';
+export const SELECT_HELPER_ELEMENT_INDEX: 'editor/SELECT_HELPER_ELEMENT_INDEX' =
+    'editor/SELECT_HELPER_ELEMENT_INDEX';
 export const SET_INITIAL_TRANSLATION: 'editor/SET_INITIAL_TRANSLATION' =
     'editor/SET_INITIAL_TRANSLATION';
 export const START_UPDATE_TRANSLATION: 'editor/START_UPDATE_TRANSLATION' =
@@ -99,24 +99,27 @@ export function updateMachinerySources(
 }
 
 /**
- * Reset selected helpers index to its initial value.
+ * Reset selected helper element index to its initial value.
  */
-export type ResetHelperIndexAction = {|
-    +type: typeof RESET_HELPER_INDEX,
+export type ResetHelperElementIndexAction = {|
+    +type: typeof RESET_HELPER_ELEMENT_INDEX,
 |};
-export function resetHelperIndex(): ResetHelperIndexAction {
+export function resetHelperElementIndex(): ResetHelperElementIndexAction {
     return {
-        type: RESET_HELPER_INDEX,
+        type: RESET_HELPER_ELEMENT_INDEX,
     };
 }
 
-export type SelectHelperIndexAction = {|
-    +type: typeof SELECT_HELPER_INDEX,
+/**
+ * Set selected helper element index to a specific value.
+ */
+export type SelectHelperElementIndexAction = {|
+    +type: typeof SELECT_HELPER_ELEMENT_INDEX,
     +index: number,
 |};
-function selectHelperIndex(index: number): SelectHelperIndexAction {
+function selectHelperElementIndex(index: number): SelectHelperElementIndexAction {
     return {
-        type: SELECT_HELPER_INDEX,
+        type: SELECT_HELPER_ELEMENT_INDEX,
         index,
     };
 }
@@ -313,10 +316,10 @@ export default {
     endUpdateTranslation,
     reset,
     resetFailedChecks,
-    resetHelperIndex,
+    resetHelperElementIndex,
     resetSelection,
     sendTranslation,
-    selectHelperIndex,
+    selectHelperElementIndex,
     setInitialTranslation,
     startUpdateTranslation,
     update,

--- a/frontend/src/core/editor/actions.js
+++ b/frontend/src/core/editor/actions.js
@@ -26,6 +26,8 @@ export const RESET_SELECTION: 'editor/RESET_SELECTION' =
     'editor/RESET_SELECTION';
 export const SELECT_HELPER_ELEMENT_INDEX: 'editor/SELECT_HELPER_ELEMENT_INDEX' =
     'editor/SELECT_HELPER_ELEMENT_INDEX';
+export const SELECT_HELPER_TAB_INDEX: 'editor/SELECT_HELPER_TAB_INDEX' =
+    'editor/SELECT_HELPER_TAB_INDEX';
 export const SET_INITIAL_TRANSLATION: 'editor/SET_INITIAL_TRANSLATION' =
     'editor/SET_INITIAL_TRANSLATION';
 export const START_UPDATE_TRANSLATION: 'editor/START_UPDATE_TRANSLATION' =
@@ -117,9 +119,25 @@ export type SelectHelperElementIndexAction = {|
     +type: typeof SELECT_HELPER_ELEMENT_INDEX,
     +index: number,
 |};
-function selectHelperElementIndex(index: number): SelectHelperElementIndexAction {
+function selectHelperElementIndex(
+    index: number,
+): SelectHelperElementIndexAction {
     return {
         type: SELECT_HELPER_ELEMENT_INDEX,
+        index,
+    };
+}
+
+/**
+ * Set selected helper tab index to a specific value.
+ */
+export type SelectHelperTabIndexAction = {|
+    +type: typeof SELECT_HELPER_TAB_INDEX,
+    +index: number,
+|};
+function selectHelperTabIndex(index: number): SelectHelperTabIndexAction {
+    return {
+        type: SELECT_HELPER_TAB_INDEX,
         index,
     };
 }
@@ -320,6 +338,7 @@ export default {
     resetSelection,
     sendTranslation,
     selectHelperElementIndex,
+    selectHelperTabIndex,
     setInitialTranslation,
     startUpdateTranslation,
     update,

--- a/frontend/src/core/editor/hooks/useCopyOtherLocaleTranslation.js
+++ b/frontend/src/core/editor/hooks/useCopyOtherLocaleTranslation.js
@@ -1,0 +1,35 @@
+/* @flow */
+
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+
+import * as entities from 'core/entities';
+import type { OtherLocaleTranslation } from 'core/api';
+
+import useUpdateTranslation from './useUpdateTranslation';
+
+/**
+ * Return a function to copy the other locale translation into the editor.
+ */
+export default function useCopyOtherLocaleTranslation() {
+    const updateTranslation = useUpdateTranslation();
+    const isReadOnlyEditor = useSelector((state) =>
+        entities.selectors.isReadOnlyEditor(state),
+    );
+
+    return useCallback(
+        (translation: OtherLocaleTranslation) => {
+            if (isReadOnlyEditor) {
+                return;
+            }
+
+            // Ignore if selecting text
+            if (window.getSelection().toString()) {
+                return;
+            }
+
+            updateTranslation(translation.translation, 'otherlocales');
+        },
+        [isReadOnlyEditor, updateTranslation],
+    );
+}

--- a/frontend/src/core/editor/hooks/useHandleShortcuts.js
+++ b/frontend/src/core/editor/hooks/useHandleShortcuts.js
@@ -123,7 +123,7 @@ export default function useHandleShortcuts() {
             if (!numTranslations) {
                 return;
             }
-            const currentIdx = editorState.selectedHelperIndex;
+            const currentIdx = editorState.selectedHelperElementIndex;
             let nextIdx;
             if (!event.shiftKey) {
                 nextIdx = (currentIdx + 1) % numTranslations;
@@ -131,7 +131,7 @@ export default function useHandleShortcuts() {
                 nextIdx = (currentIdx - 1 + numTranslations) % numTranslations;
             }
             const newMachineryTranslation = machineryTranslations[nextIdx];
-            dispatch(editor.actions.selectHelperIndex(nextIdx));
+            dispatch(editor.actions.selectHelperElementIndex(nextIdx));
             handledEvent = true;
             copyMachineryTranslation(newMachineryTranslation);
         }

--- a/frontend/src/core/editor/index.js
+++ b/frontend/src/core/editor/index.js
@@ -14,6 +14,7 @@ export { default as useAddTextToTranslation } from './hooks/useAddTextToTranslat
 export { default as useClearEditor } from './hooks/useClearEditor';
 export { default as useCopyMachineryTranslation } from './hooks/useCopyMachineryTranslation';
 export { default as useCopyOriginalIntoEditor } from './hooks/useCopyOriginalIntoEditor';
+export { default as useCopyOtherLocaleTranslation } from './hooks/useCopyOtherLocaleTranslation';
 export { default as useHandleShortcuts } from './hooks/useHandleShortcuts';
 export { default as useLoadTranslation } from './hooks/useLoadTranslation';
 export { default as useSendTranslation } from './hooks/useSendTranslation';

--- a/frontend/src/core/editor/reducer.js
+++ b/frontend/src/core/editor/reducer.js
@@ -8,6 +8,7 @@ import {
     RESET_EDITOR,
     RESET_HELPER_ELEMENT_INDEX,
     SELECT_HELPER_ELEMENT_INDEX,
+    SELECT_HELPER_TAB_INDEX,
     SET_INITIAL_TRANSLATION,
     START_UPDATE_TRANSLATION,
     UPDATE,
@@ -25,6 +26,7 @@ import type {
     ResetFailedChecksAction,
     ResetSelectionAction,
     SelectHelperElementIndexAction,
+    SelectHelperTabIndexAction,
     StartUpdateTranslationAction,
     Translation,
     UpdateAction,
@@ -41,6 +43,7 @@ type Action =
     | ResetFailedChecksAction
     | ResetSelectionAction
     | SelectHelperElementIndexAction
+    | SelectHelperTabIndexAction
     | StartUpdateTranslationAction
     | UpdateAction
     | UpdateFailedChecksAction
@@ -87,6 +90,10 @@ export type EditorState = {|
 
     // Index of selected item in the helpers box
     +selectedHelperElementIndex: number,
+    // Index of selected tab in the helpers box. Assumes the following:
+    //  0 -> Machinery
+    //  1 -> Other Locales
+    +selectedHelperTabIndex: number,
 |};
 
 /**
@@ -122,6 +129,7 @@ const initial: EditorState = {
     source: '',
     isRunningRequest: false,
     selectedHelperElementIndex: -1,
+    selectedHelperTabIndex: 0,
 };
 
 export default function reducer(
@@ -204,6 +212,11 @@ export default function reducer(
             return {
                 ...state,
                 selectedHelperElementIndex: action.index,
+            };
+        case SELECT_HELPER_TAB_INDEX:
+            return {
+                ...state,
+                selectedHelperTabIndex: action.index,
             };
         default:
             return state;

--- a/frontend/src/core/editor/reducer.js
+++ b/frontend/src/core/editor/reducer.js
@@ -6,8 +6,8 @@ import {
     RESET_FAILED_CHECKS,
     RESET_SELECTION,
     RESET_EDITOR,
-    RESET_HELPER_INDEX,
-    SELECT_HELPER_INDEX,
+    RESET_HELPER_ELEMENT_INDEX,
+    SELECT_HELPER_ELEMENT_INDEX,
     SET_INITIAL_TRANSLATION,
     START_UPDATE_TRANSLATION,
     UPDATE,
@@ -21,8 +21,10 @@ import type {
     EndUpdateTranslationAction,
     InitialTranslationAction,
     ResetEditorAction,
+    ResetHelperElementIndexAction,
     ResetFailedChecksAction,
     ResetSelectionAction,
+    SelectHelperElementIndexAction,
     StartUpdateTranslationAction,
     Translation,
     UpdateAction,
@@ -35,8 +37,10 @@ type Action =
     | EndUpdateTranslationAction
     | InitialTranslationAction
     | ResetEditorAction
+    | ResetHelperElementIndexAction
     | ResetFailedChecksAction
     | ResetSelectionAction
+    | SelectHelperElementIndexAction
     | StartUpdateTranslationAction
     | UpdateAction
     | UpdateFailedChecksAction
@@ -82,7 +86,7 @@ export type EditorState = {|
     +isRunningRequest: boolean,
 
     // Index of selected item in the helpers box
-    +selectedHelperIndex: number,
+    +selectedHelperElementIndex: number,
 |};
 
 /**
@@ -117,7 +121,7 @@ const initial: EditorState = {
     warnings: [],
     source: '',
     isRunningRequest: false,
-    selectedHelperIndex: -1,
+    selectedHelperElementIndex: -1,
 };
 
 export default function reducer(
@@ -191,15 +195,15 @@ export default function reducer(
                 machineryTranslation: action.machineryTranslation,
                 machinerySources: action.machinerySources,
             };
-        case RESET_HELPER_INDEX:
+        case RESET_HELPER_ELEMENT_INDEX:
             return {
                 ...state,
-                selectedHelperIndex: -1,
+                selectedHelperElementIndex: -1,
             };
-        case SELECT_HELPER_INDEX:
+        case SELECT_HELPER_ELEMENT_INDEX:
             return {
                 ...state,
-                selectedHelperIndex: action.index,
+                selectedHelperElementIndex: action.index,
             };
         default:
             return state;

--- a/frontend/src/modules/entitydetails/components/EntityDetails.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.js
@@ -129,7 +129,7 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
             return;
         }
 
-        dispatch(editor.actions.resetHelperIndex());
+        dispatch(editor.actions.resetHelperElementIndex());
 
         if (
             selectedEntity.pk !== this.props.history.entity ||

--- a/frontend/src/modules/entitydetails/components/EntityDetails.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.js
@@ -457,7 +457,6 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
                         users={state.users}
                         parameters={state.parameters}
                         user={state.user}
-                        updateEditorTranslation={this.updateEditorTranslation}
                         searchMachinery={this.searchMachinery}
                         addTextToEditorTranslation={
                             this.addTextToEditorTranslation

--- a/frontend/src/modules/entitydetails/components/Helpers.js
+++ b/frontend/src/modules/entitydetails/components/Helpers.js
@@ -130,7 +130,7 @@ export default function Helpers(props: Props) {
                     if (index === lastIndex) {
                         return false;
                     }
-                    dispatch(editor.actions.resetHelperIndex());
+                    dispatch(editor.actions.resetHelperElementIndex());
                 }}>
                     <TabList>
                         <Tab>

--- a/frontend/src/modules/entitydetails/components/Helpers.js
+++ b/frontend/src/modules/entitydetails/components/Helpers.js
@@ -48,117 +48,115 @@ type Props = {|
  *
  * Shows the metadata of the entity and an editor for translations.
  */
-export default class Helpers extends React.Component<Props> {
-    render() {
-        const {
-            entity,
-            isReadOnlyEditor,
-            locale,
-            machinery,
-            otherlocales,
-            teamComments,
-            terms,
-            parameters,
-            user,
-            users,
-            commentTabRef,
-            commentTabIndex,
-            contactPerson,
-            searchMachinery,
-            addComment,
-            togglePinnedStatus,
-            addTextToEditorTranslation,
-            navigateToPath,
-            setCommentTabIndex,
-            resetContactPerson,
-        } = this.props;
+export default function Helpers(props: Props) {
+    const {
+        entity,
+        isReadOnlyEditor,
+        locale,
+        machinery,
+        otherlocales,
+        teamComments,
+        terms,
+        parameters,
+        user,
+        users,
+        commentTabRef,
+        commentTabIndex,
+        contactPerson,
+        searchMachinery,
+        addComment,
+        togglePinnedStatus,
+        addTextToEditorTranslation,
+        navigateToPath,
+        setCommentTabIndex,
+        resetContactPerson,
+    } = props;
 
-        return (
-            <>
-                <div className='top'>
-                    <Tabs
-                        selectedIndex={commentTabIndex}
-                        onSelect={(tab) => setCommentTabIndex(tab)}
-                    >
-                        <TabList>
-                            {parameters.project === 'terminology' ? null : (
-                                <Tab>
-                                    <Localized id='entitydetails-Helpers--terms'>
-                                        {'TERMS'}
-                                    </Localized>
-                                    <TermCount terms={terms} />
-                                </Tab>
-                            )}
-                            <Tab ref={commentTabRef}>
-                                <Localized id='entitydetails-Helpers--comments'>
-                                    {'COMMENTS'}
-                                </Localized>
-                                <CommentCount teamComments={teamComments} />
-                            </Tab>
-                        </TabList>
+    return (
+        <>
+            <div className='top'>
+                <Tabs
+                    selectedIndex={commentTabIndex}
+                    onSelect={(tab) => setCommentTabIndex(tab)}
+                >
+                    <TabList>
                         {parameters.project === 'terminology' ? null : (
-                            <TabPanel>
-                                <Terms
-                                    isReadOnlyEditor={isReadOnlyEditor}
-                                    locale={locale.code}
-                                    terms={terms}
-                                    addTextToEditorTranslation={
-                                        addTextToEditorTranslation
-                                    }
-                                    navigateToPath={navigateToPath}
-                                />
-                            </TabPanel>
+                            <Tab>
+                                <Localized id='entitydetails-Helpers--terms'>
+                                    {'TERMS'}
+                                </Localized>
+                                <TermCount terms={terms} />
+                            </Tab>
                         )}
+                        <Tab ref={commentTabRef}>
+                            <Localized id='entitydetails-Helpers--comments'>
+                                {'COMMENTS'}
+                            </Localized>
+                            <CommentCount teamComments={teamComments} />
+                        </Tab>
+                    </TabList>
+                    {parameters.project === 'terminology' ? null : (
                         <TabPanel>
-                            <TeamComments
-                                parameters={parameters}
-                                teamComments={teamComments}
-                                user={user}
-                                addComment={addComment}
-                                users={users}
-                                togglePinnedStatus={togglePinnedStatus}
-                                contactPerson={contactPerson}
-                                resetContactPerson={resetContactPerson}
+                            <Terms
+                                isReadOnlyEditor={isReadOnlyEditor}
+                                locale={locale.code}
+                                terms={terms}
+                                addTextToEditorTranslation={
+                                    addTextToEditorTranslation
+                                }
+                                navigateToPath={navigateToPath}
                             />
                         </TabPanel>
-                    </Tabs>
-                </div>
-                <div className='bottom'>
-                    <Tabs>
-                        <TabList>
-                            <Tab>
-                                <Localized id='entitydetails-Helpers--machinery'>
-                                    {'MACHINERY'}
-                                </Localized>
-                                <MachineryCount machinery={machinery} />
-                            </Tab>
-                            <Tab>
-                                <Localized id='entitydetails-Helpers--locales'>
-                                    {'LOCALES'}
-                                </Localized>
-                                <OtherLocalesCount
-                                    otherlocales={otherlocales}
-                                />
-                            </Tab>
-                        </TabList>
-                        <TabPanel>
-                            <Machinery
-                                locale={locale}
-                                machinery={machinery}
-                                searchMachinery={searchMachinery}
-                            />
-                        </TabPanel>
-                        <TabPanel>
-                            <OtherLocales
-                                entity={entity}
+                    )}
+                    <TabPanel>
+                        <TeamComments
+                            parameters={parameters}
+                            teamComments={teamComments}
+                            user={user}
+                            addComment={addComment}
+                            users={users}
+                            togglePinnedStatus={togglePinnedStatus}
+                            contactPerson={contactPerson}
+                            resetContactPerson={resetContactPerson}
+                        />
+                    </TabPanel>
+                </Tabs>
+            </div>
+            <div className='bottom'>
+                <Tabs>
+                    <TabList>
+                        <Tab>
+                            <Localized id='entitydetails-Helpers--machinery'>
+                                {'MACHINERY'}
+                            </Localized>
+                            <MachineryCount machinery={machinery} />
+                        </Tab>
+                        <Tab>
+                            <Localized id='entitydetails-Helpers--locales'>
+                                {'LOCALES'}
+                            </Localized>
+                            <OtherLocalesCount
                                 otherlocales={otherlocales}
-                                user={user}
-                                parameters={parameters}
                             />
-                        </TabPanel>
-                    </Tabs>
-                </div>
-            </>
-        );
-    }
+                        </Tab>
+                    </TabList>
+                    <TabPanel>
+                        <Machinery
+                            locale={locale}
+                            machinery={machinery}
+                            searchMachinery={searchMachinery}
+                        />
+                    </TabPanel>
+                    <TabPanel>
+                        <OtherLocales
+                            entity={entity}
+                            otherlocales={otherlocales}
+                            user={user}
+                            parameters={parameters}
+                        />
+                    </TabPanel>
+                </Tabs>
+            </div>
+        </>
+    );
 }

--- a/frontend/src/modules/entitydetails/components/Helpers.js
+++ b/frontend/src/modules/entitydetails/components/Helpers.js
@@ -126,12 +126,15 @@ export default function Helpers(props: Props) {
                 </Tabs>
             </div>
             <div className='bottom'>
-                <Tabs onSelect={(index, lastIndex) => {
-                    if (index === lastIndex) {
-                        return false;
-                    }
-                    dispatch(editor.actions.resetHelperElementIndex());
-                }}>
+                <Tabs
+                    onSelect={(index, lastIndex) => {
+                        if (index === lastIndex) {
+                            return false;
+                        }
+                        dispatch(editor.actions.selectHelperTabIndex(index));
+                        dispatch(editor.actions.resetHelperElementIndex());
+                    }}
+                >
                     <TabList>
                         <Tab>
                             <Localized id='entitydetails-Helpers--machinery'>
@@ -143,9 +146,7 @@ export default function Helpers(props: Props) {
                             <Localized id='entitydetails-Helpers--locales'>
                                 {'LOCALES'}
                             </Localized>
-                            <OtherLocalesCount
-                                otherlocales={otherlocales}
-                            />
+                            <OtherLocalesCount otherlocales={otherlocales} />
                         </Tab>
                     </TabList>
                     <TabPanel>

--- a/frontend/src/modules/entitydetails/components/Helpers.js
+++ b/frontend/src/modules/entitydetails/components/Helpers.js
@@ -34,7 +34,6 @@ type Props = {|
     commentTabRef: Object,
     commentTabIndex: number,
     contactPerson: string,
-    updateEditorTranslation: (string, string) => void,
     searchMachinery: (string) => void,
     addComment: (string, ?number) => void,
     togglePinnedStatus: (boolean, number) => void,
@@ -65,7 +64,6 @@ export default class Helpers extends React.Component<Props> {
             commentTabRef,
             commentTabIndex,
             contactPerson,
-            updateEditorTranslation,
             searchMachinery,
             addComment,
             togglePinnedStatus,
@@ -153,13 +151,9 @@ export default class Helpers extends React.Component<Props> {
                         <TabPanel>
                             <OtherLocales
                                 entity={entity}
-                                isReadOnlyEditor={isReadOnlyEditor}
                                 otherlocales={otherlocales}
                                 user={user}
                                 parameters={parameters}
-                                updateEditorTranslation={
-                                    updateEditorTranslation
-                                }
                             />
                         </TabPanel>
                     </Tabs>

--- a/frontend/src/modules/entitydetails/components/Helpers.js
+++ b/frontend/src/modules/entitydetails/components/Helpers.js
@@ -1,11 +1,13 @@
 /* @flow */
 
 import * as React from 'react';
+import { useDispatch } from 'react-redux';
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
 import { Localized } from '@fluent/react';
 
 import './Helpers.css';
 
+import * as editor from 'core/editor';
 import { TeamComments, CommentCount } from 'modules/teamcomments';
 import { Terms, TermCount } from 'modules/terms';
 import { Machinery, MachineryCount } from 'modules/machinery';
@@ -71,6 +73,7 @@ export default function Helpers(props: Props) {
         setCommentTabIndex,
         resetContactPerson,
     } = props;
+    const dispatch = useDispatch();
 
     return (
         <>
@@ -123,7 +126,12 @@ export default function Helpers(props: Props) {
                 </Tabs>
             </div>
             <div className='bottom'>
-                <Tabs>
+                <Tabs onSelect={(index, lastIndex) => {
+                    if (index === lastIndex) {
+                        return false;
+                    }
+                    dispatch(editor.actions.resetHelperIndex());
+                }}>
                     <TabList>
                         <Tab>
                             <Localized id='entitydetails-Helpers--machinery'>

--- a/frontend/src/modules/machinery/components/Translation.js
+++ b/frontend/src/modules/machinery/components/Translation.js
@@ -38,7 +38,7 @@ export default function Translation(props: Props) {
 
     const copyMachineryTranslation = editor.useCopyMachineryTranslation();
     const copyTranslationIntoEditor = React.useCallback(() => {
-        dispatch(editor.actions.selectHelperIndex(index));
+        dispatch(editor.actions.selectHelperElementIndex(index));
         copyMachineryTranslation(translation);
     }, [dispatch, index, translation, copyMachineryTranslation]);
 
@@ -60,7 +60,7 @@ export default function Translation(props: Props) {
     const translationRef = React.useRef();
     React.useEffect(() => {
         if (
-            editorState.selectedHelperIndex === index &&
+            editorState.selectedHelperElementIndex === index &&
             translationRef.current
         ) {
             translationRef.current.scrollIntoView({
@@ -68,7 +68,7 @@ export default function Translation(props: Props) {
                 block: 'nearest',
             });
         }
-    }, [editorState.selectedHelperIndex, index]);
+    }, [editorState.selectedHelperElementIndex, index]);
 
     return (
         <Localized id='machinery-Translation--copy' attrs={{ title: true }}>

--- a/frontend/src/modules/machinery/components/Translation.js
+++ b/frontend/src/modules/machinery/components/Translation.js
@@ -51,7 +51,7 @@ export default function Translation(props: Props) {
     const editorState = useSelector((state) => state[editor.NAME]);
     const isSelected =
         editorState.changeSource === 'machinery' &&
-        editorState.machineryTranslation === translation.translation;
+        editorState.selectedHelperElementIndex === index;
     if (isSelected) {
         // Highlight Machinery entries upon selection
         className += ' selected';

--- a/frontend/src/modules/otherlocales/components/OtherLocales.js
+++ b/frontend/src/modules/otherlocales/components/OtherLocales.js
@@ -14,11 +14,9 @@ import type { LocalesState } from '..';
 
 type Props = {|
     entity: Entity,
-    isReadOnlyEditor: boolean,
     otherlocales: LocalesState,
     parameters: NavigationParams,
     user: UserState,
-    updateEditorTranslation: (string, string) => void,
 |};
 
 /**
@@ -39,10 +37,8 @@ export default class OtherLocales extends React.Component<Props> {
         return (
             <Translation
                 entity={this.props.entity}
-                isReadOnlyEditor={this.props.isReadOnlyEditor}
                 translation={translation}
                 parameters={this.props.parameters}
-                updateEditorTranslation={this.props.updateEditorTranslation}
                 key={index}
             />
         );

--- a/frontend/src/modules/otherlocales/components/OtherLocales.js
+++ b/frontend/src/modules/otherlocales/components/OtherLocales.js
@@ -36,6 +36,7 @@ export default class OtherLocales extends React.Component<Props> {
     renderTranslations(translation: OtherLocaleTranslation, index: number) {
         return (
             <Translation
+                index={index}
                 entity={this.props.entity}
                 translation={translation}
                 parameters={this.props.parameters}
@@ -67,7 +68,11 @@ export default class OtherLocales extends React.Component<Props> {
 
                 <ul>
                     {translations.other.map((translation, index) => {
-                        return this.renderTranslations(translation, index);
+                        return this.renderTranslations(
+                            translation,
+                            // offset by the amount of preferred translations
+                            translations.preferred.length + index,
+                        );
                     })}
                 </ul>
             </section>

--- a/frontend/src/modules/otherlocales/components/Translation.css
+++ b/frontend/src/modules/otherlocales/components/Translation.css
@@ -12,7 +12,8 @@
     pointer-events: none;
 }
 
-.other-locales .translation:not(.cannot-copy):hover {
+.other-locales .translation:not(.cannot-copy):hover,
+.other-locales .translation.selected {
     background: #4d5967;
     border-color: #5e6475;
 }

--- a/frontend/src/modules/otherlocales/components/Translation.js
+++ b/frontend/src/modules/otherlocales/components/Translation.js
@@ -18,6 +18,7 @@ type Props = {|
     entity: Entity,
     translation: Object,
     parameters: NavigationParams,
+    index: number,
 |};
 
 /**
@@ -27,7 +28,7 @@ type Props = {|
  * locale and its code.
  */
 export default function Translation(props: Props) {
-    const { entity, translation, parameters } = props;
+    const { entity, translation, parameters, index } = props;
 
     const dispatch = useDispatch();
     const isReadOnlyEditor = useSelector((state) =>
@@ -51,8 +52,9 @@ export default function Translation(props: Props) {
 
     const copyOtherLocaleTranslation = editor.useCopyOtherLocaleTranslation();
     const copyTranslationIntoEditor = React.useCallback(() => {
+        dispatch(editor.actions.selectHelperIndex(index));
         copyOtherLocaleTranslation(translation);
-    }, [dispatch, translation, copyOtherLocaleTranslation]);
+    }, [dispatch, index, translation, copyOtherLocaleTranslation]);
 
     return (
         <Localized id='otherlocales-Translation--copy' attrs={{ title: true }}>

--- a/frontend/src/modules/otherlocales/components/Translation.js
+++ b/frontend/src/modules/otherlocales/components/Translation.js
@@ -40,6 +40,15 @@ export default function Translation(props: Props) {
         className += ' cannot-copy';
     }
 
+    const editorState = useSelector((state) => state[editor.NAME]);
+    const isSelected =
+        editorState.changeSource === 'otherlocales' &&
+        editorState.translation === translation.translation;
+    if (isSelected) {
+        // Highlight other locale entries upon selection
+        className += ' selected';
+    }
+
     const copyOtherLocaleTranslation = editor.useCopyOtherLocaleTranslation();
     const copyTranslationIntoEditor = React.useCallback(() => {
         copyOtherLocaleTranslation(translation);

--- a/frontend/src/modules/otherlocales/components/Translation.js
+++ b/frontend/src/modules/otherlocales/components/Translation.js
@@ -44,7 +44,7 @@ export default function Translation(props: Props) {
     const editorState = useSelector((state) => state[editor.NAME]);
     const isSelected =
         editorState.changeSource === 'otherlocales' &&
-        editorState.translation === translation.translation;
+        editorState.selectedHelperElementIndex === index;
     if (isSelected) {
         // Highlight other locale entries upon selection
         className += ' selected';

--- a/frontend/src/modules/otherlocales/components/Translation.js
+++ b/frontend/src/modules/otherlocales/components/Translation.js
@@ -52,7 +52,7 @@ export default function Translation(props: Props) {
 
     const copyOtherLocaleTranslation = editor.useCopyOtherLocaleTranslation();
     const copyTranslationIntoEditor = React.useCallback(() => {
-        dispatch(editor.actions.selectHelperIndex(index));
+        dispatch(editor.actions.selectHelperElementIndex(index));
         copyOtherLocaleTranslation(translation);
     }, [dispatch, index, translation, copyOtherLocaleTranslation]);
 

--- a/frontend/src/modules/otherlocales/components/Translation.js
+++ b/frontend/src/modules/otherlocales/components/Translation.js
@@ -56,12 +56,26 @@ export default function Translation(props: Props) {
         copyOtherLocaleTranslation(translation);
     }, [dispatch, index, translation, copyOtherLocaleTranslation]);
 
+    const translationRef = React.useRef();
+    React.useEffect(() => {
+        if (
+            editorState.selectedHelperElementIndex === index &&
+            translationRef.current
+        ) {
+            translationRef.current.scrollIntoView({
+                behavior: 'smooth',
+                block: 'nearest',
+            });
+        }
+    }, [editorState.selectedHelperElementIndex, index]);
+
     return (
         <Localized id='otherlocales-Translation--copy' attrs={{ title: true }}>
             <li
                 className={className}
                 title='Copy Into Translation'
                 onClick={copyTranslationIntoEditor}
+                ref={translationRef}
             >
                 <header>
                     {translation.locale.code === 'en-US' ? (

--- a/frontend/src/modules/otherlocales/components/Translation.js
+++ b/frontend/src/modules/otherlocales/components/Translation.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { Localized } from '@fluent/react';
 import { Link } from 'react-router-dom';
 
@@ -8,15 +9,15 @@ import './Translation.css';
 
 import { TranslationProxy } from 'core/translation';
 
+import * as editor from 'core/editor';
+import * as entities from 'core/entities';
 import type { Entity } from 'core/api';
 import type { NavigationParams } from 'core/navigation';
 
 type Props = {|
     entity: Entity,
-    isReadOnlyEditor: boolean,
     translation: Object,
     parameters: NavigationParams,
-    updateEditorTranslation: (string, string) => void,
 |};
 
 /**
@@ -25,90 +26,73 @@ type Props = {|
  * Show the translation of a given entity in a different locale, as well as the
  * locale and its code.
  */
-export default class Translation extends React.Component<Props> {
-    copyTranslationIntoEditor = () => {
-        if (this.props.isReadOnlyEditor) {
-            return;
-        }
+export default function Translation(props: Props) {
+    const { entity, translation, parameters } = props;
 
-        // Ignore if selecting text
-        if (window.getSelection().toString()) {
-            return;
-        }
+    const dispatch = useDispatch();
+    const isReadOnlyEditor = useSelector((state) =>
+        entities.selectors.isReadOnlyEditor(state),
+    );
 
-        this.props.updateEditorTranslation(
-            this.props.translation.translation,
-            'otherlocales',
-        );
-    };
+    let className = 'translation';
+    if (isReadOnlyEditor) {
+        // Copying into the editor is not allowed
+        className += ' cannot-copy';
+    }
 
-    render() {
-        const {
-            entity,
-            translation,
-            parameters,
-            isReadOnlyEditor,
-        } = this.props;
+    const copyOtherLocaleTranslation = editor.useCopyOtherLocaleTranslation();
+    const copyTranslationIntoEditor = React.useCallback(() => {
+        copyOtherLocaleTranslation(translation);
+    }, [dispatch, translation, copyOtherLocaleTranslation]);
 
-        let className = 'translation';
-
-        if (isReadOnlyEditor) {
-            // Copying into the editor is not allowed
-            className += ' cannot-copy';
-        }
-
-        return (
-            <Localized
-                id='otherlocales-Translation--copy'
-                attrs={{ title: true }}
+    return (
+        <Localized id='otherlocales-Translation--copy' attrs={{ title: true }}>
+            <li
+                className={className}
+                title='Copy Into Translation'
+                onClick={copyTranslationIntoEditor}
             >
-                <li
-                    className={className}
-                    title='Copy Into Translation'
-                    onClick={this.copyTranslationIntoEditor}
-                >
-                    <header>
-                        {translation.locale.code === 'en-US' ? (
-                            <div>
+                <header>
+                    {translation.locale.code === 'en-US' ? (
+                        <div>
+                            {translation.locale.name}
+                            <span>{translation.locale.code}</span>
+                        </div>
+                    ) : (
+                        <Localized
+                            id='otherlocales-Translation--header-link'
+                            attrs={{ title: true }}
+                            vars={{
+                                locale: translation.locale.name,
+                                code: translation.locale.code,
+                            }}
+                        >
+                            <Link
+                                to={`/${translation.locale.code}/${parameters.project}/${parameters.resource}/?string=${parameters.entity}`}
+                                target='_blank'
+                                rel='noopener noreferrer'
+                                title='Open string in { $locale } ({ $code })'
+                                onClick={(e: SyntheticMouseEvent<>) =>
+                                    e.stopPropagation()
+                                }
+                            >
                                 {translation.locale.name}
                                 <span>{translation.locale.code}</span>
-                            </div>
-                        ) : (
-                            <Localized
-                                id='otherlocales-Translation--header-link'
-                                attrs={{ title: true }}
-                                vars={{
-                                    locale: translation.locale.name,
-                                    code: translation.locale.code,
-                                }}
-                            >
-                                <Link
-                                    to={`/${translation.locale.code}/${parameters.project}/${parameters.resource}/?string=${parameters.entity}`}
-                                    target='_blank'
-                                    rel='noopener noreferrer'
-                                    title='Open string in { $locale } ({ $code })'
-                                    onClick={(e: SyntheticMouseEvent<>) =>
-                                        e.stopPropagation()
-                                    }
-                                >
-                                    {translation.locale.name}
-                                    <span>{translation.locale.code}</span>
-                                </Link>
-                            </Localized>
-                        )}
-                    </header>
-                    <p
-                        lang={translation.locale.code}
-                        dir={translation.locale.direction}
-                        script={translation.locale.script}
-                    >
-                        <TranslationProxy
-                            content={translation.translation}
-                            format={entity.format}
-                        />
-                    </p>
-                </li>
-            </Localized>
-        );
-    }
+                            </Link>
+                        </Localized>
+                    )}
+                </header>
+                <p
+                    lang={translation.locale.code}
+                    dir={translation.locale.direction}
+                    script={translation.locale.script}
+                >
+                    <TranslationProxy
+                        content={translation.translation}
+                        format={entity.format}
+                    />
+                </p>
+            </li>
+        </Localized>
+    );
 }

--- a/frontend/src/modules/otherlocales/index.js
+++ b/frontend/src/modules/otherlocales/index.js
@@ -2,6 +2,7 @@
 
 export { default as actions } from './actions';
 export { default as reducer } from './reducer';
+export { default as selectors } from './selectors';
 
 export { default as OtherLocales } from './components/OtherLocales';
 export { default as OtherLocalesCount } from './components/Count';

--- a/frontend/src/modules/otherlocales/selectors.js
+++ b/frontend/src/modules/otherlocales/selectors.js
@@ -1,0 +1,48 @@
+/* @flow */
+
+import { createSelector } from 'reselect';
+
+import type { OtherLocaleTranslation, OtherLocaleTranslations } from 'core/api';
+
+import { NAME } from '.';
+
+const otherLocalesSelector = (state): string => state[NAME].translations;
+
+/**
+ * Return the Entity that follows the current one in the list.
+ */
+
+function _flattenOtherLocales(
+    otherLocales: OtherLocaleTranslations,
+): Array<OtherLocaleTranslation> {
+    if (!otherLocales) {
+        return [];
+    }
+
+    let result = [];
+    if (otherLocales.preferred) {
+        otherLocales.preferred.forEach((translation) => {
+            result.push(translation);
+        });
+    }
+
+    if (otherLocales.other) {
+        otherLocales.other.forEach((translation) => {
+            result.push(translation);
+        });
+    }
+
+    return result;
+}
+
+/**
+ * Return the Entity that preceeds the current one in the list.
+ */
+export const getTranslationsFlatList: Function = createSelector(
+    otherLocalesSelector,
+    _flattenOtherLocales,
+);
+
+export default {
+    getTranslationsFlatList,
+};


### PR DESCRIPTION
Overall it resembles the implementation of the Machinery tab, although some extra changes have been necessary to be able to use hooks (that's why there's extra noise in the diff).