### PR TITLE
Change SYSTRAN Translate URL

### DIFF
--- a/pontoon/machinery/views.py
+++ b/pontoon/machinery/views.py
@@ -187,9 +187,7 @@ def systran_translate(request):
             {"status": False, "message": f"Bad Request: {e}"}, status=400,
         )
 
-    url = (
-        "https://translationpartners-spn9.mysystran.com:8904/translation/text/translate"
-    )
+    url = "https://api-translate.systran.net/translation/text/translate"
 
     payload = {
         "key": api_key,


### PR DESCRIPTION
SYSTRAN service currently returns 500 errors, because the endpoint URL, Credentials and Locale Profile IDs have been changed without prior notice.

This patch changes the URL. Credentials and Locale Profile IDs are obviously not stored in the codebase.