### PR TITLE
Revert "Speed up os.walk() by replacing it with scandir.walk()"

### DIFF
--- a/pontoon/sync/tests/test_vcs_models.py
+++ b/pontoon/sync/tests/test_vcs_models.py
@@ -5,8 +5,6 @@ from http.client import HTTPException
 from pathlib import Path
 from unittest.mock import Mock, patch, PropertyMock, MagicMock
 
-import scandir
-
 from pontoon.base.models import (
     Locale,
     Project,
@@ -299,10 +297,10 @@ class VCSProjectTests(VCSTestCase):
         self.project.repositories.all().delete()
         self.project.repositories.add(RepositoryFactory.create(url=url))
 
-        with patch(
-            "pontoon.sync.vcs.models.scandir", wraps=scandir
-        ) as mock_scandir, patch("pontoon.sync.vcs.models.MOZILLA_REPOS", [url]):
-            mock_scandir.walk.return_value = [
+        with patch("pontoon.sync.vcs.models.os", wraps=os) as mock_os, patch(
+            "pontoon.sync.vcs.models.MOZILLA_REPOS", [url]
+        ):
+            mock_os.walk.return_value = [
                 ("/root", [], ["foo.pot", "region.properties"])
             ]
 
@@ -323,9 +321,7 @@ class VCSProjectTests(VCSTestCase):
             ("/root/templates", [], ("foo.pot",)),
         )
         with patch(
-            "pontoon.sync.vcs.models.scandir.walk",
-            wraps=scandir,
-            return_value=hidden_paths,
+            "pontoon.sync.vcs.models.os.walk", wraps=os, return_value=hidden_paths,
         ):
             assert list(self.vcs_project.resource_paths_without_config()) == [
                 "/root/templates/foo.pot"

--- a/pontoon/sync/utils.py
+++ b/pontoon/sync/utils.py
@@ -1,6 +1,5 @@
 import errno
 import os
-import scandir
 
 from pontoon.base.models import Resource
 from pontoon.base.utils import extension_in, first
@@ -65,7 +64,7 @@ def directory_contains_resources(directory_path, source_only=False):
         If True, only check for source-only formats.
     """
     resource_check = is_source_resource if source_only else is_resource
-    for root, dirnames, filenames in scandir.walk(directory_path):
+    for root, dirnames, filenames in os.walk(directory_path):
         # first() avoids checking past the first matching resource.
         if first(filenames, resource_check) is not None:
             return True
@@ -91,7 +90,7 @@ def locale_directory_path(checkout_path, locale_code, parent_directories=None):
                 possible_paths.append(candidate)
 
     if not possible_paths:
-        for root, dirnames, filenames in scandir.walk(checkout_path):
+        for root, dirnames, filenames in os.walk(checkout_path):
             for locale in locale_code_variants:
                 if locale in dirnames:
                     possible_paths.append(os.path.join(root, locale))

--- a/pontoon/sync/vcs/models.py
+++ b/pontoon/sync/vcs/models.py
@@ -3,7 +3,6 @@ Models for working with remote translation data stored in a VCS.
 """
 import logging
 import os
-import scandir
 import shutil
 
 import requests
@@ -402,7 +401,7 @@ class VCSProject(object):
                     else:
                         shutil.copytree(source_directory, locale_directory)
 
-                        for root, dirnames, filenames in scandir.walk(locale_directory):
+                        for root, dirnames, filenames in os.walk(locale_directory):
                             for filename in filenames:
                                 path = os.path.join(root, filename)
                                 if is_resource(filename):
@@ -532,7 +531,7 @@ class VCSProject(object):
             return source_repository.checkout_path
 
         possible_sources = []
-        for root, dirnames, filenames in scandir.walk(self.checkout_path):
+        for root, dirnames, filenames in os.walk(self.checkout_path):
             for dirname in dirnames:
                 if dirname in self.SOURCE_DIR_NAMES:
                     score = self.SOURCE_DIR_SCORES[dirname]
@@ -577,7 +576,7 @@ class VCSProject(object):
         path = self.source_directory_path
         project_files = self.configuration.get_or_set_project_files(None)
 
-        for root, dirnames, filenames in scandir.walk(path):
+        for root, dirnames, filenames in os.walk(path):
             if is_hidden(root):
                 continue
 
@@ -593,7 +592,7 @@ class VCSProject(object):
         """
         path = self.source_directory_path
 
-        for root, dirnames, filenames in scandir.walk(path):
+        for root, dirnames, filenames in os.walk(path):
             if is_hidden(root):
                 continue
 

--- a/pontoon/sync/vcs/repositories.py
+++ b/pontoon/sync/vcs/repositories.py
@@ -2,7 +2,6 @@
 from abc import ABC, abstractmethod
 import logging
 import os
-import scandir
 import subprocess
 
 from django.conf import settings
@@ -460,7 +459,7 @@ def get_changed_files(repo_type, path, revision):
     # version of repository
     if revision is None:
         paths = []
-        for root, _, files in scandir.walk(path):
+        for root, _, files in os.walk(path):
             for f in files:
                 if root[0] == "." or "/." in root:
                     continue

--- a/requirements/default.in
+++ b/requirements/default.in
@@ -45,7 +45,6 @@ python-levenshtein==0.12.2
 pytz==2019.3
 raygun4py==4.3.0
 sacremoses==0.0.43
-scandir==1.5
 translate-toolkit==3.3.2
 whitenoise==5.2.0
 wsgi-sslify==1.0.1

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -467,9 +467,6 @@ rx==1.6.1 \
 sacremoses==0.0.43 \
     --hash=sha256:123c1bf2664351fb05e16f87d3786dbe44a050cfd7b85161c09ad9a63a8e2948
     # via -r requirements/default.in
-scandir==1.5 \
-    --hash=sha256:c2612d1a487d80fb4701b4a91ca1b8f8a695b1ae820570815e85e8c8b23f1283
-    # via -r requirements/default.in
 https://github.com/mathjazz/silme/archive/v0.10.0.zip#egg=silme==0.10.0 \
     --hash=sha256:6227f6cb9b2e3a5898ce6761e339dad9ee6166a449d895202045c92815dc995d
     # via -r requirements/default.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -556,9 +556,6 @@ rx==1.6.1 \
 sacremoses==0.0.43 \
     --hash=sha256:123c1bf2664351fb05e16f87d3786dbe44a050cfd7b85161c09ad9a63a8e2948
     # via -r requirements/default.txt
-scandir==1.5 \
-    --hash=sha256:c2612d1a487d80fb4701b4a91ca1b8f8a695b1ae820570815e85e8c8b23f1283
-    # via -r requirements/default.txt
 https://github.com/mathjazz/silme/archive/v0.10.0.zip#egg=silme==0.10.0 \
     --hash=sha256:6227f6cb9b2e3a5898ce6761e339dad9ee6166a449d895202045c92815dc995d
     # via -r requirements/default.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -670,9 +670,6 @@ rx==1.6.1 \
 sacremoses==0.0.43 \
     --hash=sha256:123c1bf2664351fb05e16f87d3786dbe44a050cfd7b85161c09ad9a63a8e2948
     # via -r requirements/default.txt
-scandir==1.5 \
-    --hash=sha256:c2612d1a487d80fb4701b4a91ca1b8f8a695b1ae820570815e85e8c8b23f1283
-    # via -r requirements/default.txt
 https://github.com/mathjazz/silme/archive/v0.10.0.zip#egg=silme==0.10.0 \
     --hash=sha256:6227f6cb9b2e3a5898ce6761e339dad9ee6166a449d895202045c92815dc995d
     # via -r requirements/default.txt


### PR DESCRIPTION
This reverts commit 32a695bc60b7359cffd8aaea9f18b6d5854e1c6b.

Per the README of the scandir project, the optimizations are
part of upstream python since 3.5