### PR TITLE
Fix bug 1699455: suppress warning when the dotenv file is missing

### DIFF
--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -48,7 +48,7 @@ you create:
 .. NOTE::
 
    Alternatively, you can put all variables below in a `dotenv
-   <https://github.com/jpadilla/django-dotenv>`_ text file::
+   <https://saurabh-kumar.com/python-dotenv/>`_ text file::
 
       VAR="value 1"
       OTHER_VAR="other value"

--- a/manage.py
+++ b/manage.py
@@ -1,19 +1,21 @@
 #!/usr/bin/env python
 import os
 import sys
-import warnings
 
 import dotenv
 
 
-if __name__ == '__main__':
-    # Filter out missing .env warning, it's fine if we don't have one.
-    warnings.filterwarnings('ignore', module='dotenv')
+if __name__ == "__main__":
+    # Read dotenv file and inject it's values into the environment
+    root_path = os.path.dirname(__file__)
+    if (
+        "DOTENV_PATH" in os.environ
+        or os.path.isfile(os.path.join(root_path, ".env"))
+        or os.path.isfile(os.path.join(root_path, ".env", ".env"))
+    ):
+        dotenv.read_dotenv(os.environ.get("DOTENV_PATH"))
 
-    # Read .env file and inject it's values into the environment
-    dotenv.read_dotenv(os.environ.get("DOTENV_PATH"))
-
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'pontoon.settings')
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pontoon.settings")
 
     from django.core.management import execute_from_command_line
 

--- a/manage.py
+++ b/manage.py
@@ -5,21 +5,9 @@ import sys
 import dotenv
 
 
-ROOT = os.path.dirname(__file__)
-
-
-def path(*args):
-    return os.path.join(ROOT, *args)
-
-
 if __name__ == "__main__":
     # Read dotenv file and inject it's values into the environment
-    if "DOTENV_PATH" in os.environ:
-        dotenv.read_dotenv(os.environ.get("DOTENV_PATH"))
-    elif os.path.isfile(path(".env")):
-        dotenv.read_dotenv(path(".env"))
-    elif os.path.isfile(path(".env", ".env")):
-        dotenv.read_dotenv(path(".env", ".env"))
+    dotenv.load_dotenv(dotenv_path=os.environ.get("DOTENV_PATH"))
 
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pontoon.settings")
 

--- a/manage.py
+++ b/manage.py
@@ -5,15 +5,21 @@ import sys
 import dotenv
 
 
+ROOT = os.path.dirname(__file__)
+
+
+def path(*args):
+    return os.path.join(ROOT, *args)
+
+
 if __name__ == "__main__":
     # Read dotenv file and inject it's values into the environment
-    root_path = os.path.dirname(__file__)
-    if (
-        "DOTENV_PATH" in os.environ
-        or os.path.isfile(os.path.join(root_path, ".env"))
-        or os.path.isfile(os.path.join(root_path, ".env", ".env"))
-    ):
+    if "DOTENV_PATH" in os.environ:
         dotenv.read_dotenv(os.environ.get("DOTENV_PATH"))
+    elif os.path.isfile(path(".env")):
+        dotenv.read_dotenv(path(".env"))
+    elif os.path.isfile(path(".env", ".env")):
+        dotenv.read_dotenv(path(".env", ".env"))
 
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pontoon.settings")
 

--- a/pontoon/base/celeryapp.py
+++ b/pontoon/base/celeryapp.py
@@ -1,5 +1,4 @@
 import os
-import warnings
 
 import dotenv
 from celery import Celery
@@ -13,11 +12,13 @@ def path(*args):
     return os.path.join(ROOT, *args)
 
 
-# Filter out missing .env warning, it's fine if we don't have one.
-warnings.filterwarnings("ignore", module="dotenv")
-
 # Read .env file and inject it's values into the environment
-dotenv.read_dotenv(path(".env"))
+if "DOTENV_PATH" in os.environ:
+    dotenv.read_dotenv(os.environ.get("DOTENV_PATH"))
+elif os.path.isfile(path(".env")):
+    dotenv.read_dotenv(path(".env"))
+elif os.path.isfile(path(".env", ".env")):
+    dotenv.read_dotenv(path(".env", ".env"))
 
 # Set the default Django settings module for `celery`.
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pontoon.settings")

--- a/pontoon/base/celeryapp.py
+++ b/pontoon/base/celeryapp.py
@@ -4,21 +4,8 @@ import dotenv
 from celery import Celery
 
 
