### PR TITLE
Fix bug 1713058: Only set target-language if not set

### DIFF
--- a/pontoon/sync/formats/xliff.py
+++ b/pontoon/sync/formats/xliff.py
@@ -118,10 +118,10 @@ class XLIFFResource(ParsedResource):
         if locale_code in locale_mapping:
             locale_code = locale_mapping[locale_code]
 
-        # Update target-language where necessary.
+        # Set target-language if not set
         file_node = self.xliff_file.namespaced("file")
         for node in self.xliff_file.document.getroot().iterchildren(file_node):
-            if node.get("target-language"):
+            if not node.get("target-language"):
                 node.set("target-language", locale_code)
 
         with open(self.path, "wb") as f:


### PR DESCRIPTION
The original bug report was to avoid updating values in the `target-language` attribute for non-iOS projects. As per the discussion in l10n-community on Matrix, we've decided to go a step further and never update the `target-language` attribute. We only set it, if it's not set yet.