### PR TITLE
Fix #2325: List javascript-time-ago as an explicit dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "highcharts": "9.0.0",
     "highcharts-react-official": "2.2.2",
     "html-react-parser": "0.13.0",
+    "javascript-time-ago": "2.3.8",
     "jest-each": "24.5.0",
     "linkify-it": "2.1.0",
     "lodash.clonedeep": "4.5.0",

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -3,8 +3,6 @@ import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 
 import { ConnectedRouter } from 'connected-react-router';
-// javascript-time-ago is installed automatically with react-time-ago
-// See: https://www.npmjs.com/package/react-time-ago
 import JavascriptTimeAgo from 'javascript-time-ago';
 import en from 'javascript-time-ago/locale/en';
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6877,6 +6877,13 @@ istanbul-reports@^3.0.2:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
+javascript-time-ago@2.3.8:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/javascript-time-ago/-/javascript-time-ago-2.3.8.tgz#7e1cd94a770987cc00db82e60e655d3efdd25629"
+  integrity sha512-ahVSuInQC6iJtwy/XsburOc6JMsI0OI/84b3nAhtMlDhCm9g4Py+zuiPASnt02B4GkaURqWtiyw98ce0ICAZYQ==
+  dependencies:
+    relative-time-format "^1.0.5"
+
 javascript-time-ago@^2.3.3:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/javascript-time-ago/-/javascript-time-ago-2.3.6.tgz#a78fd16b214c6b8d91e0f2cc0955648eecd92a7a"


### PR DESCRIPTION
`javascript-time-ago` is installed as a dependency of react-time-ago. Since we import it explicitly, we should also install it explicitly.

This also solves the same problem as reported in the issue in local Docker setup introduced in https://github.com/mozilla/pontoon/commit/623d7bbb39934fe2152f78449efb25f3b273529e. I haven't been able to figure out what exactly is the culprit there, but apparently the `yarn.lock` file gets ignored.

In a followup, we should also look into upgrading to latest `javascript-time-ago` and use `yarn` instead of `npm` across the board (`post_compile` and CI).