-_dirname = os.path.dirname
-ROOT = _dirname(_dirname(_dirname(os.path.abspath(__file__))))
-
-
-def path(*args):
-    return os.path.join(ROOT, *args)
-
-
-# Read .env file and inject it's values into the environment
-if "DOTENV_PATH" in os.environ:
-    dotenv.read_dotenv(os.environ.get("DOTENV_PATH"))
-elif os.path.isfile(path(".env")):
-    dotenv.read_dotenv(path(".env"))
-elif os.path.isfile(path(".env", ".env")):
-    dotenv.read_dotenv(path(".env", ".env"))
+# Read dotenv file and inject it's values into the environment
+dotenv.load_dotenv(dotenv_path=os.environ.get("DOTENV_PATH"))
 
 # Set the default Django settings module for `celery`.
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pontoon.settings")

--- a/pontoon/wsgi.py
+++ b/pontoon/wsgi.py
@@ -26,7 +26,6 @@ elif os.path.isfile(path(".env")):
 elif os.path.isfile(path(".env", ".env")):
     dotenv.read_dotenv(path(".env", ".env"))
 
-
 # Set settings env var before importing whitenoise as it depends on
 # some settings.
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "pontoon.settings")

--- a/pontoon/wsgi.py
+++ b/pontoon/wsgi.py
@@ -10,9 +10,22 @@ import dotenv
 from django.core.wsgi import get_wsgi_application
 from wsgi_sslify import sslify
 
+_dirname = os.path.dirname
+ROOT = _dirname(_dirname(os.path.abspath(__file__)))
 
+
+def path(*args):
+    return os.path.join(ROOT, *args)
+
+
+# Read .env file and inject it's values into the environment
 if "DOTENV_PATH" in os.environ:
-    dotenv.read_dotenv(os.environ["DOTENV_PATH"])
+    dotenv.read_dotenv(os.environ.get("DOTENV_PATH"))
+elif os.path.isfile(path(".env")):
+    dotenv.read_dotenv(path(".env"))
+elif os.path.isfile(path(".env", ".env")):
+    dotenv.read_dotenv(path(".env", ".env"))
+
 
 # Set settings env var before importing whitenoise as it depends on
 # some settings.

--- a/pontoon/wsgi.py
+++ b/pontoon/wsgi.py
@@ -10,21 +10,9 @@ import dotenv
 from django.core.wsgi import get_wsgi_application
 from wsgi_sslify import sslify
 
-_dirname = os.path.dirname
-ROOT = _dirname(_dirname(os.path.abspath(__file__)))
 
-
-def path(*args):
-    return os.path.join(ROOT, *args)
-
-
-# Read .env file and inject it's values into the environment
-if "DOTENV_PATH" in os.environ:
-    dotenv.read_dotenv(os.environ.get("DOTENV_PATH"))
-elif os.path.isfile(path(".env")):
-    dotenv.read_dotenv(path(".env"))
-elif os.path.isfile(path(".env", ".env")):
-    dotenv.read_dotenv(path(".env", ".env"))
+# Read dotenv file and inject it's values into the environment
+dotenv.load_dotenv(dotenv_path=os.environ.get("DOTENV_PATH"))
 
 # Set settings env var before importing whitenoise as it depends on
 # some settings.

--- a/requirements/default.in
+++ b/requirements/default.in
@@ -24,7 +24,6 @@ django-bmemcached==0.2.3
 django-cors-headers==3.5.0
 django-csp==3.7
 django-dirtyfields==1.3.1
-django-dotenv==1.4.2
 django-guardian==2.3.0
 django-jinja==2.7.0
 django-notifications-hq==1.6.0
@@ -41,6 +40,7 @@ parsimonious==0.6.2
 polib==1.0.6
 psycopg2==2.8.5
 python-dateutil==2.8.1
+python-dotenv==0.17.0
 python-levenshtein==0.12.2
 pytz==2019.3
 raygun4py==4.3.0

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -129,10 +129,6 @@ django-csp==3.7 \
 django-dirtyfields==1.3.1 \
     --hash=sha256:c3aafe524fc26c6ac573bbaf3ea852607e7b0f8622a2ec23dcdf65e1a9dcb7bb
     # via -r requirements/default.in
-django-dotenv==1.4.2 \
-    --hash=sha256:3812bb0f4876cf31f902aad140f0645e120e51ee30eb7c40c22050f58a0e4adb \
-    --hash=sha256:a9b1b40a70bd321acd231926acedb9bd2c5e873e33a1873b34a7276d196a765e
-    # via -r requirements/default.in
 django-guardian==2.3.0 \
     --hash=sha256:0e70706c6cda88ddaf8849bddb525b8df49de05ba0798d4b3506049f0d95cbc8 \
     --hash=sha256:ed2de26e4defb800919c5749fb1bbe370d72829fbd72895b6cf4f7f1a7607e1b
