### PR TITLE
Fix bug 1726749: Fail gracefully on parsing errors in XLIFF files

### DIFF
--- a/pontoon/sync/formats/ftl.py
+++ b/pontoon/sync/formats/ftl.py
@@ -74,6 +74,8 @@ class FTLResource(ParsedResource):
         try:
             with codecs.open(path, "r", "utf-8") as resource:
                 self.structure = parser.parse(resource.read())
+        # Parse errors are handled gracefully by fluent
+        # No need to catch them here
         except OSError as err:
             # If the file doesn't exist, but we have a source resource,
             # we can keep going, we'll just not have any translations.

--- a/pontoon/sync/formats/ftl.py
+++ b/pontoon/sync/formats/ftl.py
@@ -4,7 +4,7 @@ import logging
 
 from fluent.syntax import ast, FluentParser, FluentSerializer
 
-from pontoon.sync.exceptions import SyncError
+from pontoon.sync.exceptions import ParseError, SyncError
 from pontoon.sync.formats.base import ParsedResource
 from pontoon.sync.utils import create_parent_directory
 from pontoon.sync.vcs.models import VCSTranslation
@@ -74,13 +74,13 @@ class FTLResource(ParsedResource):
         try:
             with codecs.open(path, "r", "utf-8") as resource:
                 self.structure = parser.parse(resource.read())
-        except OSError:
+        except OSError as err:
             # If the file doesn't exist, but we have a source resource,
             # we can keep going, we'll just not have any translations.
             if source_resource:
                 return
             else:
-                raise
+                raise ParseError(err)
 
         group_comment = []
         resource_comment = []

--- a/pontoon/sync/formats/silme.py
+++ b/pontoon/sync/formats/silme.py
@@ -12,7 +12,7 @@ from silme.format.ini import FormatParser as IniParser
 from silme.format.inc import FormatParser as IncParser
 from silme.format.properties import FormatParser as PropertiesParser
 
-from pontoon.sync.exceptions import SyncError
+from pontoon.sync.exceptions import ParseError, SyncError
 from pontoon.sync.utils import (
     create_parent_directory,
     escape_quotes,
@@ -102,13 +102,13 @@ class SilmeResource(ParsedResource):
                     uncomment_moz_langpack=parser is IncParser and not source_resource,
                 )
             )
-        except OSError:
+        except OSError as err:
             # If the file doesn't exist, but we have a source resource,
             # we can keep going, we'll just not have any translations.
             if source_resource:
                 return
             else:
-                raise
+                raise ParseError(err)
 
         comments = []
         current_order = 0

--- a/pontoon/sync/formats/silme.py
+++ b/pontoon/sync/formats/silme.py
@@ -102,6 +102,8 @@ class SilmeResource(ParsedResource):
                     uncomment_moz_langpack=parser is IncParser and not source_resource,
                 )
             )
+        # Parse errors are handled gracefully by fluent
+        # No need to catch them here
         except OSError as err:
             # If the file doesn't exist, but we have a source resource,
             # we can keep going, we'll just not have any translations.

--- a/pontoon/sync/formats/silme.py
+++ b/pontoon/sync/formats/silme.py
@@ -102,7 +102,7 @@ class SilmeResource(ParsedResource):
                     uncomment_moz_langpack=parser is IncParser and not source_resource,
                 )
             )
-        # Parse errors are handled gracefully by fluent
+        # Parse errors are handled gracefully by silme
         # No need to catch them here
         except OSError as err:
             # If the file doesn't exist, but we have a source resource,

--- a/pontoon/sync/formats/xliff.py
+++ b/pontoon/sync/formats/xliff.py
@@ -1,8 +1,10 @@
 """
 Parser for the xliff translation format.
 """
+from lxml import etree
 from translate.storage import xliff
 
+from pontoon.sync.exceptions import ParseError
 from pontoon.sync.formats.base import ParsedResource
 from pontoon.sync.vcs.models import VCSTranslation
 
