### PR TITLE
Fix bug 1699381: make the media folder configurable

### DIFF
--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -145,6 +145,10 @@ you create:
 ``MANUAL_SYNC``
    Optional. Enable Sync button in project Admin.
 
+``MEDIA_ROOT``
+   Optional. The absolute path of the "media" folder where the projects will be
+   cloned (it located next to the "pontoon" Python module by default).
+
 ``MICROSOFT_TRANSLATOR_API_KEY``
    Optional. Set your `Microsoft Translator API key`_ to use machine translation
    by Microsoft.

--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -146,8 +146,8 @@ you create:
    Optional. Enable Sync button in project Admin.
 
 ``MEDIA_ROOT``
-   Optional. The absolute path of the "media" folder where the projects will be
-   cloned (it located next to the "pontoon" Python module by default).
+   Optional. The absolute path of the "media" folder the projects will be
+   cloned into (it is located next to the "pontoon" Python module by default).
 
 ``MICROSOFT_TRANSLATOR_API_KEY``
    Optional. Set your `Microsoft Translator API key`_ to use machine translation

--- a/media/file/.gitignore
+++ b/media/file/.gitignore
@@ -1,5 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore
-

--- a/media/git/.gitignore
+++ b/media/git/.gitignore
@@ -1,5 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore
-

--- a/media/hg/.gitignore
+++ b/media/hg/.gitignore
@@ -1,5 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore
-

--- a/media/svn/.gitignore
+++ b/media/svn/.gitignore
@@ -1,5 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore
-

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -511,7 +511,7 @@ SITE_ID = 1
 
 # Absolute path to the directory that holds media.
 # Example: "/home/media/media.lawrence.com/"
-MEDIA_ROOT = path("media")
+MEDIA_ROOT = os.environ.get("MEDIA_ROOT", path("media"))
 
 # URL that handles the media served from MEDIA_ROOT. Make sure to use a
 # trailing slash if there is a path component (optional in other cases).


### PR DESCRIPTION
This PR makes the path of the `media/` folder configurable through the `MEDIA_ROOT` environment variable.

* By default this is configured to a `media/` folder located next to the `pontoon` Python module (like the currently hardcoded value)
* The documentation was updated accordingly

This fixes the bug #1699381 → https://bugzilla.mozilla.org/show_bug.cgi?id=1699381