### PR TITLE
Avoid resetting errors & warning during editor mount

### DIFF
--- a/frontend/src/modules/entitieslist/components/EntitiesList.tsx
+++ b/frontend/src/modules/entitieslist/components/EntitiesList.tsx
@@ -199,29 +199,32 @@ export class EntitiesListBase extends React.Component<InternalProps> {
     ) => {
         const { dispatch, parameters, router, store } = this.props;
 
+        // Do not re-select already selected entity
+        if (entity.pk === parameters.entity) {
+            return;
+        }
+
         const state = store.getState();
         const unsavedChangesExist = state[unsavedchanges.NAME].exist;
         const unsavedChangesIgnored = state[unsavedchanges.NAME].ignored;
 
-        if (entity.pk !== parameters.entity) {
-            dispatch(
-                unsavedchanges.actions.check(
-                    unsavedChangesExist,
-                    unsavedChangesIgnored,
-                    () => {
-                        dispatch(batchactions.actions.resetSelection());
-                        dispatch(editor.actions.reset());
-                        dispatch(
-                            navigation.actions.updateEntity(
-                                router,
-                                entity.pk.toString(),
-                                replaceHistory,
-                            ),
-                        );
-                    },
-                ),
-            );
-        }
+        dispatch(
+            unsavedchanges.actions.check(
+                unsavedChangesExist,
+                unsavedChangesIgnored,
+                () => {
+                    dispatch(batchactions.actions.resetSelection());
+                    dispatch(editor.actions.reset());
+                    dispatch(
+                        navigation.actions.updateEntity(
+                            router,
+                            entity.pk.toString(),
+                            replaceHistory,
+                        ),
+                    );
+                },
+            ),
+        );
     };
 
     getSiblingEntities: (entity: number) => void = (entity: number) => {

--- a/frontend/src/modules/entitieslist/components/EntitiesList.tsx
+++ b/frontend/src/modules/entitieslist/components/EntitiesList.tsx
@@ -197,29 +197,31 @@ export class EntitiesListBase extends React.Component<InternalProps> {
         entity: EntityType,
         replaceHistory?: boolean,
     ) => {
-        const { dispatch, router } = this.props;
+        const { dispatch, parameters, router, store } = this.props;
 
-        const state = this.props.store.getState();
+        const state = store.getState();
         const unsavedChangesExist = state[unsavedchanges.NAME].exist;
         const unsavedChangesIgnored = state[unsavedchanges.NAME].ignored;
 
-        dispatch(
-            unsavedchanges.actions.check(
-                unsavedChangesExist,
-                unsavedChangesIgnored,
-                () => {
-                    dispatch(batchactions.actions.resetSelection());
-                    dispatch(editor.actions.reset());
-                    dispatch(
-                        navigation.actions.updateEntity(
-                            router,
-                            entity.pk.toString(),
-                            replaceHistory,
-                        ),
-                    );
-                },
-            ),
-        );
+        if (entity.pk !== parameters.entity) {
+            dispatch(
+                unsavedchanges.actions.check(
+                    unsavedChangesExist,
+                    unsavedChangesIgnored,
+                    () => {
+                        dispatch(batchactions.actions.resetSelection());
+                        dispatch(editor.actions.reset());
+                        dispatch(
+                            navigation.actions.updateEntity(
+                                router,
+                                entity.pk.toString(),
+                                replaceHistory,
+                            ),
+                        );
+                    },
+                ),
+            );
+        }
     };
 
     getSiblingEntities: (entity: number) => void = (entity: number) => {

--- a/frontend/src/modules/fluenteditor/components/rich/RichTranslationForm.tsx
+++ b/frontend/src/modules/fluenteditor/components/rich/RichTranslationForm.tsx
@@ -88,6 +88,9 @@ export default function RichTranslationForm(
     const entity = useAppSelector((state) =>
         entities.selectors.getSelectedEntity(state),
     );
+    const unsavedChangesExist = useAppSelector(
+        (state) => state.unsavedchanges.exist,
+    );
 
     const tableBodyRef: { current: any } = React.useRef();
 
@@ -157,10 +160,12 @@ export default function RichTranslationForm(
         focusedElementIdRef.current = null;
     }, [entity, changeSource]);
 
-    // Reset checks when content of the editor changes.
+    // Reset checks when content of the editor changes and some changes have been made.
     React.useEffect(() => {
-        dispatch(editor.actions.resetFailedChecks());
-    }, [message, dispatch]);
+        if (unsavedChangesExist) {
+            dispatch(editor.actions.resetFailedChecks());
+        }
+    }, [message, dispatch, unsavedChangesExist]);
 
     // When content of the translation changes, update unsaved changes.
     editor.useUpdateUnsavedChanges(false);

--- a/frontend/src/modules/genericeditor/components/GenericTranslationForm.tsx
+++ b/frontend/src/modules/genericeditor/components/GenericTranslationForm.tsx
@@ -26,6 +26,9 @@ export default function GenericTranslationForm(
     const isReadOnlyEditor = useAppSelector((state) =>
         entities.selectors.isReadOnlyEditor(state),
     );
+    const unsavedChangesExist = useAppSelector(
+        (state) => state.unsavedchanges.exist,
+    );
 
     const handleShortcutsFn = editor.useHandleShortcuts();
 
@@ -46,10 +49,12 @@ export default function GenericTranslationForm(
         }
     }, [translation, changeSource, searchInputFocused]);
 
-    // Reset checks when content of the editor changes.
+    // Reset checks when content of the editor changes and some changes have been made.
     React.useEffect(() => {
-        dispatch(editor.actions.resetFailedChecks());
-    }, [translation, dispatch]);
+        if (unsavedChangesExist) {
+            dispatch(editor.actions.resetFailedChecks());
+        }
+    }, [dispatch, translation, unsavedChangesExist]);
 
     // When the translation or the initial translation changes, check for unsaved changes.
     editor.useUpdateUnsavedChanges(false);


### PR DESCRIPTION
Fixes #2251 by adding an unsaved-changes check to the failed-checks reset that's meant to only be called during editing, rather than also applying when switching between different strings.

This is a little bit of a hack as it relies on `state.unsavedchanges.exist` to change after `state.editor.translation` changes in order to handle the corner cases of going from original -> broken -> original. But 1) it works, and 2) a truly proper fix would have me refactor editor state handling completely, and that's a big enough job that we'll need to prioritise it appropriately.