### PR TITLE
Fix bug 1688570: improve performance of initial editor change

### DIFF
--- a/frontend/src/core/plural/components/PluralSelector.test.js
+++ b/frontend/src/core/plural/components/PluralSelector.test.js
@@ -2,8 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
 
-import { createReduxStore } from 'test/store';
-import { shallowUntilTarget } from 'test/utils';
+import { createReduxStore, mountComponentWithStore } from 'test/store';
 
 import { actions } from '..';
 
@@ -78,20 +77,31 @@ describe('<PluralSelector>', () => {
             },
             router: {
                 location: {
-                    pathname: '/kg/pro/all/',
+                    pathname: '/kg/firefox/all-resources/',
                     search: '?string=42',
                 },
+                // `action` is required because
+                // https://github.com/supasate/connected-react-router/issues/312#issuecomment-500968504
+                // Please note the initial `LOCATION_CHANGE` action can and must
+                // be supressed via the `noInitialPop` prop in
+                // `ConnectedRouter`, otherwise it'll cause side-effects like
+                // executing reducers and hence altering initial state values.
+                action: 'some-string-to-please-connected-react-router',
             },
         };
         const store = createReduxStore(initialState);
         const dispatchSpy = sinon.spy(store, 'dispatch');
 
-        const wrapper = shallowUntilTarget(
-            <PluralSelector store={store} resetEditor={sinon.spy()} />,
-            PluralSelectorBase,
-        );
+        const root = mountComponentWithStore(PluralSelector, store, {
+            resetEditor: sinon.spy(),
+        });
+        const wrapper = root.find(PluralSelectorBase);
 
-        wrapper.find('button').first().simulate('click');
+        const button = wrapper.find('button').first();
+        // `simulate()` doesn't quite work in conjunction with `mount()`, so
+        // invoking the `prop()` callback directly is the way to go as suggested
+        // by the enzyme maintainer...
+        button.prop('onClick')();
 
         const expectedAction = actions.select(0);
         expect(dispatchSpy.calledWith(expectedAction)).toBeTruthy();

--- a/frontend/src/modules/entitieslist/components/EntitiesList.test.js
+++ b/frontend/src/modules/entitieslist/components/EntitiesList.test.js
@@ -1,8 +1,6 @@
-import React from 'react';
 import sinon from 'sinon';
 
-import { createReduxStore } from 'test/store';
-import { shallowUntilTarget } from 'test/utils';
+import { createReduxStore, mountComponentWithStore } from 'test/store';
 
 import * as entities from 'core/entities';
 import * as navigation from 'core/navigation';
@@ -11,7 +9,10 @@ import * as batchactions from 'modules/batchactions';
 import EntitiesList, { EntitiesListBase } from './EntitiesList';
 
 // Entities shared between tests
