### PR TITLE
Fix #2313: Add ability to show project stats for a subset of teams

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -1617,6 +1617,16 @@ class ExternalResource(models.Model):
 
 
 class ProjectLocaleQuerySet(models.QuerySet):
+    def aggregated_stats(self):
+        return self.aggregate(
+            total_strings=Sum("total_strings"),
+            approved_strings=Sum("approved_strings"),
+            fuzzy_strings=Sum("fuzzy_strings"),
+            strings_with_errors=Sum("strings_with_errors"),
+            strings_with_warnings=Sum("strings_with_warnings"),
+            unreviewed_strings=Sum("unreviewed_strings"),
+        )
+
     def visible_for(self, user):
         """
         Filter project locales by the visibility of their projects.

--- a/pontoon/base/static/js/tabs.js
+++ b/pontoon/base/static/js/tabs.js
@@ -24,6 +24,13 @@ $(function () {
                 return;
             }
 
+            // Filtered teams are only supported by the Teams tab, so we need to drop them
+            // when switching to other tabs and update stats in the heading section by
+            // reloading the page
+            if (new URLSearchParams(window.location.search).get('teams')) {
+                return;
+            }
+
             e.preventDefault();
 
             var url = $(this).attr('href');

--- a/pontoon/projects/templates/projects/project.html
+++ b/pontoon/projects/templates/projects/project.html
@@ -50,7 +50,7 @@
     </ul>
 
     {{ HeadingInfo.progress_chart() }}
-    {{ HeadingInfo.progress_chart_legend(project) }}
+    {{ HeadingInfo.progress_chart_legend(chart) }}
   </div>
 </section>
 {% endblock %}
@@ -64,7 +64,7 @@
           'Teams',
           url('pontoon.projects.project', project.slug),
           is_active = (current_page == ''),
-          count = project.locales.count(),
+          count = count,
           icon = 'folder',
         )
       }}

--- a/pontoon/projects/tests/test_views.py
+++ b/pontoon/projects/tests/test_views.py
@@ -40,6 +40,19 @@ def test_project_view(client, project_a, resource_a):
 
 
 @pytest.mark.django_db
+def test_project_view_filtered_teams(
+    client, locale_a, project_a, project_locale_a, resource_a
+):
+    """
+    Checks if project page is returned properly with filtered teams.
+    """
+    with patch("pontoon.projects.views.render", wraps=render) as mock_render:
+        client.get(f"/projects/{project_a.slug}/?teams={locale_a.code}")
+        assert mock_render.call_args[0][2]["project"] == project_a
+        assert mock_render.call_args[0][2]["count"] == 1
+
+
+@pytest.mark.django_db
 def test_project_top_contributors(client, project_a, project_b):
     """
     Tests if view returns top contributors specific for given project.


### PR DESCRIPTION
Deployed to stage:
https://mozilla-pontoon-staging.herokuapp.com/projects/firefox-for-ios/?teams=ar,zh-CN,fr,de,it,pl,sl