### PR TITLE
Fix bug 1478554: Add missing (no suggestions) filter to translate app

### DIFF
--- a/frontend/src/modules/search/components/SearchBox.css
+++ b/frontend/src/modules/search/components/SearchBox.css
@@ -120,6 +120,7 @@
 .filters-panel .menu .missing-without-unreviewed.selected .status::before,
 .filters-panel .menu .missing-without-unreviewed .status:hover:before {
     font-size: 16px;
+    margin-left: 0;
 }
 
 .search-box .tag .status:before {

--- a/frontend/src/modules/search/components/SearchBox.css
+++ b/frontend/src/modules/search/components/SearchBox.css
@@ -113,6 +113,13 @@
 
 .search-box .missing-without-unreviewed .status:before {
     content: '\f0eb';
+    font-size: 18px;
+    margin-left: 1px;
+}
+
+.filters-panel .menu .missing-without-unreviewed.selected .status::before,
+.filters-panel .menu .missing-without-unreviewed .status:hover:before {
+    font-size: 16px;
 }
 
 .search-box .tag .status:before {

--- a/frontend/src/modules/search/components/SearchBox.css
+++ b/frontend/src/modules/search/components/SearchBox.css
@@ -111,8 +111,8 @@
     content: '';
 }
 
-.search-box .missing-no-suggestions .status:before {
-    content: 'Ⓜ';
+.search-box .missing-without-unreviewed .status:before {
+    content: '\f0eb';
 }
 
 .search-box .tag .status:before {

--- a/frontend/src/modules/search/components/SearchBox.css
+++ b/frontend/src/modules/search/components/SearchBox.css
@@ -111,6 +111,10 @@
     content: '';
 }
 
+.search-box .missing-no-suggestions .status:before {
+    content: 'Ⓜ';
+}
+
 .search-box .tag .status:before {
     content: '';
 }

--- a/frontend/src/modules/search/constants.js
+++ b/frontend/src/modules/search/constants.js
@@ -49,7 +49,7 @@ export const FILTERS_EXTRA = [
         slug: 'rejected',
     },
     {
-        name: 'Missing (No Suggestions)',
-        slug: 'missing-no-suggestions',
+        name: 'Missing without Unreviewed',
+        slug: 'missing-without-unreviewed',
     },
 ];

--- a/frontend/src/modules/search/constants.js
+++ b/frontend/src/modules/search/constants.js
@@ -48,4 +48,8 @@ export const FILTERS_EXTRA = [
         name: 'Rejected',
         slug: 'rejected',
     },
+    {
+        name: 'Missing (No Suggestions)',
+        slug: 'missing-no-suggestions',
+    },
 ];

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -2328,8 +2328,8 @@ class EntityQuerySet(models.QuerySet):
         return ~Q(
             pk__in=self.get_filtered_entities(
                 locale,
-                Q(approved=True) | Q(rejected=False),
-                lambda x: x.approved or not x.rejected,
+                Q(approved=True) | Q(fuzzy=True) | Q(rejected=False),
+                lambda x: x.approved or x.fuzzy or not x.rejected,
                 match_all=True,
                 project=project,
             )

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -2330,7 +2330,7 @@ class EntityQuerySet(models.QuerySet):
                 locale,
                 Q(approved=True) | Q(rejected=False),
                 lambda x: x.approved and not x.rejected,
-                match_all=False,
+                match_all=True,
                 project=None,
             )
         )

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -2330,7 +2330,6 @@ class EntityQuerySet(models.QuerySet):
                 locale,
                 Q(approved=True) | Q(fuzzy=True) | Q(rejected=False),
                 lambda x: x.approved or x.fuzzy or not x.rejected,
-                match_all=True,
                 project=project,
             )
         )

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -2228,7 +2228,7 @@ class EntityQuerySet(models.QuerySet):
                 lambda x: (x.approved or x.fuzzy) and x.warnings.count(),
                 match_all=False,
                 prefetch=Prefetch("warnings"),
-                project=None,
+                project=project,
             )
         )
 
@@ -2312,11 +2312,11 @@ class EntityQuerySet(models.QuerySet):
                 Q(rejected=True),
                 lambda x: x.rejected,
                 match_all=False,
-                project=None,
+                project=project,
             )
         )
 
