### PR TITLE
Fix bug 1681653: Remove invalid characters from TM strings while writing tmx files.

### DIFF
--- a/pontoon/base/tests/views/data/tmx/valid_entries.tmx
+++ b/pontoon/base/tests/views/data/tmx/valid_entries.tmx
@@ -35,5 +35,13 @@
 				<seg>&lt;p&gt;translation łążśźć&lt;/p&gt;</seg>
 			</tuv>
 		</tu>
+		<tu tuid="pontoon:aa/bb/ccc:xxx" srclang="en-US">
+			<tuv xml:lang="en-US">
+				<seg>content are c.1998–2019</seg>
+			</tuv>
+			<tuv xml:lang="sl">
+				<seg>content are c.1998–2019</seg>
+			</tuv>
+		</tu>
 	</body>
 </tmx>

--- a/pontoon/base/tests/views/test_tmx.py
+++ b/pontoon/base/tests/views/test_tmx.py
@@ -74,30 +74,15 @@ def test_view_tmx_valid_entries():
         datetime(2010, 1, 1),
         "sl",
         (
-            (
-                "aa/bb/ccc",
-                "xxx",
-                "source string",
-                "translation",
-                "Pontoon App",
-                "pontoon",
-            ),
+            ("aa/bb/ccc", "xxx", "source string", "translation", "pontoon",),
             # Test escape of characters
-            (
-                "aa/bb/ccc",
-                'x&y&z#"',
-                "source string",
-                "translation",
-                "Pontoon & App",
-                "pontoon",
-            ),
+            ("aa/bb/ccc", 'x&y&z#"', "source string", "translation", "pontoon",),
             # Handle unicode characters
             (
                 "aa/bb/ccc",
                 "xxx",
                 "source string łążśźć",
                 "translation łążśźć",
-                "pontoon",
                 "pontoon",
             ),
             # Handle html content
@@ -107,7 +92,6 @@ def test_view_tmx_valid_entries():
                 "<p>source <strong>string</p>",
                 "<p>translation łążśźć</p>",
                 "pontoon",
-                "pontoon",
             ),
             # Handle illegal characters
             (
@@ -115,7 +99,6 @@ def test_view_tmx_valid_entries():
                 "xxx",
                 "content are c.1998–2019",
                 "content are c.1998–2019",
-                "pontoon",
                 "pontoon",
             ),
         ),

--- a/pontoon/base/tests/views/test_tmx.py
+++ b/pontoon/base/tests/views/test_tmx.py
@@ -109,6 +109,15 @@ def test_view_tmx_valid_entries():
                 "pontoon",
                 "pontoon",
             ),
