### PR TITLE
Fix bug 1690642: Cleanup main.js file

### DIFF
--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -512,8 +512,7 @@ tfoot td a {
     padding: 2px 4px;
 }
 
-.menu li.hover,
-.menu .static-links div.hover {
+.menu li.hover {
     color: #ffffff;
     background: #3f4752;
 }

--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -282,6 +282,10 @@ tfoot td a {
     z-index: 20; /* Must be higher than iframe-cover */
 }
 
+.select .menu.permanent {
+    z-index: 19; /* Must be lower than for the (popup) .menu */
+}
+
 .select > .button.breadcrumbs,
 #go {
     background: #3f4752;

--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -279,7 +279,7 @@ tfoot td a {
     padding: 10px 12px;
     position: absolute;
     width: 150px;
-    z-index: 20; /* Must be higher than iframe-cover */
+    z-index: 20;
 }
 
 .select .menu.permanent {

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -420,41 +420,6 @@ $(function () {
             .show();
     });
 
-    // Toggle user profile attribute
-    $('.check-box').click(function () {
-        var self = $(this);
-
-        $.ajax({
-            url: '/api/v1/user/' + $('#server').data('username') + '/',
-            type: 'POST',
-            data: {
-                csrfmiddlewaretoken: $('#server').data('csrf'),
-                attribute: self.data('attribute'),
-                value: !self.is('.enabled'),
-            },
-            success: function () {
-                self.toggleClass('enabled');
-                var is_enabled = self.is('.enabled'),
-                    status = is_enabled ? 'enabled' : 'disabled';
-
-                Pontoon.endLoader(self.text() + ' ' + status + '.');
-
-                if (self.is('.force-suggestions') && Pontoon.user) {
-                    Pontoon.user.forceSuggestions = is_enabled;
-                    Pontoon.postMessage('UPDATE-ATTRIBUTE', {
-                        object: 'user',
-                        attribute: 'forceSuggestions',
-                        value: is_enabled,
-                    });
-                    Pontoon.updateSaveButtons();
-                }
-            },
-            error: function () {
-                Pontoon.endLoader('Oops, something went wrong.', 'error');
-            },
-        });
-    });
-
     // General keyboard shortcuts
     generalShortcutsHandler = function (e) {
         function moveMenu(type) {

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -236,23 +236,6 @@ $(function () {
         Pontoon.markAllNotificationsAsRead();
     });
 
-    // Profile menu
-    $('#profile .menu li').click(function (e) {
-        if ($(this).has('a').length) {
-            return;
-        }
-        e.preventDefault();
-
-        if ($(this).is('.download')) {
-            Pontoon.updateFormFields($('form#download-file'));
-            $('form#download-file').submit();
-        } else if ($(this).is('.upload')) {
-            $('#id_uploadfile').click();
-        } else if ($(this).is('.check-box')) {
-            e.stopPropagation();
-        }
-    });
-
     // Menu search
     $('body')
         .on('click', '.menu input[type=search]', function (e) {

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -400,42 +400,6 @@ $(function () {
                 return false;
             }
         }
-
-        if (
-            $('#sidebar').is(':visible') &&
-            (Pontoon.app.advanced || !$('#editor').is('.opened'))
-        ) {
-            // Ctrl + Shift + F: Focus Search
-            if (e.ctrlKey && e.shiftKey && key === 70) {
-                $('#search').focus();
-                return false;
-            }
-
-            // Ctrl + Shift + A: Select All Strings
-            if (
-                Pontoon.user.canTranslate() &&
-                e.ctrlKey &&
-                e.shiftKey &&
-                key === 65
-            ) {
-                Pontoon.selectAllEntities();
-                return false;
-            }
-
-            // Escape: Deselect entities and switch to first entity
-            if (
-                Pontoon.user.canTranslate() &&
-                $('#entitylist .entity.selected').length &&
-                key === 27
-            ) {
-                if (Pontoon.app.advanced) {
-                    Pontoon.openFirstEntity();
-                } else {
-                    Pontoon.goBackToEntityList();
-                }
-                return false;
-            }
-        }
     };
     $('html').on('keydown', generalShortcutsHandler);
 });

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -156,6 +156,11 @@ $(function () {
         Pontoon.closeNotification();
     });
 
+    // Mark notifications as read when notification menu opens
+    $('#notifications.unread .button .icon').click(function () {
+        Pontoon.markAllNotificationsAsRead();
+    });
+
     function getRedirectUrl() {
         return window.location.pathname + window.location.search;
     }
@@ -230,11 +235,6 @@ $(function () {
 
             $('.menu li.hover, .static-links div').removeClass('hover');
         });
-
-    // Mark notifications as read when notification menu opens
-    $('#notifications.unread .button .icon').click(function () {
-        Pontoon.markAllNotificationsAsRead();
-    });
 
     // Menu search
     $('body')

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -113,26 +113,6 @@ var Pontoon = (function (my) {
         },
 
         /*
-         * Update scrollbar position in the menu
-         *
-         * menu Menu element
-         */
-        updateScroll: function (menu) {
-            var hovered = menu.find('[class*=hover]'),
-                maxHeight = menu.height(),
-                visibleTop = menu.scrollTop(),
-                visibleBottom = visibleTop + maxHeight,
-                hoveredTop = visibleTop + hovered.position().top,
-                hoveredBottom = hoveredTop + hovered.outerHeight();
-
-            if (hoveredBottom >= visibleBottom) {
-                menu.scrollTop(Math.max(hoveredBottom - maxHeight, 0));
-            } else if (hoveredTop < visibleTop) {
-                menu.scrollTop(hoveredTop);
-            }
-        },
-
-        /*
          * Do not render HTML tags
          *
          * string String that has to be displayed as is instead of rendered
@@ -334,36 +314,39 @@ $(function () {
     generalShortcutsHandler = function (e) {
         function moveMenu(type) {
             var options =
-                    type === 'up'
-                        ? ['first', 'last', -1]
-                        : ['last', 'first', 1],
-                items = menu.find(
-                    'li:visible:not(.horizontal-separator, .time-range-toolbar, :has(li))',
-                );
+                type === 'up' ? ['first', 'last', -1] : ['last', 'first', 1];
+            var items = menu.find(
+                'li:visible:not(.horizontal-separator, :has(li))',
+            );
+            var element = null;
 
             if (
                 hovered.length === 0 ||
                 menu.find('li:not(:has(li)):visible:' + options[0]).is('.hover')
             ) {
                 menu.find('li.hover').removeClass('hover');
-                items[options[1]]().addClass('hover');
+                element = items[options[1]]();
             } else {
                 var current = menu.find('li.hover'),
                     next = items.index(current) + options[2];
 
                 current.removeClass('hover');
-                $(items.get(next)).addClass('hover');
+                element = $(items.get(next));
             }
 
-            if (menu.parent().is('.project, .part, .locale')) {
-                Pontoon.updateScroll(menu.find('ul'));
+            if (element) {
+                element.addClass('hover');
+                element[0].scrollIntoView({
+                    behavior: 'smooth',
+                    block: 'nearest',
+                });
             }
         }
 
         var key = e.which;
 
         if ($('.menu:not(".permanent")').is(':visible')) {
-            var menu = $('.menu:visible'),
+            var menu = $('.menu:not(".permanent"):visible'),
                 hovered = menu.find('li.hover');
 
             // Skip for the tabs

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -33,18 +33,6 @@ var Pontoon = (function (my) {
         },
 
         /*
-         * Remove duplicate items from the array of numeric values
-         *
-         * TODO: Switch to ES6 and replace with Set
-         */
-        removeDuplicates: function (array) {
-            var seen = {};
-            return array.filter(function (item) {
-                return seen.hasOwnProperty(item) ? false : (seen[item] = true);
-            });
-        },
-
-        /*
          * Mark all notifications as read and update UI accordingly
          */
         markAllNotificationsAsRead: function () {
@@ -151,84 +139,6 @@ var Pontoon = (function (my) {
          */
         doNotRender: function (string) {
             return $('<div/>').text(string).html();
-        },
-
-        /*
-         * Strip HTML tags from the given string
-         */
-        stripHTML: function (string) {
-            return $($.parseHTML(string)).text();
-        },
-
-        /*
-         * Converts a number to a string containing commas every three digits
-         */
-        numberWithCommas: function (number) {
-            return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-        },
-
-        /*
-         * Markup XML Tags
-         *
-         * Find any XML Tags in a string and mark them up, while making sure
-         * the rest of the text in a string is displayed not rendered.
-         */
-        markXMLTags: function (string) {
-            var self = this;
-
-            var markedString = '';
-            var startMarker = '<mark class="placeable" title="XML Tag">';
-            var endMarker = '</mark>';
-
-            var re = /(<[^(><.)]+>)/gi;
-            var results;
-            var previousIndex = 0;
-
-            function doNotRenderSubstring(start, end) {
-                return self.doNotRender(string.substring(start, end));
-            }
-
-            // Find successive matches
-            while ((results = re.exec(string)) !== null) {
-                markedString +=
-                    // Substring between the previous and the current tag: do not render
-                    doNotRenderSubstring(previousIndex, results.index) +
-                    // Tag: do not render and wrap in markup
-                    startMarker +
-                    doNotRenderSubstring(results.index, re.lastIndex) +
-                    endMarker;
-                previousIndex = re.lastIndex;
-            }
-
-            // Substring between the last tag and the end of the string: do not render
-            markedString += doNotRenderSubstring(previousIndex, string.length);
-
-            return markedString;
-        },
-
-        /*
-         * Linkifies any traces of URLs present in a given string.
-         *
-         * Matches the URL Regex and parses the required matches.
-         * Can find more than one URL in the given string.
-         *
-         * Escapes HTML tags.
-         */
-        linkify: function (string) {
-            // http://, https://, ftp://
-            var urlPattern = /\b(?:https?|ftp):\/\/[a-z0-9-+&@#/%?=~_|!:,.;]*[a-z0-9-+&@#/%=~_|]/gim;
-            // www. sans http:// or https://
-            var pseudoUrlPattern = /(^|[^/])(www\.[\S]+(\b|$))/gim;
-
-            return this.doNotRender(string)
-                .replace(
-                    urlPattern,
-                    '<a href="$&" target="_blank" rel="noopener noreferrer">$&</a>',
-                )
-                .replace(
-                    pseudoUrlPattern,
-                    '$1<a href="http://$2" target="_blank" rel="noopener noreferrer">$2</a>',
-                );
         },
     });
 })(Pontoon || {});

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -269,28 +269,6 @@ $(function () {
             }
         });
 
-    // Tabs
-    $('.tabs nav a').click(function (e) {
-        e.preventDefault();
-
-        var tab = $(this),
-            section = tab.attr('href').substr(1);
-
-        tab.parents('li')
-            .siblings()
-            .removeClass('active')
-            .end()
-            .addClass('active')
-            .end()
-
-            .parents('.tabs')
-            .find('section')
-            .hide()
-            .end()
-            .find('section.' + section)
-            .show();
-    });
-
     // General keyboard shortcuts
     generalShortcutsHandler = function (e) {
         function moveMenu(type) {

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -195,14 +195,12 @@ $(function () {
             e.stopPropagation();
             $('.menu:not(".permanent")').hide();
             $('.select').removeClass('opened');
-            $('#iframe-cover:not(".hidden")').hide(); // iframe fix
             $(this)
                 .siblings('.menu')
                 .show()
                 .end()
                 .parents('.select')
                 .addClass('opened');
-            $('#iframe-cover:not(".hidden")').show(); // iframe fix
             $('.menu:not(".permanent"):visible input[type=search]')
                 .focus()
                 .trigger('input');

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -216,22 +216,22 @@ $(function () {
 
     // Menu hover
     $('body')
-        .on('mouseenter', '.menu li, .menu .static-links div', function () {
+        .on('mouseenter', '.menu li', function () {
             // Ignore on nested menus
             if ($(this).parents('li').length) {
                 return false;
             }
 
-            $('.menu li.hover, .static-links div').removeClass('hover');
+            $('.menu li.hover').removeClass('hover');
             $(this).toggleClass('hover');
         })
-        .on('mouseleave', '.menu li, .menu .static-links div', function () {
+        .on('mouseleave', '.menu li', function () {
             // Ignore on nested menus
             if ($(this).parents('li').length) {
                 return false;
             }
 
-            $('.menu li.hover, .static-links div').removeClass('hover');
+            $('.menu li.hover').removeClass('hover');
         });
 
     // Menu search

--- a/pontoon/contributors/static/js/settings.js
+++ b/pontoon/contributors/static/js/settings.js
@@ -1,4 +1,34 @@
 $(function () {
+    // Toggle user profile attribute
+    $('#check-boxes .check-box').click(function () {
+        var self = $(this);
+
+        $.ajax({
+            url: '/api/v1/user/' + $('#server').data('username') + '/',
+            type: 'POST',
+            data: {
+                csrfmiddlewaretoken: $('#server').data('csrf'),
+                attribute: self.data('attribute'),
+                value: !self.is('.enabled'),
+            },
+            success: function () {
+                self.toggleClass('enabled');
+                var is_enabled = self.is('.enabled');
+                var status = is_enabled ? 'enabled' : 'disabled';
+
+                Pontoon.endLoader(self.text() + ' ' + status + '.');
+            },
+            error: function (request) {
+                if (request.responseText === 'error') {
+                    Pontoon.endLoader('Oops, something went wrong.', 'error');
+                } else {
+                    Pontoon.endLoader(request.responseText, 'error');
+                }
+            },
+        });
+    });
+
+    // Save custom homepage
     $('#homepage .locale .menu li:not(".no-match")').click(function () {
         var custom_homepage = $(this).find('.language').data('code');
 
@@ -23,9 +53,8 @@ $(function () {
             },
         });
     });
-});
 
-$(function () {
+    // Save preferred source locale
     $('#preferred-locale .locale .menu li:not(".no-match")').click(function () {
         var preferred_source_locale = $(this).find('.language').data('code');
 

--- a/pontoon/contributors/templates/contributors/settings.html
+++ b/pontoon/contributors/templates/contributors/settings.html
@@ -25,7 +25,7 @@
 
   <h2 id="username">{{ user.first_name }}</h2>
 
-  <ul class="info">
+  <ul id="check-boxes" class="info">
     {{ Checkbox.checkbox('Translate Toolkit Checks', class='quality-checks', attribute='quality_checks', is_enabled=user.profile.quality_checks, title='Run Translate Toolkit checks before submitting translations') }}
 
     {% if user.translated_locales %}


### PR DESCRIPTION
`main.js` file is loaded on each page, except for the translate view.

It contains code, which is no longer used, because it has been replaced by the new translate app (Translate.Next).

There's also code, which is only used by one view (as discovered in bug 1690563), so it should be moved to view-specific files.

And then there's code that is obsolete, or can be rewritten using native DOM APIs.

Let's clean it up!