### PR TITLE
Include .ts and .tsx files in GH Workflow lint

### DIFF
--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -6,6 +6,8 @@ on:
       - master
     paths:
       - '**.js'
+      - '**.ts'
+      - '**.tsx'
       - '**.css'
       - package.json
       - '.*eslint*'
@@ -16,6 +18,8 @@ on:
       - master
     paths:
       - '**.js'
+      - '**.ts'
+      - '**.tsx'
       - '**.css'
       - package.json
       - '.*eslint*'

--- a/frontend/src/core/editor/hooks/useCopyMachineryTranslation.ts
+++ b/frontend/src/core/editor/hooks/useCopyMachineryTranslation.ts
@@ -13,9 +13,9 @@ import useUpdateTranslation from './useUpdateTranslation';
 /**
  * Return a function to copy the original translation into the editor.
  */
-export default function useCopyMachineryTranslation(entity?: number | null): (
-    translation: MachineryTranslation,
-) => void {
+export default function useCopyMachineryTranslation(
+    entity?: number | null,
+): (translation: MachineryTranslation) => void {
     const dispatch = useDispatch();
 
     const addTextToTranslation = useAddTextToTranslation();


### PR DESCRIPTION
Turns out we forgot to update paths for the linter after converting to TypeScript.