### PR TITLE
Fix Bug 1702396 - Update mention search

### DIFF
--- a/frontend/src/core/comments/components/AddComment.js
+++ b/frontend/src/core/comments/components/AddComment.js
@@ -81,7 +81,7 @@ export default function AddComment(props: Props): React.Element<'div'> {
 
     const userNames = users.map((user) => user.name);
     const suggestedUsers = userNames
-        .filter((c) => c.toLowerCase().startsWith(search.toLowerCase()))
+        .filter((c) => c.toLowerCase().includes(search.toLowerCase()))
         .slice(0, 5);
 
     // Set position of mentions suggestions


### PR DESCRIPTION
The current search functionality looks to see if the name for mentioning `startsWith` the string that is input into the search field. This causes problems when there are multiple people with the same name such as 'Juan' as only the first 5 results display.

This change switches the search function to check if the name `includes` the search string which should allow users to search mentions based on last names and/or parts of their name or username.