### PR TITLE
Fix bug 1720701: Add repo links to developer docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -2,6 +2,14 @@
 Contributing
 ============
 
+Source code
+===========
+
+Pontoon source code is available via GitHub:
+
+https://github.com/mozilla/pontoon
+
+
 Bugs
 ====
 

--- a/docs/dev/setup-virtualenv.rst
+++ b/docs/dev/setup-virtualenv.rst
@@ -44,7 +44,7 @@ If you're on Ubuntu 17.04, you can install all the prerequisites using the follo
 
 Installation
 ------------
-1. Clone this repository or your fork_:
+1. Clone this repository_ or your fork_:
 
    .. code-block:: bash
 
@@ -165,6 +165,7 @@ running:
 
 The site should be available at http://localhost:8000.
 
+.. _repository: https://github.com/mozilla/pontoon
 .. _fork: http://help.github.com/fork-a-repo/
 .. _issue: https://bugs.python.org/issue18378
 .. _request: https://developer.mozilla.org/docs/Mozilla/Tech/Firefox_Accounts/Introduction

--- a/docs/dev/setup.rst
+++ b/docs/dev/setup.rst
@@ -24,9 +24,15 @@ Prerequisites
 Quickstart
 ----------
 
-1. Clone your `fork <https://help.github.com/en/github/getting-started-with-github/fork-a-repo>`_ of Pontoon repository::
+1. Clone the `Pontoon repository <https://github.com/mozilla/pontoon>`_::
 
-     $ git clone https://github.com/YOUR-USERNAME/pontoon.git
+     $ git clone https://github.com/mozilla/pontoon.git
+
+   .. Note::
+
+        To contribute changes to the project, you will need to
+        `fork <https://help.github.com/en/github/getting-started-with-github/fork-a-repo>`_
+        the repository under your own GitHub account.
 
 
 2. From the root of the repository, run::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,9 +1,9 @@
 Pontoon - Mozilla's Localization Platform
 =========================================
 
-Pontoon is a translation management system used and developed by the Mozilla
-localization community. It can handle any project that uses one of the
-supported file formats:
+`Pontoon <https://github.com/mozilla/pontoon>`_ is a translation management
+system used and developed by the Mozilla localization community.
+It can handle any project that uses one of the supported file formats:
 
 +-------+---------------+-------------+--------+-----------------------+
 | .dtd  | .ftl (Fluent) | .inc        | .ini   | .json (WebExtensions) |


### PR DESCRIPTION
The documentation site did not have nearly any links to the GitHub repo; this adds such links.

This PR only touches documentation; I checked with the docs `make html` command that they render as expected.