### PR TITLE
Flatten Fluent message when copying from original

### DIFF
--- a/frontend/src/modules/fluenteditor/components/rich/RichEditor.tsx
+++ b/frontend/src/modules/fluenteditor/components/rich/RichEditor.tsx
@@ -47,7 +47,7 @@ export default function RichEditor(props: Props): React.ReactElement<any> {
             if (syntax !== 'rich') {
                 return;
             }
-            updateTranslation(message, changeSource);
+            updateTranslation(fluent.flattenMessage(message), changeSource);
         }
     }, [translation, changeSource, updateTranslation, dispatch]);
 

--- a/frontend/src/modules/fluenteditor/components/rich/RichEditor.tsx
+++ b/frontend/src/modules/fluenteditor/components/rich/RichEditor.tsx
@@ -64,7 +64,8 @@ export default function RichEditor(props: Props): React.ReactElement<any> {
 
     function copyOriginalIntoEditor() {
         if (entity) {
-            updateTranslation(fluent.parser.parseEntry(entity.original));
+            const origMsg = fluent.parser.parseEntry(entity.original);
+            updateTranslation(fluent.flattenMessage(origMsg));
         }
     }
 


### PR DESCRIPTION
Fixes #2374

It would appear that the hook discussed at https://github.com/mozilla/pontoon/pull/2367#issuecomment-972871389 was the only thing handling the message flattening when copying from the original while in the rich editor, and I'd missed it previously.

This is fixed, and I've gone through and reviewed that (hopefully!) all other code paths updating a Fluent translation are not similarly missing an otherwise expected flattening.