### PR TITLE
Fix bug 1727608: Markup JSON Placeholders as placeables by changing parser order

### DIFF
--- a/frontend/src/core/placeable/components/WithPlaceables.test.js
+++ b/frontend/src/core/placeable/components/WithPlaceables.test.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import WithPlaceables from './WithPlaceables';
+
+describe('Test parser order', () => {
+    it('matches JSON placeholder', () => {
+        const content = 'You have created $COUNT$ aliases';
+        const wrapper = shallow(<WithPlaceables>{content}</WithPlaceables>);
+
+        expect(wrapper.find('mark')).toHaveLength(1);
+        expect(wrapper.find('mark').text()).toContain('$COUNT$');
+    });
+});

--- a/frontend/src/core/placeable/components/WithPlaceables.ts
+++ b/frontend/src/core/placeable/components/WithPlaceables.ts
@@ -60,9 +60,10 @@ export const rules = [
     pythonFormattingVariable,
     javaFormattingVariable,
     stringFormattingVariable,
-    nsisVariable,
-
+    // JSON Placeholder parser Must come before NSIS Variable parser,
+    // otherwise JSON Placeholders are marked up without the trailing $
     jsonPlaceholder,
+    nsisVariable,
 
     // The Qt variables can consume the %1 in %1$s which will mask a printf
     // placeable, so it has to come later.

--- a/frontend/src/core/placeable/parsers/jsonPlaceholder.tsx
+++ b/frontend/src/core/placeable/parsers/jsonPlaceholder.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
- * Marks JSON format placeholders as user by the WebExtension API.
+ * Marks JSON format placeholders as used by the WebExtension API.
  *
  * Terms must start and end with a dollar sign "$" and contain only capital
  * letters or underscores.


### PR DESCRIPTION
Deployed to for easier comparison of states [before](https://bugzilla.mozilla.org/show_bug.cgi?id=1727608) and [after](https://mozilla-pontoon-staging.herokuapp.com/ab/firefox-private-relay-add-on/messages.json/?search=%24MAX%24&string=229155) the patch.