### PR TITLE
Update react-time-ago to v7, which has javascript-time-ago as peer dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,7 +34,7 @@
     "react-router-dom": "5.2.0",
     "react-scripts": "4.0.3",
     "react-tabs": "3.0.0",
-    "react-time-ago": "6.2.2",
+    "react-time-ago": "^7.1.3",
     "reactour": "1.15.1",
     "redux": "^4.1.1",
     "redux-logger": "3.0.6",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6884,13 +6884,6 @@ javascript-time-ago@2.3.9:
   dependencies:
     relative-time-format "^1.0.5"
 
-javascript-time-ago@^2.3.3:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/javascript-time-ago/-/javascript-time-ago-2.3.6.tgz#a78fd16b214c6b8d91e0f2cc0955648eecd92a7a"
-  integrity sha512-OZLtmx+o+LyfLLi7oKsz7taNCx2uguf1qsdN3KCYDe89L7D1OT1BcR/E0HgK5EYqvXxpPEl0oiuypFC7ugyeJA==
-  dependencies:
-    relative-time-format "^1.0.5"
-
 jest-changed-files@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-26.6.2.tgz#f6198479e1cc66f22f9ae1e22acaa0b429c042d0"
@@ -10102,12 +10095,11 @@ react-test-renderer@^16.0.0-0:
     react-is "^16.8.6"
     scheduler "^0.19.1"
 
-react-time-ago@6.2.2:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/react-time-ago/-/react-time-ago-6.2.2.tgz#0dac73632e4e75204eb307193b6d506e584316bb"
-  integrity sha512-8X4GDw3V9sUs4DJtGDkNzasmT2+TPrP911SYlnQpcY8qj4Byk1JwLhgjlhN8zP1ugrTxOUFuEeYi5pZLlYmMpg==
+react-time-ago@^7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/react-time-ago/-/react-time-ago-7.1.3.tgz#3f937bde06c018e5c0e379827debd5a432dd53e9"
+  integrity sha512-H+mhWft++gNt2x8Y9eAZ9vYwL6giPDnVIo68Ty7xFTJ2L+Tt7cyZ1sbMkTMKzHeeaQ+J8F2vt3PatdW6mFJmWQ==
   dependencies:
-    javascript-time-ago "^2.3.3"
     prop-types "^15.7.2"
     raf "^3.4.1"
 


### PR DESCRIPTION
This resolves [this upstream issue](https://gitlab.com/catamphetamine/react-time-ago/-/issues/2), which I'm also currently getting with Pontoon's master branch.

`react-time-ago@7` does not appear to come with any other breaking changes.

On a local install that's experiencing this problem, it's likely that running `yarn` and in the `frontend/` directory and then `make build-frontend` are required to fix the situation.