### PR TITLE
Bug 1704038: Make use of new admin.display decorator

### DIFF
--- a/pontoon/base/admin.py
+++ b/pontoon/base/admin.py
@@ -7,6 +7,7 @@ from django.contrib.auth.models import User
 from django.forms.models import ModelForm
 from django.forms import ChoiceField
 from django.urls import reverse
+from django.utils.html import format_html
 
 from pontoon.actionlog.models import ActionLog
 from pontoon.base import models
@@ -236,16 +237,13 @@ class ProjectAdmin(admin.ModelAdmin):
     )
     ordering = ("disabled",)
 
+    @admin.display(ordering="contact__first_name")
     def contact_person(self, obj):
         return obj.contact.name_or_email if obj.contact else "-"
 
-    contact_person.admin_order_field = "contact__first_name"
-
+    @admin.display(boolean=True, ordering="disabled")
     def enabled(self, obj):
         return not obj.disabled
-
-    enabled.boolean = True
-    enabled.admin_order_field = "disabled"
 
     fieldsets = (
         (
@@ -352,21 +350,21 @@ class UserRoleLogActionAdmin(admin.ModelAdmin):
             args=(user_pk,),
         )
 
+    @admin.display(description="Performed on")
     def performed_on_email(self, obj):
-        return '<a href="{}">{}</a>'.format(
-            self.get_user_edit_url(obj.performed_on_id), obj.performed_on.email
+        return format_html(
+            '<a href="{}">{}</a>',
+            self.get_user_edit_url(obj.performed_on_id),
+            obj.performed_on.email,
         )
 
-    performed_on_email.short_description = "Performed on"
-    performed_on_email.allow_tags = True
-
+    @admin.display(description="Performed by")
     def performed_by_email(self, obj):
-        return '<a href="{}">{}</a>'.format(
-            self.get_user_edit_url(obj.performed_by_id), obj.performed_by.email
+        return format_html(
+            '<a href="{}">{}</a>',
+            self.get_user_edit_url(obj.performed_by_id),
+            obj.performed_by.email,
         )
-
-    performed_by_email.short_description = "Performed by"
-    performed_by_email.allow_tags = True
 
 
 admin.site.unregister(User)

--- a/pontoon/checks/admin.py
+++ b/pontoon/checks/admin.py
@@ -15,15 +15,19 @@ class FailedCheckModelAdmin(admin.ModelAdmin):
         "resource",
     )
 
+    @admin.display
     def project(self, obj):
         return obj.translation.entity.resource.project.name
 
+    @admin.display
     def locale(self, obj):
         return obj.translation.locale.code
 
+    @admin.display
     def resource(self, obj):
         return obj.translation.entity.resource.path
 
+    @admin.display
     def translation(self, obj):
         return obj.translation.string
 

--- a/pontoon/sync/admin.py
+++ b/pontoon/sync/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from django.urls import reverse
-from django.utils.safestring import mark_safe
+from django.utils.html import format_html
 
 from pontoon.sync import models
 
@@ -8,24 +8,21 @@ from pontoon.sync import models
 TIMES = ("start_time", "end_time", "duration")
 
 
-class EditLinkToInlineObject:
-    def edit_link(self, instance):
-        url = reverse(
-            "admin:%s_%s_change"
-            % (instance._meta.app_label, instance._meta.model_name),
-            args=[instance.pk],
-        )
-        if instance.pk:
-            return mark_safe(f'<a href="{url}">edit</a>')
-        else:
-            return ""
-
-
-class ProjectSyncLogInline(EditLinkToInlineObject, admin.TabularInline):
+class ProjectSyncLogInline(admin.TabularInline):
     model = models.ProjectSyncLog
     extra = 0
     verbose_name_plural = "Projects"
     readonly_fields = ("edit_link",)
+
+    @admin.display
+    def edit_link(self, obj):
+        url = reverse(
+            f"admin:{obj._meta.app_label}_{obj._meta.model_name}_change", args=[obj.pk],
+        )
+        if obj.pk:
+            return format_html('<a href="{}">edit</a>', url)
+        else:
+            return ""
 
 
 class SyncLogAdmin(admin.ModelAdmin):
@@ -47,6 +44,7 @@ class ProjectSyncLogAdmin(admin.ModelAdmin):
 class RepositorySyncLogAdmin(admin.ModelAdmin):
     list_display = ("repository_url",) + TIMES
 
+    @admin.display
     def repository_url(self, obj):
         return obj.repository.url
 


### PR DESCRIPTION
This makes use of the new admin.display decorator from Django 3.2. Additionally, we use `format_html` instead of `mark_safe`.