-    def missing_no_suggestions(self, locale, project=None):
+    def missing_without_unreviewed(self, locale, project=None):
         """Return a filter to be used to select entities with no or only rejected translations.
 
         This filter will return all entities that have no or only rejected translations.
@@ -2329,9 +2329,9 @@ class EntityQuerySet(models.QuerySet):
             pk__in=self.get_filtered_entities(
                 locale,
                 Q(approved=True) | Q(rejected=False),
-                lambda x: x.approved and not x.rejected,
+                lambda x: x.approved or not x.rejected,
                 match_all=True,
-                project=None,
+                project=project,
             )
         )
 
@@ -2776,7 +2776,7 @@ class Entity(DirtyFieldsMixin, models.Model):
                 "rejected",
                 "unchanged",
                 "empty",
-                "missing-no-suggestions",
+                "missing-without-unreviewed",
             )
             post_filters.append(
                 combine_entity_filters(

--- a/pontoon/base/tests/managers/test_entity.py
+++ b/pontoon/base/tests/managers/test_entity.py
@@ -651,6 +651,107 @@ def test_mgr_entity_filter_rejected_plural(resource_a, locale_a):
 
 
 @pytest.mark.django_db
+def test_mgr_entity_filter_missing_without_unreviewed(resource_a, locale_a):
+    entities = [
+        EntityFactory.create(resource=resource_a, string="testentity%s" % i,)
+        for i in range(0, 5)
+    ]
+
+    TranslationFactory.create(
+        locale=locale_a, entity=entities[0], approved=False, fuzzy=False, rejected=True,
+    )
+    TranslationFactory.create(
+        locale=locale_a, entity=entities[0], approved=False, fuzzy=False, rejected=True,
+    )
+    TranslationFactory.create(
+        locale=locale_a, entity=entities[2], approved=True, fuzzy=False, rejected=False,
+    )
+    TranslationFactory.create(
+        locale=locale_a, entity=entities[3], approved=False, fuzzy=True, rejected=False,
+    )
+    TranslationFactory.create(
+        locale=locale_a, entity=entities[1], approved=False, fuzzy=False, rejected=True,
+    )
+    TranslationFactory.create(
+        locale=locale_a,
+        entity=entities[1],
+        approved=False,
+        fuzzy=False,
+        rejected=False,
+    )
+
+    assert set(
+        resource_a.entities.filter(Entity.objects.missing_without_unreviewed(locale_a))
+    ) == {entities[0], entities[4]}
+
+
+@pytest.mark.django_db
+def test_mgr_entity_filter_missing_without_unreviewed_plural(resource_a, locale_a):
+    locale_a.cldr_plurals = "1,5"
+    locale_a.save()
+    entities = [
+        EntityFactory.create(
+            resource=resource_a,
+            string="testentity%s" % i,
+            string_plural="testpluralentity%s" % i,
+        )
+        for i in range(0, 4)
+    ]
+
+    TranslationFactory.create(
+        locale=locale_a,
+        entity=entities[0],
+        approved=False,
+        fuzzy=False,
+        rejected=True,
+        plural_form=0,
+    )
+    TranslationFactory.create(
+        locale=locale_a,
+        entity=entities[0],
+        approved=False,
+        fuzzy=False,
+        rejected=True,
+        plural_form=1,
+    )
+    TranslationFactory.create(
+        locale=locale_a,
+        entity=entities[1],
+        approved=True,
+        fuzzy=False,
+        rejected=False,
+        plural_form=0,
+    )
+    TranslationFactory.create(
+        locale=locale_a,
+        entity=entities[1],
+        approved=False,
+        fuzzy=False,
+        rejected=True,
+        plural_form=1,
+    )
+    TranslationFactory.create(
+        locale=locale_a,
+        entity=entities[2],
+        approved=False,
+        fuzzy=False,
+        rejected=False,
+        plural_form=0,
+    )
+    TranslationFactory.create(
+        locale=locale_a,
+        entity=entities[2],
+        approved=True,
+        fuzzy=False,
+        rejected=False,
+        plural_form=1,
+    )
+    assert set(
+        resource_a.entities.filter(Entity.objects.missing_without_unreviewed(locale_a))
+    ) == {entities[0], entities[1], entities[3]}
+
+
+@pytest.mark.django_db
 def test_mgr_entity_filter_combined(admin, resource_a, locale_a, user_a):
     """
     All filters should be joined by AND instead of OR.


### PR DESCRIPTION
Added new filter to get strings with no or unrejected suggestions.

We first filter out entities with either approved or not rejected translations (for all plurals) and return a filter to not consider these. 