### PR TITLE
Fix bug 1695226: Sort projects in Concordance search results by priority and disabled status

### DIFF
--- a/frontend/src/modules/machinery/components/Translation.css
+++ b/frontend/src/modules/machinery/components/Translation.css
@@ -8,6 +8,10 @@
     pointer-events: none;
 }
 
+.machinery .translation.cannot-copy .sources.projects {
+    pointer-events: auto;
+}
+
 .machinery .translation:not(.cannot-copy):hover,
 .machinery .translation.selected {
     background: #333941;

--- a/pontoon/machinery/utils.py
+++ b/pontoon/machinery/utils.py
@@ -78,7 +78,7 @@ def get_concordance_search_data(text, locale):
         .values("source", "target")
         .annotate(
             project_names=ArrayAgg(
-                "project__name", ordering=["project__disabled", "-project__priority",],
+                "project__name", ordering=["project__disabled", "-project__priority"]
             )
         )
         .distinct()

--- a/pontoon/machinery/utils.py
+++ b/pontoon/machinery/utils.py
@@ -76,7 +76,13 @@ def get_concordance_search_data(text, locale):
     search_results = (
         base.models.TranslationMemoryEntry.objects.filter(search_query)
         .values("source", "target")
-        .annotate(project_names=ArrayAgg("project__name", distinct=True))
+        .annotate(
+            project_names=ArrayAgg(
+                "project__name",
+                distinct=True,
+                ordering=["-project__priority", "project__disabled"],
+            )
+        )
         .distinct()
     )
 

--- a/pontoon/machinery/utils.py
+++ b/pontoon/machinery/utils.py
@@ -76,11 +76,7 @@ def get_concordance_search_data(text, locale):
     search_results = (
         base.models.TranslationMemoryEntry.objects.filter(search_query)
         .values("source", "target")
-        .annotate(
-            project_names=ArrayAgg(
-                "project__name", ordering=["project__disabled", "-project__priority"]
-            )
-        )
+        .annotate(project_names=ArrayAgg("project__name", distinct=True))
         .distinct()
     )
 

--- a/pontoon/machinery/utils.py
+++ b/pontoon/machinery/utils.py
@@ -84,13 +84,6 @@ def get_concordance_search_data(text, locale):
         .distinct()
     )
 
-    # We need to remove duplicates manually - ArrayAgg does not support using distinct=True
-    # in combination with ordering.
-    for s in search_results:
-        # Fastest way to eliminate hashable duplicates while retaining order:
-        # https://twitter.com/raymondh/status/944125570534621185
-        s["project_names"] = list(dict.fromkeys(s["project_names"]))
-
     def sort_by_quality(entity):
         """Sort the results by their best Levenshtein distance from the search query"""
         return (

--- a/pontoon/machinery/views.py
+++ b/pontoon/machinery/views.py
@@ -84,6 +84,14 @@ def concordance_search(request):
     except EmptyPage:
         return JsonResponse({"results": [], "has_next": False})
 
+    # ArrayAgg (used in get_concordance_search_data()) does not support using
+    # distinct=True in combination with ordering, so we need to remove
+    # duplicates manually. After pagination, for improved performance.
+    for s in data.object_list:
+        # Fastest way to eliminate hashable duplicates while retaining order:
+        # https://twitter.com/raymondh/status/944125570534621185
+        s["project_names"] = list(dict.fromkeys(s["project_names"]))
+
     return JsonResponse(
         {"results": data.object_list, "has_next": data.has_next()}, safe=False
     )

--- a/pontoon/machinery/views.py
+++ b/pontoon/machinery/views.py
@@ -15,7 +15,7 @@ from django.template.loader import get_template
 from django.utils.datastructures import MultiValueDictKeyError
 
 from pontoon.base import utils
-from pontoon.base.models import Entity, Locale, Translation
+from pontoon.base.models import Entity, Locale, Project, Translation
 from pontoon.machinery.utils import (
     get_concordance_search_data,
     get_google_translate_data,
@@ -85,12 +85,13 @@ def concordance_search(request):
         return JsonResponse({"results": [], "has_next": False})
 
     # ArrayAgg (used in get_concordance_search_data()) does not support using
-    # distinct=True in combination with ordering, so we need to remove
-    # duplicates manually. After pagination, for improved performance.
-    for s in data.object_list:
-        # Fastest way to eliminate hashable duplicates while retaining order:
-        # https://twitter.com/raymondh/status/944125570534621185
-        s["project_names"] = list(dict.fromkeys(s["project_names"]))
+    # distinct=True in combination with ordering, so we need to do one of them
+    # manually - after pagination, to reduce the number of rows processed.
+    projects = Project.objects.order_by("disabled", "-priority").values_list(
+        "name", flat=True
+    )
+    for r in data.object_list:
+        r["project_names"] = [p for p in projects if p in r["project_names"]]
 
     return JsonResponse(
         {"results": data.object_list, "has_next": data.has_next()}, safe=False


### PR DESCRIPTION
This works if I remove the `distinct=True` (but then projects are duplicated), otherwise results in an error shown below. I guess that's because ordering of duplicate items could be ambiguous if items would be ordered by some other field.

I wonder if there's a more elegant way around this than implementing distinct or ordering in python.

```
  File "/usr/local/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.8/site-packages/django/core/handlers/base.py", line 179, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/app/pontoon/machinery/views.py", line 80, in concordance_search
    paginator = Paginator(get_concordance_search_data(text, locale), page_results_limit)
  File "/app/pontoon/machinery/utils.py", line 107, in get_concordance_search_data
    return sorted(search_results, key=sort_by_quality, reverse=True)
  File "/usr/local/lib/python3.8/site-packages/django/db/models/query.py", line 287, in __iter__
    self._fetch_all()
  File "/usr/local/lib/python3.8/site-packages/django/db/models/query.py", line 1308, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
  File "/usr/local/lib/python3.8/site-packages/django/db/models/query.py", line 111, in __iter__
    for row in compiler.results_iter(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size):
  File "/usr/local/lib/python3.8/site-packages/django/db/models/sql/compiler.py", line 1108, in results_iter
    results = self.execute_sql(MULTI, chunked_fetch=chunked_fetch, chunk_size=chunk_size)
  File "/usr/local/lib/python3.8/site-packages/django/db/models/sql/compiler.py", line 1156, in execute_sql
    cursor.execute(sql, params)
  File "/usr/local/lib/python3.8/site-packages/django/db/backends/utils.py", line 98, in execute
    return super().execute(sql, params)
  File "/usr/local/lib/python3.8/site-packages/django/db/backends/utils.py", line 66, in execute
    return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
  File "/usr/local/lib/python3.8/site-packages/django/db/backends/utils.py", line 75, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/usr/local/lib/python3.8/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
  File "/usr/local/lib/python3.8/site-packages/django/db/utils.py", line 90, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/usr/local/lib/python3.8/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
django.db.utils.ProgrammingError: in an aggregate with DISTINCT, ORDER BY expressions must appear in argument list
LINE 1: ...ARRAY_AGG(DISTINCT "base_project"."name" ORDER BY "base_proj...
                                                             ^
```