### PR TITLE
Flatten Fluent select messages more

### DIFF
--- a/frontend/src/core/editor/hooks/useUpdateUnsavedChanges.ts
+++ b/frontend/src/core/editor/hooks/useUpdateUnsavedChanges.ts
@@ -19,16 +19,14 @@ export default function useUpdateUnsavedChanges(richEditor: boolean) {
 
     // When the translation or the initial translation changes, check for unsaved changes.
     React.useEffect(() => {
-        let exist;
-        if (richEditor) {
-            if (typeof translation === 'string') {
-                return;
-            }
+        let exist: boolean;
+        if (typeof translation === 'string') {
+            if (richEditor) return
+            exist = translation !== initialTranslation;
+        } else {
             exist =
                 typeof initialTranslation !== 'string' &&
                 !translation.equals(initialTranslation);
-        } else {
-            exist = translation !== initialTranslation;
         }
 
         if (exist !== unsavedChangesExist) {

--- a/frontend/src/core/editor/hooks/useUpdateUnsavedChanges.ts
+++ b/frontend/src/core/editor/hooks/useUpdateUnsavedChanges.ts
@@ -21,7 +21,7 @@ export default function useUpdateUnsavedChanges(richEditor: boolean) {
     React.useEffect(() => {
         let exist: boolean;
         if (typeof translation === 'string') {
-            if (richEditor) return
+            if (richEditor) return;
             exist = translation !== initialTranslation;
         } else {
             exist =

--- a/frontend/src/core/utils/fluent/convertSyntax.test.js
+++ b/frontend/src/core/utils/fluent/convertSyntax.test.js
@@ -27,7 +27,7 @@ describe('getComplexFromRich', () => {
 
         const res = getComplexFromRich(current, original, initial);
 
-        expect(res[1]).toEqual('title = Mien titre');
+        expect(res[1]).toEqual('title = Mien titre\n');
     });
 
     it('returns the correct initial translation when none exist', () => {

--- a/frontend/src/core/utils/fluent/convertSyntax.ts
+++ b/frontend/src/core/utils/fluent/convertSyntax.ts
@@ -59,7 +59,7 @@ export function getRichFromComplex(
     initial: string,
     locale: Locale,
 ): [Entry, Entry] {
-    let translationContent = parser.parseEntry(current);
+    let translationContent = flattenMessage(parser.parseEntry(current));
 
     // If the parsed content is invalid, create an empty message instead.
     // Note that this should be replaced with a check that prevents
@@ -90,18 +90,20 @@ export function getComplexFromRich(
     initial: string,
     locale: Locale,
 ): [string, string] {
-    let initialContent = initial;
-
     const translationContent = serializer.serializeEntry(current);
+
+    let initialEntry: Entry;
 
     // If there is no active translation (it's an untranslated string)
     // we make the initial translation an empty fluent message to avoid
     // showing unchanged content warnings.
-    if (!initialContent) {
-        initialContent = serializer.serializeEntry(
-            getEmptyMessage(parser.parseEntry(original), locale),
-        );
+    if (!initial) {
+        initialEntry = getEmptyMessage(parser.parseEntry(original), locale);
+    } else {
+        initialEntry = flattenMessage(parser.parseEntry(initial));
     }
+
+    const initialContent = serializer.serializeEntry(initialEntry);
 
     return [translationContent, initialContent];
 }

--- a/frontend/src/core/utils/fluent/flattenMessage.test.js
+++ b/frontend/src/core/utils/fluent/flattenMessage.test.js
@@ -119,7 +119,7 @@ describe('flattenMessage', () => {
             'There are { $num } emails for { $awesome }',
         );
 
-        expect(res.value.elements[1].value).toEqual(' ')
+        expect(res.value.elements[1].value).toEqual(' ');
 
         const selGender = res.value.elements[2].expression;
         expect(selGender.variants[0].value.elements[0].value).toEqual('him');

--- a/frontend/src/core/utils/fluent/flattenMessage.test.js
+++ b/frontend/src/core/utils/fluent/flattenMessage.test.js
@@ -109,28 +109,20 @@ describe('flattenMessage', () => {
         const message = parser.parseEntry(input);
         const res = flattenMessage(message);
 
-        expect(res.value.elements).toHaveLength(4);
+        expect(res.value.elements).toHaveLength(3);
 
-        expect(res.value.elements[0].value).toEqual('There ');
+        const selEmail = res.value.elements[0].expression;
+        expect(selEmail.variants[0].value.elements[0].value).toEqual(
+            'There is one email for { $awesome }',
+        );
+        expect(selEmail.variants[1].value.elements[0].value).toEqual(
+            'There are { $num } emails for { $awesome }',
+        );
 
-        expect(
-            res.value.elements[1].expression.variants[0].value.elements[0]
-                .value,
-        ).toEqual('is one email');
-        expect(
-            res.value.elements[1].expression.variants[1].value.elements[0]
-                .value,
-        ).toEqual('are { $num } emails');
+        expect(res.value.elements[1].value).toEqual(' ')
 
-        expect(res.value.elements[2].value).toEqual(' for { $awesome } ');
-
-        expect(
-            res.value.elements[3].expression.variants[0].value.elements[0]
-                .value,
-        ).toEqual('him');
-        expect(
-            res.value.elements[3].expression.variants[1].value.elements[0]
-                .value,
-        ).toEqual('her');
+        const selGender = res.value.elements[2].expression;
+        expect(selGender.variants[0].value.elements[0].value).toEqual('him');
+        expect(selGender.variants[1].value.elements[0].value).toEqual('her');
     });
 });

--- a/frontend/src/core/utils/fluent/flattenPatternElements.ts
+++ b/frontend/src/core/utils/fluent/flattenPatternElements.ts
@@ -1,6 +1,9 @@
-import { TextElement, serializeExpression } from '@fluent/syntax';
-
-import type { PatternElement } from '@fluent/syntax';
+import {
+    PatternElement,
+    SelectExpression,
+    serializeExpression,
+    TextElement,
+} from '@fluent/syntax';
 
 /**
  * Return a flattened list of Pattern elements.
@@ -14,41 +17,82 @@ import type { PatternElement } from '@fluent/syntax';
 export default function flattenPatternElements(
     elements: Array<PatternElement>,
 ): Array<PatternElement> {
-    const flatElements = [];
-    let textFragments: string[] = [];
+    const flatElements: PatternElement[] = [];
+    let textFragment = '';
+    let prevSelect: SelectExpression | null = null;
 
-    elements.forEach((element) => {
+    for (const element of elements) {
         if (
             element.type === 'Placeable' &&
             element.expression &&
             element.expression.type === 'SelectExpression'
         ) {
-            // Before adding SelectExpression merge any collected text fragments into a TextElement
-            if (textFragments.length) {
-                flatElements.push(new TextElement(textFragments.join('')));
-                textFragments = [];
+            // In a message with multiple SelectExpressions separated by some
+            // whitespace, keep that whitespace out of select variants.
+            if (/^\s+$/.test(textFragment)) {
+                flatElements.push(new TextElement(textFragment))
+                textFragment = ''
             }
 
             // Flatten SelectExpression variant elements
-            element.expression.variants.forEach((variant) => {
+            for (const variant of element.expression.variants) {
                 variant.value.elements = flattenPatternElements(
                     variant.value.elements,
                 );
-            });
+
+                // If there is preceding text, include that for all variants
+                if (textFragment) {
+                    const { elements } = variant.value;
+                    const first = elements[0];
+                    if (first?.type === 'TextElement') {
+                        first.value = textFragment + first.value;
+                    } else {
+                        elements.unshift(new TextElement(textFragment));
+                    }
+                }
+            }
+            if (textFragment) textFragment = '';
 
             flatElements.push(element);
+            prevSelect = element.expression;
         } else {
-            if (element.type === 'TextElement') {
-                textFragments.push(element.value);
+            let strValue =
+                element.type === 'TextElement'
+                    ? element.value
+                    : serializeExpression(element);
+            if (textFragment) {
+                strValue = textFragment + strValue;
+                textFragment = '';
+            }
+
+            if (prevSelect) {
+                // Keep trailing whitespace out of variant values
+                const wsEnd = strValue.match(/\s+$/);
+                if (wsEnd) {
+                    strValue = strValue.substring(0, wsEnd.index);
+                    textFragment = wsEnd[0];
+                }
+
+                // If there is a preceding SelectExpression, append to each of its variants
+                for (const variant of prevSelect.variants) {
+                    const { elements } = variant.value;
+                    const last = elements[elements.length - 1];
+                    if (last?.type === 'TextElement') {
+                        last.value += strValue;
+                    } else {
+                        elements.push(new TextElement(strValue));
+                    }
+                }
             } else {
-                textFragments.push(serializeExpression(element));
+                // ... otherwise, append to a temporary string
+                textFragment += strValue;
             }
         }
-    });
+    }
 
-    // Merge any remaining collected text fragments into a TextElement
-    if (textFragments.length) {
-        flatElements.push(new TextElement(textFragments.join('')));
+    // Merge any remaining collected text into a TextElement
+    if (textFragment) {
+        flatElements.push(new TextElement(textFragment));
     }
 
     return flatElements;

--- a/frontend/src/core/utils/fluent/flattenPatternElements.ts
+++ b/frontend/src/core/utils/fluent/flattenPatternElements.ts
@@ -30,8 +30,8 @@ export default function flattenPatternElements(
             // In a message with multiple SelectExpressions separated by some
             // whitespace, keep that whitespace out of select variants.
             if (/^\s+$/.test(textFragment)) {
-                flatElements.push(new TextElement(textFragment))
-                textFragment = ''
+                flatElements.push(new TextElement(textFragment));
+                textFragment = '';
             }
 
             // Flatten SelectExpression variant elements

--- a/frontend/src/core/utils/fluent/flattenPatternElements.ts
+++ b/frontend/src/core/utils/fluent/flattenPatternElements.ts
@@ -91,7 +91,7 @@ export default function flattenPatternElements(
     }
 
     // Merge any remaining collected text into a TextElement
-    if (textFragment) {
+    if (textFragment || flatElements.length === 0) {
         flatElements.push(new TextElement(textFragment));
     }
 

--- a/frontend/src/modules/fluenteditor/components/rich/RichTranslationForm.tsx
+++ b/frontend/src/modules/fluenteditor/components/rich/RichTranslationForm.tsx
@@ -369,14 +369,12 @@ export default function RichTranslationForm(
         pluralExamples: any,
         attributeName: string | null | undefined,
     ) {
+        let value: string;
         const element = variant.value.elements[0];
-        if (element.value === null) {
-            return null;
-        }
-
-        const value = element.value;
-        if (typeof value !== 'string') {
-            return null;
+        if (element && element.value && typeof element.value === 'string') {
+            value = element.value;
+        } else {
+            value = '';
         }
 
         const label = serializeVariantKey(variant.key);

--- a/frontend/src/modules/fluenteditor/components/rich/RichTranslationForm.tsx
+++ b/frontend/src/modules/fluenteditor/components/rich/RichTranslationForm.tsx
@@ -157,17 +157,6 @@ export default function RichTranslationForm(
         focusedElementIdRef.current = null;
     }, [entity, changeSource]);
 
-    // Walks the tree and unify all simple elements into just one.
-    React.useEffect(() => {
-        if (typeof message === 'string') {
-            return;
-        }
-        const flatMessage = fluent.flattenMessage(message);
-        if (!flatMessage.equals(message)) {
-            updateTranslation(flatMessage);
-        }
-    }, [entity, message, updateTranslation]);
-
     // Reset checks when content of the editor changes.
     React.useEffect(() => {
         dispatch(editor.actions.resetFailedChecks());


### PR DESCRIPTION
Closes #2366 

This refactors the behaviour of `flattenPatternElements()` to, well, flatten them some more. See the above issue for why this is a good idea.

If a Fluent message has a source like:
```fluent
msg = before { $foo ->
   [one] one
  *[other] other
} after
```
this will now be rendered and, if modified, saved as:
```fluent
msg = { $foo ->
   [one] before one after
  *[other] before other after
}
```

With the RichEditor, this means that for the above message a translator will see the fields `one` and `other`, rather than `Value`, `one`, `other`, `Value` as happens currently.

If a message has more than one selector, any whitespace immediately before each selector after the first will be kept out of the selector variants, so for instance this:
```fluent
my-entry =
    There { $num ->
        [one] is one email
       *[other] are { $num } emails
    } for { $awesome } { $gender ->
       *[masculine] him
        [feminine] her
    }.
```
gets parsed as:
```fluent
my-entry =
    { $num ->
        [one] There is one email for { $awesome }
       *[other] There are { $num } emails for { $awesome }
    } { $gender ->
       *[masculine] him.
        [feminine] her.
    }
```

There aren't all that many messages affected by this change; most of those are under Common Voice, e.g. `help-reach-hours-pluralized` and `activity-needed-calculation-plural`. For a number of languages, this change makes it clear that current translations are missing whitespace around the selector. Outside of Common Voice, only one locale (Czech) has many such constructs, see e.g. `toolkit/toolkit/global/resetProfile.ftl` in Firefox.

Editing the FTL source of a message to a different form is still fully supported. Switching from complex to rich editor will re-flatten the message according to the same logic.

The robustness of change detection in messages is slightly improved, and e.g. toggling rich -> source -> rich will now no longer always consider the message to have changed.