### PR TITLE
Bug 1690485: Use HTTPS for the Microsoft Terminology endpoint

### DIFF
--- a/pontoon/machinery/templates/machinery/microsoft_terminology.jinja
+++ b/pontoon/machinery/templates/machinery/microsoft_terminology.jinja
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='utf-8'?>
 <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/">
     <soap-env:Header>
-        <wsa:Action xmlns:wsa="http://www.w3.org/2005/08/addressing">http://api.terminology.microsoft.com/terminology/Terminology/GetTranslations</wsa:Action>
-        <wsa:MessageID xmlns:wsa="http://www.w3.org/2005/08/addressing">urn:uuid:{{ uuid }}</wsa:MessageID>
-        <wsa:To xmlns:wsa="http://www.w3.org/2005/08/addressing">http://api.terminology.microsoft.com/Terminology.svc</wsa:To>
+        <wsa:Action xmlns:wsa="https://www.w3.org/2005/08/addressing">https://api.terminology.microsoft.com/terminology/Terminology/GetTranslations</wsa:Action>
+        <wsa:MessageID xmlns:wsa="https://www.w3.org/2005/08/addressing">urn:uuid:{{ uuid }}</wsa:MessageID>
+        <wsa:To xmlns:wsa="https://www.w3.org/2005/08/addressing">https://api.terminology.microsoft.com/Terminology.svc</wsa:To>
     </soap-env:Header>
     <soap-env:Body>
         <ns0:GetTranslations xmlns:ns0="http://api.terminology.microsoft.com/terminology">

--- a/pontoon/machinery/templates/machinery/microsoft_terminology.jinja
+++ b/pontoon/machinery/templates/machinery/microsoft_terminology.jinja
@@ -2,15 +2,15 @@
 <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/">
     <soap-env:Header></soap-env:Header>
     <soap-env:Body>
-        <ns0:GetTranslations xmlns:ns0="http://api.terminology.microsoft.com/terminology">
-            <ns0:text>{{ text }}</ns0:text>
-            <ns0:from>en-US</ns0:from>
-            <ns0:to>{{ to }}</ns0:to>
-            <ns0:sources>
-                <ns0:TranslationSource>Terms</ns0:TranslationSource>
-                <ns0:TranslationSource>UiStrings</ns0:TranslationSource>
-            </ns0:sources>
-            <ns0:maxTranslations>{{ max_result }}</ns0:maxTranslations>
-        </ns0:GetTranslations>
+        <GetTranslations xmlns="http://api.terminology.microsoft.com/terminology">
+            <text>{{ text }}</text>
+            <from>en-US</from>
+            <to>{{ to }}</to>
+            <sources>
+                <TranslationSource>Terms</TranslationSource>
+                <TranslationSource>UiStrings</TranslationSource>
+            </sources>
+            <maxTranslations>{{ max_result }}</maxTranslations>
+        </GetTranslations>
     </soap-env:Body>
 </soap-env:Envelope>

--- a/pontoon/machinery/templates/machinery/microsoft_terminology.jinja
+++ b/pontoon/machinery/templates/machinery/microsoft_terminology.jinja
@@ -1,10 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/">
-    <soap-env:Header>
-        <wsa:Action xmlns:wsa="http://www.w3.org/2005/08/addressing">https://api.terminology.microsoft.com/terminology/Terminology/GetTranslations</wsa:Action>
-        <wsa:MessageID xmlns:wsa="http://www.w3.org/2005/08/addressing">urn:uuid:{{ uuid }}</wsa:MessageID>
-        <wsa:To xmlns:wsa="http://www.w3.org/2005/08/addressing">https://api.terminology.microsoft.com/Terminology.svc</wsa:To>
-    </soap-env:Header>
+    <soap-env:Header></soap-env:Header>
     <soap-env:Body>
         <ns0:GetTranslations xmlns:ns0="http://api.terminology.microsoft.com/terminology">
             <ns0:text>{{ text }}</ns0:text>

--- a/pontoon/machinery/templates/machinery/microsoft_terminology.jinja
+++ b/pontoon/machinery/templates/machinery/microsoft_terminology.jinja
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='utf-8'?>
 <soap-env:Envelope xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/">
     <soap-env:Header>
-        <wsa:Action xmlns:wsa="https://www.w3.org/2005/08/addressing">https://api.terminology.microsoft.com/terminology/Terminology/GetTranslations</wsa:Action>
-        <wsa:MessageID xmlns:wsa="https://www.w3.org/2005/08/addressing">urn:uuid:{{ uuid }}</wsa:MessageID>
-        <wsa:To xmlns:wsa="https://www.w3.org/2005/08/addressing">https://api.terminology.microsoft.com/Terminology.svc</wsa:To>
+        <wsa:Action xmlns:wsa="http://www.w3.org/2005/08/addressing">https://api.terminology.microsoft.com/terminology/Terminology/GetTranslations</wsa:Action>
+        <wsa:MessageID xmlns:wsa="http://www.w3.org/2005/08/addressing">urn:uuid:{{ uuid }}</wsa:MessageID>
+        <wsa:To xmlns:wsa="http://www.w3.org/2005/08/addressing">https://api.terminology.microsoft.com/Terminology.svc</wsa:To>
     </soap-env:Header>
     <soap-env:Body>
         <ns0:GetTranslations xmlns:ns0="http://api.terminology.microsoft.com/terminology">

--- a/pontoon/machinery/views.py
+++ b/pontoon/machinery/views.py
@@ -7,7 +7,6 @@ from urllib.parse import quote
 
 from caighdean import Translator
 from caighdean.exceptions import TranslationError
-from uuid import uuid4
 
 from django.conf import settings
 from django.core.paginator import EmptyPage, Paginator
@@ -333,7 +332,6 @@ def microsoft_terminology(request):
         "Content-Type": "text/xml; charset=utf-8",
     }
     payload = {
-        "uuid": uuid4(),
         "text": quote(text.encode("utf-8")),
         "to": locale_code,
         "max_result": 5,

--- a/pontoon/machinery/views.py
+++ b/pontoon/machinery/views.py
@@ -325,7 +325,7 @@ def microsoft_terminology(request):
         )
 
     obj = {}
-    url = "http://api.terminology.microsoft.com/Terminology.svc"
+    url = "https://api.terminology.microsoft.com/Terminology.svc"
     headers = {
         "SOAPAction": (
             '"http://api.terminology.microsoft.com/terminology/Terminology/GetTranslations"'


### PR DESCRIPTION
Microsoft Terminology added support for HTTPS, so let's use it! We still have to use HTTP in the SOAP header, though - otherwise it 500s.

Note that the issue with the service availability has been resolved independently of this change.