### PR TITLE
Add infinite scroll hook to Machinery tab

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "react": "16.13.1",
     "react-content-marker": "2.0.0",
     "react-dom": "16.13.1",
+    "react-infinite-scroll-hook": "^4.0.1",
     "react-infinite-scroller": "1.2.4",
     "react-linkify": "0.2.2",
     "react-redux": "7.1.3",

--- a/frontend/src/modules/machinery/components/Machinery.tsx
+++ b/frontend/src/modules/machinery/components/Machinery.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Localized } from '@fluent/react';
+import useInfiniteScroll from 'react-infinite-scroll-hook';
 
 import './Machinery.css';
 
@@ -56,6 +57,13 @@ export const Machinery = ({
         }
     }, [page, searchMachinery]);
 
+    const [sentryRef, { rootRef }] = useInfiniteScroll({
+        loading: machinery.fetching,
+        hasNextPage: machinery.hasMore,
+        onLoadMore: () => setPage((page) => page + 1),
+        rootMargin: '0px 0px 400px 0px',
+    });
+
     const resetSearch = () => {
         searchMachinery('');
         searchInput.current.value = '';
@@ -103,7 +111,7 @@ export const Machinery = ({
                     </Localized>
                 </form>
             </div>
-            <div className='list-wrapper'>
+            <div className='list-wrapper' ref={rootRef}>
                 <ul>
                     {machinery.translations.map((translation, index) => (
                         <Translation
@@ -126,20 +134,13 @@ export const Machinery = ({
                         />
                     ))}
                 </ul>
-                {machinery.hasMore && (
-                    <div className='load-more-container'>
-                        <Localized id='machinery-Machinery--load-more'>
-                            <button
-                                className='load-more-button'
-                                onClick={() => setPage((page) => page + 1)}
-                            >
-                                LOAD MORE
-                            </button>
-                        </Localized>
+                {(machinery.fetching || machinery.hasMore) && (
+                    <div ref={sentryRef}>
+                        <SkeletonLoader
+                            key={0}
+                            items={machinery.searchResults}
+                        />
                     </div>
-                )}
-                {machinery.fetching && (
-                    <SkeletonLoader key={0} items={machinery.searchResults} />
                 )}
             </div>
         </section>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -9890,12 +9890,24 @@ react-focus-lock@2.0.5:
     react-clientside-effect "^1.2.2"
     use-sidecar "^1.0.1"
 
+react-infinite-scroll-hook@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/react-infinite-scroll-hook/-/react-infinite-scroll-hook-4.0.1.tgz#0fea9de7a84764975aad1209baeff286681d83b9"
+  integrity sha512-UzRt1TPLnWV8TZ6Yw2k5vuVZX/d/gOm2NB1hrp48iTcVwV/4dSsUFDsnwrdTqioSl2n6wz2kfo8BowOczsaJRw==
+  dependencies:
+    react-intersection-observer-hook "^2.0.3"
+
 react-infinite-scroller@1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/react-infinite-scroller/-/react-infinite-scroller-1.2.4.tgz#f67eaec4940a4ce6417bebdd6e3433bfc38826e9"
   integrity sha512-/oOa0QhZjXPqaD6sictN2edFMsd3kkMiE19Vcz5JDgHpzEJVqYcmq+V3mkwO88087kvKGe1URNksHEOt839Ubw==
   dependencies:
     prop-types "^15.5.8"
+
+react-intersection-observer-hook@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer-hook/-/react-intersection-observer-hook-2.0.3.tgz#de6a1fb00ffac1acee651e908e7e17e0eff1e8b6"
+  integrity sha512-6LcrY/oUtZqn7HbwLTgSk43/KdZD5LZJsWUOwQB11aMPi3OkjyDcm2dwAQ1ydlbrSDlL4fHUNXisNt4B470UJg==
 
 react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-is@^16.9.0:
   version "16.13.1"


### PR DESCRIPTION
Resolves: #2270 

This PR replaces the `Load more` button used for pagination in the Machinery tab with an infinite scroll utilizing a [React hook](https://github.com/onderonur/react-infinite-scroll-hook).