### PR TITLE
No bug - ESLint: remove fullpage.js globals

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,8 +42,6 @@ module.exports = {
         diff_match_patch: false,
         Highcharts: false,
         Sideshow: false,
-        fullpage: false,
-        fullpage_api: false,
         editor: false,
         DIFF_INSERT: false,
         DIFF_EQUAL: false,


### PR DESCRIPTION
These two globals are not present anymore. This is a follow-up of #1814.