### PR TITLE
Exclude Black 21.10b0 reformatting from git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,5 +1,6 @@
 # Black formatting
 e92124bf208c9355cf47b914acd1ce3dfd942fb0
+87cb4090099b98553af87817a877019947f05be2
 
 # Prettier formatting
 0f31239f210c3a4b3fb1593deaff219a876dec2d


### PR DESCRIPTION
Excludes https://github.com/mozilla/pontoon/commit/87cb4090099b98553af87817a877019947f05be2.