### PR TITLE
Bug 1688571: add discard functionality hook

### DIFF
--- a/frontend/src/core/plural/selectors.js
+++ b/frontend/src/core/plural/selectors.js
@@ -24,7 +24,7 @@ export function _getPluralForm(pluralForm: number, entity: ?Entity): number {
  */
 export const getPluralForm: Function = createSelector(
     pluralSelector,
-    entities.selectors.getSelectedEntity,
+    (state) => entities.selectors.getSelectedEntity(state),
     _getPluralForm,
 );
 
@@ -55,7 +55,7 @@ export function _getTranslationForSelectedEntity(
  * most recent non-rejected one.
  */
 export const getTranslationForSelectedEntity: Function = createSelector(
-    entities.selectors.getSelectedEntity,
+    (state) => entities.selectors.getSelectedEntity(state),
     getPluralForm,
     _getTranslationForSelectedEntity,
 );
@@ -79,7 +79,7 @@ export function _getTranslationStringForSelectedEntity(
  * most recent non-rejected one.
  */
 export const getTranslationStringForSelectedEntity: Function = createSelector(
-    entities.selectors.getSelectedEntity,
+    (state) => entities.selectors.getSelectedEntity(state),
     getPluralForm,
     _getTranslationStringForSelectedEntity,
 );

--- a/frontend/src/core/utils/hooks/useOnDiscard.js
+++ b/frontend/src/core/utils/hooks/useOnDiscard.js
@@ -1,0 +1,26 @@
+/* @flow */
+import * as React from 'react';
+
+export default function useOnDiscard(
+    ref: { current: null | React.ElementRef<any> },
+    onDiscard: (e: SyntheticEvent<any>) => void,
+) {
+    const handleClick = React.useCallback(
+        (e: SyntheticEvent<any>) => {
+            const el = ref.current;
+            if (!el || el.contains(e.target)) {
+                return;
+            }
+
+            onDiscard(e);
+        },
+        [ref, onDiscard],
+    );
+
+    React.useEffect(() => {
+        window.document.addEventListener('click', handleClick);
+        return () => {
+            window.document.removeEventListener('click', handleClick);
+        };
+    }, [handleClick]);
+}

--- a/frontend/src/core/utils/hooks/useOnDiscard.test.js
+++ b/frontend/src/core/utils/hooks/useOnDiscard.test.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, unmountComponentAtNode } from 'react-dom';
+import { act } from 'react-dom/test-utils';
+import sinon from 'sinon';
+
+import useOnDiscard from './useOnDiscard';
+
+function TestComponent({ onDiscard }) {
+    const ref = React.useRef(null);
+    useOnDiscard(ref, onDiscard);
+    return (
+        <div>
+            <div id='js-outside'>Outside Content</div>
+            {/* Discardable element */}
+            <div ref={ref}>
+                <button id='js-inside'>Inside Content</button>
+            </div>
+        </div>
+    );
+}
+
+describe('useOnDiscard', () => {
+    let root;
+
+    beforeEach(async () => {
+        root = document.createElement('div');
+        document.body.appendChild(root);
+    });
+
+    afterEach(() => {
+        unmountComponentAtNode(root);
+        root.remove();
+        root = null;
+    });
+
+    it('runs discard callback upon outside click', () => {
+        const onDiscardSpy = sinon.spy();
+        act(() => {
+            render(<TestComponent onDiscard={onDiscardSpy} />, root);
+        });
+
+        const click = new Event('click', { bubbles: true });
+        const outside = document.getElementById('js-outside');
+        outside.dispatchEvent(click);
+
+        expect(onDiscardSpy.calledOnce).toBe(true);
+    });
+
+    it('does not run discard callback upon inside click', () => {
+        const onDiscardSpy = sinon.spy();
+        act(() => {
+            render(<TestComponent onDiscard={onDiscardSpy} />, root);
+        });
+
+        const click = new Event('click', { bubbles: true });
+        const inside = document.getElementById('js-inside');
+        inside.dispatchEvent(click);
+
+        expect(onDiscardSpy.callCount).toBe(0);
+    });
+});

--- a/frontend/src/core/utils/index.js
+++ b/frontend/src/core/utils/index.js
@@ -7,5 +7,6 @@ export { default as fluent } from './fluent';
 export { default as getOptimizedContent } from './getOptimizedContent';
 export { default as asLocaleString } from './asLocaleString';
 
-// Components and HOC
+// Components, HOC, and Hooks
 export { default as withActionsDisabled } from './components/withActionsDisabled';
+export { default as useOnDiscard } from './hooks/useOnDiscard';


### PR DESCRIPTION
This will be used as a replacement for react-onclickoutside, because the functionality only needs a few lines of code and it's more explicit than using a HoC.

Because 10 components of different complexity are affected, it's going to be way easier to review if we move with individual PRs, one component at a time. So the plan would be:
1. Introduce this hook
2. Replace every single use of `onClickOutside()` with `useOnDiscard()`
3. Remove react-onclickoutside