### PR TITLE
Fix bug 1687371 - pipeline: delegate JS compression to Terser

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,7 @@ ENV PYTHONPATH /app
 # JavaScript applications paths
 ENV WEBPACK_BINARY /app/node_modules/.bin/webpack
 ENV YUGLIFY_BINARY /app/node_modules/.bin/yuglify
+ENV TERSER_BINARY /app/node_modules/.bin/terser
 
 # Install required software.
 RUN apt-get update \

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -475,11 +475,11 @@ PIPELINE_JS = {
 PIPELINE = {
     "STYLESHEETS": PIPELINE_CSS,
     "JAVASCRIPT": PIPELINE_JS,
+    "JS_COMPRESSOR": "pipeline.compressors.terser.TerserCompressor",
     "YUGLIFY_BINARY": path(
         os.environ.get("YUGLIFY_BINARY", "node_modules/.bin/yuglify")
     ),
-    "BABEL_BINARY": path("node_modules/.bin/babel"),
-    "BABEL_ARGUMENTS": "--modules ignore",
+    "TERSER_BINARY": path(os.environ.get("TERSER_BINARY", "node_modules/.bin/terser")),
     "DISABLE_WRAPPER": True,
 }
 

--- a/requirements/default.in
+++ b/requirements/default.in
@@ -29,7 +29,7 @@ django-dotenv==1.3.0
 django-guardian==2.3.0
 django-jinja==2.7.0
 django-notifications-hq==1.6.0
-django-pipeline==2.0.5
+django-pipeline==2.0.6
 django-webpack-loader==0.5.0
 graphene-django==2.13.0
 gunicorn==19.9.0

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -100,9 +100,9 @@ django-notifications-hq==1.6.0 \
     --hash=sha256:debeb71b7076b08487b40bf07664d1cc43b9977c4480bbc969b30236dda7a461 \
     --hash=sha256:dfc6f8bd4034ceae91143bc3802ddfb6e276eaec90e63dd23e2584c052561576
     # via -r requirements/default.in
-django-pipeline==2.0.5 \
-    --hash=sha256:6c7bd5c2a922ddb7e989a1c5a6852f3a8bffcf6e14d9f228261c8ba04b5b79a7 \
-    --hash=sha256:7bf3d304c655ca20f77d66a4f4f3511a7b2f317768110967828aa5088806d4ce
+django-pipeline==2.0.6 \
+    --hash=sha256:3ec726e2bf9f61f213f41ee4513f4191a02ab2f5df86c9e3751a9a607c814031 \
+    --hash=sha256:443c560000b3202dafa873cf9b9a49018ded4b2090979dec8e8858b8b1f867c0
     # via -r requirements/default.in
 django-webpack-loader==0.5.0 \
     --hash=sha256:0a8536e36a30d719018cd4c5da6e9d2377771134e713c14e617bb484b4f0acce \

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -132,9 +132,9 @@ django-notifications-hq==1.6.0 \
     --hash=sha256:debeb71b7076b08487b40bf07664d1cc43b9977c4480bbc969b30236dda7a461 \
     --hash=sha256:dfc6f8bd4034ceae91143bc3802ddfb6e276eaec90e63dd23e2584c052561576
     # via -r requirements/default.txt
-django-pipeline==2.0.5 \
-    --hash=sha256:6c7bd5c2a922ddb7e989a1c5a6852f3a8bffcf6e14d9f228261c8ba04b5b79a7 \
-    --hash=sha256:7bf3d304c655ca20f77d66a4f4f3511a7b2f317768110967828aa5088806d4ce
+django-pipeline==2.0.6 \
+    --hash=sha256:3ec726e2bf9f61f213f41ee4513f4191a02ab2f5df86c9e3751a9a607c814031 \
+    --hash=sha256:443c560000b3202dafa873cf9b9a49018ded4b2090979dec8e8858b8b1f867c0
     # via -r requirements/default.txt
 django-sslserver==0.19 \
     --hash=sha256:1363835229a0585f89c42f3beca836572f3f6babdc1508f13352aed84b0924b3

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -177,9 +177,9 @@ django-notifications-hq==1.6.0 \
     --hash=sha256:debeb71b7076b08487b40bf07664d1cc43b9977c4480bbc969b30236dda7a461 \
     --hash=sha256:dfc6f8bd4034ceae91143bc3802ddfb6e276eaec90e63dd23e2584c052561576
     # via -r requirements/default.txt
-django-pipeline==2.0.5 \
-    --hash=sha256:6c7bd5c2a922ddb7e989a1c5a6852f3a8bffcf6e14d9f228261c8ba04b5b79a7 \
-    --hash=sha256:7bf3d304c655ca20f77d66a4f4f3511a7b2f317768110967828aa5088806d4ce
+django-pipeline==2.0.6 \
+    --hash=sha256:3ec726e2bf9f61f213f41ee4513f4191a02ab2f5df86c9e3751a9a607c814031 \
+    --hash=sha256:443c560000b3202dafa873cf9b9a49018ded4b2090979dec8e8858b8b1f867c0
     # via -r requirements/default.txt
 django-webpack-loader==0.5.0 \
     --hash=sha256:0a8536e36a30d719018cd4c5da6e9d2377771134e713c14e617bb484b4f0acce \


### PR DESCRIPTION
Yuglify doesn't understand ES2015+ code, whereas Terser handles it well.