### PR TITLE
Fix bug 1686711: Add basic unit test for Translation.machinery_sources_values

### DIFF
--- a/pontoon/base/tests/models/test_translation.py
+++ b/pontoon/base/tests/models/test_translation.py
@@ -273,3 +273,23 @@ def test_translation_not_in_terminology_saved(
     TranslationFactory.create(locale=locale_a, entity=entity_a)
 
     assert not reset_term_translation_mock.called
+
+
+@pytest.mark.django_db
+def test_machinery_sources_values(locale_a, entity_a):
+    """
+    Return comma-separated machinery_sources values for the given translation.
+    """
+    translation_no_machinery_sources = TranslationFactory.create(
+        locale=locale_a, entity=entity_a,
+    )
+    assert translation_no_machinery_sources.machinery_sources_values == ""
+
+    translation = TranslationFactory.create(
+        locale=locale_a,
+        entity=entity_a,
+        machinery_sources=["translation-memory", "google-translate"],
+    )
+    assert (
+        translation.machinery_sources_values == "Translation Memory, Google Translate"
+    )

--- a/pontoon/base/tests/models/test_translation.py
+++ b/pontoon/base/tests/models/test_translation.py
@@ -2,7 +2,7 @@ from unittest.mock import patch, call
 
 import pytest
 
-from pontoon.base.models import Project, TranslationMemoryEntry
+from pontoon.base.models import Project, Translation, TranslationMemoryEntry
 from pontoon.test.factories import (
     EntityFactory,
     ProjectLocaleFactory,
@@ -288,7 +288,10 @@ def test_machinery_sources_values(locale_a, entity_a):
     translation = TranslationFactory.create(
         locale=locale_a,
         entity=entity_a,
-        machinery_sources=["translation-memory", "google-translate"],
+        machinery_sources=[
+            Translation.MachinerySource.TRANSLATION_MEMORY,
+            Translation.MachinerySource.GOOGLE_TRANSLATE,
+        ],
     )
     assert (
         translation.machinery_sources_values == "Translation Memory, Google Translate"


### PR DESCRIPTION
We had to land a hotfix for the error we'd catch with a test like this: https://github.com/mozilla/pontoon/commit/7181fd430bac94725eab7880d1eb8e54f8192eb6.