@@ -386,6 +382,10 @@ python-binary-memcached==0.30.1 \
 python-dateutil==2.8.1 \
     --hash=sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c \
     --hash=sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a
+    # via -r requirements/default.in
+python-dotenv==0.17.0 \
+    --hash=sha256:471b782da0af10da1a80341e8438fca5fadeba2881c54360d5fd8d03d03a4f4a \
+    --hash=sha256:49782a97c9d641e8a09ae1d9af0856cc587c8d2474919342d5104d85be9890b2
     # via -r requirements/default.in
 python-levenshtein==0.12.2 \
     --hash=sha256:dc2395fbd148a1ab31090dd113c366695934b9e85fe5a4b2a032745efd0346f6

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -156,10 +156,6 @@ django-debug-toolbar==3.2 \
 django-dirtyfields==1.3.1 \
     --hash=sha256:c3aafe524fc26c6ac573bbaf3ea852607e7b0f8622a2ec23dcdf65e1a9dcb7bb
     # via -r requirements/default.txt
-django-dotenv==1.4.2 \
-    --hash=sha256:3812bb0f4876cf31f902aad140f0645e120e51ee30eb7c40c22050f58a0e4adb \
-    --hash=sha256:a9b1b40a70bd321acd231926acedb9bd2c5e873e33a1873b34a7276d196a765e
-    # via -r requirements/default.txt
 django-extensions==3.0.9 \
     --hash=sha256:6809c89ca952f0e08d4e0766bc0101dfaf508d7649aced1180c091d737046ea7 \
     --hash=sha256:dc663652ac9460fd06580a973576820430c6d428720e874ae46b041fa63e0efa
@@ -460,6 +456,10 @@ python-binary-memcached==0.30.1 \
 python-dateutil==2.8.1 \
     --hash=sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c \
     --hash=sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a
+    # via -r requirements/default.txt
+python-dotenv==0.17.0 \
+    --hash=sha256:471b782da0af10da1a80341e8438fca5fadeba2881c54360d5fd8d03d03a4f4a \
+    --hash=sha256:49782a97c9d641e8a09ae1d9af0856cc587c8d2474919342d5104d85be9890b2
     # via -r requirements/default.txt
 python-levenshtein==0.12.2 \
     --hash=sha256:dc2395fbd148a1ab31090dd113c366695934b9e85fe5a4b2a032745efd0346f6

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -208,10 +208,6 @@ django-csp==3.7 \
 django-dirtyfields==1.3.1 \
     --hash=sha256:c3aafe524fc26c6ac573bbaf3ea852607e7b0f8622a2ec23dcdf65e1a9dcb7bb
     # via -r requirements/default.txt
-django-dotenv==1.4.2 \
-    --hash=sha256:3812bb0f4876cf31f902aad140f0645e120e51ee30eb7c40c22050f58a0e4adb \
-    --hash=sha256:a9b1b40a70bd321acd231926acedb9bd2c5e873e33a1873b34a7276d196a765e
-    # via -r requirements/default.txt
 django-guardian==2.3.0 \
     --hash=sha256:0e70706c6cda88ddaf8849bddb525b8df49de05ba0798d4b3506049f0d95cbc8 \
     --hash=sha256:ed2de26e4defb800919c5749fb1bbe370d72829fbd72895b6cf4f7f1a7607e1b
@@ -572,6 +568,10 @@ python-dateutil==2.8.1 \
     # via
     #   -r requirements/default.txt
     #   faker
+python-dotenv==0.17.0 \
+    --hash=sha256:471b782da0af10da1a80341e8438fca5fadeba2881c54360d5fd8d03d03a4f4a \
+    --hash=sha256:49782a97c9d641e8a09ae1d9af0856cc587c8d2474919342d5104d85be9890b2
+    # via -r requirements/default.txt
 python-levenshtein==0.12.2 \
     --hash=sha256:dc2395fbd148a1ab31090dd113c366695934b9e85fe5a4b2a032745efd0346f6
     # via -r requirements/default.txt


### PR DESCRIPTION
With this PR, `manage.py` call the `dotenv.read_dotenv()` function only

* if the `DOTENV_PATH` environment variable is defined,
* if the `.env` or `.env/.env` file is exists (both are checked by the `dotenv` module).

This will suppress useless warnings.

Related bug → https://bugzilla.mozilla.org/show_bug.cgi?id=1699455