### PR TITLE
Fix bug 1690500: Only collect and pass user data once

### DIFF
--- a/frontend/src/core/comments/components/AddComment.js
+++ b/frontend/src/core/comments/components/AddComment.js
@@ -16,11 +16,9 @@ import type { NavigationParams } from 'core/navigation';
 import type { UserState } from 'core/user';
 
 type Props = {|
-    username: string,
-    imageURL: string,
     parameters: ?NavigationParams,
     translation?: ?number,
-    users: UserState,
+    user: UserState,
     contactPerson?: string,
     addComment: (string, ?number) => void,
     resetContactPerson?: () => void,
@@ -28,11 +26,9 @@ type Props = {|
 
 export default function AddComment(props: Props) {
     const {
-        username,
-        imageURL,
         parameters,
         translation,
-        users,
+        user,
         contactPerson,
         addComment,
         resetContactPerson,
@@ -49,7 +45,7 @@ export default function AddComment(props: Props) {
     );
     const initialValue = [{ type: 'paragraph', children: [{ text: '' }] }];
     const [value, setValue] = React.useState(initialValue);
-    const usersList = users.users;
+    const users = user.users;
     const placeFocus = React.useCallback(() => {
         ReactEditor.focus(editor);
         Transforms.select(editor, Editor.end(editor, []));
@@ -66,7 +62,7 @@ export default function AddComment(props: Props) {
 
         if (contactPerson) {
             if (!isMentioned) {
-                insertMention(editor, contactPerson, usersList);
+                insertMention(editor, contactPerson, users);
             }
 
             if (resetContactPerson) {
@@ -74,7 +70,7 @@ export default function AddComment(props: Props) {
                 placeFocus();
             }
         }
-    }, [editor, contactPerson, usersList, resetContactPerson, placeFocus]);
+    }, [editor, contactPerson, users, resetContactPerson, placeFocus]);
 
     // Set focus on Editor
     React.useEffect(() => {
@@ -83,10 +79,10 @@ export default function AddComment(props: Props) {
         }
     }, [parameters, placeFocus]);
 
-    const USERS = usersList.map((user) => user.name);
-    const suggestedUsers = USERS.filter((c) =>
-        c.toLowerCase().startsWith(search.toLowerCase()),
-    ).slice(0, 5);
+    const userNames = users.map((user) => user.name);
+    const suggestedUsers = userNames
+        .filter((c) => c.toLowerCase().startsWith(search.toLowerCase()))
+        .slice(0, 5);
 
     // Set position of mentions suggestions
     React.useLayoutEffect(() => {
@@ -268,7 +264,7 @@ export default function AddComment(props: Props) {
             case 'Enter':
                 event.preventDefault();
                 Transforms.select(editor, target);
-                insertMention(editor, suggestedUsers[index], usersList);
+                insertMention(editor, suggestedUsers[index], users);
                 setTarget(null);
                 placeFocus();
                 break;
@@ -308,24 +304,20 @@ export default function AddComment(props: Props) {
                 event.currentTarget.innerText,
             );
             Transforms.select(editor, target);
-            insertMention(
-                editor,
-                suggestedUsers[suggestedUserIndex],
-                usersList,
-            );
+            insertMention(editor, suggestedUsers[suggestedUserIndex], users);
             return setTarget(null);
         }
     };
 
     const getUserGravatar = React.useCallback(
         (name: string) => {
-            const user = usersList.find((user) => user.name === name);
+            const user = users.find((user) => user.name === name);
             if (!user) {
                 return;
             }
             return user.gravatar;
         },
-        [usersList],
+        [users],
     );
 
     const handleEditorOnChange = (value) => {
@@ -420,7 +412,10 @@ export default function AddComment(props: Props) {
 
     return (
         <div className='comment add-comment'>
-            <UserAvatar username={username} imageUrl={imageURL} />
+            <UserAvatar
+                username={user.username}
+                imageUrl={user.gravatarURLSmall}
+            />
             <div className='container'>
                 <Slate
                     editor={editor}

--- a/frontend/src/core/comments/components/AddComment.test.js
+++ b/frontend/src/core/comments/components/AddComment.test.js
@@ -4,14 +4,11 @@ import sinon from 'sinon';
 
 import AddComment from './AddComment';
 
-const DEFAULT_USER = {
-    user: 'RSwanson',
-    username: 'Ron_Swanson',
-    imageURL: '',
-};
-
-const USERS = {
-    users: {
+const USER = {
+    user: {
+        user: 'RSwanson',
+        username: 'Ron_Swanson',
+        imageURL: '',
         users: [
             {
                 name: 'April Ludwig',
@@ -26,11 +23,7 @@ describe('<AddComment>', () => {
     it('calls submitComment function', () => {
         const submitCommentFn = sinon.spy();
         const wrapper = shallow(
-            <AddComment
-                {...DEFAULT_USER}
-                {...USERS}
-                submitComment={submitCommentFn}
-            />,
+            <AddComment {...USER} submitComment={submitCommentFn} />,
         );
 
         const event = {

--- a/frontend/src/core/comments/components/CommentsList.js
+++ b/frontend/src/core/comments/components/CommentsList.js
@@ -17,7 +17,6 @@ type Props = {|
     parameters?: NavigationParams,
     translation?: HistoryTranslation,
     user: UserState,
-    users: UserState,
     contactPerson?: string,
     canComment: boolean,
     canPin?: boolean,
@@ -35,7 +34,6 @@ export default function CommentsList(props: Props) {
         canComment,
         canPin,
         addComment,
-        users,
         togglePinnedStatus,
         contactPerson,
         resetContactPerson,
@@ -81,10 +79,8 @@ export default function CommentsList(props: Props) {
                 {!canComment ? null : (
                     <AddComment
                         parameters={parameters}
-                        username={user.username}
-                        imageURL={user.gravatarURLSmall}
                         translation={translationId}
-                        users={users}
+                        user={user}
                         addComment={addComment}
                         contactPerson={contactPerson}
                         resetContactPerson={resetContactPerson}

--- a/frontend/src/modules/entitydetails/components/EntityDetails.js
+++ b/frontend/src/modules/entitydetails/components/EntityDetails.js
@@ -55,7 +55,6 @@ type Props = {|
     router: Object,
     selectedEntity: Entity,
     user: UserState,
-    users: UserState,
 |};
 
 type InternalProps = {|
@@ -454,7 +453,6 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
                         user={state.user}
                         deleteTranslation={this.deleteTranslation}
                         addComment={this.addComment}
-                        users={state.users}
                         updateTranslationStatus={this.updateTranslationStatus}
                         updateEditorTranslation={this.updateEditorTranslation}
                     />
@@ -470,7 +468,6 @@ export class EntityDetailsBase extends React.Component<InternalProps, State> {
                         terms={state.terms}
                         addComment={this.addComment}
                         togglePinnedStatus={this.togglePinnedStatus}
-                        users={state.users}
                         parameters={state.parameters}
                         user={state.user}
                         searchMachinery={this.searchMachinery}
@@ -524,7 +521,6 @@ export default function EntityDetails() {
             entities.selectors.getSelectedEntity(state),
         ),
         user: useSelector((state) => state[user.NAME]),
-        users: useSelector((state) => state[user.NAME]),
     };
     return (
         <EntityDetailsBase

--- a/frontend/src/modules/entitydetails/components/Helpers.js
+++ b/frontend/src/modules/entitydetails/components/Helpers.js
@@ -32,7 +32,6 @@ type Props = {|
     terms: TermState,
     parameters: NavigationParams,
     user: UserState,
-    users: UserState,
     commentTabRef: Object,
     commentTabIndex: number,
     contactPerson: string,
@@ -61,7 +60,6 @@ export default function Helpers(props: Props) {
         terms,
         parameters,
         user,
-        users,
         commentTabRef,
         commentTabIndex,
         contactPerson,
@@ -117,7 +115,6 @@ export default function Helpers(props: Props) {
                             teamComments={teamComments}
                             user={user}
                             addComment={addComment}
-                            users={users}
                             togglePinnedStatus={togglePinnedStatus}
                             contactPerson={contactPerson}
                             resetContactPerson={resetContactPerson}

--- a/frontend/src/modules/history/components/History.js
+++ b/frontend/src/modules/history/components/History.js
@@ -19,7 +19,6 @@ type Props = {|
     isTranslator: boolean,
     locale: Locale,
     user: UserState,
-    users: UserState,
     deleteTranslation: (number) => void,
     addComment: (string, ?number) => void,
     updateEditorTranslation: (string, string) => void,
@@ -50,7 +49,6 @@ export default class History extends React.Component<Props> {
             isTranslator,
             locale,
             user,
-            users,
             deleteTranslation,
             addComment,
             updateEditorTranslation,
@@ -80,7 +78,6 @@ export default class History extends React.Component<Props> {
                                 user={user}
                                 deleteTranslation={deleteTranslation}
                                 addComment={addComment}
-                                users={users}
                                 updateEditorTranslation={
                                     updateEditorTranslation
                                 }

--- a/frontend/src/modules/history/components/Translation.js
+++ b/frontend/src/modules/history/components/Translation.js
@@ -25,7 +25,6 @@ type Props = {|
     activeTranslation: HistoryTranslation,
     locale: Locale,
     user: UserState,
-    users: UserState,
     index: number,
     deleteTranslation: (number) => void,
     addComment: (string, ?number) => void,
@@ -238,7 +237,6 @@ export class TranslationBase extends React.Component<InternalProps, State> {
             translation,
             locale,
             user,
-            users,
             activeTranslation,
             addComment,
         } = this.props;
@@ -499,7 +497,6 @@ export class TranslationBase extends React.Component<InternalProps, State> {
                         comments={translation.comments}
                         translation={translation}
                         user={user}
-                        users={users}
                         canComment={canComment}
                         addComment={addComment}
                     />

--- a/frontend/src/modules/teamcomments/components/TeamComments.js
+++ b/frontend/src/modules/teamcomments/components/TeamComments.js
@@ -15,7 +15,6 @@ type Props = {|
     parameters: NavigationParams,
     teamComments: TeamCommentState,
     user: UserState,
-    users: UserState,
     contactPerson: string,
     addComment: (string, ?number) => void,
     togglePinnedStatus: (boolean, number) => void,
@@ -27,7 +26,6 @@ export default function TeamComments(props: Props) {
         teamComments,
         user,
         parameters,
-        users,
         addComment,
         togglePinnedStatus,
         contactPerson,
@@ -54,7 +52,6 @@ export default function TeamComments(props: Props) {
                     comments={comments}
                     parameters={parameters}
                     user={user}
-                    users={users}
                     canComment={canComment}
                     canPin={canPin}
                     addComment={addComment}


### PR DESCRIPTION
We currently collect user data twice in the `EntityDetails` component and pass it as two different props (`user` and `users`):

1. EntityDetails > History > Translation > CommentsList > AddComment
1. EntityDetails > Helpers > TeamComments > CommentsList > AddComment

It's enough to collect and pass the same data once. :)