### PR TITLE
Fix #2372 wrong docker-compose version number

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # docker-compose for Pontoon development.
 #
 # Note: Requires docker-compose 1.10+.
-version: "2"
+version: "2.3"
 services:
   frontend:
     build:


### PR DESCRIPTION
Docker won't start up since the use of the property
target: and the mismatch with the version of the
docker-compose.yml (version: "2"). The minimum version
required to use target: is 2.3.

Changing the value of the version to 2.3 of the docker-compose.yml will
allow for the docker containers to start up.