### PR TITLE
Update to translate toolkit 3.3.2

### DIFF
--- a/pontoon/checks/libraries/translate_toolkit.py
+++ b/pontoon/checks/libraries/translate_toolkit.py
@@ -5,8 +5,8 @@ from translate.storage import base as storage_base
 
 def run_checks(original, string, locale_code, disabled_checks=None):
     """Check for obvious errors like blanks and missing interpunction."""
-    original = lang_data.normalized_unicode(original)
-    string = lang_data.normalized_unicode(string)
+    original = lang_data.normalize(original)
+    string = lang_data.normalize(string)
     disabled_checks = disabled_checks or []
 
     unit = storage_base.TranslationUnit(original)

--- a/pontoon/sync/formats/xliff.py
+++ b/pontoon/sync/formats/xliff.py
@@ -23,7 +23,7 @@ class XLIFFEntity(VCSTranslation):
 
     @property
     def source_string(self):
-        return str(self.unit.get_rich_source()[0])
+        return str(self.unit.rich_source[0])
 
     @property
     def source_string_plural(self):

--- a/pontoon/sync/tests/formats/test_xliff.py
+++ b/pontoon/sync/tests/formats/test_xliff.py
@@ -108,7 +108,7 @@ class XLIFFTests(FormatTestsMixin, TestCase):
         expected_string = self.generate_xliff(
             dedent(
                 """
-            <trans-unit id="Source String Key">
+            <trans-unit id="Source String Key" xml:space="preserve">
                 <source>Source String</source>
                 <target>New Translated String</target>
                 <note>Comment</note>

--- a/requirements/default.in
+++ b/requirements/default.in
@@ -46,7 +46,7 @@ python-levenshtein==0.12.2
 pytz==2019.3
 raygun4py==4.3.0
 scandir==1.5
-translate-toolkit==2.4.0
+translate-toolkit==3.3.2
 whitenoise==5.2.0
 wsgi-sslify==1.0.1
 

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -274,7 +274,9 @@ lxml==4.6.2 \
     --hash=sha256:f4822c0660c3754f1a41a655e37cb4dbbc9be3d35b125a37fab6f82d47674ebc \
     --hash=sha256:f83d281bb2a6217cd806f4cf0ddded436790e66f393e124dfe9731f6b3fb9afe \
     --hash=sha256:fc37870d6716b137e80d19241d0e2cff7a7643b925dfa49b4c8ebd1295eb506e
-    # via -r requirements/default.in
+    # via
+    #   -r requirements/default.in
+    #   translate-toolkit
 markupsafe==1.1.1 \
     --hash=sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473 \
     --hash=sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161 \
@@ -484,7 +486,6 @@ six==1.15.0 \
     #   python-dateutil
     #   sacremoses
     #   singledispatch
-    #   translate-toolkit
 sqlparse==0.4.1 \
     --hash=sha256:017cde379adbd6a1f15a61873f43e8274179378e95ef3fede90b5aa64d304ed0 \
     --hash=sha256:0f91fd2e829c44362cbcfab3e9ae12e22badaa8a29ad5ff599f9ec109f0454e8
@@ -497,8 +498,8 @@ tqdm==4.54.1 \
     --hash=sha256:38b658a3e4ecf9b4f6f8ff75ca16221ae3378b2e175d846b6b33ea3a20852cf5 \
     --hash=sha256:d4f413aecb61c9779888c64ddf0c62910ad56dcbe857d8922bb505d4dbff0df1
     # via sacremoses
-translate-toolkit==2.4.0 \
-    --hash=sha256:4039dae336e1471e1933868262ad6addd81161f546c00da6929d8f3883341e7f
+translate-toolkit==3.3.2 \
+    --hash=sha256:0795bd3c8668213199550ae4ed8938874083139ec1f8c473dcca1524a206b108
     # via -r requirements/default.in
 uhashring==1.2 \
     --hash=sha256:f7304ca2ff763bbf1e2f8a78f21131721811619c5841de4f8c98063344906931

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -333,7 +333,9 @@ lxml==4.6.2 \
     --hash=sha256:f4822c0660c3754f1a41a655e37cb4dbbc9be3d35b125a37fab6f82d47674ebc \
     --hash=sha256:f83d281bb2a6217cd806f4cf0ddded436790e66f393e124dfe9731f6b3fb9afe \
     --hash=sha256:fc37870d6716b137e80d19241d0e2cff7a7643b925dfa49b4c8ebd1295eb506e
-    # via -r requirements/default.txt
+    # via
+    #   -r requirements/default.txt
+    #   translate-toolkit
 markupsafe==1.1.1 \
     --hash=sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473 \
     --hash=sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161 \
@@ -578,7 +580,6 @@ six==1.15.0 \
     #   python-dateutil
     #   sacremoses
     #   singledispatch
-    #   translate-toolkit
 sqlparse==0.4.1 \
     --hash=sha256:017cde379adbd6a1f15a61873f43e8274179378e95ef3fede90b5aa64d304ed0 \
     --hash=sha256:0f91fd2e829c44362cbcfab3e9ae12e22badaa8a29ad5ff599f9ec109f0454e8
@@ -598,8 +599,8 @@ tqdm==4.54.1 \
     # via
     #   -r requirements/default.txt
     #   sacremoses
-translate-toolkit==2.4.0 \
-    --hash=sha256:4039dae336e1471e1933868262ad6addd81161f546c00da6929d8f3883341e7f
+translate-toolkit==3.3.2 \
+    --hash=sha256:0795bd3c8668213199550ae4ed8938874083139ec1f8c473dcca1524a206b108
     # via -r requirements/default.txt
 uhashring==1.2 \
     --hash=sha256:f7304ca2ff763bbf1e2f8a78f21131721811619c5841de4f8c98063344906931

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -394,7 +394,9 @@ lxml==4.6.2 \
     --hash=sha256:f4822c0660c3754f1a41a655e37cb4dbbc9be3d35b125a37fab6f82d47674ebc \
     --hash=sha256:f83d281bb2a6217cd806f4cf0ddded436790e66f393e124dfe9731f6b3fb9afe \
     --hash=sha256:fc37870d6716b137e80d19241d0e2cff7a7643b925dfa49b4c8ebd1295eb506e
-    # via -r requirements/default.txt
+    # via
+    #   -r requirements/default.txt
+    #   translate-toolkit
 markupsafe==1.1.1 \
     --hash=sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473 \
     --hash=sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161 \
@@ -693,7 +695,6 @@ six==1.15.0 \
     #   requests-mock
     #   sacremoses
     #   singledispatch
-    #   translate-toolkit
 sqlparse==0.4.1 \
     --hash=sha256:017cde379adbd6a1f15a61873f43e8274179378e95ef3fede90b5aa64d304ed0 \
     --hash=sha256:0f91fd2e829c44362cbcfab3e9ae12e22badaa8a29ad5ff599f9ec109f0454e8
@@ -723,8 +724,8 @@ tqdm==4.54.1 \
     # via
     #   -r requirements/default.txt
     #   sacremoses
-translate-toolkit==2.4.0 \
-    --hash=sha256:4039dae336e1471e1933868262ad6addd81161f546c00da6929d8f3883341e7f
+translate-toolkit==3.3.2 \
+    --hash=sha256:0795bd3c8668213199550ae4ed8938874083139ec1f8c473dcca1524a206b108
     # via -r requirements/default.txt
 typed-ast==1.4.1 \
     --hash=sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355 \


### PR DESCRIPTION
* New API: `translate.lang.data.normalized_unicode` -> `translate.lang.data.normalize` ([click](https://github.com/translate/translate/commit/cc4ed15f79eb233e500c8a8c178f733d134fbb63))
* Drop deprecated `get_rich_source()` method ([click](https://github.com/translate/translate/commit/19abe9f19d4b5d3b645ce1986e5fa9402173fe8d))
* Ensure xml:space="preserve" is set when updating target ([click](https://github.com/translate/translate/commit/a17c23bbf344d3b614667e361562aab98d696774))
