### PR TITLE
Fix bug 1687328: Replace Tab keyboard shortcut with Ctrl + Shift + Up/Down

### DIFF
--- a/frontend/public/static/locale/en-US/translate.ftl
+++ b/frontend/public/static/locale/en-US/translate.ftl
@@ -177,8 +177,11 @@ editor-KeyboardShortcuts--search-strings-shortcut = <mod1>Ctrl</mod1> + <mod2>Sh
 editor-KeyboardShortcuts--select-all-strings = Select All Strings
 editor-KeyboardShortcuts--select-all-strings-shortcut = <mod1>Ctrl</mod1> + <mod2>Shift</mod2> + <accel>A</accel>
 
-editor-KeyboardShortcuts--copy-from-helpers = Copy From Helpers
-editor-KeyboardShortcuts--copy-from-helpers-shortcut = <mod1>Alt</mod1> + <accel>Tab</accel>
+editor-KeyboardShortcuts--copy-from-next-helper = Copy From Next Helper
+editor-KeyboardShortcuts--copy-from-next-helper-shortcut = <mod1>Ctrl</mod1> + <mod2>Shift</mod2> + <accel>Down</accel>
+
+editor-KeyboardShortcuts--copy-from-previous-helper = Copy From Previous Helper
+editor-KeyboardShortcuts--copy-from-previous-helper-shortcut = <mod1>Ctrl</mod1> + <mod2>Shift</mod2> + <accel>Up</accel>
 
 
 ## Editor Unsaved Changes
@@ -457,7 +460,7 @@ machinery-MicrosoftTerminology--visit-microsoft = MICROSOFT
 ## Machinery Translation
 ## Shows a specific translation from machinery.
 machinery-Translation--copy =
-    .title = Copy Into Translation (Alt + Tab)
+    .title = Copy Into Translation (Ctrl + Shift + Down)
 
 
 ## Machinery Translation Memory
@@ -503,7 +506,7 @@ notification--comment-added = Comment added
 ## Shows a specific translation from a different locale
 
 otherlocales-Translation--copy =
-    .title = Copy Into Translation (Alt + Tab)
+    .title = Copy Into Translation (Ctrl + Shift + Down)
 
 otherlocales-Translation--header-link =
     .title = Open string in { $locale } ({ $code })

--- a/frontend/public/static/locale/en-US/translate.ftl
+++ b/frontend/public/static/locale/en-US/translate.ftl
@@ -177,6 +177,9 @@ editor-KeyboardShortcuts--search-strings-shortcut = <mod1>Ctrl</mod1> + <mod2>Sh
 editor-KeyboardShortcuts--select-all-strings = Select All Strings
 editor-KeyboardShortcuts--select-all-strings-shortcut = <mod1>Ctrl</mod1> + <mod2>Shift</mod2> + <accel>A</accel>
 
+editor-KeyboardShortcuts--copy-from-helpers = Copy From Helpers
+editor-KeyboardShortcuts--copy-from-helpers-shortcut = <mod1>Alt</mod1> + <accel>Tab</accel>
+
 
 ## Editor Unsaved Changes
 ## Renders the unsaved changes popup
@@ -454,7 +457,7 @@ machinery-MicrosoftTerminology--visit-microsoft = MICROSOFT
 ## Machinery Translation
 ## Shows a specific translation from machinery.
 machinery-Translation--copy =
-    .title = Copy Into Translation (Tab)
+    .title = Copy Into Translation (Alt + Tab)
 
 
 ## Machinery Translation Memory
@@ -500,7 +503,7 @@ notification--comment-added = Comment added
 ## Shows a specific translation from a different locale
 
 otherlocales-Translation--copy =
-    .title = Copy Into Translation
+    .title = Copy Into Translation (Alt + Tab)
 
 otherlocales-Translation--header-link =
     .title = Open string in { $locale } ({ $code })

--- a/frontend/public/static/locale/en-US/translate.ftl
+++ b/frontend/public/static/locale/en-US/translate.ftl
@@ -159,11 +159,11 @@ editor-KeyboardShortcuts--cancel-translation-shortcut = <accel>Esc</accel>
 editor-KeyboardShortcuts--insert-a-new-line = Insert A New Line
 editor-KeyboardShortcuts--insert-a-new-line-shortcut = <mod1>Shift</mod1> + <accel>Enter</accel>
 
-editor-KeyboardShortcuts--go-to-next-string = Go To Next String
-editor-KeyboardShortcuts--go-to-next-string-shortcut = <mod1>Alt</mod1> + <accel>Down</accel>
-
 editor-KeyboardShortcuts--go-to-previous-string = Go To Previous String
 editor-KeyboardShortcuts--go-to-previous-string-shortcut = <mod1>Alt</mod1> + <accel>Up</accel>
