### PR TITLE
Fix bad alignment on Contributor page on Webkit/Blink browsers

### DIFF
--- a/pontoon/contributors/templates/contributors/profile.html
+++ b/pontoon/contributors/templates/contributors/profile.html
@@ -41,7 +41,7 @@
     </li>
     <li>
       <span class="fa fa-fw fa-lock"></span>
-      {{ contributor|display_permissions() }}
+      <span>{{ contributor|display_permissions() }}</span>
     </li>
     {% if my_profile %}
     <li class="settings">


### PR DESCRIPTION
If you open https://pontoon.mozilla.org/contributors/dvgiVCmoeidF2xcqSnBHtpzLTFU/ in e.g. Safari, you'll notice misaligned email and permission entries:

<img width="435" alt="Screenshot 2022-01-14 at 21 31 12" src="https://user-images.githubusercontent.com/626716/149581251-6bb45045-667d-4caa-9fca-319862fdb299.png">

This patch fixes that.