### PR TITLE
Fix Add Comment input height to match submit button

### DIFF
--- a/frontend/src/core/comments/components/AddComment.css
+++ b/frontend/src/core/comments/components/AddComment.css
@@ -13,7 +13,6 @@
     flex-grow: 2;
     font-size: 11px;
     max-height: 144px;
-    line-height: 20px;
     margin: auto;
     overflow: auto;
     padding: 7px;


### PR DESCRIPTION
Add Comment input box in the Comments tab is smaller than the submit button.
We don't have that problem in translation comments, because line-height is
defined in History.css.