### PR TITLE
Use yarn instead of npm for install on Heroku

### DIFF
--- a/bin/post_compile
+++ b/bin/post_compile
@@ -9,13 +9,14 @@ fi
 # Compile static assets
 export PATH=/app/.heroku/node/bin:$PATH
 npm install .
-pushd frontend && npm install && popd
+npm install -g yarn
+pushd frontend && yarn && popd
 
 echo "Running webpack..."
 ./node_modules/.bin/webpack -p
 
 echo "Building frontend resources..."
-pushd frontend && npm run build && popd
+pushd frontend && yarn run build && popd
 
 echo "Collecting static files..."
 ./manage.py migrate --noinput


### PR DESCRIPTION
Fixes #2331 

The prod & staging environments on Heroku were using `npm install` rather than `yarn` in the `frontend/` directory, which meant that the `yarn.lock` lockfile was ignored, leading to some incompatibilities between dependencies.

We'll need to sort out those incompatibilities separately a bit later, but at least for now the difference between the prod & staging environments vs. dev & ci ought to be removed, and this should allow for the Heroku builds to succeed.