### PR TITLE
Fix bug 1688573: avoid redundant editor re-renders

### DIFF
--- a/frontend/src/core/diff/withDiff.js
+++ b/frontend/src/core/diff/withDiff.js
@@ -37,11 +37,11 @@ type Props = {
 export default function withDiff<Config: Object>(
     WrappedComponent: React.AbstractComponent<Config>,
 ): React.AbstractComponent<Config> {
-    return function WithDiff(props: { ...Config, ...Props }) {
+    return React.memo(function WithDiff(props: { ...Config, ...Props }) {
         return (
             <WrappedComponent {...props}>
                 {getDiff(props.diffTarget, props.children)}
             </WrappedComponent>
         );
-    };
+    });
 }

--- a/frontend/src/core/editor/hooks/useCopyMachineryTranslation.js
+++ b/frontend/src/core/editor/hooks/useCopyMachineryTranslation.js
@@ -5,6 +5,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import { actions } from '..';
 
+import * as editor from 'core/editor';
 import * as entities from 'core/entities';
 import type { MachineryTranslation, SourceType } from 'core/api';
 
@@ -31,12 +32,14 @@ export default function useCopyMachineryTranslation() {
         [dispatch],
     );
 
-    const editorContent = useSelector((state) => state.editor.translation);
     const isReadOnlyEditor = useSelector((state) =>
         entities.selectors.isReadOnlyEditor(state),
     );
     const entity = useSelector((state) =>
         entities.selectors.getSelectedEntity(state),
+    );
+    const isFluentTranslationMessage = useSelector((state) =>
+        editor.selectors.isFluentTranslationMessage(state),
     );
 
     return useCallback(
@@ -57,7 +60,7 @@ export default function useCopyMachineryTranslation() {
             }
             // This is a Fluent Message, thus we are in the RichEditor.
             // Handle machinery differently.
-            else if (typeof editorContent !== 'string') {
+            else if (isFluentTranslationMessage) {
                 addTextToTranslation(translation.translation, 'machinery');
             }
             // By default replace editor content
@@ -70,9 +73,9 @@ export default function useCopyMachineryTranslation() {
             );
         },
         [
+            isFluentTranslationMessage,
             isReadOnlyEditor,
             entity,
-            editorContent,
             addTextToTranslation,
             updateTranslation,
             updateMachinerySources,

--- a/frontend/src/core/editor/selectors.js
+++ b/frontend/src/core/editor/selectors.js
@@ -102,6 +102,19 @@ export const sameExistingTranslation: Function = createSelector(
     _existingTranslation,
 );
 
+function _isFluentMessage(editorState: EditorState) {
+    return typeof editorState.translation !== 'string';
+}
+
+/**
+ * Returns `true` if the current editor translation contains a Fluent message.
+ */
+const isFluentTranslationMessage = createSelector(
+    editorSelector,
+    _isFluentMessage,
+);
+
 export default {
     sameExistingTranslation,
+    isFluentTranslationMessage,
 };

--- a/frontend/src/modules/machinery/components/Translation.js
+++ b/frontend/src/modules/machinery/components/Translation.js
@@ -48,10 +48,14 @@ export default function Translation(props: Props) {
         className += ' cannot-copy';
     }
 
-    const editorState = useSelector((state) => state[editor.NAME]);
+    const selectedHelperElementIndex = useSelector(
+        (state) => state[editor.NAME].selectedHelperElementIndex,
+    );
+    const changeSource = useSelector(
+        (state) => state[editor.NAME].changeSource,
+    );
     const isSelected =
-        editorState.changeSource === 'machinery' &&
-        editorState.selectedHelperElementIndex === index;
+        changeSource === 'machinery' && selectedHelperElementIndex === index;
     if (isSelected) {
         // Highlight Machinery entries upon selection
         className += ' selected';
@@ -59,16 +63,13 @@ export default function Translation(props: Props) {
 
     const translationRef = React.useRef();
     React.useEffect(() => {
-        if (
-            editorState.selectedHelperElementIndex === index &&
-            translationRef.current
-        ) {
+        if (selectedHelperElementIndex === index && translationRef.current) {
             translationRef.current.scrollIntoView({
                 behavior: 'smooth',
                 block: 'nearest',
             });
         }
-    }, [editorState.selectedHelperElementIndex, index]);
+    }, [selectedHelperElementIndex, index]);
 
     return (
         <Localized id='machinery-Translation--copy' attrs={{ title: true }}>

--- a/frontend/src/modules/otherlocales/components/Translation.js
+++ b/frontend/src/modules/otherlocales/components/Translation.js
@@ -41,10 +41,14 @@ export default function Translation(props: Props) {
         className += ' cannot-copy';
     }
 
-    const editorState = useSelector((state) => state[editor.NAME]);
+    const selectedHelperElementIndex = useSelector(
+        (state) => state[editor.NAME].selectedHelperElementIndex,
+    );
+    const changeSource = useSelector(
+        (state) => state[editor.NAME].changeSource,
+    );
     const isSelected =
-        editorState.changeSource === 'otherlocales' &&
-        editorState.selectedHelperElementIndex === index;
+        changeSource === 'otherlocales' && selectedHelperElementIndex === index;
     if (isSelected) {
         // Highlight other locale entries upon selection
         className += ' selected';
@@ -58,16 +62,13 @@ export default function Translation(props: Props) {
 
     const translationRef = React.useRef();
     React.useEffect(() => {
-        if (
-            editorState.selectedHelperElementIndex === index &&
-            translationRef.current
-        ) {
+        if (selectedHelperElementIndex === index && translationRef.current) {
             translationRef.current.scrollIntoView({
                 behavior: 'smooth',
                 block: 'nearest',
             });
         }
-    }, [editorState.selectedHelperElementIndex, index]);
+    }, [selectedHelperElementIndex, index]);
 
     return (
         <Localized id='otherlocales-Translation--copy' attrs={{ title: true }}>


### PR DESCRIPTION
This PR avoids major part of redundant re-renders in the helper components. As I have observed, the components making use of diff functionality as well as the `Localized` components incur in perceptible performance cost.

Before:
<img width="798" alt="before" src="https://user-images.githubusercontent.com/16768/107027253-29e76b00-67ac-11eb-9d3f-c552618e59cf.png">

After:
<img width="769" alt="after" src="https://user-images.githubusercontent.com/16768/107027267-2ce25b80-67ac-11eb-9618-8c161a080806.png">

I think the result is good enough for the sake of bug 1688573.

It's worth noting though, there are a few other areas that could still be improved:
* The first keystroke produces a re-render in the helpers components because the editor's `changeSource` changes.
* `EditorMenu` > `MenuContent` constantly re-renders due to translation and translation length being changed. This becomes more expensive than expected because the button texts are wrapped in `Localized` elements.
* Every keystroke of the translation textarea triggers a series of redux actions, which could potentially be minimized to reduce the amount of work done per keystroke.