### PR TITLE
Fix bug 1704038: Upgrade to Django 3.2

### DIFF
--- a/pontoon/administration/tests/test_views.py
+++ b/pontoon/administration/tests/test_views.py
@@ -301,7 +301,7 @@ def test_manage_project_strings_download_csv(client_superuser):
     # Test downloading the data.
     response = client_superuser.get(url, {"format": "csv"})
     assert response.status_code == 200
-    assert response._headers["content-type"] == ("Content-Type", "text/csv")
+    assert response.headers["content-type"] == "text/csv"
 
     # Verify the original content is here.
     assert b"pedestal" in response.content

--- a/pontoon/base/__init__.py
+++ b/pontoon/base/__init__.py
@@ -1,7 +1,3 @@
-"""Application base, containing global templates."""
-default_app_config = "pontoon.base.apps.BaseConfig"
-
-
 MOZILLA_REPOS = (
     "ssh://hg.mozilla.org/users/m_owca.info/firefox-beta/",
     "ssh://hg.mozilla.org/users/m_owca.info/firefox-for-android-beta/",

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -428,14 +428,14 @@ class AggregatedStats(models.Model):
         """
         Get sum of stats for all items in the queryset.
         """
-        return cls(
-            total_strings=sum(x.total_strings for x in qs),
-            approved_strings=sum(x.approved_strings for x in qs),
-            fuzzy_strings=sum(x.fuzzy_strings for x in qs),
-            strings_with_errors=sum(x.strings_with_errors for x in qs),
-            strings_with_warnings=sum(x.strings_with_warnings for x in qs),
-            unreviewed_strings=sum(x.unreviewed_strings for x in qs),
-        )
+        return {
+            "total_strings": sum(x.total_strings for x in qs),
+            "approved_strings": sum(x.approved_strings for x in qs),
+            "fuzzy_strings": sum(x.fuzzy_strings for x in qs),
+            "strings_with_errors": sum(x.strings_with_errors for x in qs),
+            "strings_with_warnings": sum(x.strings_with_warnings for x in qs),
+            "unreviewed_strings": sum(x.unreviewed_strings for x in qs),
+        }
 
     @classmethod
     def get_top_instances(cls, qs):

--- a/pontoon/contributors/apps.py
+++ b/pontoon/contributors/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class ContributorsConfig(AppConfig):
-    name = "contributors"

--- a/pontoon/homepage/apps.py
+++ b/pontoon/homepage/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class HomepageConfig(AppConfig):
-    name = "homepage"

--- a/pontoon/insights/apps.py
+++ b/pontoon/insights/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class InsightsConfig(AppConfig):
-    name = "insights"

--- a/pontoon/localizations/apps.py
+++ b/pontoon/localizations/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class LocalizationConfig(AppConfig):
-    name = "localization"

--- a/pontoon/machinery/apps.py
+++ b/pontoon/machinery/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class MachineryConfig(AppConfig):
-    name = "machinery"

--- a/pontoon/projects/apps.py
+++ b/pontoon/projects/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class ProjectsConfig(AppConfig):
-    name = "projects"

--- a/pontoon/projects/tests/test_views.py
+++ b/pontoon/projects/tests/test_views.py
@@ -4,12 +4,17 @@ import pytest
 from django.http import HttpResponse
 from django.shortcuts import render
 
-from pontoon.base.models import Project
-from pontoon.base.tests import (
-    ProjectFactory,
-    ResourceFactory,
-    TranslationFactory,
-)
+from pontoon.base.tests import TranslationFactory
+
+
+@pytest.mark.django_db
+def test_projects_list(client, project_a, resource_a):
+    """
+    Checks if list of projects is properly rendered.
+    """
+    response = client.get("/projects/")
+    assert response.status_code == 200
+    assert response.resolver_match.view_name == "pontoon.projects"
 
 
 @pytest.mark.django_db
@@ -24,33 +29,26 @@ def test_project_doesnt_exist(client):
 
 
 @pytest.mark.django_db
-def test_project_view(client):
+def test_project_view(client, project_a, resource_a):
     """
     Checks if project page is returned properly.
     """
-    project = ProjectFactory.create(visibility=Project.Visibility.PUBLIC)
-    ResourceFactory.create(project=project)
-
     with patch("pontoon.projects.views.render", wraps=render) as mock_render:
-        client.get(f"/projects/{project.slug}/")
-        assert mock_render.call_args[0][2]["project"] == project
+        client.get(f"/projects/{project_a.slug}/")
+        assert mock_render.call_args[0][2]["project"] == project_a
 
 
 @pytest.mark.django_db
-def test_project_top_contributors(client):
+def test_project_top_contributors(client, project_a, project_b):
     """
     Tests if view returns top contributors specific for given project.
     """
-    first_project = ProjectFactory.create(visibility=Project.Visibility.PUBLIC)
-    ResourceFactory.create(project=first_project)
-    first_project_contributor = TranslationFactory.create(
-        entity__resource__project=first_project
+    project_a_contributor = TranslationFactory.create(
+        entity__resource__project=project_a
     ).user
 
-    second_project = ProjectFactory.create(visibility=Project.Visibility.PUBLIC)
-    ResourceFactory.create(project=second_project)
-    second_project_contributor = TranslationFactory.create(
-        entity__resource__project=second_project
+    project_b_contributor = TranslationFactory.create(
+        entity__resource__project=project_b
     ).user
 
     with patch(
@@ -58,19 +56,19 @@ def test_project_top_contributors(client):
         return_value=HttpResponse(""),
     ) as mock_render:
         client.get(
-            f"/projects/{first_project.slug}/ajax/contributors/",
+            f"/projects/{project_a.slug}/ajax/contributors/",
             HTTP_X_REQUESTED_WITH="XMLHttpRequest",
         )
-        assert mock_render.call_args[0][0]["project"] == first_project
+        assert mock_render.call_args[0][0]["project"] == project_a
         assert list(mock_render.call_args[0][0]["contributors"]) == [
-            first_project_contributor
+            project_a_contributor
         ]
 
         client.get(
-            f"/projects/{second_project.slug}/ajax/contributors/",
+            f"/projects/{project_b.slug}/ajax/contributors/",
             HTTP_X_REQUESTED_WITH="XMLHttpRequest",
         )
-        assert mock_render.call_args[0][0]["project"] == second_project
+        assert mock_render.call_args[0][0]["project"] == project_b
         assert list(mock_render.call_args[0][0]["contributors"]) == [
-            second_project_contributor
+            project_b_contributor
         ]

--- a/pontoon/projects/tests/test_views.py
+++ b/pontoon/projects/tests/test_views.py
@@ -7,6 +7,7 @@ from django.shortcuts import render
 from pontoon.base.tests import TranslationFactory
 
 
+@pytest.mark.no_cover
 @pytest.mark.django_db
 def test_projects_list(client, project_a, resource_a):
     """

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -844,3 +844,5 @@ NOTIFICATIONS_MAX_COUNT = 7
 
 # Number of events displayed on the Contributor's timeline per page.
 CONTRIBUTORS_TIMELINE_EVENTS_PER_PAGE = 10
+
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"

--- a/pontoon/tags/__init__.py
+++ b/pontoon/tags/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = "pontoon.tags.apps.TagsConfig"

--- a/pontoon/tags/apps.py
+++ b/pontoon/tags/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class TagsConfig(AppConfig):
-    name = "pontoon.tags"

--- a/pontoon/teams/apps.py
+++ b/pontoon/teams/apps.py
@@ -1,5 +1,0 @@
-from django.apps import AppConfig
-
-
-class TeamsConfig(AppConfig):
-    name = "teams"

--- a/pontoon/teams/tests/test_views.py
+++ b/pontoon/teams/tests/test_views.py
@@ -22,6 +22,7 @@ def managers():
     return _get_sorted_users()
 
 
+@pytest.mark.no_cover
 @pytest.mark.django_db
 def test_teams_list(client, locale_a):
     """

--- a/pontoon/teams/tests/test_views.py
+++ b/pontoon/teams/tests/test_views.py
@@ -23,6 +23,16 @@ def managers():
 
 
 @pytest.mark.django_db
+def test_teams_list(client, locale_a):
+    """
+    Tests if the teams list is rendered properly.
+    """
+    response = client.get("/teams/")
+    assert response.status_code == 200
+    assert response.resolver_match.view_name == "pontoon.teams"
+
+
+@pytest.mark.django_db
 def test_missing_locale(client):
     """
     Tests if the backend is returning an error on the missing locale.

--- a/requirements/default.in
+++ b/requirements/default.in
@@ -17,7 +17,7 @@ bleach==3.3.0
 celery==4.3.0
 compare-locales==8.1.0
 dj-database-url==0.3.0
-Django==3.1.8
+Django==3.2.0
 django-ace==1.0.5
 django-allauth==0.44.0
 django-bmemcached==0.2.3

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -153,9 +153,9 @@ django-webpack-loader==0.5.0 \
     --hash=sha256:0a8536e36a30d719018cd4c5da6e9d2377771134e713c14e617bb484b4f0acce \
     --hash=sha256:7094bcd8cc40c9824e5b482ce8ff9e8ae09e1982e5d08e078e5fe2411fb40a03
     # via -r requirements/default.in
-django==3.1.8 \
-    --hash=sha256:c348b3ddc452bf4b62361f0752f71a339140c777ebea3cdaaaa8fdb7f417a862 \
-    --hash=sha256:f8393103e15ec2d2d313ccbb95a3f1da092f9f58d74ac1c61ca2ac0436ae1eac
+django==3.2 \
+    --hash=sha256:0604e84c4fb698a5e53e5857b5aea945b2f19a18f25f10b8748dbdf935788927 \
+    --hash=sha256:21f0f9643722675976004eb683c55d33c05486f94506672df3d6a141546f389d
     # via
     #   -r requirements/default.in
     #   django-ace

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -189,9 +189,9 @@ django-webpack-loader==0.5.0 \
     --hash=sha256:0a8536e36a30d719018cd4c5da6e9d2377771134e713c14e617bb484b4f0acce \
     --hash=sha256:7094bcd8cc40c9824e5b482ce8ff9e8ae09e1982e5d08e078e5fe2411fb40a03
     # via -r requirements/default.txt
-django==3.1.8 \
-    --hash=sha256:c348b3ddc452bf4b62361f0752f71a339140c777ebea3cdaaaa8fdb7f417a862 \
-    --hash=sha256:f8393103e15ec2d2d313ccbb95a3f1da092f9f58d74ac1c61ca2ac0436ae1eac
+django==3.2 \
+    --hash=sha256:0604e84c4fb698a5e53e5857b5aea945b2f19a18f25f10b8748dbdf935788927 \
+    --hash=sha256:21f0f9643722675976004eb683c55d33c05486f94506672df3d6a141546f389d
     # via
     #   -r requirements/default.txt
     #   django-ace

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -234,9 +234,9 @@ django-webpack-loader==0.5.0 \
     --hash=sha256:0a8536e36a30d719018cd4c5da6e9d2377771134e713c14e617bb484b4f0acce \
     --hash=sha256:7094bcd8cc40c9824e5b482ce8ff9e8ae09e1982e5d08e078e5fe2411fb40a03
     # via -r requirements/default.txt
-django==3.1.8 \
-    --hash=sha256:c348b3ddc452bf4b62361f0752f71a339140c777ebea3cdaaaa8fdb7f417a862 \
-    --hash=sha256:f8393103e15ec2d2d313ccbb95a3f1da092f9f58d74ac1c61ca2ac0436ae1eac
+django==3.2 \
+    --hash=sha256:0604e84c4fb698a5e53e5857b5aea945b2f19a18f25f10b8748dbdf935788927 \
+    --hash=sha256:21f0f9643722675976004eb683c55d33c05486f94506672df3d6a141546f389d
     # via
     #   -r requirements/default.txt
     #   django-ace


### PR DESCRIPTION
This upgrades Pontoon to Django 3.2, which means we should be good to go until April 2024 :smile: 

App configs are now automatically discovered, and most of our current app configs were redundant or had wrong names.
The `DEFAULT_AUTO_FIELD` is needed to prevent unwanted migrations in the future, when the default value will change to BigAutoField.

I'll submit a small additional PR to make use of the new `@admin.display` decorator.