### PR TITLE
No bug, use in-tree action to group tsc checks output

### DIFF
--- a/.github/actions/check-tsc/action.yml
+++ b/.github/actions/check-tsc/action.yml
@@ -1,0 +1,18 @@
+name: 'Check TSC'
+description: 'Run TypeScript Compiler and gather error count'
+author: 'Pontoon'
+inputs:
+  run:
+    required: true
+    description: 'yarn tsc command'
+    default: 'default value if applicable'
+  working-directory:
+    required: false
+    description: 'working directory'
+    default: '.'
+outputs:
+  errors:
+    description: 'Number of errors that tsc found'
+runs:
+  using: 'node12'
+  main: 'index.js'

--- a/.github/actions/check-tsc/index.js
+++ b/.github/actions/check-tsc/index.js
@@ -1,0 +1,31 @@
+const { promisify } = require('util');
+const {exec} = require('child_process');
+
+
+async function run() {
+    console.log("::group::tsc");
+    let errors = '0';
+    const run = process.env['INPUT_RUN'] || 'yarn types --pretty ';
+    const cwd = process.env['INPUT_WORKING-DIRECTORY'] || 'frontend';
+    let stdout, stderr;
+    try {
+        ({stdout, stderr} = await asyncExec(run, {
+            cwd,
+        }));
+    } catch (failed_proc) {
+        ({stdout, stderr } = failed_proc);
+    }
+    console.log(stdout);
+    console.log(stderr);
+    const m = /Found ([0-9]+) errors\./.exec(stdout);
+    if (m) {
+        errors = m[1];
+    }
+    console.log('::endgroup::');
+    console.log(`\nFound ${errors} errors.\n`);
+    console.log(`::set-output name=errors::${errors}`);
+}
+
+const asyncExec = promisify(exec);
+
+run()

--- a/.github/actions/check-tsc/index.js
+++ b/.github/actions/check-tsc/index.js
@@ -1,19 +1,19 @@
+/* eslint no-console: "off" */
 const { promisify } = require('util');
-const {exec} = require('child_process');
-
+const { exec } = require('child_process');
 
 async function run() {
-    console.log("::group::tsc");
+    console.log('::group::tsc');
     let errors = '0';
     const run = process.env['INPUT_RUN'] || 'yarn types --pretty ';
     const cwd = process.env['INPUT_WORKING-DIRECTORY'] || 'frontend';
     let stdout, stderr;
     try {
-        ({stdout, stderr} = await asyncExec(run, {
+        ({ stdout, stderr } = await asyncExec(run, {
             cwd,
         }));
     } catch (failed_proc) {
-        ({stdout, stderr } = failed_proc);
+        ({ stdout, stderr } = failed_proc);
     }
     console.log(stdout);
     console.log(stderr);
@@ -28,4 +28,4 @@ async function run() {
 
 const asyncExec = promisify(exec);
 
-run()
+run();

--- a/.github/actions/check-tsc/package.json
+++ b/.github/actions/check-tsc/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "check-tsc",
+  "version": "0.0.0",
+  "description": "Run tsc checks",
+  "main": "index.js",
+  "private": true
+}

--- a/.github/actions/check-tsc/package.json
+++ b/.github/actions/check-tsc/package.json
@@ -1,6 +1,5 @@
 {
   "name": "check-tsc",
-  "version": "0.0.0",
   "description": "Run tsc checks",
   "main": "index.js",
   "private": true

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -50,15 +50,29 @@ jobs:
       - name: Install dependencies
         run: yarn
         working-directory: frontend
-      - name: noImplicitAny
-        run: yarn types --pretty --noImplicitAny || true
-        working-directory: frontend
-      - name: strictNullChecks
-        run: yarn types --pretty --strictNullChecks || true
-        working-directory: frontend
-      - name: strict
-        run: yarn types --pretty --strict || true
-        working-directory: frontend
+      - id: noImplicitAny
+        name: noImplicitAny
+        uses: ./.github/actions/check-tsc
+        with:
+          run: yarn types --pretty --noImplicitAny
+          working-directory: frontend
+      - id: strictNullChecks
+        name: strictNullChecks
+        uses: ./.github/actions/check-tsc
+        with:
+          run: yarn types --pretty --strictNullChecks
+          working-directory: frontend
+      - id: strict
+        name: strict
+        uses: ./.github/actions/check-tsc
+        with:
+          run: yarn types --pretty --strict
+          working-directory: frontend
+      - name: Summary
+        run: |
+          echo "noImplicitAny:    ${{ steps.noImplicitAny.outputs.errors }}"
+          echo "strictNullChecks: ${{ steps.strictNullChecks.outputs.errors }}"
+          echo "strict:           ${{ steps.strict.outputs.errors }}"
 
   jest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I wanted to make it easier to see the numbers of errors in a PR, and thought this could be done in two ways:

Add an extra log group for the tsc invocation, which collapses the full log. You can still expand the twisty if you want to know the details. It repeats the error count afterwards.

Collect the error count as step output, and thus enabling a summary step that just prints all the numbers together.

The best way to do that that I could come up with was to actually create an action to wrap tsc invocations.