### PR TITLE
Fix #2267 Set dir attribute on placeables

### DIFF
--- a/frontend/src/core/placeable/parsers/altAttribute.tsx
+++ b/frontend/src/core/placeable/parsers/altAttribute.tsx
@@ -23,6 +23,7 @@ const altAttribute = {
                 <mark
                     className='placeable'
                     title="'alt' attribute inside XML tag"
+                    dir='ltr'
                 >
                     {x}
                 </mark>

--- a/frontend/src/core/placeable/parsers/camelCaseString.tsx
+++ b/frontend/src/core/placeable/parsers/camelCaseString.tsx
@@ -22,7 +22,7 @@ const camelCaseString = {
                 id='placeable-parser-camelCaseString'
                 attrs={{ title: true }}
             >
-                <mark className='placeable' title='Camel case string'>
+                <mark className='placeable' title='Camel case string' dir='ltr'>
                     {x}
                 </mark>
             </Localized>

--- a/frontend/src/core/placeable/parsers/emailPattern.tsx
+++ b/frontend/src/core/placeable/parsers/emailPattern.tsx
@@ -22,7 +22,7 @@ const emailPattern = {
                 id='placeable-parser-emailPattern'
                 attrs={{ title: true }}
             >
-                <mark className='placeable' title='Email'>
+                <mark className='placeable' title='Email' dir='ltr'>
                     {x}
                 </mark>
             </Localized>

--- a/frontend/src/core/placeable/parsers/escapeSequence.tsx
+++ b/frontend/src/core/placeable/parsers/escapeSequence.tsx
@@ -12,7 +12,7 @@ const escapeSequence = {
                 id='placeable-parser-escapeSequence'
                 attrs={{ title: true }}
             >
-                <mark className='placeable' title='Escape sequence'>
+                <mark className='placeable' title='Escape sequence' dir='ltr'>
                     {x}
                 </mark>
             </Localized>

--- a/frontend/src/core/placeable/parsers/filePattern.tsx
+++ b/frontend/src/core/placeable/parsers/filePattern.tsx
@@ -22,7 +22,7 @@ const filePattern = {
                 id='placeable-parser-filePattern'
                 attrs={{ title: true }}
             >
-                <mark className='placeable' title='File location'>
+                <mark className='placeable' title='File location' dir='ltr'>
                     {x}
                 </mark>
             </Localized>

--- a/frontend/src/core/placeable/parsers/fluentFunction.tsx
+++ b/frontend/src/core/placeable/parsers/fluentFunction.tsx
@@ -20,7 +20,7 @@ const fluentFunction = {
                 id='placeable-parser-fluentFunction'
                 attrs={{ title: true }}
             >
-                <mark className='placeable' title='Fluent function'>
+                <mark className='placeable' title='Fluent function' dir='ltr'>
                     {x}
                 </mark>
             </Localized>

--- a/frontend/src/core/placeable/parsers/fluentParametrizedTerm.tsx
+++ b/frontend/src/core/placeable/parsers/fluentParametrizedTerm.tsx
@@ -21,7 +21,11 @@ const fluentParametrizedTerm = {
                 id='placeable-parser-fluentParametrizedTerm'
                 attrs={{ title: true }}
             >
-                <mark className='placeable' title='Fluent parametrized term'>
+                <mark
+                    className='placeable'
+                    title='Fluent parametrized term'
+                    dir='ltr'
+                >
                     {x}
                 </mark>
             </Localized>

--- a/frontend/src/core/placeable/parsers/fluentString.tsx
+++ b/frontend/src/core/placeable/parsers/fluentString.tsx
@@ -19,7 +19,11 @@ const fluentString = {
                 id='placeable-parser-fluentString'
                 attrs={{ title: true }}
             >
-                <mark className='placeable' title='Fluent string expression'>
+                <mark
+                    className='placeable'
+                    title='Fluent string expression'
+                    dir='ltr'
+                >
                     {x}
                 </mark>
             </Localized>

--- a/frontend/src/core/placeable/parsers/fluentTerm.tsx
+++ b/frontend/src/core/placeable/parsers/fluentTerm.tsx
@@ -17,7 +17,7 @@ const fluentTerm = {
     tag: (x: string): React.ReactElement<React.ElementType> => {
         return (
             <Localized id='placeable-parser-fluentTerm' attrs={{ title: true }}>
-                <mark className='placeable' title='Fluent term'>
+                <mark className='placeable' title='Fluent term' dir='ltr'>
                     {x}
                 </mark>
             </Localized>

--- a/frontend/src/core/placeable/parsers/javaFormattingVariable.tsx
+++ b/frontend/src/core/placeable/parsers/javaFormattingVariable.tsx
@@ -33,6 +33,7 @@ const javaFormattingVariable = {
                 <mark
                     className='placeable'
                     title='Java Message formatting variable'
+                    dir='ltr'
                 >
                     {x}
                 </mark>

--- a/frontend/src/core/placeable/parsers/jsonPlaceholder.tsx
+++ b/frontend/src/core/placeable/parsers/jsonPlaceholder.tsx
@@ -20,7 +20,7 @@ const jsonPlaceholder = {
                 id='placeable-parser-jsonPlaceholder'
                 attrs={{ title: true }}
             >
-                <mark className='placeable' title='JSON placeholder'>
+                <mark className='placeable' title='JSON placeholder' dir='ltr'>
                     {x}
                 </mark>
             </Localized>

--- a/frontend/src/core/placeable/parsers/leadingSpace.tsx
+++ b/frontend/src/core/placeable/parsers/leadingSpace.tsx
@@ -16,7 +16,7 @@ const leadingSpace = {
                 id='placeable-parser-leadingSpace'
                 attrs={{ title: true }}
             >
-                <mark className='placeable' title='Leading space'>
+                <mark className='placeable' title='Leading space' dir='ltr'>
                     {x}
                 </mark>
             </Localized>

--- a/frontend/src/core/placeable/parsers/multipleSpaces.tsx
+++ b/frontend/src/core/placeable/parsers/multipleSpaces.tsx
@@ -16,6 +16,7 @@ const multipleSpaces = {
                     className='placeable'
                     title='Multiple spaces'
                     data-match={x}
+                    dir='ltr'
                 >
                     <span className='hidden-source'>{x}</span>
                     <span aria-hidden> &middot; </span>

--- a/frontend/src/core/placeable/parsers/narrowNonBreakingSpace.tsx
+++ b/frontend/src/core/placeable/parsers/narrowNonBreakingSpace.tsx
@@ -12,7 +12,11 @@ const narrowNonBreakingSpace = {
                 id='placeable-parser-narrowNonBreakingSpace'
                 attrs={{ title: true }}
             >
-                <mark className='placeable' title='Narrow non-breaking space'>
+                <mark
+                    className='placeable'
+                    title='Narrow non-breaking space'
+                    dir='ltr'
+                >
                     {x}
                 </mark>
             </Localized>

--- a/frontend/src/core/placeable/parsers/newlineCharacter.tsx
+++ b/frontend/src/core/placeable/parsers/newlineCharacter.tsx
@@ -16,6 +16,7 @@ const newlineCharacter = {
                     className='placeable'
                     title='Newline character'
                     data-match={x}
+                    dir='ltr'
                 >
                     <span aria-hidden>¶</span>
                     {x}

--- a/frontend/src/core/placeable/parsers/newlineEscape.tsx
+++ b/frontend/src/core/placeable/parsers/newlineEscape.tsx
@@ -12,7 +12,7 @@ const newlineEscape = {
                 id='placeable-parser-newlineEscape'
                 attrs={{ title: true }}
             >
-                <mark className='placeable' title='Escaped newline'>
+                <mark className='placeable' title='Escaped newline' dir='ltr'>
                     {x}
                 </mark>
             </Localized>

--- a/frontend/src/core/placeable/parsers/nonBreakingSpace.tsx
+++ b/frontend/src/core/placeable/parsers/nonBreakingSpace.tsx
@@ -12,7 +12,11 @@ const nonBreakingSpace = {
                 id='placeable-parser-nonBreakingSpace'
                 attrs={{ title: true }}
             >
-                <mark className='placeable' title='Non-breaking space'>
+                <mark
+                    className='placeable'
+                    title='Non-breaking space'
+                    dir='ltr'
+                >
                     {x}
                 </mark>
             </Localized>

--- a/frontend/src/core/placeable/parsers/nsisVariable.tsx
+++ b/frontend/src/core/placeable/parsers/nsisVariable.tsx
@@ -18,7 +18,7 @@ const nsisVariable = {
                 id='placeable-parser-nsisVariable'
                 attrs={{ title: true }}
             >
-                <mark className='placeable' title='NSIS variable'>
+                <mark className='placeable' title='NSIS variable' dir='ltr'>
                     {x}
                 </mark>
             </Localized>

--- a/frontend/src/core/placeable/parsers/numberString.tsx
+++ b/frontend/src/core/placeable/parsers/numberString.tsx
@@ -23,7 +23,7 @@ const numberString = {
                 id='placeable-parser-numberString'
                 attrs={{ title: true }}
             >
-                <mark className='placeable' title='Number'>
+                <mark className='placeable' title='Number' dir='ltr'>
                     {x}
                 </mark>
             </Localized>

--- a/frontend/src/core/placeable/parsers/optionPattern.tsx
+++ b/frontend/src/core/placeable/parsers/optionPattern.tsx
@@ -21,7 +21,11 @@ const optionPattern = {
                 id='placeable-parser-optionPattern'
                 attrs={{ title: true }}
             >
-                <mark className='placeable' title='Command line option'>
+                <mark
+                    className='placeable'
+                    title='Command line option'
+                    dir='ltr'
+                >
                     {x}
                 </mark>
             </Localized>

--- a/frontend/src/core/placeable/parsers/punctuation.tsx
+++ b/frontend/src/core/placeable/parsers/punctuation.tsx
@@ -31,7 +31,7 @@ const punctuation = {
                 id='placeable-parser-punctuation'
                 attrs={{ title: true }}
             >
-                <mark className='placeable' title='Punctuation'>
+                <mark className='placeable' title='Punctuation' dir='ltr'>
                     {x}
                 </mark>
             </Localized>

--- a/frontend/src/core/placeable/parsers/pythonFormatNamedString.tsx
+++ b/frontend/src/core/placeable/parsers/pythonFormatNamedString.tsx
@@ -17,7 +17,11 @@ const pythonFormatNamedString = {
                 id='placeable-parser-pythonFormatNamedString'
                 attrs={{ title: true }}
             >
-                <mark className='placeable' title='Python format string'>
+                <mark
+                    className='placeable'
+                    title='Python format string'
+                    dir='ltr'
+                >
                     {x}
                 </mark>
             </Localized>

--- a/frontend/src/core/placeable/parsers/pythonFormatString.tsx
+++ b/frontend/src/core/placeable/parsers/pythonFormatString.tsx
@@ -21,7 +21,11 @@ const pythonFormatString = {
                 id='placeable-parser-pythonFormatString'
                 attrs={{ title: true }}
             >
-                <mark className='placeable' title='Python format string'>
+                <mark
+                    className='placeable'
+                    title='Python format string'
+                    dir='ltr'
+                >
                     {x}
                 </mark>
             </Localized>

--- a/frontend/src/core/placeable/parsers/pythonFormattingVariable.tsx
+++ b/frontend/src/core/placeable/parsers/pythonFormattingVariable.tsx
@@ -28,6 +28,7 @@ const pythonFormattingVariable = {
                 <mark
                     className='placeable'
                     title='Python string formatting variable'
+                    dir='ltr'
                 >
                     {x}
                 </mark>

--- a/frontend/src/core/placeable/parsers/qtFormatting.tsx
+++ b/frontend/src/core/placeable/parsers/qtFormatting.tsx
@@ -35,6 +35,7 @@ const qtFormatting = {
                 <mark
                     className='placeable'
                     title='Qt string formatting variable'
+                    dir='ltr'
                 >
                     {x}
                 </mark>

--- a/frontend/src/core/placeable/parsers/shortCapitalNumberString.tsx
+++ b/frontend/src/core/placeable/parsers/shortCapitalNumberString.tsx
@@ -21,6 +21,7 @@ const shortCapitalNumberString = {
                 <mark
                     className='placeable'
                     title='Short capital letter and number string'
+                    dir='ltr'
                 >
                     {x}
                 </mark>

--- a/frontend/src/core/placeable/parsers/stringFormattingVariable.tsx
+++ b/frontend/src/core/placeable/parsers/stringFormattingVariable.tsx
@@ -24,7 +24,11 @@ const stringFormattingVariable = {
                 id='placeable-parser-stringFormattingVariable'
                 attrs={{ title: true }}
             >
-                <mark className='placeable' title='String formatting variable'>
+                <mark
+                    className='placeable'
+                    title='String formatting variable'
+                    dir='ltr'
+                >
                     {x}
                 </mark>
             </Localized>

--- a/frontend/src/core/placeable/parsers/tabCharacter.tsx
+++ b/frontend/src/core/placeable/parsers/tabCharacter.tsx
@@ -16,6 +16,7 @@ const tabCharacter = {
                     className='placeable'
                     title='Tab character'
                     data-match={x}
+                    dir='ltr'
                 >
                     <span className='hidden-source'>{x}</span>
                     <span aria-hidden>&rarr;</span>

--- a/frontend/src/core/placeable/parsers/thinSpace.tsx
+++ b/frontend/src/core/placeable/parsers/thinSpace.tsx
@@ -9,7 +9,7 @@ const thinSpace = {
     tag: (x: string): React.ReactElement<React.ElementType> => {
         return (
             <Localized id='placeable-parser-thinSpace' attrs={{ title: true }}>
-                <mark className='placeable' title='Thin space'>
+                <mark className='placeable' title='Thin space' dir='ltr'>
                     {x}
                 </mark>
             </Localized>

--- a/frontend/src/core/placeable/parsers/unusualSpace.tsx
+++ b/frontend/src/core/placeable/parsers/unusualSpace.tsx
@@ -21,7 +21,7 @@ const unusualSpace = {
                 id='placeable-parser-unusualSpace'
                 attrs={{ title: true }}
             >
-                <mark className='placeable' title='Unusual space'>
+                <mark className='placeable' title='Unusual space' dir='ltr'>
                     {x}
                 </mark>
             </Localized>

--- a/frontend/src/core/placeable/parsers/uriPattern.tsx
+++ b/frontend/src/core/placeable/parsers/uriPattern.tsx
@@ -34,7 +34,7 @@ const uriPattern = {
     tag: (x: string): React.ReactElement<React.ElementType> => {
         return (
             <Localized id='placeable-parser-uriPattern' attrs={{ title: true }}>
-                <mark className='placeable' title='URI'>
+                <mark className='placeable' title='URI' dir='ltr'>
                     {x}
                 </mark>
             </Localized>

--- a/frontend/src/core/placeable/parsers/xmlEntity.tsx
+++ b/frontend/src/core/placeable/parsers/xmlEntity.tsx
@@ -18,7 +18,7 @@ const xmlEntity = {
     tag: (x: string): React.ReactElement<React.ElementType> => {
         return (
             <Localized id='placeable-parser-xmlEntity' attrs={{ title: true }}>
-                <mark className='placeable' title='XML entity'>
+                <mark className='placeable' title='XML entity' dir='ltr'>
                     {x}
                 </mark>
             </Localized>

--- a/frontend/src/core/placeable/parsers/xmlTag.tsx
+++ b/frontend/src/core/placeable/parsers/xmlTag.tsx
@@ -19,7 +19,7 @@ const xmlTag = {
     tag: (x: string): React.ReactElement<React.ElementType> => {
         return (
             <Localized id='placeable-parser-xmlTag' attrs={{ title: true }}>
-                <mark className='placeable' title='XML tag'>
+                <mark className='placeable' title='XML tag' dir='ltr'>
                     {x}
                 </mark>
             </Localized>


### PR DESCRIPTION
This PR sets the dir attribute to ltr for placeable instances in parsers folder. This prevents bad display of placeables in RTL strings.

Anywhere there are placeables in the frontend app when viewing a translation for a RTL locale (for example Arabic) should now display correctly, i.e. `{$placeable}` instead of `{placeable$}`

This fixes #2267 

See [Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1692620) post for screenshot of bug. 