### PR TITLE
Remove unused brace package

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,6 @@
     "@fluent/react": "0.13.0",
     "@fluent/syntax": "0.16.1",
     "abortcontroller-polyfill": "1.3.0",
-    "brace": "0.11.1",
     "connected-react-router": "6.8.0",
     "date-and-time": "0.14.2",
     "diff-match-patch": "1.0.4",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2597,11 +2597,6 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-brace@0.11.1:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/brace/-/brace-0.11.1.tgz#4896fcc9d544eef45f4bb7660db320d3b379fe58"
-  integrity sha1-SJb8ydVE7vRfS7dmDbMg07N5/lg=
-
 braces@^2.3.1, braces@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"


### PR DESCRIPTION
The package was introduced by bug 1433994 (#1162), which brought support for the Ace Editor.

The editor was removed by bug 1563457 (#1382), but the package remained.