### PR TITLE
Bug 1688846: Point contributing docs from Bugzilla to GitHub

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -13,7 +13,7 @@ https://github.com/mozilla/pontoon
 Issues
 ======
 
-All bugs and ideas are tracked in `GitHub <https://github.com/mozilla/pontoon/issues>`_.
+Our work is tracked in `GitHub <https://github.com/mozilla/pontoon/issues>`_.
 
 Report a `new issue <https://github.com/mozilla/pontoon/issues/new>`_:
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -160,14 +160,15 @@ Git conventions
 
 The first line is a summary of the commit. It should start with one of the following::
 
-    Fix bug XXXXXXX
+    Fix #1234
 
 or::
 
-    Bug XXXXXXX
+    #1234
 
 
-The first, when it lands, will cause the bug to be closed. The second one does not.
+The first, when it lands, will cause the issue to be closed. The second one just adds
+a cross-reference.
 
 After that, the commit should explain *why* the changes are being made and any
 notes that future readers should know for context or be aware of.
@@ -186,7 +187,7 @@ We follow `The seven rules of a great Git commit message <https://chris.beams.io
 Pull requests
 =============
 
-Pull request summary should indicate the bug the pull request addresses.
+Pull request summary should indicate the issue the pull request addresses.
 
 Pull request descriptions should cover at least some of the following:
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -10,14 +10,12 @@ Pontoon source code is available via GitHub:
 https://github.com/mozilla/pontoon
 
 
-Bugs
-====
+Issues
+======
 
-All bugs are tracked in `<https://bugzilla.mozilla.org/>`_.
+All bugs and ideas are tracked in `GitHub <https://github.com/mozilla/pontoon/issues>`_.
 
