### PR TITLE
Fix bug 1697583 : Filter out invalid machinery translations

### DIFF
--- a/frontend/src/modules/entitydetails/components/Helpers.js
+++ b/frontend/src/modules/entitydetails/components/Helpers.js
@@ -150,6 +150,7 @@ export default function Helpers(props: Props): React.Node {
                         <Machinery
                             locale={locale}
                             machinery={machinery}
+                            entity={entity}
                             searchMachinery={searchMachinery}
                         />
                     </TabPanel>

--- a/frontend/src/modules/machinery/components/Machinery.js
+++ b/frontend/src/modules/machinery/components/Machinery.js
@@ -7,14 +7,17 @@ import './Machinery.css';
 
 import Translation from './Translation';
 import { SkeletonLoader } from 'core/loaders';
+import * as utils from 'core/utils';
 
 import type { Locale } from 'core/locale';
+import type { Entity } from 'core/api';
 import type { MachineryState } from '..';
 
 type Props = {|
     locale: ?Locale,
     machinery: MachineryState,
     searchMachinery: (string, ?number) => void,
+    entity: Entity,
 |};
 
 type State = {|
@@ -81,7 +84,12 @@ export default class Machinery extends React.Component<Props, State> {
     };
 
     render(): null | React.Element<'section'> {
-        const { locale, machinery } = this.props;
+        const { locale, machinery, entity } = this.props;
+
+        const source = utils.getOptimizedContent(
+            entity.machinery_original,
+            entity.format,
+        );
 
         if (!locale) {
             return null;
@@ -122,14 +130,15 @@ export default class Machinery extends React.Component<Props, State> {
                 <div className='list-wrapper'>
                     <ul>
                         {machinery.translations.map((translation, index) => {
-                            return (
+                            return !machinery.entity ||
+                                translation.original == source ? (
                                 <Translation
                                     index={index}
                                     sourceString={machinery.sourceString}
                                     translation={translation}
                                     key={index}
                                 />
-                            );
+                            ) : null;
                         })}
                     </ul>
                     <ul>

--- a/frontend/src/modules/machinery/components/Machinery.test.js
+++ b/frontend/src/modules/machinery/components/Machinery.test.js
@@ -8,13 +8,18 @@ describe('<Machinery>', () => {
         code: 'kg',
     };
 
+    const ENTITY = {
+        machinery_original: 'Plus ultra',
+        format: 'po',
+    };
+
     it('shows a search form', () => {
         const machinery = {
             translations: [],
             searchResults: [],
         };
         const wrapper = shallow(
-            <Machinery machinery={machinery} locale={LOCALE} />,
+            <Machinery machinery={machinery} locale={LOCALE} entity={ENTITY} />,
         );
 
         expect(wrapper.find('.search-wrapper')).toHaveLength(1);
@@ -33,7 +38,7 @@ describe('<Machinery>', () => {
             searchResults: [{ original: '4' }, { original: '5' }],
         };
         const wrapper = shallow(
-            <Machinery machinery={machinery} locale={LOCALE} />,
+            <Machinery machinery={machinery} locale={LOCALE} entity={ENTITY} />,
         );
 
         expect(wrapper.find('Translation')).toHaveLength(5);
@@ -42,7 +47,7 @@ describe('<Machinery>', () => {
     it('returns null if there is no locale', () => {
         const machinery = {};
         const wrapper = shallow(
-            <Machinery machinery={machinery} locale={null} />,
+            <Machinery machinery={machinery} locale={null} entity={ENTITY} />,
         );
 
         expect(wrapper.type()).toBeNull();
@@ -55,7 +60,7 @@ describe('<Machinery>', () => {
             sourceString: 'test',
         };
         const wrapper = mount(
-            <Machinery machinery={machinery} locale={LOCALE} />,
+            <Machinery machinery={machinery} locale={LOCALE} entity={ENTITY} />,
         );
 
         expect(wrapper.find('button')).toHaveLength(1);


### PR DESCRIPTION
### Issue
If you perform a concordance search and submit a translation immediately after, the previous source string (the one that was just translated) gets used as an input for Machinery along with the current string when the next string opens. i.e. we actually make two requests, and results from both appear in machinery.

### Fix
Filter out the translations for which source != entity except for concordance search translations. 
