### PR TITLE
Fix bug 1688571: ensure `ResourceMenu` can be discarded

### DIFF
--- a/frontend/src/core/resource/components/ResourceMenu.js
+++ b/frontend/src/core/resource/components/ResourceMenu.js
@@ -80,7 +80,7 @@ export function ResourceMenu({
     useOnDiscard(ref, onDiscard);
 
     return (
-        <div className='menu'>
+        <div ref={ref} className='menu'>
             <div className='search-wrapper'>
                 <div className='icon fa fa-search'></div>
                 <Localized


### PR DESCRIPTION
Follow-up fix for PR#1840.