### PR TITLE
Persist dev env postgres data in a named volume

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ help:
 	@echo "  format           Runs formatters for both the frontend and Python code"
 	@echo "  types            Runs the tsc compiler to check TypeScript on all frontend code"
 	@echo "  eslint           Runs a code linter on the JavaScript code"
+	@echo "  dropdb           Completely remove the postgres container and its data"
 	@echo "  dumpdb           Create a postgres database dump with timestamp used as file name"
 	@echo "  loaddb           Load a database dump into postgres, file name in DB_DUMP_FILE"
 	@echo "  build-frontend   Builds the frontend static files"
@@ -95,6 +96,9 @@ eslint:
 
 shell:
 	"${DC}" run --rm webapp //bin/bash
+
+dropdb:
+	"${DC}" down --volumes postgresql 
 
 dumpdb:
 	"${DOCKER}" exec -t `"${DC}" ps -q postgresql` pg_dumpall -c -U pontoon > dump_`date +%d-%m-%Y"_"%H_%M_%S`.sql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,3 +34,9 @@ services:
       - POSTGRES_USER=pontoon
       - POSTGRES_PASSWORD=asdf
       - POSTGRES_DB=pontoon
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+# Persist database
+volumes:
+  pgdata: null


### PR DESCRIPTION
Right now, data retention effectively works because the `postgresql` container is mentioned in `webapp`'s depends entry in `docker-compose.yml`, and the `make run` command does not explicitly start it. This means that it's started in the background, and then stays running because it's never actually stopped. But it may go away when e.g. the developer's computer is restarted.

This adds a named `pgdata` volume which explicitly persists the data, and a `make dropdb` command for explicitly wiping the database when that's desirable.