### PR TITLE
Upgrade flow to 0.145.0

### DIFF
--- a/frontend/.flowconfig
+++ b/frontend/.flowconfig
@@ -11,8 +11,4 @@ module.system=node
 module.system.node.resolve_dirname=node_modules
 module.system.node.resolve_dirname=./src
 
-# This is used to ignore some Flow errors if needed.
-suppress_comment= \\(.\\|\n\\)*\\$FLOW_FIXME
-suppress_comment= \\(.\\|\n\\)*\\$FLOW_IGNORE
-
 [strict]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "connected-react-router": "6.8.0",
     "date-and-time": "0.14.2",
     "diff-match-patch": "1.0.4",
-    "flow-bin": "0.95.1",
+    "flow-bin": "0.145.0",
     "highcharts": "7.2.2",
     "highcharts-react-official": "2.2.2",
     "html-react-parser": "0.13.0",

--- a/frontend/src/core/comments/components/AddComment.js
+++ b/frontend/src/core/comments/components/AddComment.js
@@ -211,7 +211,7 @@ export default function AddComment(props: Props) {
     React.useEffect(() => {
         // Flow does not recognize the event listeners with 'SyntheticEvent`,
         // so I'm ignoring the errors Flow throws here.
-        // $FLOW_IGNORE
+        // $FlowIgnore
         const handleScroll = (e: SyntheticEvent<HTMLElement>) => {
             const element = e.currentTarget;
             setScrollPosition(element.scrollTop);

--- a/frontend/src/core/editor/selectors.js
+++ b/frontend/src/core/editor/selectors.js
@@ -31,7 +31,7 @@ export function _existingTranslation(
         (translation === initialTranslation ||
             // If translation is a FluentMessage, from the fluent editor.
             (translation.equals &&
-                // $FLOW_IGNORE: `equals`, if defined, will always be a function.
+                // $FlowIgnore: `equals`, if defined, will always be a function.
                 translation.equals(initialTranslation)))
     ) {
         existingTranslation = activeTranslation;

--- a/frontend/src/core/translation/components/FluentTranslation.js
+++ b/frontend/src/core/translation/components/FluentTranslation.js
@@ -12,12 +12,12 @@ import { withSearch } from 'modules/search';
 
 import type { TranslationProps } from './GenericTranslation';
 
-// $FLOW_IGNORE: I just can't get HOC working with Flow.
+// $FlowIgnore: I just can't get HOC working with Flow.
 const TranslationPlaceablesDiff = withDiff(
     WithPlaceablesForFluentNoLeadingSpace,
 );
 
-// $FLOW_IGNORE: I just can't get HOC working with Flow.
+// $FlowIgnore: I just can't get HOC working with Flow.
 const TranslationPlaceablesSearch = withSearch(
     WithPlaceablesForFluentNoLeadingSpace,
 );

--- a/frontend/src/core/translation/components/GenericTranslation.js
+++ b/frontend/src/core/translation/components/GenericTranslation.js
@@ -6,10 +6,10 @@ import { withDiff } from 'core/diff';
 import { WithPlaceables, WithPlaceablesNoLeadingSpace } from 'core/placeable';
 import { withSearch } from 'modules/search';
 
-// $FLOW_IGNORE: I just can't get HOC working with Flow.
+// $FlowIgnore: I just can't get HOC working with Flow.
 const TranslationPlaceablesDiff = withDiff(WithPlaceablesNoLeadingSpace);
 
-// $FLOW_IGNORE: I just can't get HOC working with Flow.
+// $FlowIgnore: I just can't get HOC working with Flow.
 const TranslationPlaceablesSearch = withSearch(WithPlaceablesNoLeadingSpace);
 
 export type TranslationProps = {|

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -31,6 +31,6 @@ ReactDOM.render(
             </AppLocalizationProvider>
         </ConnectedRouter>
     </Provider>,
-    // $FLOW_IGNORE: we know that the 'root' element exists.
+    // $FlowIgnore: we know that the 'root' element exists.
     document.getElementById('root'),
 );

--- a/frontend/src/modules/batchactions/components/BatchActions.js
+++ b/frontend/src/modules/batchactions/components/BatchActions.js
@@ -41,12 +41,12 @@ export class BatchActionsBase extends React.Component<InternalProps> {
     }
 
     componentDidMount() {
-        // $FLOW_IGNORE (errors that I don't understand, no help from the Web)
+        // $FlowIgnore (errors that I don't understand, no help from the Web)
         document.addEventListener('keydown', this.handleShortcuts);
     }
 
     componentWillUnmount() {
-        // $FLOW_IGNORE (errors that I don't understand, no help from the Web)
+        // $FlowIgnore (errors that I don't understand, no help from the Web)
         document.removeEventListener('keydown', this.handleShortcuts);
     }
 

--- a/frontend/src/modules/entitieslist/components/EntitiesList.js
+++ b/frontend/src/modules/entitieslist/components/EntitiesList.js
@@ -56,14 +56,14 @@ export class EntitiesListBase extends React.Component<InternalProps> {
     }
 
     componentDidMount() {
-        // $FLOW_IGNORE (errors that I don't understand, no help from the Web)
+        // $FlowIgnore (errors that I don't understand, no help from the Web)
         document.addEventListener('keydown', this.handleShortcuts);
 
         this.selectFirstEntityIfNoneSelected();
     }
 
     componentWillUnmount() {
-        // $FLOW_IGNORE (errors that I don't understand, no help from the Web)
+        // $FlowIgnore (errors that I don't understand, no help from the Web)
         document.removeEventListener('keydown', this.handleShortcuts);
     }
 

--- a/frontend/src/modules/entitieslist/components/Entity.js
+++ b/frontend/src/modules/entitieslist/components/Entity.js
@@ -87,7 +87,7 @@ export default class Entity extends React.Component<Props> {
         // Flow requires that we use `e.currentTarget` instead of `e.target`.
         // However in this case, we do want to use that, so I'm ignoring all
         // errors Flow throws there.
-        // $FLOW_IGNORE
+        // $FlowIgnore
         if (e.target && e.target.classList.contains('status')) {
             return null;
         }

--- a/frontend/src/modules/entitydetails/components/EntityNavigation.js
+++ b/frontend/src/modules/entitydetails/components/EntityNavigation.js
@@ -18,12 +18,12 @@ type Props = {|
  */
 export default class EntityNavigation extends React.Component<Props> {
     componentDidMount() {
-        // $FLOW_IGNORE (errors that I don't understand, no help from the Web)
+        // $FlowIgnore (errors that I don't understand, no help from the Web)
         document.addEventListener('keydown', this.handleShortcuts);
     }
 
     componentWillUnmount() {
-        // $FLOW_IGNORE (errors that I don't understand, no help from the Web)
+        // $FlowIgnore (errors that I don't understand, no help from the Web)
         document.removeEventListener('keydown', this.handleShortcuts);
     }
 

--- a/frontend/src/modules/entitydetails/components/Metadata.js
+++ b/frontend/src/modules/entitydetails/components/Metadata.js
@@ -81,19 +81,19 @@ export default class Metadata extends React.Component<Props, State> {
         // However in this case, we do want to use that, so we're ignoring all
         // errors Flow throws there.
 
-        // $FLOW_IGNORE
+        // $FlowIgnore
         if (e.target && e.target.classList.contains('placeable')) {
             if (this.props.isReadOnlyEditor) {
                 return;
             }
-            // $FLOW_IGNORE
+            // $FlowIgnore
             if (e.target.dataset['match']) {
                 this.props.addTextToEditorTranslation(
-                    // $FLOW_IGNORE
+                    // $FlowIgnore
                     e.target.dataset['match'],
                 );
             }
-            // $FLOW_IGNORE
+            // $FlowIgnore
             else if (e.target.childNodes.length) {
                 this.props.addTextToEditorTranslation(
                     e.target.childNodes[0].data,
@@ -103,7 +103,7 @@ export default class Metadata extends React.Component<Props, State> {
 
         // Handle click on Term
 
-        // $FLOW_IGNORE
+        // $FlowIgnore
         const markedTerm = e.target.dataset['term'];
         if (e.target && markedTerm) {
             const popupTerms = this.props.terms.terms.filter(

--- a/frontend/src/modules/fluenteditor/components/rich/RichTranslationForm.js
+++ b/frontend/src/modules/fluenteditor/components/rich/RichTranslationForm.js
@@ -226,7 +226,7 @@ export default function RichTranslationForm(props: Props) {
 
         updateRichTranslation(
             event.currentTarget.textContent,
-            // $FLOW_IGNORE: Bug in Flow, again.
+            // $FlowIgnore: Bug in Flow, again.
             accessKeyElementIdRef.current.split('-'),
         );
     }

--- a/frontend/src/modules/genericeditor/components/GenericTranslationForm.js
+++ b/frontend/src/modules/genericeditor/components/GenericTranslationForm.js
@@ -93,7 +93,7 @@ export default function GenericTranslationForm(props: Props) {
                     : 'Type translation and press Enter to save'
             }
             readOnly={isReadOnlyEditor}
-            // $FLOW_IGNORE: No idea why this is erroring out.
+            // $FlowIgnore: No idea why this is erroring out.
             ref={textareaRef}
             value={translation}
             onKeyDown={handleShortcuts}

--- a/frontend/src/modules/history/components/Translation.js
+++ b/frontend/src/modules/history/components/Translation.js
@@ -69,7 +69,7 @@ export class TranslationBase extends React.Component<InternalProps, State> {
         this.props.disableAction();
 
         event.stopPropagation();
-        // $FLOW_IGNORE: Flow and the DOM… >_<
+        // $FlowIgnore: Flow and the DOM… >_<
         const action = event.target.name;
 
         this.props.updateTranslationStatus(this.props.translation.pk, action);

--- a/frontend/src/modules/search/components/SearchBox.js
+++ b/frontend/src/modules/search/components/SearchBox.js
@@ -120,7 +120,7 @@ export class SearchBoxBase extends React.Component<InternalProps, State> {
     };
 
     componentDidMount() {
-        // $FLOW_IGNORE (errors that I don't understand, no help from the Web)
+        // $FlowIgnore (errors that I don't understand, no help from the Web)
         document.addEventListener('keydown', this.handleShortcuts);
         this.updateFiltersFromURLParams();
 
@@ -152,7 +152,7 @@ export class SearchBoxBase extends React.Component<InternalProps, State> {
     }
 
     componentWillUnmount() {
-        // $FLOW_IGNORE (errors that I don't understand, no help from the Web)
+        // $FlowIgnore (errors that I don't understand, no help from the Web)
         document.removeEventListener('keydown', this.handleShortcuts);
     }
 


### PR DESCRIPTION
We know migrating to TypeScript will be time consuming and will probably require frontend code freeze:
https://bugzilla.mozilla.org/show_bug.cgi?id=1685565

Given [flow](https://github.com/facebook/flow/commits/master) is far from being dead and we use a very old version of it, let's see if it makes sense to update to the latest version.

Maybe it will help with the migration to TS?
Maybe it will be almost as hard to do?
Maybe if we upgrade flow, we don't need to migrate to TS?

This is just a start. 791 errors. :)

Probably mostly caused by https://flow.org/en/docs/lang/types-first/. Although... there are 423 errors already when upgrading to 0.124.0 (Types-First was introduced by 0.125.0).