### PR TITLE
Fix bug 1693321: Link to actionable strings from "new strings" notifications

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -290,12 +290,26 @@ def serialized_notifications(self):
         is_comment = False
 
         if hasattr(notification.actor, "slug"):
-            actor = {
-                "anchor": notification.actor.name,
-                "url": reverse(
-                    "pontoon.projects.project", kwargs={"slug": notification.actor.slug}
-                ),
-            }
+            if "new string" in notification.verb and self.profile.custom_homepage:
+                actor = {
+                    "anchor": notification.actor.name,
+                    "url": reverse(
+                        "pontoon.translate.locale.agnostic",
+                        kwargs={
+                            "slug": notification.actor.slug,
+                            "part": "all-resources",
+                        },
+                    )
+                    + "?status=missing,unreviewed,fuzzy",
+                }
+            else:
+                actor = {
+                    "anchor": notification.actor.name,
+                    "url": reverse(
+                        "pontoon.projects.project",
+                        kwargs={"slug": notification.actor.slug},
+                    ),
+                }
         elif hasattr(notification.actor, "email"):
             actor = {
                 "anchor": notification.actor.name_or_email,

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -300,7 +300,7 @@ def serialized_notifications(self):
                             "part": "all-resources",
                         },
                     )
-                    + "?status=missing,unreviewed,fuzzy",
+                    + "?status=missing,fuzzy",
                 }
             else:
                 actor = {

--- a/pontoon/contributors/templates/contributors/widgets/notifications_menu.html
+++ b/pontoon/contributors/templates/contributors/widgets/notifications_menu.html
@@ -33,7 +33,11 @@
 
         {% if notification.actor.slug %}
           {% set actor_anchor = notification.actor %}
-          {% set actor_url = url('pontoon.projects.project', notification.actor.slug) %}
+          {% if "new string" in notification.verb and user.profile.custom_homepage %}
+            {% set actor_url = url('pontoon.translate.locale.agnostic', notification.actor.slug, "all-resources") + '?status=missing,unreviewed,fuzzy' %}
+          {% else %}
+            {% set actor_url = url('pontoon.projects.project', notification.actor.slug) %}
+          {% endif %}
 
         {% elif notification.actor.email %}
           {% set actor_anchor = notification.actor.name_or_email|nospam %}

--- a/pontoon/contributors/templates/contributors/widgets/notifications_menu.html
+++ b/pontoon/contributors/templates/contributors/widgets/notifications_menu.html
@@ -34,7 +34,7 @@
         {% if notification.actor.slug %}
           {% set actor_anchor = notification.actor %}
           {% if "new string" in notification.verb and user.profile.custom_homepage %}
-            {% set actor_url = url('pontoon.translate.locale.agnostic', notification.actor.slug, "all-resources") + '?status=missing,unreviewed,fuzzy' %}
+            {% set actor_url = url('pontoon.translate.locale.agnostic', notification.actor.slug, "all-resources") + '?status=missing,fuzzy' %}
           {% else %}
             {% set actor_url = url('pontoon.projects.project', notification.actor.slug) %}
           {% endif %}


### PR DESCRIPTION
This turned out to be a decent intro to Pontoon's structure. The logic I went with is that if the user has their homepage locale set, that's the one that's used for the strings; otherwise we default to the project's frontpage, as before. The notification itself is locale-less, so that info needs to come from somewhere.

The URL that's actually used is the locale-agnostic one, though, as that will check if the homepage locale actually exists for the project. The redirect should be really fast, but this allows for that check to only be done when a notification link is clicked. It would be possible to use this even if the homepage locale is unset, in which case the request's `Accept-Language` instead controls the redirect target. Would that be better than going to the project's frontpage?

In some cases it might be possible to use the current rather than preferred locale by parsing it from the `Referer` HTTP request field, but it doesn't look like any of the endpoints currently vary depending on that field, so this would be somewhat novel behaviour.