### PR TITLE
Makes email settings configurable

### DIFF
--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -99,6 +99,21 @@ you create:
    production.
    Adds some additional django apps that can be helpful during day to day development.
 
+``EMAIL_HOST_PASSWORD``
+   Optional. Password for the SMTP connection (no e-mail will be sent if not defined).
+
+``EMAIL_HOST_USER``
+   Optional. Username for the SMTP connection (no e-mail will be sent if not defined).
+
+``EMAIL_HOST``
+   SMTP host (default: ``'smtp.sendgrid.net'``)
+
+``EMAIL_PORT``
+   SMTP port (default: ``587``)
+
+``EMAIL_USE_TLS``
+   Use TLS for the SMTP connection (default: ``True``)
+
 ``ENABLE_BUGS_TAB``
    Optional. Enables Bugs tab on team pages, which pulls team data from
    bugzilla.mozilla.org. Specific for Mozilla deployments.

--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -100,7 +100,7 @@ you create:
    Adds some additional django apps that can be helpful during day to day development.
 
 ``EMAIL_HOST_PASSWORD``
-   Optional. Password for the SMTP connection (no e-mail will be sent if not defined).
+   Optional. Password for the SMTP connection (default: ``'apikey'``, no e-mail will be sent if it is set to an empty string).
 
 ``EMAIL_HOST_USER``
    Optional. Username for the SMTP connection (no e-mail will be sent if not defined).

--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -99,14 +99,14 @@ you create:
    production.
    Adds some additional django apps that can be helpful during day to day development.
 
-``EMAIL_HOST_PASSWORD``
-   Optional. Password for the SMTP connection (default: ``'apikey'``, no e-mail will be sent if it is set to an empty string).
-
-``EMAIL_HOST_USER``
-   Optional. Username for the SMTP connection (no e-mail will be sent if not defined).
-
 ``EMAIL_HOST``
    SMTP host (default: ``'smtp.sendgrid.net'``)
+
+``EMAIL_HOST_PASSWORD``
+   Password for the SMTP connection.
+
+``EMAIL_HOST_USER``
+   Username for the SMTP connection (default: ``'apikey'``).
 
 ``EMAIL_PORT``
    SMTP port (default: ``587``)
@@ -260,13 +260,12 @@ SendGrid Add-on
 Pontoon uses `SendGrid`_, which expects the following environment variable:
 
 ``SENDGRID_PASSWORD``
-
    Use SendGrid API key.
 
 .. _SendGrid: https://devcenter.heroku.com/articles/sendgrid
 
-Cache Add-ons
-~~~~~~~~~~~~~
+Cache Add-on
+~~~~~~~~~~~~
 Pontoon uses `django-bmemcached`_, which expects the following environment
 variables from the cache add-on:
 
@@ -294,8 +293,8 @@ variables from the cache add-on:
 
 .. _django-bmemcached: https://github.com/jaysonsantos/python-binary-memcached
 
-RabbitMQ Add-ons
-~~~~~~~~~~~~~~~~
+RabbitMQ Add-on
+~~~~~~~~~~~~~~~
 Similar to the cache add-ons, Pontoon expects environment variables from the
 RabbitMQ add-on:
 

--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -255,6 +255,16 @@ Pontoon is designed to run with the following add-ons enabled:
 It's possible to run with the free tiers of all of these add-ons, but it is
 recommended that, at a minimum, you run the "Standard 0" tier of Postgres.
 
+SendGrid Add-on
+~~~~~~~~~~~~~~~
+Pontoon uses `SendGrid`_, which expects the following environment variable:
+
+``SENDGRID_PASSWORD``
+
+   Use SendGrid API key.
+
+.. _SendGrid: https://devcenter.heroku.com/articles/sendgrid
+
 Cache Add-ons
 ~~~~~~~~~~~~~
 Pontoon uses `django-bmemcached`_, which expects the following environment

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -107,12 +107,14 @@ RAYGUN4PY_CONFIG = {"api_key": os.environ.get("RAYGUN_APIKEY", "")}
 
 # Email settings
 EMAIL_HOST_USER = os.environ.get(
-    "EMAIL_HOST_USER", os.environ.get("SENDGRID_USERNAME", ""))
+    "EMAIL_HOST_USER", os.environ.get("SENDGRID_USERNAME", "")
+)
 EMAIL_HOST = os.environ.get("EMAIL_HOST", "smtp.sendgrid.net")
 EMAIL_PORT = int(os.environ.get("EMAIL_PORT", "587"))
 EMAIL_USE_TLS = os.environ.get("EMAIL_USE_TLS", "True") != "False"
 EMAIL_HOST_PASSWORD = os.environ.get(
-    "EMAIL_HOST_PASSWORD", os.environ.get("SENDGRID_PASSWORD", ""))
+    "EMAIL_HOST_PASSWORD", os.environ.get("SENDGRID_PASSWORD", "")
+)
 
 # Log emails to console if the SendGrid credentials are missing.
 if EMAIL_HOST_USER and EMAIL_HOST_PASSWORD:

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -107,7 +107,7 @@ RAYGUN4PY_CONFIG = {"api_key": os.environ.get("RAYGUN_APIKEY", "")}
 
 # Email settings
 EMAIL_HOST_USER = os.environ.get(
-    "EMAIL_HOST_USER", os.environ.get("SENDGRID_USERNAME", "")
+    "EMAIL_HOST_USER", os.environ.get("SENDGRID_USERNAME", "apikey")
 )
 EMAIL_HOST = os.environ.get("EMAIL_HOST", "smtp.sendgrid.net")
 EMAIL_PORT = int(os.environ.get("EMAIL_PORT", "587"))

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -106,11 +106,13 @@ GOOGLE_ANALYTICS_KEY = os.environ.get("GOOGLE_ANALYTICS_KEY", "")
 RAYGUN4PY_CONFIG = {"api_key": os.environ.get("RAYGUN_APIKEY", "")}
 
 # Email settings
-EMAIL_HOST_USER = os.environ.get("SENDGRID_USERNAME", "")
-EMAIL_HOST = "smtp.sendgrid.net"
-EMAIL_PORT = 587
-EMAIL_USE_TLS = True
-EMAIL_HOST_PASSWORD = os.environ.get("SENDGRID_PASSWORD", "")
+EMAIL_HOST_USER = os.environ.get(
+    "EMAIL_HOST_USER", os.environ.get("SENDGRID_USERNAME", ""))
+EMAIL_HOST = os.environ.get("EMAIL_HOST", "smtp.sendgrid.net")
+EMAIL_PORT = int(os.environ.get("EMAIL_PORT", "587"))
+EMAIL_USE_TLS = os.environ.get("EMAIL_USE_TLS", "True") != "False"
+EMAIL_HOST_PASSWORD = os.environ.get(
+    "EMAIL_HOST_PASSWORD", os.environ.get("SENDGRID_PASSWORD", ""))
 
 # Log emails to console if the SendGrid credentials are missing.
 if EMAIL_HOST_USER and EMAIL_HOST_PASSWORD:


### PR DESCRIPTION
This PR makes email settings configurable through the following environment variables:

```
EMAIL_HOST=
EMAIL_PORT=
EMAIL_USE_TLS=
EMAIL_HOST_USER=
EMAIL_HOST_PASSWORD=
```
Also,

* I updated the documentation accordingly
* I kept the previously hardcoded setting as default values
* The old `SENDGRID_USERNAME` and `SENDGRID_PASSWORD` settings will still work to not break any prod.

:)