+            # Handle illegal characters
+            (
+                "aa/bb/ccc",
+                "xxx",
+                "content are c.1998–2019",
+                "content are c.1998–2019",
+                "pontoon",
+                "pontoon",
+            ),
         ),
     )
     _check_xml(

--- a/pontoon/base/utils.py
+++ b/pontoon/base/utils.py
@@ -517,7 +517,6 @@ def build_translation_memory_file(creation_date, locale_code, entries):
                          * key - key of an entity,
                          * source - source string of entity,
                          * target - translated string,
-                         * project_name - name of a project,
                          * project_slug - slugified name of a project,
     """
     yield (

--- a/pontoon/base/utils.py
+++ b/pontoon/base/utils.py
@@ -553,19 +553,19 @@ def build_translation_memory_file(creation_date, locale_code, entries):
                          * project_slug - slugified name of a project,
     """
     yield (
-        u'<?xml version="1.0" encoding="UTF-8"?>'
-        u'\n<tmx version="1.4">'
-        u"\n\t<header"
-        u' adminlang="en-US"'
-        u' creationtoolversion="0.1"'
-        u' creationtool="pontoon"'
-        u' datatype="plaintext"'
-        u' segtype="sentence"'
-        u' o-tmf="plain text"'
-        u' srclang="en-US"'
-        u' creationdate="%(creation_date)s">'
-        u"\n\t</header>"
-        u"\n\t<body>" % {"creation_date": creation_date.isoformat()}
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '\n<tmx version="1.4">'
+        "\n\t<header"
+        ' adminlang="en-US"'
+        ' creationtoolversion="0.1"'
+        ' creationtool="pontoon"'
+        ' datatype="plaintext"'
+        ' segtype="sentence"'
+        ' o-tmf="plain text"'
+        ' srclang="en-US"'
+        ' creationdate="%(creation_date)s">'
+        "\n\t</header>"
+        "\n\t<body>" % {"creation_date": creation_date.isoformat()}
     )
     for resource_path, key, source, target, project_name, project_slug in entries:
         tuid = ":".join((project_slug, resource_path, slugify(key)))
@@ -573,14 +573,14 @@ def build_translation_memory_file(creation_date, locale_code, entries):
         target = sanitise_xml_input_string(target)
 
         yield (
-            u'\n\t\t<tu tuid=%(tuid)s srclang="en-US">'
-            u'\n\t\t\t<tuv xml:lang="en-US">'
-            u"\n\t\t\t\t<seg>%(source)s</seg>"
-            u"\n\t\t\t</tuv>"
-            u"\n\t\t\t<tuv xml:lang=%(locale_code)s>"
-            u"\n\t\t\t\t<seg>%(target)s</seg>"
-            u"\n\t\t\t</tuv>"
-            u"\n\t\t</tu>"
+            '\n\t\t<tu tuid=%(tuid)s srclang="en-US">'
+            '\n\t\t\t<tuv xml:lang="en-US">'
+            "\n\t\t\t\t<seg>%(source)s</seg>"
+            "\n\t\t\t</tuv>"
+            "\n\t\t\t<tuv xml:lang=%(locale_code)s>"
+            "\n\t\t\t\t<seg>%(target)s</seg>"
+            "\n\t\t\t</tuv>"
+            "\n\t\t</tu>"
             % {
                 "tuid": quoteattr(tuid),
                 "source": escape(source),
@@ -590,7 +590,7 @@ def build_translation_memory_file(creation_date, locale_code, entries):
             }
         )
 
-    yield (u"\n\t</body>" u"\n</tmx>\n")
+    yield ("\n\t</body>" "\n</tmx>\n")
 
 
 def get_m2m_changes(current_qs, new_qs):

--- a/pontoon/base/utils.py
+++ b/pontoon/base/utils.py
@@ -3,7 +3,6 @@ import functools
 import io
 import os
 import re
-import sys
 
 import pytz
 import requests
@@ -494,46 +493,15 @@ def get_last_months(n):
         start_date += relativedelta(months=-1)
 
 
-def sanitise_xml_input_string(string):
+def sanitize_xml_input_string(string):
     """
-    The XML specification (http://www.w3.org/TR/xml11/#charsets) lists a bunch of Unicode characters
-    that are either illegal or "discouraged". Relace these characters to get valid XML strings
+    The XML specification (http://www.w3.org/TR/xml11/#charsets) lists a set of Unicode characters
+    that are either illegal or "discouraged". Replace these characters to get valid XML strings
     """
 
-    illegal_unichrs = [
-        (0x00, 0x08),
-        (0x0B, 0x0C),
-        (0x0E, 0x1F),
-        (0x7F, 0x84),
-        (0x86, 0x9F),
-        (0xFDD0, 0xFDDF),
-        (0xFFFE, 0xFFFF),
-    ]
-    if sys.maxunicode >= 0x10000:  # not narrow build
-        illegal_unichrs.extend(
-            [
-                (0x1FFFE, 0x1FFFF),
-                (0x2FFFE, 0x2FFFF),
-                (0x3FFFE, 0x3FFFF),
-                (0x4FFFE, 0x4FFFF),
-                (0x5FFFE, 0x5FFFF),
-                (0x6FFFE, 0x6FFFF),
-                (0x7FFFE, 0x7FFFF),
-                (0x8FFFE, 0x8FFFF),
-                (0x9FFFE, 0x9FFFF),
-                (0xAFFFE, 0xAFFFF),
-                (0xBFFFE, 0xBFFFF),
-                (0xCFFFE, 0xCFFFF),
-                (0xDFFFE, 0xDFFFF),
-                (0xEFFFE, 0xEFFFF),
-                (0xFFFFE, 0xFFFFF),
-                (0x10FFFE, 0x10FFFF),
-            ]
-        )
-
-    illegal_ranges = [fr"{chr(low)}-{chr(high)}" for (low, high) in illegal_unichrs]
-    xml_illegal_character_regex = "[" + "".join(illegal_ranges) + "]"
-    illegal_xml_chars_re = re.compile(xml_illegal_character_regex)
+    illegal_xml_chars_re = re.compile(
+        u"[\x00-\x08\x0b\x0c\x0e-\x1F\uD800-\uDFFF\uFFFE\uFFFF]"
+    )
 
     return illegal_xml_chars_re.sub("", string)
 
@@ -567,10 +535,10 @@ def build_translation_memory_file(creation_date, locale_code, entries):
         "\n\t</header>"
         "\n\t<body>" % {"creation_date": creation_date.isoformat()}
     )
-    for resource_path, key, source, target, project_name, project_slug in entries:
+    for resource_path, key, source, target, project_slug in entries:
         tuid = ":".join((project_slug, resource_path, slugify(key)))
-        source = sanitise_xml_input_string(source)
-        target = sanitise_xml_input_string(target)
+        source = sanitize_xml_input_string(source)
+        target = sanitize_xml_input_string(target)
 
         yield (
             '\n\t\t<tu tuid=%(tuid)s srclang="en-US">'
@@ -586,7 +554,6 @@ def build_translation_memory_file(creation_date, locale_code, entries):
                 "source": escape(source),
                 "locale_code": quoteattr(locale_code),
                 "target": escape(target),
-                "project_name": escape(project_name),
             }
         )
 

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -810,7 +810,6 @@ def download_translation_memory(request, locale, slug):
                 "entity__key",
                 "source",
                 "target",
-                "project__name",
                 "project__slug",
             ).order_by("project__slug", "source"),
         ),


### PR DESCRIPTION
Following string in translation memory has a special character considered invalid for XML format hence which prevents tmx file from parsing 

`"Portions of this content are c.1998–2019 by individual mozilla.org "
"contributors. Content available under a <a rel=\"external noopener\" "
"href=\"https://www.mozilla.org/foundation/licensing/website-"
"content/\">Creative Commons license</a>."`

Got rid of such characters from the source and target strings to generate a valid tmx file

Reference: https://stackoverflow.com/questions/1707890/fast-way-to-filter-illegal-xml-unicode-chars-in-python