### PR TITLE
Remove warning for M1 MacBook from Developer Docs

### DIFF
--- a/docs/dev/setup.rst
+++ b/docs/dev/setup.rst
@@ -42,14 +42,6 @@ Quickstart
    That will build the containers required for development:
    frontend and server.
 
-   .. Warning::
-
-        On M1 MacBooks, a workaround is currently required for successful
-        operations: Add a ``platform: linux/amd64`` specifier under the
-        ``webapp`` service of ``docker-compose.yml``. This avoids a
-        segmentation fault in curl due to the libssl version used by
-        images based on Debian Buster.
-
    .. Note::
 
         If you want to share your development instance in your local network,


### PR DESCRIPTION
This is effectively reverting #1973.

The warning is no longer needed as of #2008.