### PR TITLE
Some noImplicitAny TS fixes

### DIFF
--- a/frontend/src/core/editor/selectors.ts
+++ b/frontend/src/core/editor/selectors.ts
@@ -33,8 +33,8 @@ export function _existingTranslation(
     ) {
         return activeTranslation;
     }
-    if (!history.translations.length) {
-        return;
+    if (history.translations.length === 0) {
+        return undefined;
     }
     // If translation is a FluentMessage, from the fluent editor.
     if (typeof translation !== 'string') {

--- a/frontend/src/core/editor/selectors.ts
+++ b/frontend/src/core/editor/selectors.ts
@@ -6,22 +6,21 @@ import { fluent } from 'core/utils';
 import * as history from 'modules/history';
 import { NAME } from '.';
 
-import type { EntityTranslation, Entity } from 'core/api';
-import type { HistoryTranslation, HistoryState } from 'modules/history';
-import type { EditorState } from '.';
+import type { RootState } from '../../store';
 
-const editorSelector = (state): EditorState => state[NAME];
-const historySelector = (state): HistoryState => state[history.NAME];
+const editorSelector = (state: RootState) => state[NAME];
+const historySelector = (state: RootState) => state[history.NAME];
 
 export function _existingTranslation(
-    editor: EditorState,
-    activeTranslation: EntityTranslation,
-    history: HistoryState,
-    entity: Entity,
-): (EntityTranslation | HistoryTranslation) | null | undefined {
+    editor: ReturnType<typeof editorSelector>,
+    activeTranslation: ReturnType<
+        typeof plural.selectors.getTranslationForSelectedEntity
+    >,
+    history: ReturnType<typeof historySelector>,
+    entity: ReturnType<typeof entities.selectors.getSelectedEntity>,
+) {
     const { translation, initialTranslation } = editor;
 
-    let existingTranslation = null;
     if (
         activeTranslation &&
         activeTranslation.pk &&
@@ -32,58 +31,51 @@ export function _existingTranslation(
                 typeof initialTranslation !== 'string' &&
                 translation.equals(initialTranslation)))
     ) {
-        existingTranslation = activeTranslation;
-    } else if (history.translations.length) {
-        // If translation is a FluentMessage, from the fluent editor.
-        if (typeof translation !== 'string') {
-            // We apply a bunch of logic on the stored translation, to
-            // make it work with our Editor. So here, we need to
-            // re-serialize it and re-parse it to make sure the translation
-            // object is a "clean" one, as produced by Fluent. Otherwise
-            // we encounter bugs when comparing it with the history items.
-            const fluentTranslation = fluent.parser.parseEntry(
-                fluent.serializer.serializeEntry(translation),
-            );
-            existingTranslation = history.translations.find((t) =>
-                fluentTranslation.equals(fluent.parser.parseEntry(t.string)),
-            );
-        }
-        // If translation is a string, from the generic editor.
-        else {
-            // Except it might actually be a Fluent message from the Simple or Source
-            // editors.
-            if (entity.format === 'ftl') {
-                // For Fluent files, the translation can be stored as a simple string
-                // when the Source editor or the Simple editor are on. Because of that,
-                // we want to turn the string into a Fluent message, as that's simpler
-                // to handle and less prone to errors. We do the same for each history
-                // entry.
-                let fluentTranslation = fluent.parser.parseEntry(translation);
-                if (fluentTranslation.type === 'Junk') {
-                    // If the message was junk, it means we are likely in the Simple
-                    // editor, and we thus want to reconstruct the Fluent message.
-                    // Note that if the user is actually in the Source editor, and
-                    // entered an invalid value (which creates this junk entry),
-                    // it doesn't matter as there shouldn't be anything matching anyway.
-                    fluentTranslation = fluent.getReconstructedMessage(
-                        entity.original,
-                        translation,
-                    );
-                }
-                existingTranslation = history.translations.find((t) =>
-                    fluentTranslation.equals(
-                        fluent.parser.parseEntry(t.string),
-                    ),
-                );
-            } else {
-                existingTranslation = history.translations.find(
-                    (t) => t.string === translation,
-                );
-            }
-        }
+        return activeTranslation;
     }
-
-    return existingTranslation;
+    if (!history.translations.length) {
+        return;
+    }
+    // If translation is a FluentMessage, from the fluent editor.
+    if (typeof translation !== 'string') {
+        // We apply a bunch of logic on the stored translation, to
+        // make it work with our Editor. So here, we need to
+        // re-serialize it and re-parse it to make sure the translation
+        // object is a "clean" one, as produced by Fluent. Otherwise
+        // we encounter bugs when comparing it with the history items.
+        const fluentTranslation = fluent.parser.parseEntry(
+            fluent.serializer.serializeEntry(translation),
+        );
+        return history.translations.find((t) =>
+            fluentTranslation.equals(fluent.parser.parseEntry(t.string)),
+        );
+    }
+    // If translation is a string, from the generic editor.
+    // Except it might actually be a Fluent message from the Simple or Source
+    // editors.
+    if (entity.format === 'ftl') {
+        // For Fluent files, the translation can be stored as a simple string
+        // when the Source editor or the Simple editor are on. Because of that,
+        // we want to turn the string into a Fluent message, as that's simpler
+        // to handle and less prone to errors. We do the same for each history
+        // entry.
+        let fluentTranslation = fluent.parser.parseEntry(translation);
+        if (fluentTranslation.type === 'Junk') {
+            // If the message was junk, it means we are likely in the Simple
+            // editor, and we thus want to reconstruct the Fluent message.
+            // Note that if the user is actually in the Source editor, and
+            // entered an invalid value (which creates this junk entry),
+            // it doesn't matter as there shouldn't be anything matching anyway.
+            fluentTranslation = fluent.getReconstructedMessage(
+                entity.original,
+                translation,
+            );
+        }
+        return history.translations.find((t) =>
+            fluentTranslation.equals(fluent.parser.parseEntry(t.string)),
+        );
+    }
+    return history.translations.find((t) => t.string === translation);
 }
 
 /**
@@ -93,9 +85,7 @@ export function _existingTranslation(
  * exists in the history of the entity, this selector returns that Translation.
  * Othewise, it returns null.
  */
-export const sameExistingTranslation: (
-    ...args: Array<any>
-) => any = createSelector(
+export const sameExistingTranslation = createSelector(
     editorSelector,
     plural.selectors.getTranslationForSelectedEntity,
     historySelector,
@@ -103,14 +93,14 @@ export const sameExistingTranslation: (
     _existingTranslation,
 );
 
-function _isFluentMessage(editorState: EditorState) {
+function _isFluentMessage(editorState: ReturnType<typeof editorSelector>) {
     return typeof editorState.translation !== 'string';
 }
 
 /**
  * Returns `true` if the current editor translation contains a Fluent message.
  */
-const isFluentTranslationMessage: any = createSelector(
+const isFluentTranslationMessage = createSelector(
     editorSelector,
     _isFluentMessage,
 );

--- a/frontend/src/core/entities/selectors.test.js
+++ b/frontend/src/core/entities/selectors.test.js
@@ -24,7 +24,7 @@ describe('selectors', () => {
         it('returns null when the current entity does not exist', () => {
             const params = { entity: 5 };
             const res = _getNextEntity(ENTITIES, params);
-            expect(res).toBeNull();
+            expect(res).toBeUndefined();
         });
     });
 
@@ -46,7 +46,7 @@ describe('selectors', () => {
         it('returns null when the current entity does not exist', () => {
             const params = { entity: 5 };
             const res = _getPreviousEntity(ENTITIES, params);
-            expect(res).toBeNull();
+            expect(res).toBeUndefined();
         });
     });
 

--- a/frontend/src/core/entities/selectors.ts
+++ b/frontend/src/core/entities/selectors.ts
@@ -8,21 +8,22 @@ import { NAME } from '.';
 import type { Entities, Entity } from 'core/api';
 import type { NavigationParams } from 'core/navigation';
 import type { UserState } from 'core/user';
+import type { RootState } from '../../store';
 
-const entitiesSelector = (state): Entities => state[NAME].entities;
-const userSelector = (state): UserState => state[user.NAME];
+const entitiesSelector = (state: RootState) => state[NAME].entities;
+const userSelector = (state: RootState) => state[user.NAME];
 
 export function _getSelectedEntity(
-    entities: Entities,
+    entities: ReturnType<typeof entitiesSelector>,
     params: NavigationParams,
-): Entity | null | undefined {
+): Entity | undefined {
     return entities.find((element) => element.pk === params.entity);
 }
 
 /**
  * Return the currently selected Entity object.
  */
-export const getSelectedEntity: (...args: Array<any>) => any = createSelector(
+export const getSelectedEntity = createSelector(
     entitiesSelector,
     navigation.selectors.getNavigationParams,
     _getSelectedEntity,
@@ -31,13 +32,13 @@ export const getSelectedEntity: (...args: Array<any>) => any = createSelector(
 export function _getNextEntity(
     entities: Entities,
     params: NavigationParams,
-): Entity | null | undefined {
+): Entity | undefined {
     const currentIndex = entities.findIndex(
         (element) => element.pk === params.entity,
     );
 
     if (currentIndex === -1) {
-        return null;
+        return undefined;
     }
 
     const next = currentIndex + 1 >= entities.length ? 0 : currentIndex + 1;
@@ -47,7 +48,7 @@ export function _getNextEntity(
 /**
  * Return the Entity that follows the current one in the list.
  */
-export const getNextEntity: (...args: Array<any>) => any = createSelector(
+export const getNextEntity = createSelector(
     entitiesSelector,
     navigation.selectors.getNavigationParams,
     _getNextEntity,
@@ -56,13 +57,13 @@ export const getNextEntity: (...args: Array<any>) => any = createSelector(
 export function _getPreviousEntity(
     entities: Entities,
     params: NavigationParams,
-): Entity | null | undefined {
+): Entity | undefined {
     const currentIndex = entities.findIndex(
         (element) => element.pk === params.entity,
     );
 
     if (currentIndex === -1) {
-        return null;
+        return undefined;
     }
 
     const previous =
@@ -73,7 +74,7 @@ export function _getPreviousEntity(
 /**
  * Return the Entity that preceeds the current one in the list.
  */
-export const getPreviousEntity: (...args: Array<any>) => any = createSelector(
+export const getPreviousEntity = createSelector(
     entitiesSelector,
     navigation.selectors.getNavigationParams,
     _getPreviousEntity,
@@ -88,7 +89,7 @@ export function _isReadOnlyEditor(entity: Entity, user: UserState): boolean {
  *   - the entity is read-only OR
  *   - the user is not authenticated
  */
-export const isReadOnlyEditor: (...args: Array<any>) => any = createSelector(
+export const isReadOnlyEditor = createSelector(
     getSelectedEntity,
     userSelector,
     _isReadOnlyEditor,

--- a/frontend/src/core/navigation/selectors.ts
+++ b/frontend/src/core/navigation/selectors.ts
@@ -1,7 +1,9 @@
 import { createSelector } from 'reselect';
 
-const pathSelector = (state): string => state.router.location.pathname;
-const querySelector = (state): string => state.router.location.search;
+import type { RootState } from '../../store';
+
+const pathSelector = (state: RootState) => state.router.location.pathname;
+const querySelector = (state: RootState) => state.router.location.search;
 
 export type NavigationParams = {
     locale: string;
@@ -20,7 +22,7 @@ export type NavigationParams = {
  * Return the locale, project, resource and entity that correspond to the
  * current URL.
  */
-export const getNavigationParams: (...args: Array<any>) => any = createSelector(
+export const getNavigationParams = createSelector(
     pathSelector,
     querySelector,
     (path: string, query: string): NavigationParams => {

--- a/frontend/src/core/plural/selectors.ts
+++ b/frontend/src/core/plural/selectors.ts
@@ -3,8 +3,9 @@ import { createSelector } from 'reselect';
 import * as entities from 'core/entities';
 
 import type { EntityTranslation, Entity } from 'core/api';
+import type { RootState } from '../../store';
 
-const pluralSelector = (state): number => state.plural.pluralForm;
+const pluralSelector = (state: RootState) => state.plural.pluralForm;
 
 export function _getPluralForm(
     pluralForm: number,
@@ -23,9 +24,9 @@ export function _getPluralForm(
  * this will correctly return 0 instead of -1. In all other cases, return
  * the plural form as stored in the state.
  */
-export const getPluralForm: (...args: Array<any>) => any = createSelector(
+export const getPluralForm = createSelector(
     pluralSelector,
-    (state) => entities.selectors.getSelectedEntity(state),
+    (state: RootState) => entities.selectors.getSelectedEntity(state),
     _getPluralForm,
 );
 
@@ -55,10 +56,8 @@ export function _getTranslationForSelectedEntity(
  * The active translation is either the approved one, the fuzzy one, or the
  * most recent non-rejected one.
  */
-export const getTranslationForSelectedEntity: (
-    ...args: Array<any>
-) => any = createSelector(
-    (state) => entities.selectors.getSelectedEntity(state),
+export const getTranslationForSelectedEntity = createSelector(
+    (state: RootState) => entities.selectors.getSelectedEntity(state),
     getPluralForm,
     _getTranslationForSelectedEntity,
 );
@@ -81,10 +80,8 @@ export function _getTranslationStringForSelectedEntity(
  * The active translation is either the approved one, the fuzzy one, or the
  * most recent non-rejected one.
  */
-export const getTranslationStringForSelectedEntity: (
-    ...args: Array<any>
-) => any = createSelector(
-    (state) => entities.selectors.getSelectedEntity(state),
+export const getTranslationStringForSelectedEntity = createSelector(
+    (state: RootState) => entities.selectors.getSelectedEntity(state),
     getPluralForm,
     _getTranslationStringForSelectedEntity,
 );

--- a/frontend/src/core/user/selectors.ts
+++ b/frontend/src/core/user/selectors.ts
@@ -5,18 +5,16 @@ import { NAME as PROJECT_NAME } from 'core/project';
 
 import { NAME } from '.';
 
-import type { LocaleState } from 'core/locale';
-import type { ProjectState } from 'core/project';
-import type { UserState } from 'core/user';
+import type { RootState } from '../../store';
 
-const userSelector = (state): UserState => state[NAME];
-const localeSelector = (state): LocaleState => state[LOCALE_NAME];
-const projectSelector = (state): ProjectState => state[PROJECT_NAME];
+const userSelector = (state: RootState) => state[NAME];
+const localeSelector = (state: RootState) => state[LOCALE_NAME];
+const projectSelector = (state: RootState) => state[PROJECT_NAME];
 
 export function _isTranslator(
-    user: UserState,
-    locale: LocaleState,
-    project: ProjectState,
+    user: ReturnType<typeof userSelector>,
+    locale: ReturnType<typeof localeSelector>,
+    project: ReturnType<typeof projectSelector>,
 ): boolean {
     const localeProject = locale.code + '-' + project.slug;
 
@@ -39,7 +37,7 @@ export function _isTranslator(
  * Return true if the user has translator permission for the current project
  * and locale.
  */
-export const isTranslator: (...args: Array<any>) => any = createSelector(
+export const isTranslator = createSelector(
     userSelector,
     localeSelector,
     projectSelector,


### PR DESCRIPTION
This is mostly about fixing selectors to work on the `RootState`.

This reduces the TS errors for `--noImplicitAny`, but increases `--strictNullChecks`. The culprit there is `getSelectedEntity`, which used to be `any` and is `Entity | undefined` now.

I wonder what state we're in when that's undefined.

I also made things just `undefined` instead of `null | undefined`