### PR TITLE
Bug 1688571: fix negative performance side-effects of `EditorSettings`

### DIFF
--- a/frontend/src/core/editor/components/EditorSettings.js
+++ b/frontend/src/core/editor/components/EditorSettings.js
@@ -1,8 +1,9 @@
 /* @flow */
 
 import * as React from 'react';
-import onClickOutside from 'react-onclickoutside';
 import { Localized } from '@fluent/react';
+
+import { useOnDiscard } from 'core/utils';
 
 import './EditorSettings.css';
 
@@ -17,10 +18,70 @@ type State = {|
     visible: boolean,
 |};
 
+type EditorSettingsProps = {
+    settings: Settings,
+    toggleSetting: Function,
+    onDiscard: (e: SyntheticEvent<any>) => void,
+};
+
+export function EditorSettings({
+    settings,
+    toggleSetting,
+    onDiscard,
+}: EditorSettingsProps) {
+    const ref = React.useRef(null);
+    useOnDiscard(ref, onDiscard);
+
+    return (
+        <ul ref={ref} className='menu'>
+            <Localized
+                id='editor-EditorSettings--toolkit-checks'
+                attrs={{ title: true }}
+                elems={{ glyph: <i className='fa fa-fw' /> }}
+            >
+                <li
+                    className={
+                        'check-box' +
+                        (settings.runQualityChecks ? ' enabled' : '')
+                    }
+                    title='Run Translate Toolkit checks before submitting translations'
+                    onClick={() => toggleSetting('runQualityChecks')}
+                >
+                    {'<glyph></glyph>Translate Toolkit Checks'}
+                </li>
+            </Localized>
+
+            <Localized
+                id='editor-EditorSettings--force-suggestions'
+                attrs={{ title: true }}
+                elems={{ glyph: <i className='fa fa-fw' /> }}
+            >
+                <li
+                    className={
+                        'check-box' +
+                        (settings.forceSuggestions ? ' enabled' : '')
+                    }
+                    title='Save suggestions instead of translations'
+                    onClick={() => toggleSetting('forceSuggestions')}
+                >
+                    {'<glyph></glyph>Make Suggestions'}
+                </li>
+            </Localized>
+
+            <li className='horizontal-separator'></li>
+            <li>
+                <Localized id='editor-EditorSettings--change-all'>
+                    <a href='/settings/'>{'Change All Settings'}</a>
+                </Localized>
+            </li>
+        </ul>
+    );
+}
+
 /*
  * Renders settings to be used to customize interactions with the Editor.
  */
