### PR TITLE
Fix bug 1720895: Disable Django admin login form

### DIFF
--- a/pontoon/urls.py
+++ b/pontoon/urls.py
@@ -73,6 +73,8 @@ urlpatterns = [
     path("accounts/", include("pontoon.allauth_urls")),
     # Admin
     path("admin/", include("pontoon.administration.urls")),
+    # Django admin: Disable the login form
+    path("a/login/", permission_denied_view),
     # Django admin
     path("a/", admin.site.urls),
     # Logout

--- a/pontoon/urls.py
+++ b/pontoon/urls.py
@@ -17,6 +17,9 @@ pontoon_js_view = TemplateView.as_view(
     template_name="js/pontoon.js", content_type="text/javascript"
 )
 
+permission_denied_view = TemplateView.as_view(template_name="403.html")
+page_not_found_view = TemplateView.as_view(template_name="404.html")
+server_error_view = TemplateView.as_view(template_name="500.html")
 
 urlpatterns = [
     # Legacy: Locale redirect for compatibility with i18n ready URL scheme
@@ -75,9 +78,9 @@ urlpatterns = [
     # Logout
     path("signout/", logout, {"next_page": "/"}, name="signout"),
     # Error pages
-    path("403/", TemplateView.as_view(template_name="403.html")),
-    path("404/", TemplateView.as_view(template_name="404.html")),
-    path("500/", TemplateView.as_view(template_name="500.html")),
+    path("403/", permission_denied_view),
+    path("404/", page_not_found_view),
+    path("500/", server_error_view),
     # Robots.txt
     path(
         "robots.txt",


### PR DESCRIPTION
Django admin login form appears when Django admin (`/a/`) is accessed by users that aren't authenticated or don't have permission to access it (i.e. non-admins).

On https://pontoon.mozilla.org/ we use Firefox Accounts, which is based on OAuth, so we don't store user passwords, which means the form is useless.

Other installs might use authentication methods that store usernames and passwords, in which case the form could be useful, but it also poses a security risk. Brute-force attack could be used to find valid credentials.

This patch disables the Django admin login form and shows the standard Pontoon 403 page instead.