### PR TITLE
manage.py: read dotenv files from alternative path

### DIFF
--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -48,7 +48,7 @@ you create:
 .. NOTE::
 
    Alternatively, you can put all variables below in a `dotenv
-   <https://github.com/theskumar/python-dotenv>`_ text file::
+   <https://github.com/jpadilla/django-dotenv>`_ text file::
 
       VAR="value 1"
       OTHER_VAR="other value"

--- a/manage.py
+++ b/manage.py
@@ -11,7 +11,7 @@ if __name__ == '__main__':
     warnings.filterwarnings('ignore', module='dotenv')
 
     # Read .env file and inject it's values into the environment
-    dotenv.read_dotenv()
+    dotenv.read_dotenv(os.environ.get("DOTENV_PATH"))
 
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'pontoon.settings')
 

--- a/requirements/default.in
+++ b/requirements/default.in
@@ -24,7 +24,7 @@ django-bmemcached==0.2.3
 django-cors-headers==3.5.0
 django-csp==3.7
 django-dirtyfields==1.3.1
-django-dotenv==1.3.0
+django-dotenv==1.4.2
 django-guardian==2.3.0
 django-jinja==2.7.0
 django-notifications-hq==1.6.0

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -124,9 +124,9 @@ django-csp==3.7 \
 django-dirtyfields==1.3.1 \
     --hash=sha256:c3aafe524fc26c6ac573bbaf3ea852607e7b0f8622a2ec23dcdf65e1a9dcb7bb
     # via -r requirements/default.in
-django-dotenv==1.3.0 \
-    --hash=sha256:120c4621d1e4f5adabe0a683463d1be7a5a6b992edd4764d323c627d229251e0 \
-    --hash=sha256:dfe5b8c2be5ab3435b3d71e5a1c66bb14da8104da44ef0dd8ccc3e8a927616d9
+django-dotenv==1.4.2 \
+    --hash=sha256:3812bb0f4876cf31f902aad140f0645e120e51ee30eb7c40c22050f58a0e4adb \
+    --hash=sha256:a9b1b40a70bd321acd231926acedb9bd2c5e873e33a1873b34a7276d196a765e
     # via -r requirements/default.in
 django-guardian==2.3.0 \
     --hash=sha256:0e70706c6cda88ddaf8849bddb525b8df49de05ba0798d4b3506049f0d95cbc8 \


### PR DESCRIPTION
Hello,

A very small PR that allows `manage.py` to read dotenv files from an alternative path defined by the `DOTENV_PATH` environment variable (like `wsgi.py` does).

This feature is already documented:

![Capture d’écran de 2021-03-17 11-06-20](https://user-images.githubusercontent.com/971438/111450617-dce2a700-8710-11eb-8dc0-dd378ef60ba1.png)

:)