### PR TITLE
Avoid using calc(A + Npx) to circumvent bug in a CSS compressor

### DIFF
--- a/pontoon/homepage/static/css/homepage.css
+++ b/pontoon/homepage/static/css/homepage.css
@@ -2,7 +2,6 @@
 
 :root {
     --content-width: 980px;
-    --header-height: 60px;
 }
 
 body > header {
@@ -178,7 +177,7 @@ nav#sections ul li:hover a span {
 }
 
 #edit-homepage .select {
-    top: calc(var(--header-height) + 10px);
+    top: 70px;
 }
 
 #edit-homepage .button {


### PR DESCRIPTION
The + and - operators in CSS calc() must be surrounded by whitespace:
https://developer.mozilla.org/en-US/docs/Web/CSS/calc()#notes

The yuglify CSS compressor we use removes them and breaks CSS.
I tried yuicompressor instead, which has the same bug:
https://github.com/yui/yuicompressor/issues/59

Other CSS compressors I've checked look (even more) outdated.
I haven't tested any.

The only other instance of calc() in our code uses - instead of +,
which is fine.