+
+editor-KeyboardShortcuts--go-to-next-string = Go To Next String
+editor-KeyboardShortcuts--go-to-next-string-shortcut = <mod1>Alt</mod1> + <accel>Down</accel>
 
 editor-KeyboardShortcuts--copy-from-source = Copy From Source
 editor-KeyboardShortcuts--copy-from-source-shortcut = <mod1>Ctrl</mod1> + <mod2>Shift</mod2> + <accel>C</accel>
@@ -177,11 +177,11 @@ editor-KeyboardShortcuts--search-strings-shortcut = <mod1>Ctrl</mod1> + <mod2>Sh
 editor-KeyboardShortcuts--select-all-strings = Select All Strings
 editor-KeyboardShortcuts--select-all-strings-shortcut = <mod1>Ctrl</mod1> + <mod2>Shift</mod2> + <accel>A</accel>
 
-editor-KeyboardShortcuts--copy-from-next-helper = Copy From Next Helper
-editor-KeyboardShortcuts--copy-from-next-helper-shortcut = <mod1>Ctrl</mod1> + <mod2>Shift</mod2> + <accel>Down</accel>
-
 editor-KeyboardShortcuts--copy-from-previous-helper = Copy From Previous Helper
 editor-KeyboardShortcuts--copy-from-previous-helper-shortcut = <mod1>Ctrl</mod1> + <mod2>Shift</mod2> + <accel>Up</accel>
+
+editor-KeyboardShortcuts--copy-from-next-helper = Copy From Next Helper
+editor-KeyboardShortcuts--copy-from-next-helper-shortcut = <mod1>Ctrl</mod1> + <mod2>Shift</mod2> + <accel>Down</accel>
 
 
 ## Editor Unsaved Changes

--- a/frontend/src/core/editor/components/KeyboardShortcuts.css
+++ b/frontend/src/core/editor/components/KeyboardShortcuts.css
@@ -14,7 +14,7 @@
     border: 1px solid #333941;
     font-size: 13px;
     width: 400px;
-    height: 400px;
+    height: 435px;
     left: 0;
     top: 0;
     bottom: 0;

