### PR TITLE
Mark up Fluent placeables in Simple and Source Fluent editor

### DIFF
--- a/frontend/src/modules/fluentoriginal/components/SimpleString.tsx
+++ b/frontend/src/modules/fluentoriginal/components/SimpleString.tsx
@@ -19,7 +19,7 @@ type Props = {
  */
 export default function SimpleString(props: Props): React.ReactElement<'p'> {
     const original = fluent.getSimplePreview(props.entity.original);
-    const TermsAndPlaceablesMarker = getMarker(props.terms);
+    const TermsAndPlaceablesMarker = getMarker(props.terms, true);
     return (
         <p className='original' onClick={props.handleClickOnPlaceable}>
             <TermsAndPlaceablesMarker>{original}</TermsAndPlaceablesMarker>

--- a/frontend/src/modules/fluentoriginal/components/SourceString.tsx
+++ b/frontend/src/modules/fluentoriginal/components/SourceString.tsx
@@ -17,7 +17,7 @@ type Props = {
  * Show the source string of a Fluent entity.
  */
 export default function SourceString(props: Props): React.ReactElement<'p'> {
-    const TermsAndPlaceablesMarker = getMarker(props.terms);
+    const TermsAndPlaceablesMarker = getMarker(props.terms, true);
 
     return (
         <p className='original' onClick={props.handleClickOnPlaceable}>


### PR DESCRIPTION
Fixes #2345.

This patch fixes a bug introduced in #1661, which by mistake only applied Fluent placeable detection in Rich Fluent editor. Now, we also include the other Fluent editors - Simple and Source.

Fixing the placeable detection when searching (string list) or diffing (Machinery, History) is much harder due to [react-content-marker](https://github.com/mozilla/react-content-marker) limitations:

> You can use as many parsers as you want. However, note that once a part of your input has been marked by a rule, it will be ignored for all following rules. That means that the order of your parsers is very important.
