### PR TITLE
Bug 1688571: fix negative performance side-effects of `TermsPopup`

### DIFF
--- a/frontend/src/modules/entitydetails/components/Metadata.js
+++ b/frontend/src/modules/entitydetails/components/Metadata.js
@@ -384,16 +384,18 @@ export default class Metadata extends React.Component<Props, State> {
                     terms={terms}
                     handleClickOnPlaceable={this.handleClickOnPlaceable}
                 />
-                <TermsPopup
-                    isReadOnlyEditor={isReadOnlyEditor}
-                    locale={locale.code}
-                    terms={popupTerms}
-                    addTextToEditorTranslation={
-                        this.props.addTextToEditorTranslation
-                    }
-                    hide={this.hidePopupTerms}
-                    navigateToPath={this.props.navigateToPath}
-                />
+                {popupTerms.length > 0 && (
+                    <TermsPopup
+                        isReadOnlyEditor={isReadOnlyEditor}
+                        locale={locale.code}
+                        terms={popupTerms}
+                        addTextToEditorTranslation={
+                            this.props.addTextToEditorTranslation
+                        }
+                        hide={this.hidePopupTerms}
+                        navigateToPath={this.props.navigateToPath}
+                    />
+                )}
                 {this.renderPinnedComments(teamComments)}
                 {this.renderComment(entity)}
                 {this.renderGroupComment(entity)}

--- a/frontend/src/modules/entitydetails/components/TermsPopup.js
+++ b/frontend/src/modules/entitydetails/components/TermsPopup.js
@@ -1,11 +1,11 @@
 /* @flow */
 
 import * as React from 'react';
-import onClickOutside from 'react-onclickoutside';
 
 import './TermsPopup.css';
 
 import { TermsList } from 'core/term';
+import { useOnDiscard } from 'core/utils';
 
 import type { TermType } from 'core/api';
 
@@ -21,32 +21,19 @@ type Props = {|
 /**
  * Shows a popup with a list of all terms belonging to the highlighted one.
  */
-export function TermsPopup(props: Props) {
-    const { terms } = props;
-
-    // This method is called by the Higher-Order Component `onClickOutside`
-    // when a user clicks outside this component.
-    TermsPopup.handleClickOutside = () => props.hide();
-
-    if (!terms.length) {
-        return null;
-    }
+export default function TermsPopup(props: Props) {
+    const ref = React.useRef(null);
+    useOnDiscard(ref, props.hide);
 
     return (
-        <div className='terms-popup' onClick={props.hide}>
+        <div ref={ref} className='terms-popup' onClick={props.hide}>
             <TermsList
                 isReadOnlyEditor={props.isReadOnlyEditor}
                 locale={props.locale}
-                terms={terms}
+                terms={props.terms}
                 addTextToEditorTranslation={props.addTextToEditorTranslation}
                 navigateToPath={props.navigateToPath}
             />
         </div>
     );
 }
-
-const clickOutsideConfig = {
-    handleClickOutside: () => TermsPopup.handleClickOutside,
-};
-
-export default onClickOutside(TermsPopup, clickOutsideConfig);


### PR DESCRIPTION
This now only listens for `click` events when the menu is visible by the means of leveraging the `useOnDiscard` hook.