### PR TITLE
Fix bug 1692423: Replace broken CSS compressor with a no-op compressor

### DIFF
--- a/pontoon/homepage/static/css/homepage.css
+++ b/pontoon/homepage/static/css/homepage.css
@@ -2,6 +2,7 @@
 
 :root {
     --content-width: 980px;
+    --header-height: 60px;
 }
 
 body > header {
@@ -177,7 +178,7 @@ nav#sections ul li:hover a span {
 }
 
 #edit-homepage .select {
-    top: calc(70px);
+    top: calc(var(--header-height) + 10px);
 }
 
 #edit-homepage .button {

--- a/pontoon/homepage/static/css/homepage.css
+++ b/pontoon/homepage/static/css/homepage.css
@@ -2,7 +2,6 @@
 
 :root {
     --content-width: 980px;
-    --header-height: 60px;
 }
 
 body > header {
@@ -178,7 +177,7 @@ nav#sections ul li:hover a span {
 }
 
 #edit-homepage .select {
-    top: calc(var(--header-height) + 10px);
+    top: calc(70px);
 }
 
 #edit-homepage .button {

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -476,6 +476,7 @@ PIPELINE = {
     "STYLESHEETS": PIPELINE_CSS,
     "JAVASCRIPT": PIPELINE_JS,
     "JS_COMPRESSOR": "pipeline.compressors.terser.TerserCompressor",
+    "CSS_COMPRESSOR": "pipeline.compressors.terser.NoopCompressor",
     "YUGLIFY_BINARY": path(
         os.environ.get("YUGLIFY_BINARY", "node_modules/.bin/yuglify")
     ),

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -476,7 +476,7 @@ PIPELINE = {
     "STYLESHEETS": PIPELINE_CSS,
     "JAVASCRIPT": PIPELINE_JS,
     "JS_COMPRESSOR": "pipeline.compressors.terser.TerserCompressor",
-    "CSS_COMPRESSOR": "pipeline.compressors.terser.NoopCompressor",
+    "CSS_COMPRESSOR": "pipeline.compressors.NoopCompressor",
     "YUGLIFY_BINARY": path(
         os.environ.get("YUGLIFY_BINARY", "node_modules/.bin/yuglify")
     ),


### PR DESCRIPTION
The + and - operators in CSS calc() must be surrounded by whitespace:
https://developer.mozilla.org/en-US/docs/Web/CSS/calc()#notes

The yuglify CSS compressor we use removes them and breaks CSS.
I tried yuicompressor instead, which has the same bug: https://github.com/yui/yuicompressor/issues/59

Other CSS compressors I've checked look (even more) outdated. I haven't tested any.

The only other instance of calc() in our code uses - instead of +, which is fine.