### PR TITLE
Fix broken CSS on the Profile page

### DIFF
--- a/pontoon/contributors/static/css/contributor.css
+++ b/pontoon/contributors/static/css/contributor.css
@@ -39,16 +39,15 @@ a.avatar:hover .desc ~ img {
     text-transform: none;
 }
 
-.check-list {
+.info {
     list-style: none;
     margin: 0;
     display: inline-block;
     text-align: left;
 }
 
-.check-list li {
+.info li {
     color: #aaaaaa;
-    cursor: pointer;
     display: table;
     font-size: 16px;
     font-weight: 300;
@@ -59,11 +58,11 @@ a.avatar:hover .desc ~ img {
     max-width: 980px;
 }
 
-.check-list a {
+.info a {
     color: #7bc876;
 }
 
-.check-list .fa {
+.info .fa {
     margin-right: 6px;
 }
 

--- a/pontoon/contributors/static/css/settings.css
+++ b/pontoon/contributors/static/css/settings.css
@@ -108,3 +108,7 @@
     margin-top: 5px;
     text-align: left;
 }
+
+.check-list {
+    cursor: pointer;
+}

--- a/pontoon/contributors/templates/contributors/settings.html
+++ b/pontoon/contributors/templates/contributors/settings.html
@@ -24,7 +24,7 @@
 
   <h2 id="username">{{ user.first_name }}</h2>
 
-  <ul id="editor-settings" class="check-list">
+  <ul id="editor-settings" class="info check-list">
     {{ Checkbox.checkbox('Translate Toolkit Checks', class='quality-checks', attribute='quality_checks', is_enabled=user.profile.quality_checks, title='Run Translate Toolkit checks before submitting translations') }}
 
     {% if user.translated_locales %}
@@ -74,7 +74,7 @@
 
     <section>
         <h3>Notification subscriptions</h3>
-        <ul class="check-list">
+        <ul class="info check-list">
             {{ Checkbox.checkbox('New string notifications', class='new-string-notifications', attribute='new_string_notifications', is_enabled=user.profile.new_string_notifications, title='Get notified when new strings are added to your projects') }}
             {{ Checkbox.checkbox('Project deadline notifications', class='project-deadline-notifications', attribute='project_deadline_notifications', is_enabled=user.profile.project_deadline_notifications, title='Get notified when project deadline approaches') }}
             {{ Checkbox.checkbox('Comment notifications', class='comment-notifications', attribute='comment_notifications', is_enabled=user.profile.comment_notifications, title='Get notified when comments are submitted to your strings') }}


### PR DESCRIPTION
CSS in the heading of the User Profile page is broken since #2349.

Let's fix it.

<img width="393" alt="Screenshot 2021-11-10 at 14 25 05" src="https://user-images.githubusercontent.com/626716/141121326-b794e894-4e2f-4673-bcbb-316789c11beb.png">