### PR TITLE
Fix Bug 1679565 Title Missing In Terms Panel and Popup

### DIFF
--- a/frontend/public/static/locale/en-US/translate.ftl
+++ b/frontend/public/static/locale/en-US/translate.ftl
@@ -459,11 +459,6 @@ machinery-MicrosoftTerminology--visit-microsoft = MICROSOFT
         Visit Microsoft Terminology Service API.
         © 2018 Microsoft Corporation. All rights reserved.
 
-## Machinery Microsoft Terminology
-## Shows the translation source from Microsoft Terminology.
-terms-MicrosoftTerminology--visit-microsoft = MICROSOFT
-    .title = Copy Into Translation
-
 ## Machinery Translation
 ## Shows a specific translation from machinery.
 machinery-Translation--copy =
@@ -633,6 +628,9 @@ search-TimeRangeFilter--save-range = SAVE RANGE
 
 ## Term
 ## Shows term entry with its metadata
+
+term-Term--copy = 
+    .title = Copy Into Translation
 
 term-Term--for-example = E.G.
 

--- a/frontend/public/static/locale/en-US/translate.ftl
+++ b/frontend/public/static/locale/en-US/translate.ftl
@@ -459,6 +459,10 @@ machinery-MicrosoftTerminology--visit-microsoft = MICROSOFT
         Visit Microsoft Terminology Service API.
         © 2018 Microsoft Corporation. All rights reserved.
 
+## Machinery Microsoft Terminology
+## Shows the translation source from Microsoft Terminology.
+terms-MicrosoftTerminology--visit-microsoft = MICROSOFT
+    .title = Copy Into Translation
 
 ## Machinery Translation
 ## Shows a specific translation from machinery.

--- a/frontend/public/static/locale/en-US/translate.ftl
+++ b/frontend/public/static/locale/en-US/translate.ftl
@@ -459,6 +459,7 @@ machinery-MicrosoftTerminology--visit-microsoft = MICROSOFT
         Visit Microsoft Terminology Service API.
         © 2018 Microsoft Corporation. All rights reserved.
 
+
 ## Machinery Translation
 ## Shows a specific translation from machinery.
 machinery-Translation--copy =

--- a/frontend/src/core/term/components/Term.js
+++ b/frontend/src/core/term/components/Term.js
@@ -53,35 +53,35 @@ export default function Term(props: Props) {
 
     return (
         <Localized id='terms-Translation--copy' attrs={{ title: true }}>
-        <li
-            className={`term ${cannotCopy}`}
-            title='Copy Into Translation'
-            onClick={() => copyTermIntoEditor(term.translation)}
-        >
-            <header>
-                <span className='text'>{term.text}</span>
-                <span className='part-of-speech'>{term.partOfSpeech}</span>
-                <a
-                    href={`/${locale}/terminology/common/?string=${term.entityId}`}
-                    onClick={navigateToPath}
-                    className='translate'
-                >
-                    Translate
-                </a>
-            </header>
-            <p className='translation'>{term.translation}</p>
-            <div className='details'>
-                <p className='definition'>{term.definition}</p>
-                {!term.usage ? null : (
-                    <p className='usage'>
-                        <Localized id='term-Term--for-example'>
-                            <span className='title'>E.G.</span>
-                        </Localized>
-                        <span className='content'>{term.usage}</span>
-                    </p>
-                )}
-            </div>
-        </li>
+            <li
+                className={`term ${cannotCopy}`}
+                title='Copy Into Translation'
+                onClick={() => copyTermIntoEditor(term.translation)}
+            >
+                <header>
+                    <span className='text'>{term.text}</span>
+                    <span className='part-of-speech'>{term.partOfSpeech}</span>
+                    <a
+                        href={`/${locale}/terminology/common/?string=${term.entityId}`}
+                        onClick={navigateToPath}
+                        className='translate'
+                    >
+                        Translate
+                    </a>
+                </header>
+                <p className='translation'>{term.translation}</p>
+                <div className='details'>
+                    <p className='definition'>{term.definition}</p>
+                    {!term.usage ? null : (
+                        <p className='usage'>
+                            <Localized id='term-Term--for-example'>
+                                <span className='title'>E.G.</span>
+                            </Localized>
+                            <span className='content'>{term.usage}</span>
+                        </p>
+                    )}
+                </div>
+            </li>
         </Localized>
     );
 }

--- a/frontend/src/core/term/components/Term.js
+++ b/frontend/src/core/term/components/Term.js
@@ -52,8 +52,10 @@ export default function Term(props: Props) {
         isReadOnlyEditor || !term.translation ? 'cannot-copy' : '';
 
     return (
+        <Localized id='terms-Translation--copy' attrs={{ title: true }}>
         <li
             className={`term ${cannotCopy}`}
+            title='Copy Into Translation'
             onClick={() => copyTermIntoEditor(term.translation)}
         >
             <header>
@@ -80,5 +82,6 @@ export default function Term(props: Props) {
                 )}
             </div>
         </li>
+        </Localized>
     );
 }

--- a/frontend/src/core/term/components/Term.js
+++ b/frontend/src/core/term/components/Term.js
@@ -52,7 +52,7 @@ export default function Term(props: Props) {
         isReadOnlyEditor || !term.translation ? 'cannot-copy' : '';
 
     return (
-        <Localized id='terms-Translation--copy' attrs={{ title: true }}>
+        <Localized id='term-Term--copy' attrs={{ title: true }}>
             <li
                 className={`term ${cannotCopy}`}
                 title='Copy Into Translation'


### PR DESCRIPTION
1) Wrapped the LI element in a LOCALIZED element with a Localized id='terms-Translation--copy'
2) Added the title 'Copy Into Translation' for the tooltip
3) Made an entry for the corresponding title in the translate.ftl file (Line 462)