--- a/frontend/src/core/editor/components/KeyboardShortcuts.js
+++ b/frontend/src/core/editor/components/KeyboardShortcuts.js
@@ -222,9 +222,14 @@ export class KeyboardShortcutsBase extends React.Component<Props, State> {
                                         id='editor-KeyboardShortcuts--copy-from-helpers-shortcut'
                                         elems={{
                                             accel: <span />,
+                                            mod1: <span />,
                                         }}
                                     >
-                                        <td>{'<accel>Tab</accel>'}</td>
+                                        <td>
+                                            {
+                                                '<mod1>Alt</mod1> + <accel>Tab</accel>'
+                                            }
+                                        </td>
                                     </Localized>
                                 </tr>
                             </tbody>

--- a/frontend/src/core/editor/components/KeyboardShortcuts.js
+++ b/frontend/src/core/editor/components/KeyboardShortcuts.js
@@ -215,19 +215,39 @@ export class KeyboardShortcutsBase extends React.Component<Props, State> {
                                     </Localized>
                                 </tr>
                                 <tr>
-                                    <Localized id='editor-KeyboardShortcuts--copy-from-helpers'>
-                                        <td>Copy From Helpers</td>
+                                    <Localized id='editor-KeyboardShortcuts--copy-from-next-helper'>
+                                        <td>Copy From Next Helper</td>
                                     </Localized>
                                     <Localized
-                                        id='editor-KeyboardShortcuts--copy-from-helpers-shortcut'
+                                        id='editor-KeyboardShortcuts--copy-from-next-helper-shortcut'
                                         elems={{
                                             accel: <span />,
                                             mod1: <span />,
+                                            mod2: <span />,
                                         }}
                                     >
                                         <td>
                                             {
-                                                '<mod1>Alt</mod1> + <accel>Tab</accel>'
+                                                '<mod1>Ctrl</mod1> + <mod2>Shift</mod2> + <accel>Down</accel>'
+                                            }
+                                        </td>
+                                    </Localized>
+                                </tr>
+                                <tr>
+                                    <Localized id='editor-KeyboardShortcuts--copy-from-previous-helper'>
+                                        <td>Copy From Previous Helper</td>
+                                    </Localized>
+                                    <Localized
+                                        id='editor-KeyboardShortcuts--copy-from-previous-helper-shortcut'
+                                        elems={{
+                                            accel: <span />,
+                                            mod1: <span />,
+                                            mod2: <span />,
+                                        }}
+                                    >
+                                        <td>
+                                            {
+                                                '<mod1>Ctrl</mod1> + <mod2>Shift</mod2> + <accel>Up</accel>'
                                             }
                                         </td>
                                     </Localized>

--- a/frontend/src/core/editor/components/KeyboardShortcuts.js
+++ b/frontend/src/core/editor/components/KeyboardShortcuts.js
@@ -103,24 +103,6 @@ export class KeyboardShortcutsBase extends React.Component<Props, State> {
                                     </Localized>
                                 </tr>
                                 <tr>
-                                    <Localized id='editor-KeyboardShortcuts--go-to-next-string'>
-                                        <td>Go To Next String</td>
-                                    </Localized>
-                                    <Localized
-                                        id='editor-KeyboardShortcuts--go-to-next-string-shortcut'
-                                        elems={{
-                                            accel: <span />,
-                                            mod1: <span />,
-                                        }}
-                                    >
-                                        <td>
-                                            {
-                                                '<mod1>Alt</mod1> + <accel>Down</accel>'
-                                            }
-                                        </td>
-                                    </Localized>
-                                </tr>
-                                <tr>
                                     <Localized id='editor-KeyboardShortcuts--go-to-previous-string'>
                                         <td>Go To Previous String</td>
                                     </Localized>
@@ -134,6 +116,24 @@ export class KeyboardShortcutsBase extends React.Component<Props, State> {
                                         <td>
                                             {
                                                 '<mod1>Alt</mod1> + <accel>Up</accel>'
+                                            }
+                                        </td>
+                                    </Localized>
+                                </tr>
+                                <tr>
+                                    <Localized id='editor-KeyboardShortcuts--go-to-next-string'>
+                                        <td>Go To Next String</td>
+                                    </Localized>
+                                    <Localized
+                                        id='editor-KeyboardShortcuts--go-to-next-string-shortcut'
+                                        elems={{
+                                            accel: <span />,
+                                            mod1: <span />,
+                                        }}
+                                    >
+                                        <td>
+                                            {
+                                                '<mod1>Alt</mod1> + <accel>Down</accel>'
                                             }
                                         </td>
                                     </Localized>
@@ -215,25 +215,6 @@ export class KeyboardShortcutsBase extends React.Component<Props, State> {
                                     </Localized>
                                 </tr>
                                 <tr>
-                                    <Localized id='editor-KeyboardShortcuts--copy-from-next-helper'>
-                                        <td>Copy From Next Helper</td>
-                                    </Localized>
-                                    <Localized
-                                        id='editor-KeyboardShortcuts--copy-from-next-helper-shortcut'
-                                        elems={{
-                                            accel: <span />,
-                                            mod1: <span />,
-                                            mod2: <span />,
-                                        }}
-                                    >
-                                        <td>
-                                            {
-                                                '<mod1>Ctrl</mod1> + <mod2>Shift</mod2> + <accel>Down</accel>'
-                                            }
-                                        </td>
-                                    </Localized>
-                                </tr>
-                                <tr>
                                     <Localized id='editor-KeyboardShortcuts--copy-from-previous-helper'>
                                         <td>Copy From Previous Helper</td>
                                     </Localized>
@@ -248,6 +229,25 @@ export class KeyboardShortcutsBase extends React.Component<Props, State> {
                                         <td>
                                             {
                                                 '<mod1>Ctrl</mod1> + <mod2>Shift</mod2> + <accel>Up</accel>'
+                                            }
+                                        </td>
+                                    </Localized>
+                                </tr>
+                                <tr>
+                                    <Localized id='editor-KeyboardShortcuts--copy-from-next-helper'>
+                                        <td>Copy From Next Helper</td>
+                                    </Localized>
+                                    <Localized
+                                        id='editor-KeyboardShortcuts--copy-from-next-helper-shortcut'
+                                        elems={{
+                                            accel: <span />,
+                                            mod1: <span />,
+                                            mod2: <span />,
+                                        }}
+                                    >
+                                        <td>
+                                            {
+                                                '<mod1>Ctrl</mod1> + <mod2>Shift</mod2> + <accel>Down</accel>'
                                             }
                                         </td>
                                     </Localized>

--- a/frontend/src/core/editor/hooks/useHandleShortcuts.js
+++ b/frontend/src/core/editor/hooks/useHandleShortcuts.js
@@ -122,8 +122,8 @@ export default function useHandleShortcuts() {
             clearEditorFn();
         }
 
-        // On (Shift+) Tab, copy Machinery/Locales matches into translation.
-        if (key === 9) {
+        // On Alt + Tab, copy Machinery/Locales matches into translation.
+        if (key === 9 && event.altKey) {
             let translations;
             let copyTranslationFn;
             if (editorState.selectedHelperTabIndex === 0) {

--- a/frontend/src/core/editor/hooks/useHandleShortcuts.js
+++ b/frontend/src/core/editor/hooks/useHandleShortcuts.js
@@ -122,8 +122,13 @@ export default function useHandleShortcuts() {
             clearEditorFn();
         }
 
-        // On Alt + Tab, copy Machinery/Locales matches into translation.
-        if (key === 9 && event.altKey) {
+        // On Ctrl + Shift + Up/Down, copy next/previous entry from active
+        // helper tab (Machinery or Locales) into translation.
+        if (event.ctrlKey && event.shiftKey && !event.altKey) {
+            if (key !== 38 && key !== 40) {
+                return;
+            }
+
             let translations;
             let copyTranslationFn;
             if (editorState.selectedHelperTabIndex === 0) {
@@ -138,15 +143,18 @@ export default function useHandleShortcuts() {
             if (!numTranslations) {
                 return;
             }
+
             const currentIdx = editorState.selectedHelperElementIndex;
             let nextIdx;
-            if (!event.shiftKey) {
+            if (key === 40) {
                 nextIdx = (currentIdx + 1) % numTranslations;
             } else {
                 nextIdx = (currentIdx - 1 + numTranslations) % numTranslations;
             }
-            const newTranslation = translations[nextIdx];
+
             dispatch(editor.actions.selectHelperElementIndex(nextIdx));
+
+            const newTranslation = translations[nextIdx];
             handledEvent = true;
             copyTranslationFn(newTranslation);
         }

--- a/frontend/src/core/editor/reducer.js
+++ b/frontend/src/core/editor/reducer.js
@@ -196,6 +196,7 @@ export default function reducer(
             return {
                 ...initial,
                 isRunningRequest: state.isRunningRequest,
+                selectedHelperTabIndex: state.selectedHelperTabIndex,
             };
         case UPDATE_MACHINERY_SOURCES:
             return {

--- a/frontend/src/modules/machinery/components/Translation.js
+++ b/frontend/src/modules/machinery/components/Translation.js
@@ -74,7 +74,7 @@ export default function Translation(props: Props) {
         <Localized id='machinery-Translation--copy' attrs={{ title: true }}>
             <li
                 className={className}
-                title='Copy Into Translation (Alt + Tab)'
+                title='Copy Into Translation (Ctrl + Shift + Down)'
                 onClick={copyTranslationIntoEditor}
                 ref={translationRef}
             >

--- a/frontend/src/modules/machinery/components/Translation.js
+++ b/frontend/src/modules/machinery/components/Translation.js
@@ -74,7 +74,7 @@ export default function Translation(props: Props) {
         <Localized id='machinery-Translation--copy' attrs={{ title: true }}>
             <li
                 className={className}
-                title='Copy Into Translation (Tab)'
+                title='Copy Into Translation (Alt + Tab)'
                 onClick={copyTranslationIntoEditor}
                 ref={translationRef}
             >

--- a/frontend/src/modules/otherlocales/components/Translation.js
+++ b/frontend/src/modules/otherlocales/components/Translation.js
@@ -73,7 +73,7 @@ export default function Translation(props: Props) {
         <Localized id='otherlocales-Translation--copy' attrs={{ title: true }}>
             <li
                 className={className}
-                title='Copy Into Translation (Alt + Tab)'
+                title='Copy Into Translation (Ctrl + Shift + Down)'
                 onClick={copyTranslationIntoEditor}
                 ref={translationRef}
             >

--- a/frontend/src/modules/otherlocales/components/Translation.js
+++ b/frontend/src/modules/otherlocales/components/Translation.js
@@ -73,7 +73,7 @@ export default function Translation(props: Props) {
         <Localized id='otherlocales-Translation--copy' attrs={{ title: true }}>
             <li
                 className={className}
-                title='Copy Into Translation'
+                title='Copy Into Translation (Alt + Tab)'
                 onClick={copyTranslationIntoEditor}
                 ref={translationRef}
             >


### PR DESCRIPTION
That leaves the default and expected behavior of the Tab key unchanged,
which is critical for accessibility and usability.

Also included:
- Add shortcut to the Locales tab tooltip
- Fix keyboard shortcut display in the panel

Deployed to stage:
https://mozilla-pontoon-staging.herokuapp.com/projects/firefox/all-resources/