-Write up a new bug:
-
-https://bugzilla.mozilla.org/enter_bug.cgi?product=Webtools&component=Pontoon
+Report a `new issue <https://github.com/mozilla/pontoon/issues/new>`_:
 
 
 Docker

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ database, run tests, and send your contribution.
 If you want to go further, you can:
 
 * Check out development roadmap on the [wiki](https://wiki.mozilla.org/Pontoon)
-* File a [bug](https://bugzilla.mozilla.org/enter_bug.cgi?product=Webtools&component=Pontoon&rep_platform=all&op_sys=all)
-* Check [existing bugs](https://bugzilla.mozilla.org/buglist.cgi?product=Webtools&component=Pontoon&resolution=---&list_id=13740920)
+* Report an [issue](https://github.com/mozilla/pontoon/issues/new)
+* Check [existing issues](https://github.com/mozilla/pontoon/issues)
 * See Mozilla's Pontoon servers:
     * [Staging](https://mozilla-pontoon-staging.herokuapp.com/)
     * [Production](https://pontoon.mozilla.org/)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+To report a security vulnerability, please use [Bugzilla](https://bugzilla.mozilla.org/enter_bug.cgi?product=Websites&component=Pontoon%20Security%20Issues),
+Mozilla's bug tracking software. It allows us to hide security problems from
+the public until they are resolved.

--- a/contribute.json
+++ b/contribute.json
@@ -17,9 +17,9 @@
         "mailing-list": "https://discourse.mozilla.org/c/pontoon"
     },
     "bugs": {
-        "list": "https://bugzilla.mozilla.org/buglist.cgi?product=Webtools&component=Pontoon",
-        "report": "https://bugzilla.mozilla.org/enter_bug.cgi?product=Webtools&component=Pontoon",
-        "mentored": "https://bugzilla.mozilla.org/buglist.cgi?f1=bug_mentor&o1=isnotempty&query_format=advanced&bug_status=NEW&product=Webtools&component=Pontoon"
+        "list": "https://github.com/mozilla/pontoon/issues",
+        "report": "https://github.com/mozilla/pontoon/issues/new",
+        "mentored": "https://github.com/mozilla/pontoon/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22"
     },
     "urls": {
         "prod": "https://pontoon.mozilla.org",

--- a/contribute.json
+++ b/contribute.json
@@ -11,8 +11,7 @@
         "chat": "https://chat.mozilla.org/#/room/#pontoon:mozilla.org",
         "chat-contacts": [
             "mathjazz",
-            "adrian",
-            "Pike"
+            "eemeli"
         ],
         "mailing-list": "https://discourse.mozilla.org/c/pontoon"
     },

--- a/docs/dev/first-contribution.rst
+++ b/docs/dev/first-contribution.rst
@@ -174,26 +174,15 @@ are where you should introduce yourself, ask questions, show your work,
 etc.
 
 Pontoon's core developer team is currently composed of Matjaž and
-Adrian, with occasional help from other members of Mozilla's L10n team,
-Axel and Staś. We also receive invaluable help from community members.
+Eemeli. We also regularly receive invaluable help from community members.
 
 +------------+----------+--------------------------+------------------+-----------------------------------------------+
 |            | Name     | ROLE                     | chat.mozilla.org | github                                        |
 +============+==========+==========================+==================+===============================================+
-| |image4|   | Matjaž   | Pontoon Core Developer   | mathjazz         | `mathjazz <https://github.com/mathjazz/>`_    |
+| |image0|   | Matjaž   | Pontoon Core Developer   | mathjazz         | `mathjazz <https://github.com/mathjazz/>`_    |
 +------------+----------+--------------------------+------------------+-----------------------------------------------+
-| |image5|   | Adrian   | Pontoon Core Developer   | adrian           | `adngdb <https://github.com/adngdb/>`_        |
-+------------+----------+--------------------------+------------------+-----------------------------------------------+
-| |image6|   | Axel     | L10n Tech Lead           | Pike             | `Pike <https://github.com/Pike/>`_            |
-+------------+----------+--------------------------+------------------+-----------------------------------------------+
-| |image7|   | Staś     | Fluent Core Developer    | stas             | `stasm <https://github.com/stasm/>`_          |
+| |image1|   | Eemeli   | Pontoon Core Developer   | eemeli           | `eemeli <https://github.com/eemeli/>`_        |
 +------------+----------+--------------------------+------------------+-----------------------------------------------+
 
 .. |image0| image:: https://avatars2.githubusercontent.com/u/626716?s=32&v=4
-.. |image1| image:: https://avatars1.githubusercontent.com/u/328790?s=32&v=4
-.. |image2| image:: https://avatars3.githubusercontent.com/u/43494?s=32&v=4
-.. |image3| image:: https://avatars2.githubusercontent.com/u/265818?s=32&v=4
-.. |image4| image:: https://avatars2.githubusercontent.com/u/626716?s=32&v=4
-.. |image5| image:: https://avatars1.githubusercontent.com/u/328790?s=32&v=4
-.. |image6| image:: https://avatars3.githubusercontent.com/u/43494?s=32&v=4
-.. |image7| image:: https://avatars2.githubusercontent.com/u/265818?s=32&v=4
+.. |image1| image:: https://avatars3.githubusercontent.com/u/617000?s=32&v=4

--- a/docs/dev/first-contribution.rst
+++ b/docs/dev/first-contribution.rst
@@ -104,28 +104,22 @@ the command ``make test``.
 When you have successfully verified that your setup works correctly, you
 can safely move to the next part.
 
-5. Choose a bug to work on
---------------------------
+5. Choose an issue to work on
+-----------------------------
 
 *You are now ready to make a contribution! Open source projects usually
-have a list of mentored bugs that are appropriate to work on first, and
+have a list of mentored issues that are appropriate to work on first, and
 on which mentors will be available to help you.*
 
 Work that needs to be done on Pontoon is tracked in
-`bugzilla <https://bugzilla.mozilla.org/>`_, Mozilla's bug tracking
-software. You will need to create an account there in order to be
-assigned to a bug.
+`GitHub <https://github.com/mozilla/pontoon/issues>`_, where we maintain
+a list of what we deem `good first issues <https://github.com/mozilla/pontoon/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22>`_.
 
-We maintain a list of what we deem "good first bugs". They are marked as
-mentored on bugzilla, and can be found quickly on our `Pontoon wiki
-page <https://wiki.mozilla.org/L10n:Pontoon#Get_involved>`_ or through
-`this bugzilla
-search <https://bugzilla.mozilla.org/buglist.cgi?f1=bug_mentor&list_id=15050149&o1=isnotempty&resolution=---&classification=Server%20Software&query_format=advanced&emailbug_mentor1=1&component=Pontoon&product=Webtools>`_.
-Look through that list for unassigned bugs (marked as ``NEW``), choose
-one that is appealing to you and seems adapted to your skill set, then
-comment on that bug asking to be assigned to it. Feel free to start
+Look through that list for unassigned issues, choose
+one that is appealing to you and seems appropriate for your skill set, then
+comment on that issue asking to be assigned to it. Feel free to start
 working on it right away — even if you end up not being assigned for
-some reason, it will still be good experience for you.
+some reason, it will still be a good experience for you.
 
 6. Read the contributing rules
 ------------------------------

--- a/specs/0000-template.md
+++ b/specs/0000-template.md
@@ -1,6 +1,6 @@
 - Feature Name: Name Of The Feature
 - Created: YYYY-MM-DD
-- Associated Issue: https://github.com/mozilla/pontoon/issues/ISSUE-ID
+- Associated Issue: #ISSUE-ID
 
 # Summary
 

--- a/specs/0000-template.md
+++ b/specs/0000-template.md
@@ -1,6 +1,6 @@
 - Feature Name: Name Of The Feature
 - Created: YYYY-MM-DD
-- Associated Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=BUG-ID
+- Associated Issue: https://github.com/mozilla/pontoon/issues/ISSUE-ID
 
 # Summary
 
@@ -14,7 +14,7 @@ Explain the rationale for developing the new feature — what value does it prov
 
 A general explanation of a feature written from the perspective of the end user. Define user interface and user interactions precisely enough for developers to be able to start coding.
 
-This section also provides a concise technical specification, but keep in mind that once the specification is approved, bugs will be filed with all implementation details.
+This section also provides a concise technical specification, but keep in mind that once the specification is approved, issues will be filed with all the implementation details.
 
 Note that we use present simple tense across the entire specification.
 


### PR DESCRIPTION
One of the last steps of the migration of Pontoon bugs from Bugzilla to GitHub is to update the docs, which means merging this PR. So let's use this PR to track the process and collect feedback.

## Before Migration

- [x] Coordinate [retirement of Webtools::Pontoon](https://bugzilla.mozilla.org/show_bug.cgi?id=1728575) with BMO team.
- [x] Update [bugzilla2github](https://github.com/mathjazz/bugzilla2github/tree/pontoon-migration) script to suit our needs.
- [x] Perform test bug export/issue import into a [test repository](https://github.com/mathjazz/pontoon/issues) using the above script.
- [x] Figure out and document the plan to [report security vulnerabilities](https://bugzilla.mozilla.org/show_bug.cgi?id=1730480) ([security policy](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository), [existing security bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1261893)).
- [x] Announce when we'll be making migration on Pontoon and L10n Matrix.

## Migration

- [x] Let BMO [retire Webtools::Pontoon](https://bugzilla.mozilla.org/show_bug.cgi?id=1728575).
- [x] Enable Issues on https://github.com/mozilla/pontoon/.
- [x] Export [existing bugs](https://bugzilla.mozilla.org/buglist.cgi?product=Webtools&component=Pontoon&resolution=---&list_id=15669458) from Webtools::Pontoon and import them into https://github.com/mozilla/pontoon/.
- [x] Let BMO [close open bugs in Webtools::Pontoon](https://bugzilla.mozilla.org/show_bug.cgi?id=1728575).

## After Migration

- [x] Update docs by merging this PR.
- [ ] Announce migration (Mozilla L10n Blog, Mozilla L10n Twitter, Pontoon/L10n Matrix, Pontoon/L10n Discourse).
- [ ] Replace all `bug 123456` comments in the code with the respective issues.