### PR TITLE
No bug - package-lock.json: remove obsolete fluent-syntax

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8033,11 +8033,6 @@
         "write": "^0.2.1"
       }
     },
-    "fluent-syntax": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/fluent-syntax/-/fluent-syntax-0.12.0.tgz",
-      "integrity": "sha512-ZQvs21EHRwta16BdIKPJ95AVzbmitgGIbVR6SWodr2t9aMLN5nh3Yj183fDP9lQdjNP1YrDc3kAOrlWVzwhMmQ=="
-    },
     "flush-write-stream": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",


### PR DESCRIPTION
This should've been removed as part of c52a603.