### PR TITLE
Bug 1720875: Add warning for M1 MacBook users to Developer Setup docs

### DIFF
--- a/docs/dev/setup.rst
+++ b/docs/dev/setup.rst
@@ -42,6 +42,14 @@ Quickstart
    That will build the containers required for development: base and
    webapp.
 
+   .. Warning::
+
+        On M1 MacBooks, a workaround is currently required for successful
+        operations: Add a ``platform: linux/amd64`` specifier under the
+        ``webapp`` service of ``docker-compose.yml``. This avoids a
+        segmentation fault in curl due to the libssl version used by
+        images based on Debian Buster.
+
    .. Note::
 
         If you want to share your development instance in your local network,


### PR DESCRIPTION
This doesn't fix the problem, but at least it documents a workaround for those affected.