### PR TITLE
Add spacing to time range buttons

### DIFF
--- a/frontend/src/modules/search/components/chart-options.ts
+++ b/frontend/src/modules/search/components/chart-options.ts
@@ -80,6 +80,7 @@ export const CHART_OPTIONS = {
             x: -4,
             y: 95,
         },
+        buttonSpacing: 20,
         buttonTheme: {
             fill: 'none',
             stroke: 'none',


### PR DESCRIPTION
Fixes #2319 

The buttons at the bottom of the DATE/TIME range picker were having overlapping text. This adds spacing between them. Note that this adds spacing between _all_ of the buttons, not just the overlapping one from the issue, however it looks like we can't change the positioning of individual buttons with Highcharts, see [here](https://www.highcharts.com/docs/chart-design-and-style/style-by-css?_ga=2.63616175.1495014264.1638378248-1071920560.1638378248#what-can-be-styled). 