### PR TITLE
Bug 1688571: fix negative performance side-effects of `UserNotificationsMenu`

### DIFF
--- a/frontend/src/core/user/components/UserNotificationsMenu.js
+++ b/frontend/src/core/user/components/UserNotificationsMenu.js
@@ -1,14 +1,15 @@
 /* @flow */
 
 import * as React from 'react';
-import onClickOutside from 'react-onclickoutside';
 import { Localized } from '@fluent/react';
 
 import './UserNotificationsMenu.css';
 
 import UserNotification from './UserNotification';
 
-import type { UserState } from 'core/user';
+import { useOnDiscard } from 'core/utils';
+
+import type { UserState, Notification } from 'core/user';
 
 type Props = {
     markAllNotificationsAsRead: () => void,
@@ -20,10 +21,62 @@ type State = {|
     visible: boolean,
 |};
 
+type UserNotificationsMenuProps = {
+    notifications: Array<Notification>,
+    onDiscard: (e: SyntheticEvent<any>) => void,
+};
+
+export function UserNotificationsMenu({
+    notifications,
+    onDiscard,
+}: UserNotificationsMenuProps) {
+    const ref = React.useRef(null);
+    useOnDiscard(ref, onDiscard);
+
+    return (
+        <div ref={ref} className='menu'>
+            <ul className='notification-list'>
+                {notifications.length ? (
+                    notifications.map((notification) => {
+                        return (
+                            <UserNotification
+                                notification={notification}
+                                key={notification.id}
+                            />
+                        );
+                    })
+                ) : (
+                    <li className='no'>
+                        <i className='icon fa fa-bell fa-fw'></i>
+                        <Localized id='user-UserNotificationsMenu--no-notifications-title'>
+                            <p className='title'>No new notifications.</p>
+                        </Localized>
+                        <Localized id='user-UserNotificationsMenu--no-notifications-description'>
+                            <p className='description'>
+                                Here you’ll see updates for localizations you
+                                contribute to.
+                            </p>
+                        </Localized>
+                    </li>
+                )}
+            </ul>
+
+            <div className='see-all'>
+                <Localized id='user-UserNotificationsMenu--see-all-notifications'>
+                    <a href='/notifications'>See all Notifications</a>
+                </Localized>
+            </div>
+        </div>
+    );
+}
+
 /**
  * Renders user notifications.
  */
-export class UserNotificationsMenuBase extends React.Component<Props, State> {
+export default class UserNotificationsMenuBase extends React.Component<
+    Props,
+    State,
+> {
     constructor(props: Props) {
         super(props);
 
@@ -71,9 +124,7 @@ export class UserNotificationsMenuBase extends React.Component<Props, State> {
         }
     };
 
-    // This method is called by the Higher-Order Component `onClickOutside`
-    // when a user clicks outside the user menu.
-    handleClickOutside = () => {
+    handleDiscard = () => {
         this.setState({
             visible: false,
         });
@@ -87,7 +138,7 @@ export class UserNotificationsMenuBase extends React.Component<Props, State> {
         }
 
         let className = 'user-notifications-menu';
-        if (this.props.user.notifications.has_unread) {
+        if (user.notifications.has_unread) {
             className += ' unread';
         } else if (this.state.markAsRead) {
             className += ' read';
@@ -97,56 +148,19 @@ export class UserNotificationsMenuBase extends React.Component<Props, State> {
             className += ' menu-visible';
         }
 
-        const notifications = user.notifications.notifications;
-
         return (
             <div className={className}>
                 <div className='selector' onClick={this.handleClick}>
                     <i className='icon far fa-bell fa-fw'></i>
                 </div>
 
-                {!this.state.visible ? null : (
-                    <div className='menu'>
-                        <ul className='notification-list'>
-                            {notifications.length ? (
-                                notifications.map((notification) => {
-                                    return (
-                                        <UserNotification
-                                            notification={notification}
-                                            key={notification.id}
-                                        />
-                                    );
-                                })
-                            ) : (
-                                <li className='no'>
-                                    <i className='icon fa fa-bell fa-fw'></i>
-                                    <Localized id='user-UserNotificationsMenu--no-notifications-title'>
-                                        <p className='title'>
-                                            No new notifications.
-                                        </p>
-                                    </Localized>
-                                    <Localized id='user-UserNotificationsMenu--no-notifications-description'>
-                                        <p className='description'>
-                                            Here you’ll see updates for
-                                            localizations you contribute to.
-                                        </p>
-                                    </Localized>
-                                </li>
-                            )}
-                        </ul>
-
-                        <div className='see-all'>
-                            <Localized id='user-UserNotificationsMenu--see-all-notifications'>
-                                <a href='/notifications'>
-                                    See all Notifications
-                                </a>
-                            </Localized>
-                        </div>
-                    </div>
+                {this.state.visible && (
+                    <UserNotificationsMenu
+                        notifications={user.notifications.notifications}
+                        onDiscard={this.handleDiscard}
+                    />
                 )}
             </div>
         );
     }
 }
-
-export default onClickOutside(UserNotificationsMenuBase);

--- a/frontend/src/core/user/components/UserNotificationsMenu.test.js
+++ b/frontend/src/core/user/components/UserNotificationsMenu.test.js
@@ -1,8 +1,53 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import { UserNotificationsMenuBase } from './UserNotificationsMenu';
+import UserNotificationsMenuBase, {
+    UserNotificationsMenu,
+} from './UserNotificationsMenu';
 import UserNotification from './UserNotification';
+
+describe('<UserNotificationsMenu>', () => {
+    it('shows empty notifications menu if user has no notifications', () => {
+        const notifications = [];
+        const wrapper = shallow(
+            <UserNotificationsMenu notifications={notifications} />,
+        );
+
+        expect(
+            wrapper.find('.notification-list .user-notification'),
+        ).toHaveLength(0);
+        expect(wrapper.find('.notification-list .no')).toHaveLength(1);
+    });
+
+    it('shows a notification in the notifications menu', () => {
+        const notifications = [
+            {
+                id: 0,
+                level: 'level',
+                unread: false,
+                description: 'description',
+                verb: 'verb',
+                date: 'Jan 31, 2000 10:20',
+                date_iso: '2019-01-31T10:20:00+00:00',
+                actor: {
+                    anchor: 'actor_anchor',
+                    url: 'actor_url',
+                },
+                target: {
+                    anchor: 'target_anchor',
+                    url: 'target_url',
+                },
+            },
+        ];
+
+        const wrapper = shallow(
+            <UserNotificationsMenu notifications={notifications} />,
+        );
+
+        expect(wrapper.find('.notification-list .no')).toHaveLength(0);
+        expect(wrapper.find(UserNotification)).toHaveLength(1);
+    });
+});
 
 describe('<UserNotificationsMenuBase>', () => {
     it('hides the notifications icon when the user is logged out', () => {
@@ -38,56 +83,5 @@ describe('<UserNotificationsMenuBase>', () => {
         const wrapper = shallow(<UserNotificationsMenuBase user={user} />);
 
         expect(wrapper.find('.user-notifications-menu.unread')).toHaveLength(1);
-    });
-
-    it('shows empty notifications menu if user has no notifications', () => {
-        const user = {
-            isAuthenticated: true,
-            notifications: {
-                has_unread: false,
-                notifications: [],
-            },
-        };
-        const wrapper = shallow(<UserNotificationsMenuBase user={user} />);
-        wrapper.instance().setState({ visible: true });
-
-        expect(
-            wrapper.find('.notification-list .user-notification'),
-        ).toHaveLength(0);
-        expect(wrapper.find('.notification-list .no')).toHaveLength(1);
-    });
-
-    it('shows a notification in the notifications menu', () => {
-        const user = {
-            isAuthenticated: true,
-            notifications: {
-                has_unread: false,
-                notifications: [
-                    {
-                        id: 0,
-                        level: 'level',
-                        unread: false,
-                        description: 'description',
-                        verb: 'verb',
-                        date: 'Jan 31, 2000 10:20',
-                        date_iso: '2019-01-31T10:20:00+00:00',
-                        actor: {
-                            anchor: 'actor_anchor',
-                            url: 'actor_url',
-                        },
-                        target: {
-                            anchor: 'target_anchor',
-                            url: 'target_url',
-                        },
-                    },
-                ],
-            },
-        };
-
-        const wrapper = shallow(<UserNotificationsMenuBase user={user} />);
-        wrapper.instance().setState({ visible: true });
-
-        expect(wrapper.find('.notification-list .no')).toHaveLength(0);
-        expect(wrapper.find(UserNotification)).toHaveLength(1);
     });
 });

--- a/frontend/src/core/user/index.js
+++ b/frontend/src/core/user/index.js
@@ -9,7 +9,7 @@ export { default as UserControls } from './components/UserControls';
 export { default as UserAvatar } from './components/UserAvatar';
 
 export type { Settings } from './actions';
-export type { SettingsState, UserState } from './reducer';
+export type { SettingsState, UserState, Notification } from './reducer';
 
 // Name of this module.
 // Used as the key to store this module's reducer.


### PR DESCRIPTION
This now only listens for `click` events when the menu is visible by
the means of leveraging the `useOnDiscard` hook.