### PR TITLE
Fix bug 1706936: Collect baseline notifications metrics

### DIFF
--- a/frontend/src/core/api/user.js
+++ b/frontend/src/core/api/user.js
@@ -29,6 +29,35 @@ export default class UserAPI extends APIBase {
     }
 
     /**
+     * Log UX action.
+     */
+    async logUxAction(
+        action_type: string,
+        experiment: ?string,
+        data: ?any,
+    ): Promise<any> {
+        const csrfToken = this.getCSRFToken();
+
+        const payload = new URLSearchParams();
+        payload.append('csrfmiddlewaretoken', csrfToken);
+        payload.append('action_type', action_type);
+
+        if (experiment) {
+            payload.append('experiment', experiment);
+        }
+
+        if (data) {
+            payload.append('data', JSON.stringify(data));
+        }
+
+        const headers = new Headers();
+        headers.append('X-Requested-With', 'XMLHttpRequest');
+        headers.append('X-CSRFToken', csrfToken);
+
+        return await this.fetch('/log-ux-action/', 'POST', payload, headers);
+    }
+
+    /**
      * Mark all notifications of the current user as read.
      */
     async markAllNotificationsAsRead(): Promise<any> {

--- a/frontend/src/core/api/user.js
+++ b/frontend/src/core/api/user.js
@@ -31,7 +31,7 @@ export default class UserAPI extends APIBase {
     /**
      * Log UX action.
      */
-    async logUxAction(
+    logUxAction(
         action_type: string,
         experiment: ?string,
         data: ?any,
@@ -54,7 +54,7 @@ export default class UserAPI extends APIBase {
         headers.append('X-Requested-With', 'XMLHttpRequest');
         headers.append('X-CSRFToken', csrfToken);
 
-        return await this.fetch('/log-ux-action/', 'POST', payload, headers);
+        return this.fetch('/log-ux-action/', 'POST', payload, headers);
     }
 
     /**

--- a/frontend/src/core/user/actions.js
+++ b/frontend/src/core/user/actions.js
@@ -114,6 +114,16 @@ export function markAllNotificationsAsRead(): Function {
     };
 }
 
+export function logUxAction(
+    action_type: string,
+    experiment: ?string,
+    data: ?any,
+): Function {
+    return async () => {
+        await api.user.logUxAction(action_type, experiment, data);
+    };
+}
+
 /**
  * Get data about the current user from the server.
  *
@@ -137,6 +147,7 @@ export function getUsers(): Function {
 export default {
     get,
     getUsers,
+    logUxAction,
     markAllNotificationsAsRead,
     saveSetting,
     signOut,

--- a/frontend/src/core/user/components/UserControls.js
+++ b/frontend/src/core/user/components/UserControls.js
@@ -36,6 +36,14 @@ export class UserControlsBase extends React.Component<InternalProps> {
         this.props.dispatch(actions.get());
     };
 
+    logUxAction: (
+        action_type: string,
+        experiment: ?string,
+        data: ?any,
+    ) => void = (action_type, experiment, data) => {
+        this.props.dispatch(actions.logUxAction(action_type, experiment, data));
+    };
+
     markAllNotificationsAsRead: () => void = () => {
         this.props.dispatch(actions.markAllNotificationsAsRead());
     };
@@ -63,6 +71,7 @@ export class UserControlsBase extends React.Component<InternalProps> {
                 />
 
                 <UserNotificationsMenu
+                    logUxAction={this.logUxAction}
                     markAllNotificationsAsRead={this.markAllNotificationsAsRead}
                     user={user}
                 />

--- a/frontend/src/core/user/components/UserNotification.css
+++ b/frontend/src/core/user/components/UserNotification.css
@@ -17,16 +17,12 @@
 }
 
 .user-notification.read {
-    animation-duration: 2s;
+    animation-duration: 1s;
     animation-name: fadeout-background;
 }
 
 @keyframes fadeout-background {
     0% {
-        background: #3f4752;
-    }
-
-    50% {
         background: #3f4752;
     }
 

--- a/frontend/src/core/user/components/UserNotificationsMenu.css
+++ b/frontend/src/core/user/components/UserNotificationsMenu.css
@@ -21,16 +21,12 @@
 }
 
 .user-notifications-menu.read.menu-visible .selector .icon {
-    animation-duration: 2s;
+    animation-duration: 1s;
     animation-name: fadeout-color;
 }
 
 @keyframes fadeout-color {
     0% {
-        color: #f36;
-    }
-
-    50% {
         color: #f36;
     }
 

--- a/frontend/src/core/user/components/UserNotificationsMenu.js
+++ b/frontend/src/core/user/components/UserNotificationsMenu.js
@@ -23,26 +23,16 @@ type State = {|
 |};
 
 type UserNotificationsMenuProps = {
-    has_unread: boolean,
-    logUxAction: (string, ?string, ?any) => void,
     notifications: Array<Notification>,
     onDiscard: (e: SyntheticEvent<any>) => void,
 };
 
 export function UserNotificationsMenu({
-    has_unread,
-    logUxAction,
     notifications,
     onDiscard,
 }: UserNotificationsMenuProps): React.Element<'div'> {
     const ref = React.useRef(null);
     useOnDiscard(ref, onDiscard);
-
-    function handleClickSeeAll() {
-        logUxAction('See all Notifications link clicked', 'Notifications 1.0', {
-            unread: has_unread,
-        });
-    }
 
     return (
         <div ref={ref} className='menu'>
@@ -72,9 +62,11 @@ export function UserNotificationsMenu({
                 )}
             </ul>
 
-            <div className='see-all' onClick={handleClickSeeAll}>
+            <div className='see-all'>
                 <Localized id='user-UserNotificationsMenu--see-all-notifications'>
-                    <a href='/notifications'>See all Notifications</a>
+                    <a href='/notifications?referrer=ui'>
+                        See all Notifications
+                    </a>
                 </Localized>
             </div>
         </div>
@@ -130,7 +122,7 @@ export default class UserNotificationsMenuBase extends React.Component<
         }
     }
 
-    handleClickIcon: () => void = () => {
+    handleClick: () => void = () => {
         if (this.state.markAsRead) {
             this.setState({
                 markAsRead: false,
@@ -189,14 +181,12 @@ export default class UserNotificationsMenuBase extends React.Component<
 
         return (
             <div className={className}>
-                <div className='selector' onClick={this.handleClickIcon}>
+                <div className='selector' onClick={this.handleClick}>
                     <i className='icon far fa-bell fa-fw'></i>
                 </div>
 
                 {this.state.visible && (
                     <UserNotificationsMenu
-                        has_unread={user.notifications.has_unread}
-                        logUxAction={this.props.logUxAction}
                         notifications={user.notifications.notifications}
                         onDiscard={this.handleDiscard}
                     />

--- a/frontend/src/core/user/components/UserNotificationsMenu.js
+++ b/frontend/src/core/user/components/UserNotificationsMenu.js
@@ -87,6 +87,20 @@ export default class UserNotificationsMenuBase extends React.Component<
         };
     }
 
+    componentDidMount() {
+        if (!this.props.user.notifications.has_unread) {
+            return;
+        }
+
+        this.props.logUxAction(
+            'Unread notifications icon displayed',
+            'Notifications 1.0',
+            {
+                pathname: window.location.pathname,
+            },
+        );
+    }
+
     componentDidUpdate(prevProps: Props) {
         if (!this.props.user.isAuthenticated) {
             return;

--- a/frontend/src/core/user/components/UserNotificationsMenu.js
+++ b/frontend/src/core/user/components/UserNotificationsMenu.js
@@ -98,6 +98,10 @@ export default class UserNotificationsMenuBase extends React.Component<
     }
 
     componentDidMount() {
+        if (!this.props.user.isAuthenticated) {
+            return;
+        }
+
         if (!this.props.user.notifications.has_unread) {
             return;
         }

--- a/frontend/src/core/user/components/UserNotificationsMenu.js
+++ b/frontend/src/core/user/components/UserNotificationsMenu.js
@@ -12,6 +12,7 @@ import { useOnDiscard } from 'core/utils';
 import type { UserState, Notification } from 'core/user';
 
 type Props = {
+    logUxAction: (string, ?string, ?any) => void,
     markAllNotificationsAsRead: () => void,
     user: UserState,
 };
@@ -106,6 +107,16 @@ export default class UserNotificationsMenuBase extends React.Component<
             this.setState({
                 markAsRead: false,
             });
+        }
+
+        if (!this.state.visible) {
+            this.props.logUxAction(
+                'Notifications icon clicked',
+                'Notifications 1.0',
+                {
+                    unread: this.props.user.notifications.has_unread,
+                },
+            );
         }
 
         this.toggleVisibility();

--- a/frontend/src/core/user/components/UserNotificationsMenu.js
+++ b/frontend/src/core/user/components/UserNotificationsMenu.js
@@ -99,7 +99,7 @@ export default class UserNotificationsMenuBase extends React.Component<
         }
 
         this.props.logUxAction(
-            'Unread notifications icon displayed',
+            'Render: Unread notifications icon',
             'Notifications 1.0',
             {
                 pathname: window.location.pathname,
@@ -131,9 +131,10 @@ export default class UserNotificationsMenuBase extends React.Component<
 
         if (!this.state.visible) {
             this.props.logUxAction(
-                'Notifications icon clicked',
+                'Click: Notifications icon',
                 'Notifications 1.0',
                 {
+                    pathname: window.location.pathname,
                     unread: this.props.user.notifications.has_unread,
                 },
             );

--- a/frontend/src/core/user/components/UserNotificationsMenu.js
+++ b/frontend/src/core/user/components/UserNotificationsMenu.js
@@ -23,16 +23,26 @@ type State = {|
 |};
 
 type UserNotificationsMenuProps = {
+    has_unread: boolean,
+    logUxAction: (string, ?string, ?any) => void,
     notifications: Array<Notification>,
     onDiscard: (e: SyntheticEvent<any>) => void,
 };
 
 export function UserNotificationsMenu({
+    has_unread,
+    logUxAction,
     notifications,
     onDiscard,
 }: UserNotificationsMenuProps): React.Element<'div'> {
     const ref = React.useRef(null);
     useOnDiscard(ref, onDiscard);
+
+    function handleClickSeeAll() {
+        logUxAction('See all Notifications link clicked', 'Notifications 1.0', {
+            unread: has_unread,
+        });
+    }
 
     return (
         <div ref={ref} className='menu'>
@@ -62,7 +72,7 @@ export function UserNotificationsMenu({
                 )}
             </ul>
 
-            <div className='see-all'>
+            <div className='see-all' onClick={handleClickSeeAll}>
                 <Localized id='user-UserNotificationsMenu--see-all-notifications'>
                     <a href='/notifications'>See all Notifications</a>
                 </Localized>
@@ -116,7 +126,7 @@ export default class UserNotificationsMenuBase extends React.Component<
         }
     }
 
-    handleClick: () => void = () => {
+    handleClickIcon: () => void = () => {
         if (this.state.markAsRead) {
             this.setState({
                 markAsRead: false,
@@ -175,12 +185,14 @@ export default class UserNotificationsMenuBase extends React.Component<
 
         return (
             <div className={className}>
-                <div className='selector' onClick={this.handleClick}>
+                <div className='selector' onClick={this.handleClickIcon}>
                     <i className='icon far fa-bell fa-fw'></i>
                 </div>
 
                 {this.state.visible && (
                     <UserNotificationsMenu
+                        has_unread={user.notifications.has_unread}
+                        logUxAction={this.props.logUxAction}
                         notifications={user.notifications.notifications}
                         onDiscard={this.handleDiscard}
                     />

--- a/frontend/src/core/user/components/UserNotificationsMenu.test.js
+++ b/frontend/src/core/user/components/UserNotificationsMenu.test.js
@@ -48,20 +48,6 @@ describe('<UserNotificationsMenu>', () => {
         expect(wrapper.find('.notification-list .no')).toHaveLength(0);
         expect(wrapper.find(UserNotification)).toHaveLength(1);
     });
-
-    it('calls the logUxAction function on click on .see-all', () => {
-        const logUxAction = sinon.spy();
-        const notifications = [];
-        const wrapper = shallow(
-            <UserNotificationsMenu
-                logUxAction={logUxAction}
-                notifications={notifications}
-            />,
-        );
-
-        wrapper.find('.see-all').simulate('click');
-        expect(logUxAction.called).toEqual(true);
-    });
 });
 
 describe('<UserNotificationsMenuBase>', () => {
@@ -81,7 +67,6 @@ describe('<UserNotificationsMenuBase>', () => {
         const user = {
             isAuthenticated: true,
             notifications: {
-                has_unread: false,
                 notifications: [],
             },
         };

--- a/frontend/src/core/user/components/UserNotificationsMenu.test.js
+++ b/frontend/src/core/user/components/UserNotificationsMenu.test.js
@@ -48,6 +48,20 @@ describe('<UserNotificationsMenu>', () => {
         expect(wrapper.find('.notification-list .no')).toHaveLength(0);
         expect(wrapper.find(UserNotification)).toHaveLength(1);
     });
+
+    it('calls the logUxAction function on click on .see-all', () => {
+        const logUxAction = sinon.spy();
+        const notifications = [];
+        const wrapper = shallow(
+            <UserNotificationsMenu
+                logUxAction={logUxAction}
+                notifications={notifications}
+            />,
+        );
+
+        wrapper.find('.see-all').simulate('click');
+        expect(logUxAction.called).toEqual(true);
+    });
 });
 
 describe('<UserNotificationsMenuBase>', () => {
@@ -76,7 +90,8 @@ describe('<UserNotificationsMenuBase>', () => {
         expect(wrapper.find('.user-notifications-menu')).toHaveLength(1);
     });
 
-    it('highlights the notifications icon when the user has unread notifications', () => {
+    it('highlights the notifications icon when the user has unread notifications and call logUxAction', () => {
+        const logUxAction = sinon.spy();
         const user = {
             isAuthenticated: true,
             notifications: {
@@ -85,9 +100,35 @@ describe('<UserNotificationsMenuBase>', () => {
             },
         };
         const wrapper = shallow(
-            <UserNotificationsMenuBase user={user} logUxAction={sinon.spy()} />,
+            <UserNotificationsMenuBase user={user} logUxAction={logUxAction} />,
         );
 
         expect(wrapper.find('.user-notifications-menu.unread')).toHaveLength(1);
+        expect(logUxAction.called).toEqual(true);
+    });
+
+    it('calls the logUxAction function on click on the icon if menu not visible', () => {
+        const logUxAction = sinon.spy();
+        const markAllNotificationsAsRead = sinon.spy();
+        const user = {
+            isAuthenticated: true,
+            notifications: {
+                has_unread: true,
+                notifications: [],
+            },
+        };
+        const wrapper = shallow(
+            <UserNotificationsMenuBase
+                logUxAction={logUxAction}
+                markAllNotificationsAsRead={markAllNotificationsAsRead}
+                user={user}
+            />,
+        );
+
+        wrapper.setState({
+            visible: false,
+        });
+        wrapper.find('.selector').simulate('click');
+        expect(logUxAction.called).toEqual(true);
     });
 });

--- a/frontend/src/core/user/components/UserNotificationsMenu.test.js
+++ b/frontend/src/core/user/components/UserNotificationsMenu.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import sinon from 'sinon';
 import { shallow } from 'enzyme';
 
 import UserNotificationsMenuBase, {
@@ -53,6 +54,9 @@ describe('<UserNotificationsMenuBase>', () => {
     it('hides the notifications icon when the user is logged out', () => {
         const user = {
             isAuthenticated: false,
+            notifications: {
+                has_unread: false,
+            },
         };
         const wrapper = shallow(<UserNotificationsMenuBase user={user} />);
 
@@ -80,7 +84,9 @@ describe('<UserNotificationsMenuBase>', () => {
                 notifications: [],
             },
         };
-        const wrapper = shallow(<UserNotificationsMenuBase user={user} />);
+        const wrapper = shallow(
+            <UserNotificationsMenuBase user={user} logUxAction={sinon.spy()} />,
+        );
 
         expect(wrapper.find('.user-notifications-menu.unread')).toHaveLength(1);
     });

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -189,17 +189,6 @@ $(function () {
         });
     });
 
-    // Log clicks on the See all Notifications link
-    $('#notifications .see-all').click(function () {
-        Pontoon.logUxAction(
-            'See all Notifications link clicked',
-            'Notifications 1.0',
-            {
-                unread: unreadNotificationsExist,
-            },
-        );
-    });
-
     // Display any notifications
     var notifications = $('.notification li');
     if (notifications.length) {

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -173,7 +173,7 @@ $(function () {
     });
 
     // Mark notifications as read when notification menu opens
-    $('#notifications.unread .button .icon').click(function () {
+    $('#notifications.unread .button').click(function () {
         Pontoon.markAllNotificationsAsRead();
     });
 

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -170,7 +170,7 @@ $(function () {
     // Log display of the unread notification icon
     if (unreadNotificationsExist) {
         Pontoon.logUxAction(
-            'Unread notifications icon displayed',
+            'Render: Unread notifications icon',
             'Notifications 1.0',
             {
                 pathname: window.location.pathname,
@@ -184,7 +184,8 @@ $(function () {
             return;
         }
 
-        Pontoon.logUxAction('Notifications icon clicked', 'Notifications 1.0', {
+        Pontoon.logUxAction('Click: Notifications icon', 'Notifications 1.0', {
+            pathname: window.location.pathname,
             unread: unreadNotificationsExist,
         });
     });

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -193,6 +193,17 @@ $(function () {
         );
     });
 
+    // Log clicks on the See all Notifications link
+    $('#notifications .see-all').click(function () {
+        Pontoon.logUxAction(
+            'See all Notifications link clicked',
+            'Notifications 1.0',
+            {
+                unread: unreadNotificationsExist,
+            },
+        );
+    });
+
     // Display any notifications
     var notifications = $('.notification li');
     if (notifications.length) {

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -165,7 +165,7 @@ $(function () {
 
     Pontoon.NProgressBind();
 
-    var unreadNotificationsExist = $("#notifications").is(".unread");
+    var unreadNotificationsExist = $('#notifications').is('.unread');
 
     // Log display of the unread notification icon
     if (unreadNotificationsExist) {
@@ -184,13 +184,9 @@ $(function () {
             return;
         }
 
-        Pontoon.logUxAction(
-            'Notifications icon clicked',
-            'Notifications 1.0',
-            {
-                unread: unreadNotificationsExist,
-            },
-        );
+        Pontoon.logUxAction('Notifications icon clicked', 'Notifications 1.0', {
+            unread: unreadNotificationsExist,
+        });
     });
 
     // Log clicks on the See all Notifications link

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -143,6 +143,22 @@ $(function () {
         ga('send', 'event', 'ajax', 'request', settings.url);
     });
 
+    // Log display of the unread notification icon
+    if ($("#notifications").is(".unread")) {
+        $.ajax({
+            url: '/log-ux-action/',
+            type: 'POST',
+            data: {
+                csrfmiddlewaretoken: $('body').data('csrf'),
+                action_type: 'Unread notifications icon displayed',
+                experiment: 'Notifications 1.0',
+                data: JSON.stringify({
+                    pathname: window.location.pathname,
+                }),
+            },
+        });
+    }
+
     Pontoon.NProgressBind();
 
     // Display any notifications

--- a/pontoon/base/templates/base.html
+++ b/pontoon/base/templates/base.html
@@ -31,7 +31,10 @@
     {% include "tracker.html" %}
   </head>
 
-  <body class="{% block class %}{% endblock %}">
+  <body
+    class="{% block class %}{% endblock %}"
+    {% if csrf_token %}data-csrf="{{ csrf_token }}"{% endif %}
+  >
     {% block content %}
 
       {% include "header.html" %}

--- a/pontoon/contributors/static/js/notifications.js
+++ b/pontoon/contributors/static/js/notifications.js
@@ -1,4 +1,10 @@
 $(function () {
+    window.history.replaceState(
+        {},
+        document.title,
+        document.location.href.split('?')[0],
+    );
+
     // Filter notifications
     $('.left-column a').on('click', function () {
         var notifications = $(this).data('notifications');

--- a/pontoon/contributors/static/js/settings.js
+++ b/pontoon/contributors/static/js/settings.js
@@ -7,7 +7,7 @@ $(function () {
             url: '/api/v1/user/' + $('#server').data('username') + '/',
             type: 'POST',
             data: {
-                csrfmiddlewaretoken: $('#server').data('csrf'),
+                csrfmiddlewaretoken: $('body').data('csrf'),
                 attribute: self.data('attribute'),
                 value: !self.is('.enabled'),
             },
@@ -36,7 +36,7 @@ $(function () {
             url: '/save-custom-homepage/',
             type: 'POST',
             data: {
-                csrfmiddlewaretoken: $('#server').data('csrf'),
+                csrfmiddlewaretoken: $('body').data('csrf'),
                 custom_homepage: custom_homepage,
             },
             success: function (data) {
@@ -62,7 +62,7 @@ $(function () {
             url: '/save-preferred-source-locale/',
             type: 'POST',
             data: {
-                csrfmiddlewaretoken: $('#server').data('csrf'),
+                csrfmiddlewaretoken: $('body').data('csrf'),
                 preferred_source_locale: preferred_source_locale,
             },
             success: function (data) {

--- a/pontoon/contributors/templates/contributors/profile.html
+++ b/pontoon/contributors/templates/contributors/profile.html
@@ -7,7 +7,6 @@
 {% block before %}
 <!-- Server data -->
 <div id="server" class="hidden"
-     {% if csrf_token %}data-csrf="{{ csrf_token }}"{% endif %}
      {% if user.is_authenticated and user.email %}data-email="{{ user.email|nospam }}"{% endif %}
      >
 </div>

--- a/pontoon/contributors/templates/contributors/settings.html
+++ b/pontoon/contributors/templates/contributors/settings.html
@@ -10,7 +10,6 @@
 {% block before %}
 <!-- Server data -->
 <div id="server" class="hidden"
-     data-csrf="{{ csrf_token }}"
      data-username="{{ user.username }}"
      >
 </div>

--- a/pontoon/contributors/templates/contributors/widgets/notifications_menu.html
+++ b/pontoon/contributors/templates/contributors/widgets/notifications_menu.html
@@ -12,7 +12,7 @@
 
     <ul>
       <li class="horizontal-separator"></li>
-      <li class="see-all"><a href="{{ url('pontoon.contributors.notifications') }}">See all Notifications</a></li>
+      <li class="see-all"><a href="{{ url('pontoon.contributors.notifications') }}?referrer=ui">See all Notifications</a></li>
     </ul>
   </div>
 

--- a/pontoon/contributors/views.py
+++ b/pontoon/contributors/views.py
@@ -282,7 +282,7 @@ def mark_all_notifications_as_read(request):
     log_ux_action(
         action_type="mark_all_notifications_as_read",
         experiment="Notifications 1.0",
-        data={"utm_source": request.GET.get("utm_source"),},
+        data={"utm_source": request.GET.get("utm_source")},
     )
 
     return JsonResponse({"status": True})

--- a/pontoon/contributors/views.py
+++ b/pontoon/contributors/views.py
@@ -13,11 +13,9 @@ from django.http import (
     Http404,
     HttpResponse,
     HttpResponseBadRequest,
-    HttpResponseRedirect,
     JsonResponse,
 )
 from django.shortcuts import get_object_or_404, render, redirect
-from django.urls import reverse
 from django.utils import timezone
 from django.views.decorators.http import require_POST
 from django.views.generic import TemplateView
@@ -234,15 +232,6 @@ def settings(request):
 
 @login_required(redirect_field_name="", login_url="/403")
 def notifications(request):
-    if request.GET.get("referrer"):
-        log_ux_action(
-            action_type="See all Notifications link clicked",
-            experiment="Notifications 1.0",
-            data={"referrer": request.GET.get("referrer")},
-        )
-
-        return HttpResponseRedirect(reverse("pontoon.contributors.notifications"))
-
     """View and edit user notifications."""
     notifications = request.user.notifications.prefetch_related(
         "actor", "target"
@@ -271,6 +260,12 @@ def notifications(request):
         projects, key=lambda slug: len(projects[slug]["notifications"]), reverse=True
     ):
         ordered_projects.append(slug)
+
+    log_ux_action(
+        action_type="Notifications page loaded",
+        experiment="Notifications 1.0",
+        data={"referrer": request.GET.get("referrer", "")},
+    )
 
     return render(
         request,

--- a/pontoon/contributors/views.py
+++ b/pontoon/contributors/views.py
@@ -13,9 +13,11 @@ from django.http import (
     Http404,
     HttpResponse,
     HttpResponseBadRequest,
+    HttpResponseRedirect,
     JsonResponse,
 )
 from django.shortcuts import get_object_or_404, render, redirect
+from django.urls import reverse
 from django.utils import timezone
 from django.views.decorators.http import require_POST
 from django.views.generic import TemplateView
@@ -232,6 +234,15 @@ def settings(request):
 
 @login_required(redirect_field_name="", login_url="/403")
 def notifications(request):
+    if request.GET.get("referrer"):
+        log_ux_action(
+            action_type="See all Notifications link clicked",
+            experiment="Notifications 1.0",
+            data={"referrer": request.GET.get("referrer")},
+        )
+
+        return HttpResponseRedirect(reverse("pontoon.contributors.notifications"))
+
     """View and edit user notifications."""
     notifications = request.user.notifications.prefetch_related(
         "actor", "target"

--- a/pontoon/contributors/views.py
+++ b/pontoon/contributors/views.py
@@ -28,6 +28,7 @@ from pontoon.contributors.utils import (
     map_translations_to_events,
     users_with_translations_counts,
 )
+from pontoon.uxactionlog.utils import log_ux_action
 
 
 @login_required(redirect_field_name="", login_url="/403")
@@ -277,6 +278,13 @@ def notifications(request):
 def mark_all_notifications_as_read(request):
     """Mark all notifications of the currently logged in user as read"""
     request.user.notifications.mark_all_as_read()
+
+    utm_source = request.GET.get("utm_source")
+    if utm_source == "pontoon-addon-automation":
+        log_ux_action(
+            action_type="mark_all_notifications_as_read",
+            experiment="Notifications 1.0",
+        )
 
     return JsonResponse({"status": True})
 

--- a/pontoon/contributors/views.py
+++ b/pontoon/contributors/views.py
@@ -279,12 +279,11 @@ def mark_all_notifications_as_read(request):
     """Mark all notifications of the currently logged in user as read"""
     request.user.notifications.mark_all_as_read()
 
-    utm_source = request.GET.get("utm_source")
-    if utm_source == "pontoon-addon-automation":
-        log_ux_action(
-            action_type="mark_all_notifications_as_read",
-            experiment="Notifications 1.0",
-        )
+    log_ux_action(
+        action_type="mark_all_notifications_as_read",
+        experiment="Notifications 1.0",
+        data={"utm_source": request.GET.get("utm_source"),},
+    )
 
     return JsonResponse({"status": True})
 

--- a/pontoon/contributors/views.py
+++ b/pontoon/contributors/views.py
@@ -262,7 +262,7 @@ def notifications(request):
         ordered_projects.append(slug)
 
     log_ux_action(
-        action_type="Notifications page loaded",
+        action_type="Page load: Notifications",
         experiment="Notifications 1.0",
         data={"referrer": request.GET.get("referrer", "")},
     )
@@ -286,7 +286,7 @@ def mark_all_notifications_as_read(request):
     request.user.notifications.mark_all_as_read()
 
     log_ux_action(
-        action_type="mark_all_notifications_as_read",
+        action_type="Background action: Mark all notifications as read",
         experiment="Notifications 1.0",
         data={"utm_source": request.GET.get("utm_source")},
     )

--- a/pontoon/localizations/templates/localizations/localization.html
+++ b/pontoon/localizations/templates/localizations/localization.html
@@ -10,7 +10,6 @@
 <!-- Server data -->
 <div id="server"
      class="hidden"
-     {% if csrf_token %}data-csrf="{{ csrf_token }}"{% endif %}
      data-url-split="{{ locale.code }}/{{ project.slug }}">
 </div>
 {% endblock %}

--- a/pontoon/projects/templates/projects/project.html
+++ b/pontoon/projects/templates/projects/project.html
@@ -10,7 +10,6 @@
 <!-- Server data -->
 <div id="server"
      class="hidden"
-     {% if csrf_token %}data-csrf="{{ csrf_token }}"{% endif %}
      data-url-split="projects/{{ project.slug }}"
      data-project="{{ project.slug }}"
      data-locale-projects="{{ project.available_locales_list()|to_json }}">

--- a/pontoon/tags/templates/tags/tag.html
+++ b/pontoon/tags/templates/tags/tag.html
@@ -10,7 +10,6 @@
 <!-- Server data -->
 <div id="server"
      class="hidden"
-     {% if csrf_token %}data-csrf="{{ csrf_token }}"{% endif %}
      data-url-split="projects/{{ project.slug }}">
 </div>
 {% endblock %}

--- a/pontoon/teams/static/js/info.js
+++ b/pontoon/teams/static/js/info.js
@@ -35,7 +35,7 @@ $(function () {
             url: textArea.parent().data('url'),
             type: 'POST',
             data: {
-                csrfmiddlewaretoken: textArea.parent().data('csrf'),
+                csrfmiddlewaretoken: $('body').data('csrf'),
                 team_info: textArea.val(),
             },
             success: function (data) {

--- a/pontoon/teams/static/js/request.js
+++ b/pontoon/teams/static/js/request.js
@@ -76,7 +76,7 @@ var Pontoon = (function (my) {
                     url: '/' + locale + '/request/',
                     type: 'POST',
                     data: {
-                        csrfmiddlewaretoken: $('#server').data('csrf'),
+                        csrfmiddlewaretoken: $('body').data('csrf'),
                         projects: projects,
                     },
                     success: function () {
@@ -108,7 +108,7 @@ var Pontoon = (function (my) {
                     url: '/teams/request/',
                     type: 'POST',
                     data: {
-                        csrfmiddlewaretoken: $('#server').data('csrf'),
+                        csrfmiddlewaretoken: $('body').data('csrf'),
                         name: name,
                         code: code,
                     },

--- a/pontoon/teams/templates/teams/includes/info.html
+++ b/pontoon/teams/templates/teams/includes/info.html
@@ -14,8 +14,7 @@
 
   {% if request.user.has_perm('base.can_manage_locale', locale) %}
   <div class="read-write-info hidden"
-       data-url="{{ url('pontoon.teams.ajax.update-info', locale.code) }}"
-       {% if csrf_token %}data-csrf="{{ csrf_token }}"{% endif %}>
+       data-url="{{ url('pontoon.teams.ajax.update-info', locale.code) }}">
 
     <textarea rows="10" />
 

--- a/pontoon/teams/templates/teams/team.html
+++ b/pontoon/teams/templates/teams/team.html
@@ -10,7 +10,6 @@
 <!-- Server data -->
 <div id="server"
      class="hidden"
-     {% if csrf_token %}data-csrf="{{ csrf_token }}"{% endif %}
      data-url-split="{{ locale.code }}"
      data-locale="{{ locale.code }}"
      data-locale-projects="{{ locale.available_projects_list(request.user)|to_json }}">

--- a/pontoon/teams/templates/teams/teams.html
+++ b/pontoon/teams/templates/teams/teams.html
@@ -6,14 +6,6 @@
 
 {% block class %}teams{% endblock %}
 
-{% block before %}
-<!-- Server data -->
-<div id="server"
-     class="hidden"
-     {% if csrf_token %}data-csrf="{{ csrf_token }}"{% endif %}>
-</div>
-{% endblock %}
-
 {% block heading %}
 <section id="heading">
   <div class="container clearfix">

--- a/pontoon/urls.py
+++ b/pontoon/urls.py
@@ -115,6 +115,7 @@ urlpatterns = [
     path("", include("pontoon.api.urls")),
     path("", include("pontoon.homepage.urls")),
     path("", include("pontoon.in_context.urls")),
+    path("", include("pontoon.uxactionlog.urls")),
     # Team page: Must be at the end
     path("<locale:locale>/", team, name="pontoon.teams.team"),
 ]

--- a/pontoon/uxactionlog/forms.py
+++ b/pontoon/uxactionlog/forms.py
@@ -4,6 +4,7 @@ from django import forms
 class UXActionLogForm(forms.Form):
     """Handles the arguments passed to the log UX action view.
     """
+
     action_type = forms.CharField()
     experiment = forms.CharField(required=False)
     data = forms.JSONField(required=False)

--- a/pontoon/uxactionlog/forms.py
+++ b/pontoon/uxactionlog/forms.py
@@ -1,0 +1,9 @@
+from django import forms
+
+
+class UXActionLogForm(forms.Form):
+    """Handles the arguments passed to the log UX action view.
+    """
+    action_type = forms.CharField()
+    experiment = forms.CharField(required=False)
+    data = forms.JSONField(required=False)

--- a/pontoon/uxactionlog/urls.py
+++ b/pontoon/uxactionlog/urls.py
@@ -1,0 +1,13 @@
+from django.urls import path
+
+from . import views
+
+
+urlpatterns = [
+    # AJAX: Save a new UX action in the database
+    path(
+        "log-ux-action/",
+        views.log_ux_action,
+        name="pontoon.uxactionlog.log_ux_action",
+    ),
+]

--- a/pontoon/uxactionlog/urls.py
+++ b/pontoon/uxactionlog/urls.py
@@ -6,8 +6,6 @@ from . import views
 urlpatterns = [
     # AJAX: Save a new UX action in the database
     path(
-        "log-ux-action/",
-        views.log_ux_action,
-        name="pontoon.uxactionlog.log_ux_action",
+        "log-ux-action/", views.log_ux_action, name="pontoon.uxactionlog.log_ux_action",
     ),
 ]

--- a/pontoon/uxactionlog/views.py
+++ b/pontoon/uxactionlog/views.py
@@ -1,0 +1,35 @@
+from django.contrib.auth.decorators import login_required
+from django.db import transaction
+from django.http import JsonResponse
+from django.views.decorators.http import require_POST
+
+from pontoon.base.utils import require_AJAX
+from pontoon.uxactionlog import forms, utils
+
+
+@login_required(redirect_field_name="", login_url="/403")
+@require_POST
+@require_AJAX
+@transaction.atomic
+def log_ux_action(request):
+    """Save a new UX action in the database."""
+    form = forms.UXActionLogForm(request.POST)
+
+    if not form.is_valid():
+        return JsonResponse(
+            {
+                "status": False,
+                "message": "{error}".format(
+                    error=form.errors.as_json(escape_html=True)
+                ),
+            },
+            status=400,
+        )
+
+    utils.log_ux_action(
+        action_type=form.cleaned_data["action_type"],
+        experiment=form.cleaned_data["experiment"],
+        data=form.cleaned_data["data"],
+    )
+
+    return JsonResponse({"status": True})


### PR DESCRIPTION
This patch introduces collection of user interaction metrics of the existing notifications UI.

It also includes the following improvements:
* CSRF token is now globally accessible on all pages using the base template (https://github.com/mozilla/pontoon/pull/1931/commits/21aad3d05234269f17c1c144e1f5bea88f2f7a15), which allows us to collect metrics on all pages that contain the notification icon/menu.
* Click-area to open the notification menu and to mark notifications as read is now exactly the same (https://github.com/mozilla/pontoon/pull/1931/commits/40b218874fe6cd1ce0f1ff21af1a7245216955b8). That is currently not the case, which can result in notifications not being marked as read in some edge cases, even if the menu is opened.
* Notification animation times in the old and new frontend code have been unified (https://github.com/mozilla/pontoon/pull/1931/commits/8c3be510d0a128698a0deb97d99e75d03ce9401d).