### PR TITLE
refactor pinned comments to be only in pinned comment section

### DIFF
--- a/frontend/src/core/comments/components/CommentsList.css
+++ b/frontend/src/core/comments/components/CommentsList.css
@@ -28,6 +28,13 @@
     margin-left: 58px;
 }
 
+.comments-list .all-comments .title {
+    color: #aaa;
+    font-size: 11px;
+    font-weight: 100;
+    margin-bottom: 6px;
+}
+
 .comments-list .comment .user-avatar {
     padding-right: 8px;
 }

--- a/frontend/src/core/comments/components/CommentsList.css
+++ b/frontend/src/core/comments/components/CommentsList.css
@@ -28,13 +28,6 @@
     margin-left: 58px;
 }
 
-.comments-list .all-comments .title {
-    color: #aaa;
-    font-size: 11px;
-    font-weight: 100;
-    margin-bottom: 6px;
-}
-
 .comments-list .comment .user-avatar {
     padding-right: 8px;
 }

--- a/frontend/src/core/comments/components/CommentsList.tsx
+++ b/frontend/src/core/comments/components/CommentsList.tsx
@@ -37,6 +37,7 @@ export default function CommentsList(props: Props): React.ReactElement<'div'> {
         resetContactPerson,
     } = props;
 
+    console.log({ user });
     const translationId = translation ? translation.pk : null;
 
     // rendering comment
@@ -53,6 +54,10 @@ export default function CommentsList(props: Props): React.ReactElement<'div'> {
 
     const pinnedComments = comments.filter((comment) => comment.pinned);
     const unpinnedComments = comments.filter((comment) => !comment.pinned);
+    const produceAllComments =
+        !user.isAuthenticated &&
+        unpinnedComments.length === 0 &&
+        pinnedComments.length;
 
     return (
         <div className='comments-list'>
@@ -69,25 +74,29 @@ export default function CommentsList(props: Props): React.ReactElement<'div'> {
                     </ul>
                 </section>
             ) : null}
-            <section className='all-comments'>
-                <Localized id='comments-CommentsList--all-comments'>
-                    <h2 className='title'>ALL COMMENTS</h2>
-                </Localized>
+            {!produceAllComments ? (
+                <section className='all-comments'>
+                    <Localized id='comments-CommentsList--all-comments'>
+                        <h2 className='title'>ALL COMMENTS</h2>
+                    </Localized>
 
-                <ul>
-                    {unpinnedComments.map((comment) => renderComment(comment))}
-                </ul>
-                {!canComment ? null : (
-                    <AddComment
-                        parameters={parameters}
-                        translation={translationId}
-                        user={user}
-                        addComment={addComment}
-                        contactPerson={contactPerson}
-                        resetContactPerson={resetContactPerson}
-                    />
-                )}
-            </section>
+                    <ul>
+                        {unpinnedComments.map((comment) =>
+                            renderComment(comment),
+                        )}
+                    </ul>
+                    {!canComment ? null : (
+                        <AddComment
+                            parameters={parameters}
+                            translation={translationId}
+                            user={user}
+                            addComment={addComment}
+                            contactPerson={contactPerson}
+                            resetContactPerson={resetContactPerson}
+                        />
+                    )}
+                </section>
+            ) : null}
         </div>
     );
 }