-export class EditorSettingsBase extends React.Component<Props, State> {
+export default class EditorSettingsBase extends React.Component<Props, State> {
     constructor(props: Props) {
         super(props);
         this.state = {
@@ -34,24 +95,18 @@ export class EditorSettingsBase extends React.Component<Props, State> {
         });
     };
 
-    // This method is called by the Higher-Order Component `onClickOutside`
-    // when a user clicks outside the search panel.
-    handleClickOutside = () => {
+    handleDiscard = () => {
         this.setState({
             visible: false,
         });
     };
 
-    toggleSetting(setting: string) {
-        return () => {
-            this.props.updateSetting(setting, !this.props.settings[setting]);
-            this.toggleVisibility();
-        };
+    toggleSetting(name: string) {
+        this.props.updateSetting(name, !this.props.settings[name]);
+        this.toggleVisibility();
     }
 
     render() {
-        const { settings } = this.props;
-
         return (
             <div className='editor-settings'>
                 <div
@@ -60,57 +115,14 @@ export class EditorSettingsBase extends React.Component<Props, State> {
                     onClick={this.toggleVisibility}
                 />
 
-                {!this.state.visible ? null : (
-                    <ul className='menu'>
-                        <Localized
-                            id='editor-EditorSettings--toolkit-checks'
-                            attrs={{ title: true }}
-                            elems={{ glyph: <i className='fa fa-fw' /> }}
-                        >
-                            <li
-                                className={
-                                    'check-box' +
-                                    (settings.runQualityChecks
-                                        ? ' enabled'
-                                        : '')
-                                }
-                                title='Run Translate Toolkit checks before submitting translations'
-                                onClick={this.toggleSetting('runQualityChecks')}
-                            >
-                                {'<glyph></glyph>Translate Toolkit Checks'}
-                            </li>
-                        </Localized>
-
-                        <Localized
-                            id='editor-EditorSettings--force-suggestions'
-                            attrs={{ title: true }}
-                            elems={{ glyph: <i className='fa fa-fw' /> }}
-                        >
-                            <li
-                                className={
-                                    'check-box' +
-                                    (settings.forceSuggestions
-                                        ? ' enabled'
-                                        : '')
-                                }
-                                title='Save suggestions instead of translations'
-                                onClick={this.toggleSetting('forceSuggestions')}
-                            >
-                                {'<glyph></glyph>Make Suggestions'}
-                            </li>
-                        </Localized>
-
-                        <li className='horizontal-separator'></li>
-                        <li>
-                            <Localized id='editor-EditorSettings--change-all'>
-                                <a href='/settings/'>{'Change All Settings'}</a>
-                            </Localized>
-                        </li>
-                    </ul>
+                {this.state.visible && (
+                    <EditorSettings
+                        settings={this.props.settings}
+                        toggleSetting={this.toggleSetting.bind(this)}
+                        onDiscard={this.handleDiscard}
+                    />
                 )}
             </div>
         );
     }
 }
-
-export default onClickOutside(EditorSettingsBase);

--- a/frontend/src/core/editor/components/EditorSettings.test.js
+++ b/frontend/src/core/editor/components/EditorSettings.test.js
@@ -2,64 +2,65 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
 
-import { EditorSettingsBase } from './EditorSettings';
+import EditorSettingsBase, { EditorSettings } from './EditorSettings';
 
 function createEditorSettings() {
-    const updateSettingMock = sinon.stub();
+    const toggleSettingMock = sinon.stub();
     const wrapper = shallow(
-        <EditorSettingsBase
+        <EditorSettings
             settings={{
                 runQualityChecks: false,
                 forceSuggestions: false,
             }}
-            updateSetting={updateSettingMock}
+            toggleSetting={toggleSettingMock}
         />,
     );
-    return [wrapper, updateSettingMock];
+    return [wrapper, toggleSettingMock];
 }
 
 describe('<EditorSettings>', () => {
     it('toggles the runQualityChecks setting', () => {
-        const [wrapper, updateSettingMock] = createEditorSettings();
+        const [wrapper, toggleSettingMock] = createEditorSettings();
 
         // Do it once to turn it on.
-        wrapper.find('.selector').simulate('click');
         wrapper.find('.menu li').at(0).simulate('click');
-        expect(updateSettingMock.calledOnce).toBeTruthy();
-        expect(
-            updateSettingMock.calledWith('runQualityChecks', true),
-        ).toBeTruthy();
+        expect(toggleSettingMock.calledOnce).toBeTruthy();
+        expect(toggleSettingMock.calledWith('runQualityChecks')).toBeTruthy();
 
         // Do it twice to turn it off.
         wrapper.setProps({ settings: { runQualityChecks: true } });
 
-        wrapper.find('.selector').simulate('click');
         wrapper.find('.menu li').at(0).simulate('click');
-        expect(updateSettingMock.calledTwice).toBeTruthy();
-        expect(
-            updateSettingMock.calledWith('runQualityChecks', false),
-        ).toBeTruthy();
+        expect(toggleSettingMock.calledTwice).toBeTruthy();
+        expect(toggleSettingMock.calledWith('runQualityChecks')).toBeTruthy();
     });
 
     it('toggles the forceSuggestions setting', () => {
-        const [wrapper, updateSettingMock] = createEditorSettings();
+        const [wrapper, toggleSettingMock] = createEditorSettings();
 
         // Do it once to turn it on.
-        wrapper.find('.selector').simulate('click');
         wrapper.find('.menu li').at(1).simulate('click');
-        expect(updateSettingMock.calledOnce).toBeTruthy();
-        expect(
-            updateSettingMock.calledWith('forceSuggestions', true),
-        ).toBeTruthy();
+        expect(toggleSettingMock.calledOnce).toBeTruthy();
+        expect(toggleSettingMock.calledWith('forceSuggestions')).toBeTruthy();
 
         // Do it twice to turn it off.
         wrapper.setProps({ settings: { forceSuggestions: true } });
 
-        wrapper.find('.selector').simulate('click');
         wrapper.find('.menu li').at(1).simulate('click');
-        expect(updateSettingMock.calledTwice).toBeTruthy();
-        expect(
-            updateSettingMock.calledWith('forceSuggestions', false),
-        ).toBeTruthy();
+        expect(toggleSettingMock.calledTwice).toBeTruthy();
+        expect(toggleSettingMock.calledWith('forceSuggestions')).toBeTruthy();
+    });
+});
+
+describe('<EditorSettingsBase>', () => {
+    it('toggles the settings menu when clicking the gear icon', () => {
+        const wrapper = shallow(<EditorSettingsBase />);
+        expect(wrapper.find('EditorSettings')).toHaveLength(0);
+
+        wrapper.find('.selector').simulate('click');
+        expect(wrapper.find('EditorSettings')).toHaveLength(1);
+
+        wrapper.find('.selector').simulate('click');
+        expect(wrapper.find('EditorSettings')).toHaveLength(0);
     });
 });


### PR DESCRIPTION
This now only listens for `click` events when the menu is visible by the means of leveraging the `useOnDiscard` hook.