-const ENTITIES = [{ pk: 1 }, { pk: 2 }];
+const ENTITIES = [
+    { pk: 1, translation: [{ string: '', errors: [], warnings: [] }] },
+    { pk: 2, translation: [{ string: '', errors: [], warnings: [] }] },
+];
 
 describe('<EntitiesList>', () => {
     beforeAll(() => {
@@ -47,13 +48,9 @@ describe('<EntitiesList>', () => {
 
         store.dispatch(entities.actions.receive(ENTITIES, true));
 
-        const wrapper = shallowUntilTarget(
-            <EntitiesList store={store} />,
-            EntitiesListBase,
-        );
-        const scroll = wrapper
-            .find('InfiniteScroll')
-            .shallow({ disableLifecycleMethods: true });
+        const root = mountComponentWithStore(EntitiesList, store);
+        const wrapper = root.find(EntitiesListBase);
+        const scroll = wrapper.find('InfiniteScroll');
 
         expect(scroll.find('SkeletonLoader')).toHaveLength(1);
     });
@@ -63,13 +60,9 @@ describe('<EntitiesList>', () => {
 
         store.dispatch(entities.actions.receive(ENTITIES, false));
 
-        const wrapper = shallowUntilTarget(
-            <EntitiesList store={store} />,
-            EntitiesListBase,
-        );
-        const scroll = wrapper
-            .find('InfiniteScroll')
-            .shallow({ disableLifecycleMethods: true });
+        const root = mountComponentWithStore(EntitiesList, store);
+        const wrapper = root.find(EntitiesListBase);
+        const scroll = wrapper.find('InfiniteScroll');
 
         expect(scroll.find('SkeletonLoader')).toHaveLength(0);
     });
@@ -79,13 +72,9 @@ describe('<EntitiesList>', () => {
 
         store.dispatch(entities.actions.request());
 
-        const wrapper = shallowUntilTarget(
-            <EntitiesList store={store} />,
-            EntitiesListBase,
-        );
-        const scroll = wrapper
-            .find('InfiniteScroll')
-            .shallow({ disableLifecycleMethods: true });
+        const root = mountComponentWithStore(EntitiesList, store);
+        const wrapper = root.find(EntitiesListBase);
+        const scroll = wrapper.find('InfiniteScroll');
 
         expect(scroll.find('SkeletonLoader')).toHaveLength(1);
     });
@@ -95,10 +84,8 @@ describe('<EntitiesList>', () => {
 
         store.dispatch(entities.actions.receive(ENTITIES, false));
 
-        const wrapper = shallowUntilTarget(
-            <EntitiesList store={store} />,
-            EntitiesListBase,
-        );
+        const root = mountComponentWithStore(EntitiesList, store);
+        const wrapper = root.find(EntitiesListBase);
 
         expect(wrapper.find('Entity')).toHaveLength(2);
     });
@@ -108,10 +95,8 @@ describe('<EntitiesList>', () => {
 
         store.dispatch(entities.actions.receive(ENTITIES, false));
 
-        const wrapper = shallowUntilTarget(
-            <EntitiesList store={store} />,
-            EntitiesListBase,
-        );
+        const root = mountComponentWithStore(EntitiesList, store);
+        const wrapper = root.find(EntitiesListBase);
 
         wrapper.instance().getMoreEntities();
 
@@ -124,7 +109,7 @@ describe('<EntitiesList>', () => {
 
         store.dispatch(entities.actions.receive(ENTITIES, false));
 
-        shallowUntilTarget(<EntitiesList store={store} />, EntitiesListBase);
+        mountComponentWithStore(EntitiesList, store);
 
         expect(batchactions.actions.resetSelection.calledOnce).toBeTruthy();
         expect(navigation.actions.updateEntity.calledOnce).toBeTruthy();
@@ -138,10 +123,8 @@ describe('<EntitiesList>', () => {
 
         store.dispatch(entities.actions.receive(ENTITIES, false));
 
-        const wrapper = shallowUntilTarget(
-            <EntitiesList store={store} />,
-            EntitiesListBase,
-        );
+        const root = mountComponentWithStore(EntitiesList, store);
+        const wrapper = root.find(EntitiesListBase);
 
         wrapper.instance().toggleForBatchEditing(ENTITIES[0].pk, false);
 

--- a/frontend/src/modules/entitydetails/components/EntityDetails.test.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.test.js
@@ -2,11 +2,11 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
 
-import { createReduxStore } from 'test/store';
-import { shallowUntilTarget } from 'test/utils';
+import { createReduxStore, mountComponentWithStore } from 'test/store';
 
 import * as editor from 'core/editor';
 import * as history from 'modules/history';
+import * as unsavedchanges from 'modules/unsavedchanges';
 
 import EntityDetails, { EntityDetailsBase } from './EntityDetails';
 
@@ -21,6 +21,8 @@ const ENTITIES = [
                 warnings: [],
             },
         ],
+        project: { contact: '' },
+        comment: '',
     },
     {
         pk: 1,
@@ -32,6 +34,8 @@ const ENTITIES = [
                 warnings: [],
             },
         ],
+        project: { contact: '' },
+        comment: '',
     },
 ];
 const TRANSLATION = 'test';
@@ -87,17 +91,16 @@ function createEntityDetailsWithStore() {
                 pathname: '/kg/pro/all/',
                 search: '?string=' + ENTITIES[0].pk,
             },
+            action: 'some-string-to-please-connected-react-router',
         },
         locale: {
             code: 'kg',
         },
     };
     const store = createReduxStore(initialState);
+    const root = mountComponentWithStore(EntityDetails, store);
 
-    return [
-        shallowUntilTarget(<EntityDetails store={store} />, EntityDetailsBase),
-        store,
-    ];
+    return [root.find(EntityDetailsBase), store];
 }
 
 describe('<EntityDetailsBase>', () => {
@@ -209,9 +212,11 @@ describe('<EntityDetails>', () => {
     });
 
     it('dispatches the updateStatus action when updateTranslationStatus is called', () => {
-        const [wrapper] = createEntityDetailsWithStore();
+        const [wrapper, store] = createEntityDetailsWithStore();
 
         wrapper.instance().updateTranslationStatus(42, 'fake translation');
+        // Proceed with changes even if unsaved
+        store.dispatch(unsavedchanges.actions.ignore());
         expect(history.actions.updateStatus.calledOnce).toBeTruthy();
     });
 });

--- a/frontend/src/test/store.js
+++ b/frontend/src/test/store.js
@@ -31,7 +31,10 @@ export function createReduxStore(initialState = {}) {
 export function mountComponentWithStore(Component, store, props = {}) {
     return mount(
         <Provider store={store}>
-            <ConnectedRouter history={history}>
+            {/* `noInitialPop` is required to omit an initial navigation dispatch
+            from the router, which could have side-effects like resetting some
+            initial state passed to the root reducer factory function.*/}
+            <ConnectedRouter history={history} noInitialPop>
                 <Component {...props} />
             </ConnectedRouter>
         </Provider>,


### PR DESCRIPTION
Changing from/to initial textarea values would result in redundant
re-renders due to subscribing to `unsavedChangesExist` and
`unsavedChangesIgnored` redux state changes.

Implementation-wise, this accesses `unsavedchanges` state directly,
without subscribing to its changes because the state members are not
used for rendering purposes.

For direct store access react-redux strongly suggests to leverage the
`useStore()` API, because accessing the store via context is an
implementation detail and it might change in the future. That's why the
components connecting redux state -> props have been converted to hooks.

It'd also have been possible to avoid these intermediate components and
co-locate redux state directly within components, however that would
require more invasive changes, creeping the scope of this change
considerably.

Refs. https://react-redux.js.org/using-react-redux/accessing-store


----

Before:
<img width="1012" alt="before" src="https://user-images.githubusercontent.com/16768/105884224-097b1c00-6008-11eb-9e7b-9687229fde8b.png">


After:
<img width="644" alt="after" src="https://user-images.githubusercontent.com/16768/105884256-126bed80-6008-11eb-93fe-b83f6402e9e2.png">