### PR TITLE
Bug 1703748: Prevent sync breakage due to a typo

### DIFF
--- a/pontoon/sync/tasks.py
+++ b/pontoon/sync/tasks.py
@@ -333,7 +333,7 @@ def sync_translations(
             if locale in locales:
                 created = update_translated_resources(db_project, vcs_project, locale)
                 if created:
-                    new_locales.append[locale.pk]
+                    new_locales.append(locale.pk)
 
             # We don't have files: we can still update asymmetric translated resources.
             else:


### PR DESCRIPTION
This is a hotfix for an obvious error.

I'll keep the bug open to increase test coverage and catch the error early.