### PR TITLE
Fix #2155: Create portable Docker image

### DIFF
--- a/docker.production/Dockerfile
+++ b/docker.production/Dockerfile
@@ -1,0 +1,112 @@
+# Frontend build
+FROM node:14-bullseye-slim AS frontend
+WORKDIR /frontend
+COPY frontend/package.json frontend/yarn.lock ./
+RUN yarn install
+COPY frontend/ .
+RUN yarn build
+
+
+FROM python:3.9-slim-bullseye AS webapp_build
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV HGPYTHON3=1
+
+# Python environment variables
+ENV PYTHONUNBUFFERED 1
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONPATH /app
+
+# JavaScript applications paths
+ENV WEBPACK_BINARY /app/node_modules/.bin/webpack
+ENV YUGLIFY_BINARY /app/node_modules/.bin/yuglify
+ENV TERSER_BINARY /app/node_modules/.bin/terser
+
+# Django environment variables
+ENV DJANGO_DEV False
+ENV SECRET_KEY override_me_at_runtime
+ENV DATABASE_URL postgres://pontoon:asdf@postgresql/pontoon
+
+# Install required software.
+RUN apt-get update \
+    # Enable downloading packages over https
+    && apt-get install -y --no-install-recommends \
+        apt-transport-https \
+        curl \
+    # Get source for node.js
+    && curl -fsSL https://deb.nodesource.com/setup_14.x | bash - \
+    # Get source for yarn
+    && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+    && echo 'deb https://dl.yarnpkg.com/debian/ stable main' > /etc/apt/sources.list.d/yarn.list \
+    # Install software
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        libmemcached-dev \
+        nodejs \
+        postgresql-client \
+        postgresql-server-dev-13 \
+        yarn \
+    # Clean up what can be cleaned up.
+    && apt-get autoremove -y
+
+WORKDIR /app
+
+# Install Pontoon Python requirements
+COPY requirements/* /app/requirements/
+RUN pip install -U 'pip>=8' && \
+    pip install --no-cache-dir --require-hashes -r requirements/default.txt
+
+
+COPY package.json .
+COPY package-lock.json .
+RUN npm install
+
+COPY ./pontoon /app/pontoon
+COPY --from=frontend /frontend/build /app/frontend/build
+COPY webpack.config.js .babelrc manage.py setup.py /app/
+
+# Create the folder for front-end assets
+RUN mkdir -p assets
+# Run webpack to compile JS files
+RUN $WEBPACK_BINARY
+
+# Run collectstatic in container which puts files in the default place for
+# static files.
+RUN python manage.py collectstatic --noinput
+
+RUN rm -rf node_modules
+
+
+FROM python:3.9-slim-bullseye AS server
+
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+
+# Install required software.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        postgresql-client \
+        subversion \
+        git \
+        openssh-client \
+    # Clean up what can be cleaned up.
+    && apt-get autoremove -y
+
+
+COPY --from=webapp_build /usr/local/bin /usr/local/bin
+COPY --from=webapp_build /usr/local/lib/python3.9/site-packages /usr/local/lib/python3.9/site-packages
+
+WORKDIR /app
+
+COPY --from=webapp_build /app ./
+COPY --from=frontend /frontend/build ./frontend/build/static
+COPY --from=frontend /frontend/build ./frontend
+
+COPY ./docker.production /app/docker
+
+RUN groupadd -r --gid=${GROUP_ID} pontoon && useradd --uid=${USER_ID} --no-log-init -r -m -g pontoon pontoon
+RUN chown -R pontoon:pontoon /app
+USER pontoon
+
+CMD ["/app/docker/server_run.sh"]

--- a/docker.production/README.md
+++ b/docker.production/README.md
@@ -1,0 +1,29 @@
+# Run Pontoon in a production environment in Docker
+
+## Deployments required
+To run Pontoon you will need a `Postgres` database as well as a `rabbitmq` or other compatible software to run Celery.
+
+## Configure runtime
+All variables usually required at build time are here used at run time.
+Please provide the following variables
+- SECRET_KEY=insert_random_key
+- SITE_URL=https://localhost:8000
+- DATABASE_URL=postgres://pontoon:asdf@postgresql/pontoon
+- CELERY_BROKER_URL=amqp://guest:guest@amqp//
+
+Then you can configure SSH using the following ENV
+- SSH_CONFIG=\<base64 encoded config>
+For instance
+```
+Host github.com
+User mail@domain.com
+```
+- SSH_KEY=<base64 encoded private key>
+- KNOWN_HOSTS=\<base64 encoded known hosts file>
+
+You can configure the Celery and Gunicorn threading using the following ENV
+- CELERY_CONCURRENCY=10
+- GUNICORN_WORKERS=5
+- GUNICORN_THREADS=2
+
+Finally you can use any other environment variable already available on pontoon to setup SSO for instance.

--- a/docker.production/server_run.sh
+++ b/docker.production/server_run.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+#user pontoon stuff --> get enc vars
+(echo ">>> running as user: " && whoami)
+if [ ! -z "$SSH_KEY" ]; then
+    echo ">>> loading ssh key and kown_hosts for default user pontoon..."
+    mkdir ~/.ssh
+    chmod 700 ~/.ssh
+
+    # To preserve newlines, the env var is base64 encoded. Flip it back.
+    echo $SSH_KEY | base64 -d > ~/.ssh/id_rsa
+    echo $KNOWN_HOSTS | base64 -d > ~/.ssh/known_hosts
+    echo $SSH_CONFIG | base64 -d > ~/.ssh/config
+
+    chmod 400 ~/.ssh/id_rsa ~/.ssh/known_hosts 
+    chown -R $(whoami):$(whoami) ~/.ssh/
+    echo "...done."
+fi
+
+# Prepares then runs the server
+
+env > .env
+
+echo ">>> Setting up the db for Django"
+python manage.py migrate
+
+echo ">>> Starting gunicorn"
+gunicorn pontoon.wsgi:application -t 120 --log-file - --log-level info -b 0.0.0.0:8000 --workers=${GUNICORN_WORKERS:-5} --threads=${GUNICORN_THREADS:-2} &
+echo ">>> Starting celery worker"
+celery worker --app=pontoon.base.celeryapp --loglevel=info --without-gossip --without-mingle --without-heartbeat --concurrency=${CELERY_CONCURRENCY:-10}

--- a/pontoon/translate/views.py
+++ b/pontoon/translate/views.py
@@ -127,7 +127,7 @@ def translate(request, locale, project, resource):
             {"content": str(x), "type": x.tags} for x in notifications
         ]
 
-    if settings.DEBUG:
+    if settings.DEV:
         return catchall_dev(request, context=context)
 
     return catchall_prod(request, context=context)


### PR DESCRIPTION
# Create a production-ready Docker image(s) (resolves #2155)
## Changes made

- Add of a production Docker image
- Tweak a small like in pontoon/translate/views.py

## Quick overview on performances gain

|                          | Development image | Production image                           |
|--------------------------|-------------------|--------------------------------------------|
| Size                     | 2.6GB             | 616MB                                      |
| Runtime memory footprint | ~800MB            | From 180 with the lowest amount of workers |

## Behavior

The dockerfile will first build the project with the bare minimum environment:
- DJANGO_DEV=False
- SECRET_KEY=somerandomstuff
- DATABASE_URL=randomURI

Then when running the Docker image you will have to inject some of the environment variables that you are used in dev.

Finally the Docker image will execute the entrypoint script containing a few things:
- A setup of SSH on the container
- Injection of $(env) into a .env file
- Database migration
- gunicorn launch
- and celery launch

Gunicorn and Celery are configurable through environment variables GUNICORN_WORKERS, GUNICORN_THREADS and CELERY_CONCURRENCY.
I would appreciate some insight on what default values I should apply here.

## Small file tweak
I've changed a thing in the `pontoon/translate/views.py` file.
While testing some stuff using the DEBUG env, I wasn't able to reach the frontend as it was trying to proxy it as in a dev environment. I guess this would make sense to change the variable used to DEV instead.