### PR TITLE
Do not overflow dashboard tabs into new line

### DIFF
--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -1116,6 +1116,7 @@ nav .links li {
 .submenu.tabs .links {
     margin-bottom: -1px;
     text-align: left;
+    white-space: nowrap;
     width: 100%;
 }
 
@@ -1132,7 +1133,7 @@ nav .links li {
 }
 
 .submenu.tabs .links a {
-    padding: 12px 25px;
+    padding: 12px 20px;
     width: 100%;
 
     -moz-box-sizing: border-box;


### PR DESCRIPTION
On https://pontoon.mozilla.org/fr/firefox/contributors/, this happens:

<img width="1008" alt="Screenshot 2022-01-15 at 22 27 25" src="https://user-images.githubusercontent.com/626716/149638246-d39ba4b9-5aca-4f75-ad76-d13b5ae633fa.png">

This patch reduces the tab width to prevent the above ugliness, and prevents dashboard tabs from overflowing into a new line in general.