@@ -125,5 +127,10 @@ class XLIFFResource(ParsedResource):
 def parse(path, source_path=None, locale=None):
     with open(path) as f:
         xml = f.read().encode("utf-8")
-        xliff_file = xliff.xlifffile(xml)
+
+        try:
+            xliff_file = xliff.xlifffile(xml)
+        except etree.XMLSyntaxError as err:
+            raise ParseError(f"Failed to parse {path}: {err}")
+
     return XLIFFResource(path, xliff_file)

--- a/pontoon/sync/tests/formats/test_ftl.py
+++ b/pontoon/sync/tests/formats/test_ftl.py
@@ -11,6 +11,7 @@ from pontoon.base.tests import (
     LocaleFactory,
     TestCase,
 )
+from pontoon.sync.exceptions import ParseError
 from pontoon.sync.formats import ftl
 from pontoon.sync.tests.formats import FormatTestsMixin
 
@@ -42,10 +43,10 @@ class FTLResourceTests(FormatTestsMixin, TestCase):
     def test_init_missing_resource(self):
         """
         If the FTLResource file doesn't exist and no source resource is
-        given, raise a IOError.
+        given, raise a ParseError.
         """
         path = self.get_nonexistant_file_path()
-        with pytest.raises(IOError):
+        with pytest.raises(ParseError):
             ftl.FTLResource(path, locale=None, source_resource=None)
 
     def test_init_missing_resource_with_source(self):

--- a/pontoon/sync/tests/formats/test_silme.py
+++ b/pontoon/sync/tests/formats/test_silme.py
@@ -11,6 +11,7 @@ from pontoon.base.tests import (
     LocaleFactory,
     TestCase,
 )
+from pontoon.sync.exceptions import ParseError
 from pontoon.sync.formats import silme
 from pontoon.sync.tests.formats import FormatTestsMixin
 
@@ -19,10 +20,10 @@ class SilmeResourceTests(TestCase):
     def test_init_missing_resource(self):
         """
         If the translated resource doesn't exist and no source resource
-        is given, raise an IOError.
+        is given, raise a ParseError.
         """
         path = os.path.join(tempfile.mkdtemp(), "does", "not", "exist.dtd")
-        with pytest.raises(IOError):
+        with pytest.raises(ParseError):
             silme.SilmeResource(DTDParser, path, source_resource=None)
 
     def create_nonexistant_resource(self, path):

--- a/pontoon/sync/tests/formats/test_xliff.py
+++ b/pontoon/sync/tests/formats/test_xliff.py
@@ -1,8 +1,11 @@
 from difflib import Differ
 from textwrap import dedent
 
+import pytest
+
 from pontoon.base.tests import TestCase
 from pontoon.sync import KEY_SEPARATOR
+from pontoon.sync.exceptions import ParseError
 from pontoon.sync.formats import xliff
 from pontoon.sync.tests.formats import FormatTestsMixin
 
@@ -83,6 +86,22 @@ class XLIFFTests(FormatTestsMixin, TestCase):
 
     def test_parse_missing_translation(self):
         self.run_parse_missing_translation(BASE_XLIFF_FILE, 3)
+
+    def test_parse_invalid_translation(self):
+        """
+        If a resource has an invalid translation, raise a ParseError.
+        """
+        with pytest.raises(ParseError):
+            self.parse_string(
+                dedent(
+                    """
+                <trans-unit id="Source String Key"
+                    <source>Source String</source>
+                    <target>Translated String</target>
+                </trans-unit>
+            """
+                )
+            )
 
     def generate_xliff(self, body, locale_code="en"):
         return XLIFF_TEMPLATE.format(body=body, locale_code=locale_code)


### PR DESCRIPTION
We already fail gracefully on parsing errors for all other file formats, i.e. we log the error and continue syncing the next file. So let's do that for XLIFF files, too.

I'm also making two other related changes along the way:
- FTL and Silme libs handle parsing errors gracefully by themselves on a message level, so I'm just adding a note to the error handling blocks for these two formats.
- For FTL and Silme we now raise `ParseError` when we hit OSError, to be consistent with other monolingual formats.