### PR TITLE
Fix bug 1726219: Prevent infinite loop on generating plural examples

### DIFF
--- a/frontend/src/core/locale/getPluralExamples.test.js
+++ b/frontend/src/core/locale/getPluralExamples.test.js
@@ -18,12 +18,20 @@ describe('getPluralExamples', () => {
     });
 
     it('prevents infinite loop if locale plurals are not configured properly', () => {
+        const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
         const locale = {
             cldrPlurals: [0, 1, 2, 3, 4, 5],
             pluralRule: '(n != 1)',
         };
-        const res = getPluralExamples(locale);
-        const expected = { undefined: 1 };
-        expect(res).toEqual(expected);
+        try {
+            const res = getPluralExamples(locale);
+            const expected = { 0: 1, 1: 2 };
+            expect(res).toEqual(expected);
+            expect(spy).toHaveBeenCalledWith(
+                'Unable to generate plural examples.',
+            );
+        } finally {
+            spy.mockRestore();
+        }
     });
 });

--- a/frontend/src/core/locale/getPluralExamples.test.js
+++ b/frontend/src/core/locale/getPluralExamples.test.js
@@ -1,0 +1,29 @@
+import getPluralExamples from './getPluralExamples';
+
+describe('getPluralExamples', () => {
+    it('returns a map of Slovenian plural examples', () => {
+        const locale = {
+            cldrPlurals: [1, 2, 3, 5],
+            pluralRule:
+                '(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3)',
+        };
+        const res = getPluralExamples(locale);
+        const expected = {
+            1: 1,
+            2: 2,
+            3: 3,
+            5: 0,
+        };
+        expect(res).toEqual(expected);
+    });
+
+    it('prevents infinite loop if locale plurals are not configured properly', () => {
+        const locale = {
+            cldrPlurals: [0, 1, 2, 3, 4, 5],
+            pluralRule: '(n != 1)',
+        };
+        const res = getPluralExamples(locale);
+        const expected = { undefined: 1 };
+        expect(res).toEqual(expected);
+    });
+});

--- a/frontend/src/core/locale/getPluralExamples.ts
+++ b/frontend/src/core/locale/getPluralExamples.ts
@@ -35,6 +35,11 @@ export default function getPluralExamples(
                 examples[locale.cldrPlurals[rule]] = n;
             }
             n++;
+            // Protection against infinite loop
+            if (n === 1000) {
+                console.error('Unable to generate plural examples.');
+                break;
+            }
         }
     }
 

--- a/frontend/src/core/locale/getPluralExamples.ts
+++ b/frontend/src/core/locale/getPluralExamples.ts
@@ -24,15 +24,14 @@ export default function getPluralExamples(
         examples[locale.cldrPlurals[0]] = 1;
         examples[locale.cldrPlurals[1]] = 2;
     } else {
-        // This variable is used in the pluralRule we eval in the while block.
+        const getRule = new Function('n', `return ${locale.pluralRule}`) as (
+            n: number,
+        ) => number | boolean;
         let n = 0;
         while (Object.keys(examples).length < pluralsCount) {
-            // This `eval` is not so much evil. The pluralRule we parse
-            // comes from our database and is not a user input.
-            // eslint-disable-next-line
-            const rule = eval(locale.pluralRule);
-            if (!examples[locale.cldrPlurals[rule]]) {
-                examples[locale.cldrPlurals[rule]] = n;
+            const rule = locale.cldrPlurals[Number(getRule(n))];
+            if (!examples[rule]) {
+                examples[rule] = n;
             }
             n++;
             // Protection against infinite loop


### PR DESCRIPTION
More context in the [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1726219) and the [Discourse post](https://discourse.mozilla.org/t/string-freezes-when-clicked/84627).