### PR TITLE
Use native events for addEventListener

### DIFF
--- a/frontend/src/core/comments/components/AddComment.js
+++ b/frontend/src/core/comments/components/AddComment.js
@@ -209,11 +209,9 @@ export default function AddComment(props: Props): React.Element<'div'> {
     // This allows for the mention suggestions to stay properly positioned
     // when the container scrolls.
     React.useEffect(() => {
-        // Flow does not recognize the addEventListener with 'SyntheticEvent` listeners,
-        // so I'm ignoring the errors Flow throws below.
 
-        const handleScroll = (e: SyntheticEvent<HTMLElement>) => {
-            const element = e.currentTarget;
+        const handleScroll = (e: Event) => {
+            const element:HTMLElement = (e.currentTarget: any);
             setScrollPosition(element.scrollTop);
         };
 
@@ -225,21 +223,17 @@ export default function AddComment(props: Props): React.Element<'div'> {
         }
 
         if (historyScroll) {
-            // $FlowIgnore
             historyScroll.addEventListener('scroll', handleScroll);
         }
         if (teamsScroll) {
-            //$FlowIgnore
             teamsScroll.addEventListener('scroll', handleScroll);
         }
 
         return () => {
             if (historyScroll) {
-                // $FlowIgnore
                 historyScroll.removeEventListener('scroll', handleScroll);
             }
             if (teamsScroll) {
-                // $FlowIgnore
                 teamsScroll.removeEventListener('scroll', handleScroll);
             }
         };

--- a/frontend/src/core/comments/components/AddComment.js
+++ b/frontend/src/core/comments/components/AddComment.js
@@ -209,9 +209,8 @@ export default function AddComment(props: Props): React.Element<'div'> {
     // This allows for the mention suggestions to stay properly positioned
     // when the container scrolls.
     React.useEffect(() => {
-
         const handleScroll = (e: Event) => {
-            const element:HTMLElement = (e.currentTarget: any);
+            const element: HTMLElement = (e.currentTarget: any);
             setScrollPosition(element.scrollTop);
         };
 

--- a/frontend/src/core/editor/components/EditorSettings.js
+++ b/frontend/src/core/editor/components/EditorSettings.js
@@ -21,7 +21,7 @@ type State = {|
 type EditorSettingsProps = {
     settings: Settings,
     toggleSetting: Function,
-    onDiscard: (e: SyntheticEvent<any>) => void,
+    onDiscard: (e: MouseEvent) => void,
 };
 
 export function EditorSettings({

--- a/frontend/src/core/editor/components/KeyboardShortcuts.js
+++ b/frontend/src/core/editor/components/KeyboardShortcuts.js
@@ -14,7 +14,7 @@ type State = {|
 |};
 
 type KeyboardShortcutsProps = {
-    onDiscard: (e: SyntheticEvent<any>) => void,
+    onDiscard: (e: MouseEvent) => void,
 };
 
 function KeyboardShortcuts({ onDiscard }: KeyboardShortcutsProps) {

--- a/frontend/src/core/project/components/ProjectMenu.js
+++ b/frontend/src/core/project/components/ProjectMenu.js
@@ -27,7 +27,7 @@ type State = {|
 type ProjectMenuProps = {|
     locale: LocaleState,
     parameters: NavigationParams,
-    onDiscard: (e: SyntheticEvent<any>) => void,
+    onDiscard: (e: MouseEvent) => void,
     onNavigate: (e: SyntheticMouseEvent<HTMLAnchorElement>) => void,
 |};
 

--- a/frontend/src/core/resource/components/ResourceMenu.js
+++ b/frontend/src/core/resource/components/ResourceMenu.js
@@ -27,7 +27,7 @@ type State = {|
 type ResourceMenuProps = {|
     parameters: NavigationParams,
     resources: ResourcesState,
-    onDiscard: (e: SyntheticEvent<any>) => void,
+    onDiscard: (e: MouseEvent) => void,
     onNavigate: (e: SyntheticMouseEvent<HTMLAnchorElement>) => void,
 |};
 

--- a/frontend/src/core/user/components/UserMenu.js
+++ b/frontend/src/core/user/components/UserMenu.js
@@ -25,7 +25,7 @@ type State = {|
 |};
 
 type UserMenuProps = Props & {
-    onDiscard: (e: SyntheticEvent<any>) => void,
+    onDiscard: (e: MouseEvent) => void,
 };
 
 export function UserMenu({

--- a/frontend/src/core/user/components/UserNotificationsMenu.js
+++ b/frontend/src/core/user/components/UserNotificationsMenu.js
@@ -24,7 +24,7 @@ type State = {|
 
 type UserNotificationsMenuProps = {
     notifications: Array<Notification>,
-    onDiscard: (e: SyntheticEvent<any>) => void,
+    onDiscard: (e: MouseEvent) => void,
 };
 
 export function UserNotificationsMenu({

--- a/frontend/src/core/utils/hooks/useOnDiscard.js
+++ b/frontend/src/core/utils/hooks/useOnDiscard.js
@@ -3,10 +3,10 @@ import * as React from 'react';
 
 export default function useOnDiscard(
     ref: { current: null | React.ElementRef<any> },
-    onDiscard: (e: SyntheticEvent<any>) => void,
+    onDiscard: (e: MouseEvent) => void,
 ) {
     const handleClick = React.useCallback(
-        (e: SyntheticEvent<any>) => {
+        (e: MouseEvent) => {
             const el = ref.current;
             if (!el || el.contains(e.target)) {
                 return;

--- a/frontend/src/modules/addonpromotion/components/AddonPromotion.js
+++ b/frontend/src/modules/addonpromotion/components/AddonPromotion.js
@@ -42,8 +42,8 @@ export class AddonPromotionBase extends React.Component<InternalProps, State> {
         window.removeEventListener('message', this.handleMessages);
     }
 
-    handleMessages: (event: SyntheticEvent<>) => void = (
-        event: SyntheticEvent<>,
+    handleMessages: (event: MessageEvent) => void = (
+        event: MessageEvent,
     ) => {
         // $FlowIgnore: not sure which event type to use
         const data = JSON.parse(event.data);

--- a/frontend/src/modules/addonpromotion/components/AddonPromotion.js
+++ b/frontend/src/modules/addonpromotion/components/AddonPromotion.js
@@ -42,9 +42,7 @@ export class AddonPromotionBase extends React.Component<InternalProps, State> {
         window.removeEventListener('message', this.handleMessages);
     }
 
-    handleMessages: (event: MessageEvent) => void = (
-        event: MessageEvent,
-    ) => {
+    handleMessages: (event: MessageEvent) => void = (event: MessageEvent) => {
         // $FlowIgnore: not sure which event type to use
         const data = JSON.parse(event.data);
         if (data._type === 'PontoonAddonInfo') {

--- a/frontend/src/modules/batchactions/components/BatchActions.js
+++ b/frontend/src/modules/batchactions/components/BatchActions.js
@@ -167,8 +167,8 @@ export class BatchActionsBase extends React.Component<InternalProps> {
         );
     };
 
-    submitReplaceForm: (event: SyntheticKeyboardEvent<>) => void = (
-        event: SyntheticKeyboardEvent<>,
+    submitReplaceForm: (event: SyntheticEvent<HTMLFormElement>) => void = (
+        event: SyntheticEvent<HTMLFormElement>,
     ) => {
         event.preventDefault();
         this.replaceAll();

--- a/frontend/src/modules/batchactions/components/BatchActions.js
+++ b/frontend/src/modules/batchactions/components/BatchActions.js
@@ -40,21 +40,16 @@ export class BatchActionsBase extends React.Component<InternalProps> {
         this.replace = React.createRef();
     }
 
-    // Flow does not recognize the addEventListener with 'SyntheticEvent` listeners,
-    // so I'm ignoring the errors Flow throws below.
-
     componentDidMount() {
-        // $FlowIgnore
         document.addEventListener('keydown', this.handleShortcuts);
     }
 
     componentWillUnmount() {
-        // $FlowIgnore
         document.removeEventListener('keydown', this.handleShortcuts);
     }
 
-    handleShortcuts: (event: SyntheticKeyboardEvent<>) => void = (
-        event: SyntheticKeyboardEvent<>,
+    handleShortcuts: (event: KeyboardEvent) => void = (
+        event: KeyboardEvent,
     ) => {
         const key = event.keyCode;
 

--- a/frontend/src/modules/entitieslist/components/EntitiesList.js
+++ b/frontend/src/modules/entitieslist/components/EntitiesList.js
@@ -55,18 +55,13 @@ export class EntitiesListBase extends React.Component<InternalProps> {
         this.list = React.createRef();
     }
 
-    // Flow does not recognize the addEventListener with 'SyntheticEvent` listeners,
-    // so I'm ignoring the errors Flow throws below.
-
     componentDidMount() {
-        // $FlowIgnore
         document.addEventListener('keydown', this.handleShortcuts);
 
         this.selectFirstEntityIfNoneSelected();
     }
 
     componentWillUnmount() {
-        // $FlowIgnore
         document.removeEventListener('keydown', this.handleShortcuts);
     }
 
@@ -126,8 +121,8 @@ export class EntitiesListBase extends React.Component<InternalProps> {
         }
     }
 
-    handleShortcuts: (event: SyntheticKeyboardEvent<>) => void = (
-        event: SyntheticKeyboardEvent<>,
+    handleShortcuts: (event: KeyboardEvent) => void = (
+        event: KeyboardEvent,
     ) => {
         const key = event.keyCode;
 

--- a/frontend/src/modules/entitydetails/components/EntityNavigation.js
+++ b/frontend/src/modules/entitydetails/components/EntityNavigation.js
@@ -18,17 +18,15 @@ type Props = {|
  */
 export default class EntityNavigation extends React.Component<Props> {
     componentDidMount() {
-        // $FlowIgnore (errors that I don't understand, no help from the Web)
         document.addEventListener('keydown', this.handleShortcuts);
     }
 
     componentWillUnmount() {
-        // $FlowIgnore (errors that I don't understand, no help from the Web)
         document.removeEventListener('keydown', this.handleShortcuts);
     }
 
-    handleShortcuts: (event: SyntheticKeyboardEvent<>) => void = (
-        event: SyntheticKeyboardEvent<>,
+    handleShortcuts: (event: KeyboardEvent) => void = (
+        event: KeyboardEvent,
     ) => {
         const key = event.keyCode;
 

--- a/frontend/src/modules/machinery/components/Machinery.js
+++ b/frontend/src/modules/machinery/components/Machinery.js
@@ -65,8 +65,8 @@ export default class Machinery extends React.Component<Props, State> {
         this.setState({ page: 1 });
     };
 
-    submitForm: (event: SyntheticKeyboardEvent<>) => void = (
-        event: SyntheticKeyboardEvent<>,
+    submitForm: (event: SyntheticEvent<HTMLFormElement>) => void = (
+        event: SyntheticEvent<HTMLFormElement>,
     ) => {
         event.preventDefault();
         this.props.searchMachinery(this.searchInput.current.value);

--- a/frontend/src/modules/projectinfo/components/ProjectInfo.js
+++ b/frontend/src/modules/projectinfo/components/ProjectInfo.js
@@ -20,7 +20,7 @@ type State = {|
 
 type ProjectInfoProps = {|
     project: ProjectState,
-    onDiscard: (e: SyntheticEvent<any>) => void,
+    onDiscard: (e: MouseEvent) => void,
 |};
 
 export function ProjectInfo({

--- a/frontend/src/modules/resourceprogress/components/ResourceProgress.js
+++ b/frontend/src/modules/resourceprogress/components/ResourceProgress.js
@@ -26,7 +26,7 @@ type ResourceProgressProps = {
     currentPath: string,
     percent: number,
     stats: Stats,
-    onDiscard: (e: SyntheticEvent<any>) => void,
+    onDiscard: (e: MouseEvent) => void,
 };
 
 function ResourceProgress({

--- a/frontend/src/modules/search/components/FiltersPanel.js
+++ b/frontend/src/modules/search/components/FiltersPanel.js
@@ -62,7 +62,7 @@ type FiltersPanelProps = {|
     onApplyFilters: () => void,
     onResetFilters: () => void,
     onToggleFilter: (string, string, SyntheticMouseEvent<any>) => void,
-    onDiscard: (e: SyntheticEvent<any>) => void,
+    onDiscard: (e: MouseEvent) => void,
 |};
 
 export function FiltersPanel({

--- a/frontend/src/modules/search/components/SearchBox.js
+++ b/frontend/src/modules/search/components/SearchBox.js
@@ -119,11 +119,7 @@ export class SearchBoxBase extends React.Component<InternalProps, State> {
         });
     };
 
-    // Flow does not recognize the addEventListener with 'SyntheticEvent` listeners,
-    // so I'm ignoring the errors Flow throws in componentDid*mount.
-
     componentDidMount() {
-        // $FlowIgnore
         document.addEventListener('keydown', this.handleShortcuts);
         this.updateFiltersFromURLParams();
 
@@ -155,7 +151,6 @@ export class SearchBoxBase extends React.Component<InternalProps, State> {
     }
 
     componentWillUnmount() {
-        // $FlowIgnore
         document.removeEventListener('keydown', this.handleShortcuts);
     }
 
@@ -330,8 +325,8 @@ export class SearchBoxBase extends React.Component<InternalProps, State> {
         );
     };
 
-    handleShortcuts: (event: SyntheticKeyboardEvent<>) => void = (
-        event: SyntheticKeyboardEvent<>,
+    handleShortcuts: (event: KeyboardEvent) => void = (
+        event: KeyboardEvent,
     ) => {
         const key = event.keyCode;
 


### PR DESCRIPTION
This is another cleanup for TS, but also fixes some flow-ignores.

The gist is that the Synthetic events are only if you use the handler as jsx prop, but when you do `addEventHandler` (and `remove`), you want to use native event types.