### PR TITLE
Fix bug 1689653: avoid lightbox actions when closed

### DIFF
--- a/frontend/src/core/lightbox/components/Lightbox.js
+++ b/frontend/src/core/lightbox/components/Lightbox.js
@@ -19,40 +19,53 @@ type InternalProps = {|
     dispatch: Function,
 |};
 
+type ContentProps = {|
+    image: string,
+    onClose: Function,
+|};
+
 /**
  * Shows an image on a grey background.
  *
  * Hides the UI behind a grey background and show a centered image.
  * Click or press a key to close.
  */
+function LightboxContent({ image, onClose }: ContentProps) {
+    const handleKeyDown = React.useCallback(
+        (event: SyntheticKeyboardEvent<>) => {
+            // On keys:
+            //   - 13: Enter
+            //   - 27: Escape
+            //   - 32: Space
+            if (
+                event.keyCode === 13 ||
+                event.keyCode === 27 ||
+                event.keyCode === 32
+            ) {
+                onClose();
+            }
+        },
+        [onClose],
+    );
+
+    React.useEffect(() => {
+        window.document.addEventListener('keydown', handleKeyDown);
+        return () => {
+            window.document.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [handleKeyDown]);
+
+    return (
+        <div className='lightbox' onClick={onClose}>
+            <img src={image} alt='' />
+        </div>
+    );
+}
+
 export class LightboxBase extends React.Component<InternalProps> {
     close = () => {
         this.props.dispatch(close());
     };
-
-    closeOnKeys = (event: SyntheticKeyboardEvent<>) => {
-        // On keys:
-        //   - 13: Enter
-        //   - 27: Escape
-        //   - 32: Space
-        if (
-            event.keyCode === 13 ||
-            event.keyCode === 27 ||
-            event.keyCode === 32
-        ) {
-            this.close();
-        }
-    };
-
-    componentDidMount() {
-        // $FLOW_IGNORE (errors that I don't understand, no help from the Web)
-        document.addEventListener('keydown', this.closeOnKeys);
-    }
-
-    componentWillUnmount() {
-        // $FLOW_IGNORE (errors that I don't understand, no help from the Web)
-        document.removeEventListener('keydown', this.closeOnKeys);
-    }
 
     render() {
         const { lightbox } = this.props;
@@ -61,11 +74,7 @@ export class LightboxBase extends React.Component<InternalProps> {
             return null;
         }
 
-        return (
-            <div className='lightbox' onClick={this.close}>
-                <img src={lightbox.image} alt='' />
-            </div>
-        );
+        return <LightboxContent image={lightbox.image} onClose={this.close} />;
     }
 }
 

--- a/frontend/src/core/lightbox/components/Lightbox.test.js
+++ b/frontend/src/core/lightbox/components/Lightbox.test.js
@@ -14,7 +14,7 @@ describe('<LightboxBase>', () => {
             image: 'http://example.org/empty.png',
             isOpen: true,
         };
-        const wrapper = shallow(<LightboxBase lightbox={state} />);
+        const wrapper = shallow(<LightboxBase lightbox={state} />).dive();
 
         expect(wrapper.find('img')).toHaveLength(1);
         expect(wrapper.find('img').props().src).toEqual(
@@ -71,8 +71,9 @@ describe('<LightboxEvents>', () => {
         expect(actions.close.calledOnce).toEqual(true);
     });
 
-    it('closes on key presses', () => {
+    it('closes on key presses if opened before', () => {
         const store = createReduxStore();
+        store.dispatch(actions.open('http://example.org/empty.png'));
 
         // Simulating the key presses on `document`.
         // See https://github.com/airbnb/enzyme/issues/426


### PR DESCRIPTION
The editor would constantly fire `lightbox/CLOSE` actions upon
pressing any of space/esc/enter keys.