### PR TITLE
Remove unused option from entities api

### DIFF
--- a/pontoon/base/tests/views/test_entity.py
+++ b/pontoon/base/tests/views/test_entity.py
@@ -7,38 +7,7 @@ from pontoon.base.models import Entity, TranslatedResource
 from pontoon.test.factories import (
     EntityFactory,
     ProjectLocaleFactory,
-    TranslatedResourceFactory,
 )
-
-
-@pytest.mark.django_db
-def test_view_entity_inplace_mode(
-    member, resource_a, locale_a,
-):
-    """
-    Inplace mode of get_entites, should return all entities in a single batch.
-    """
-    TranslatedResourceFactory.create(resource=resource_a, locale=locale_a)
-    ProjectLocaleFactory.create(project=resource_a.project, locale=locale_a)
-    entities = EntityFactory.create_batch(size=3, resource=resource_a)
-    entities_pks = [e.pk for e in entities]
-    response = member.client.post(
-        "/get-entities/",
-        {
-            "project": resource_a.project.slug,
-            "locale": locale_a.code,
-            "paths[]": [resource_a.path],
-            "inplace_editor": True,
-            # Inplace mode shouldn't respect paging or limiting page
-            "limit": 1,
-        },
-        HTTP_X_REQUESTED_WITH="XMLHttpRequest",
-    )
-    assert response.status_code == 200
-    assert json.loads(response.content)["has_next"] is False
-    assert sorted(e["pk"] for e in json.loads(response.content)["entities"]) == sorted(
-        entities_pks
-    )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This option used to be used by translate.old, but isn't used
in the translate frontend app.

Remove it to make the code a bit easier to reason about.