### PR TITLE
Fix bug 1720977: Honour prefers-reduced-motion on homepage

### DIFF
--- a/frontend/src/modules/entitieslist/components/EntitiesList.tsx
+++ b/frontend/src/modules/entitieslist/components/EntitiesList.tsx
@@ -108,10 +108,14 @@ export class EntitiesListBase extends React.Component<InternalProps> {
         ) {
             const list = this.list.current;
             const element = list.querySelector('li.selected');
+            const mediaQuery = window.matchMedia(
+                '(prefers-reduced-motion: reduce)',
+            );
+            const behavior = mediaQuery.matches ? 'auto' : 'smooth';
 
             if (element) {
                 element.scrollIntoView({
-                    behavior: 'smooth',
+                    behavior: behavior,
                     block: 'nearest',
                 });
             }

--- a/frontend/src/modules/interactivetour/components/InteractiveTour.tsx
+++ b/frontend/src/modules/interactivetour/components/InteractiveTour.tsx
@@ -236,7 +236,8 @@ export class InteractiveTourBase extends React.Component<InternalProps, State> {
                 ),
             },
             {
-                selector: '#app > .main-content > .panel-content .entity-details .history',
+                selector:
+                    '#app > .main-content > .panel-content .entity-details .history',
                 content: (
                     <div>
                         <Localized id='interactivetour-InteractiveTour--history-title'>

--- a/frontend/src/modules/machinery/components/Translation.test.js
+++ b/frontend/src/modules/machinery/components/Translation.test.js
@@ -4,6 +4,8 @@ import {
     mountComponentWithStore,
 } from 'test/store';
 
+import { mockMatchMedia } from 'test/utils';
+
 import Translation from './Translation';
 
 const ORIGINAL = 'A horse, a horse! My kingdom for a horse!';
@@ -39,6 +41,7 @@ describe('<Translation>', () => {
                 toString: () => {},
             };
         };
+        mockMatchMedia();
     });
 
     afterAll(() => {

--- a/frontend/src/modules/machinery/components/Translation.tsx
+++ b/frontend/src/modules/machinery/components/Translation.tsx
@@ -64,11 +64,14 @@ export default function Translation(
     }
 
     const translationRef = React.useRef();
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+
     React.useEffect(() => {
         if (selectedHelperElementIndex === index) {
+            const behavior = mediaQuery.matches ? 'auto' : 'smooth';
             // @ts-expect-error: What can be undefined here?
             translationRef.current?.scrollIntoView?.({
-                behavior: 'smooth',
+                behavior: behavior,
                 block: 'nearest',
             });
         }

--- a/frontend/src/modules/machinery/components/Translation.tsx
+++ b/frontend/src/modules/machinery/components/Translation.tsx
@@ -66,7 +66,9 @@ export default function Translation(
     const translationRef = React.useRef();
     React.useEffect(() => {
         if (selectedHelperElementIndex === index) {
-            const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+            const mediaQuery = window.matchMedia(
+                '(prefers-reduced-motion: reduce)',
+            );
             const behavior = mediaQuery.matches ? 'auto' : 'smooth';
             // @ts-expect-error: What can be undefined here?
             translationRef.current?.scrollIntoView?.({

--- a/frontend/src/modules/machinery/components/Translation.tsx
+++ b/frontend/src/modules/machinery/components/Translation.tsx
@@ -64,10 +64,9 @@ export default function Translation(
     }
 
     const translationRef = React.useRef();
-    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-
     React.useEffect(() => {
         if (selectedHelperElementIndex === index) {
+            const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
             const behavior = mediaQuery.matches ? 'auto' : 'smooth';
             // @ts-expect-error: What can be undefined here?
             translationRef.current?.scrollIntoView?.({

--- a/frontend/src/modules/otherlocales/components/Translation.tsx
+++ b/frontend/src/modules/otherlocales/components/Translation.tsx
@@ -62,10 +62,9 @@ export default function Translation(
     }, [dispatch, index, translation, copyOtherLocaleTranslation]);
 
     const translationRef = React.useRef();
-    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-
     React.useEffect(() => {
         if (selectedHelperElementIndex === index) {
+            const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
             const behavior = mediaQuery.matches ? 'auto' : 'smooth';
             // @ts-expect-error: What can be undefined here?
             translationRef.current?.scrollIntoView?.({

--- a/frontend/src/modules/otherlocales/components/Translation.tsx
+++ b/frontend/src/modules/otherlocales/components/Translation.tsx
@@ -64,7 +64,9 @@ export default function Translation(
     const translationRef = React.useRef();
     React.useEffect(() => {
         if (selectedHelperElementIndex === index) {
-            const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+            const mediaQuery = window.matchMedia(
+                '(prefers-reduced-motion: reduce)',
+            );
             const behavior = mediaQuery.matches ? 'auto' : 'smooth';
             // @ts-expect-error: What can be undefined here?
             translationRef.current?.scrollIntoView?.({

--- a/frontend/src/modules/otherlocales/components/Translation.tsx
+++ b/frontend/src/modules/otherlocales/components/Translation.tsx
@@ -62,11 +62,14 @@ export default function Translation(
     }, [dispatch, index, translation, copyOtherLocaleTranslation]);
 
     const translationRef = React.useRef();
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+
     React.useEffect(() => {
         if (selectedHelperElementIndex === index) {
+            const behavior = mediaQuery.matches ? 'auto' : 'smooth';
             // @ts-expect-error: What can be undefined here?
             translationRef.current?.scrollIntoView?.({
-                behavior: 'smooth',
+                behavior: behavior,
                 block: 'nearest',
             });
         }

--- a/frontend/src/test/utils.ts
+++ b/frontend/src/test/utils.ts
@@ -73,3 +73,24 @@ export function findLocalizedById(wrapper, id) {
         (elem) => elem.type() === Localized && elem.prop('id') === id,
     );
 }
+
+/*
+ * Mock window.matchMedia, which is not implemented in JSDOM.
+ *
+ * Source: https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
+ */
+export function mockMatchMedia() {
+    return Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: jest.fn().mockImplementation((query) => ({
+            matches: false,
+            media: query,
+            onchange: null,
+            addListener: jest.fn(), // deprecated
+            removeListener: jest.fn(), // deprecated
+            addEventListener: jest.fn(),
+            removeEventListener: jest.fn(),
+            dispatchEvent: jest.fn(),
+        })),
+    });
+}

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -385,6 +385,10 @@ $(function () {
 
     // General keyboard shortcuts
     generalShortcutsHandler = function (e) {
+        const mediaQuery = window.matchMedia(
+            '(prefers-reduced-motion: reduce)',
+        );
+
         function moveMenu(type) {
             var options =
                 type === 'up' ? ['first', 'last', -1] : ['last', 'first', 1];
@@ -408,9 +412,10 @@ $(function () {
             }
 
             if (element) {
+                const behavior = mediaQuery.matches ? 'auto' : 'smooth';
                 element.addClass('hover');
                 element[0].scrollIntoView({
-                    behavior: 'smooth',
+                    behavior: behavior,
                     block: 'nearest',
                 });
             }

--- a/pontoon/homepage/static/js/homepage.js
+++ b/pontoon/homepage/static/js/homepage.js
@@ -4,6 +4,7 @@ const Sections = {
         this.nav = null;
         this.sections = this.root.querySelectorAll('[id^=section-]');
         this.activeSectionIdx = 0;
+        this.mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
 
         this._initKeyboard();
         this._initWheel();
@@ -30,8 +31,10 @@ const Sections = {
     navigate() {
         requestAnimationFrame(() => {
             const section = this.sections[this.activeSectionIdx];
+            const behavior = this.mediaQuery.matches ? 'auto' : 'smooth';
+
             section.scrollIntoView({
-                behavior: 'smooth',
+                behavior: behavior,
                 block: 'nearest',
             });
             this._render();


### PR DESCRIPTION
This patch disables the smooth scrolling animation on Pontoon homepage when `prefers-reduced-motion` is used.

See MDN article on how to test it on your OS:
https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion#user_preferences