--- a/frontend/src/core/comments/components/CommentsList.tsx
+++ b/frontend/src/core/comments/components/CommentsList.tsx
@@ -53,7 +53,7 @@ export default function CommentsList(props: Props): React.ReactElement<'div'> {
 
     const pinnedComments = comments.filter((comment) => comment.pinned);
     const unpinnedComments = comments.filter((comment) => !comment.pinned);
-    const produceAllComments =
+    const hideComments =
         !canComment && unpinnedComments.length === 0 && pinnedComments.length;
 
     return (
@@ -69,7 +69,7 @@ export default function CommentsList(props: Props): React.ReactElement<'div'> {
                             renderComment(comment),
                         )}
                     </ul>
-                    {!produceAllComments ? (
+                    {!hideComments ? (
                         <Localized id='comments-CommentsList--all-comments'>
                             <h2 className='title'>ALL COMMENTS</h2>
                         </Localized>

--- a/frontend/src/core/comments/components/CommentsList.tsx
+++ b/frontend/src/core/comments/components/CommentsList.tsx
@@ -53,7 +53,7 @@ export default function CommentsList(props: Props): React.ReactElement<'div'> {
 
     const pinnedComments = comments.filter((comment) => comment.pinned);
     const unpinnedComments = comments.filter((comment) => !comment.pinned);
-    const hideComments =
+    const hideAllComments =
         !canComment && unpinnedComments.length === 0 && pinnedComments.length;
 
     return (
@@ -69,7 +69,7 @@ export default function CommentsList(props: Props): React.ReactElement<'div'> {
                             renderComment(comment),
                         )}
                     </ul>
-                    {!hideComments ? (
+                    {!hideAllComments ? (
                         <Localized id='comments-CommentsList--all-comments'>
                             <h2 className='title'>ALL COMMENTS</h2>
                         </Localized>

--- a/frontend/src/core/comments/components/CommentsList.tsx
+++ b/frontend/src/core/comments/components/CommentsList.tsx
@@ -37,7 +37,6 @@ export default function CommentsList(props: Props): React.ReactElement<'div'> {
         resetContactPerson,
     } = props;
 
-    console.log({ user });
     const translationId = translation ? translation.pk : null;
 
     // rendering comment
@@ -55,9 +54,7 @@ export default function CommentsList(props: Props): React.ReactElement<'div'> {
     const pinnedComments = comments.filter((comment) => comment.pinned);
     const unpinnedComments = comments.filter((comment) => !comment.pinned);
     const produceAllComments =
-        !user.isAuthenticated &&
-        unpinnedComments.length === 0 &&
-        pinnedComments.length;
+        !canComment && unpinnedComments.length === 0 && pinnedComments.length;
 
     return (
         <div className='comments-list'>
@@ -72,31 +69,28 @@ export default function CommentsList(props: Props): React.ReactElement<'div'> {
                             renderComment(comment),
                         )}
                     </ul>
+                    {!produceAllComments ? (
+                        <Localized id='comments-CommentsList--all-comments'>
+                            <h2 className='title'>ALL COMMENTS</h2>
+                        </Localized>
+                    ) : null}
                 </section>
             ) : null}
-            {!produceAllComments ? (
-                <section className='all-comments'>
-                    <Localized id='comments-CommentsList--all-comments'>
-                        <h2 className='title'>ALL COMMENTS</h2>
-                    </Localized>
-
-                    <ul>
-                        {unpinnedComments.map((comment) =>
-                            renderComment(comment),
-                        )}
-                    </ul>
-                    {!canComment ? null : (
-                        <AddComment
-                            parameters={parameters}
-                            translation={translationId}
-                            user={user}
-                            addComment={addComment}
-                            contactPerson={contactPerson}
-                            resetContactPerson={resetContactPerson}
-                        />
-                    )}
-                </section>
-            ) : null}
+            <section className='all-comments'>
+                <ul>
+                    {unpinnedComments.map((comment) => renderComment(comment))}
+                </ul>
+                {!canComment ? null : (
+                    <AddComment
+                        parameters={parameters}
+                        translation={translationId}
+                        user={user}
+                        addComment={addComment}
+                        contactPerson={contactPerson}
+                        resetContactPerson={resetContactPerson}
+                    />
+                )}
+            </section>
         </div>
     );
 }

--- a/frontend/src/core/comments/components/CommentsList.tsx
+++ b/frontend/src/core/comments/components/CommentsList.tsx
@@ -52,6 +52,7 @@ export default function CommentsList(props: Props): React.ReactElement<'div'> {
     };
 
     const pinnedComments = comments.filter((comment) => comment.pinned);
+    const unpinnedComments = comments.filter((comment) => !comment.pinned);
 
     return (
         <div className='comments-list'>
@@ -73,7 +74,9 @@ export default function CommentsList(props: Props): React.ReactElement<'div'> {
                 </section>
             ) : null}
             <section className='all-comments'>
-                <ul>{comments.map((comment) => renderComment(comment))}</ul>
+                <ul>
+                    {unpinnedComments.map((comment) => renderComment(comment))}
+                </ul>
                 {!canComment ? null : (
                     <AddComment
                         parameters={parameters}

--- a/frontend/src/core/comments/components/CommentsList.tsx
+++ b/frontend/src/core/comments/components/CommentsList.tsx
@@ -67,13 +67,13 @@ export default function CommentsList(props: Props): React.ReactElement<'div'> {
                             renderComment(comment),
                         )}
                     </ul>
-
-                    <Localized id='comments-CommentsList--all-comments'>
-                        <h2 className='title'>ALL COMMENTS</h2>
-                    </Localized>
                 </section>
             ) : null}
             <section className='all-comments'>
+                <Localized id='comments-CommentsList--all-comments'>
+                    <h2 className='title'>ALL COMMENTS</h2>
+                </Localized>
+
                 <ul>
                     {unpinnedComments.map((comment) => renderComment(comment))}
                 </ul>


### PR DESCRIPTION
Fixes #2266 this PR is supposed to set pinned comments in the pinned section only; this is illustrated in the screenshot below.

![Screen Shot 2022-01-05 at 5 27 13 AM](https://user-images.githubusercontent.com/69736237/148225616-7cdc12ef-a082-42cc-92f5-b68061ae3cb6.png)
