### PR TITLE
Bug 1724658 - Concordance search term should be added to editor

### DIFF
--- a/frontend/src/core/editor/hooks/useCopyMachineryTranslation.ts
+++ b/frontend/src/core/editor/hooks/useCopyMachineryTranslation.ts
@@ -13,7 +13,7 @@ import useUpdateTranslation from './useUpdateTranslation';
 /**
  * Return a function to copy the original translation into the editor.
  */
-export default function useCopyMachineryTranslation(): (
+export default function useCopyMachineryTranslation(entity?: number | null): (
     translation: MachineryTranslation,
 ) => void {
     const dispatch = useDispatch();
@@ -34,9 +34,6 @@ export default function useCopyMachineryTranslation(): (
 
     const isReadOnlyEditor = useSelector((state) =>
         entities.selectors.isReadOnlyEditor(state),
-    );
-    const entity = useSelector((state) =>
-        entities.selectors.getSelectedEntity(state),
     );
     const isFluentTranslationMessage = useSelector((state) =>
         editor.selectors.isFluentTranslationMessage(state),

--- a/frontend/src/modules/machinery/components/Machinery.tsx
+++ b/frontend/src/modules/machinery/components/Machinery.tsx
@@ -123,6 +123,7 @@ export default class Machinery extends React.Component<Props, State> {
                             return (
                                 <Translation
                                     index={index}
+                                    entity={machinery.entity}
                                     sourceString={machinery.sourceString}
                                     translation={translation}
                                     key={index}
@@ -137,6 +138,7 @@ export default class Machinery extends React.Component<Props, State> {
                                     index={
                                         index + machinery.translations.length
                                     }
+                                    entity={machinery.entity}
                                     sourceString={machinery.sourceString}
                                     translation={result}
                                     key={index + machinery.translations.length}

--- a/frontend/src/modules/machinery/components/Translation.tsx
+++ b/frontend/src/modules/machinery/components/Translation.tsx
@@ -18,6 +18,7 @@ type Props = {
     sourceString: string;
     translation: MachineryTranslation;
     index: number;
+    entity: number | null;
 };
 
 /**
@@ -30,7 +31,7 @@ type Props = {
 export default function Translation(
     props: Props,
 ): React.ReactElement<React.ElementType> {
-    const { index, sourceString, translation } = props;
+    const { index, sourceString, translation, entity } = props;
 
     const dispatch = useDispatch();
     const isReadOnlyEditor = useSelector((state) =>
@@ -38,7 +39,7 @@ export default function Translation(
     );
     const locale = useSelector((state) => state.locale);
 
-    const copyMachineryTranslation = editor.useCopyMachineryTranslation();
+    const copyMachineryTranslation = editor.useCopyMachineryTranslation(entity);
     const copyTranslationIntoEditor = React.useCallback(() => {
         dispatch(editor.actions.selectHelperElementIndex(index));
         copyMachineryTranslation(translation);


### PR DESCRIPTION
As per the [Concordance search specs](https://github.com/mozilla/pontoon/blob/master/specs/0106-concordance-search.md) when clicking on a search term the term should be added to the editor and not replace the editor contents.  

This change was made in this [PR](https://github.com/mozilla/pontoon/pull/1771); however, changes made in this [patch](https://github.com/mozilla/pontoon/pull/1799) altered that functionality.

This work restores the expected behavior.