### PR TITLE
Restore CSP and CSRF protection on /graphql

### DIFF
--- a/pontoon/api/README.md
+++ b/pontoon/api/README.md
@@ -1,10 +1,7 @@
 # GraphQL API
 
-Pontoon exposes some of its data via a public API endpoint.
-
-The API is [GraphQL](http://graphql.org/)-based and available at ``/graphql``.  
-The endpoint is exempt from CSP and CSRF validation so that is can be accessed
-by third-party code with ease.
+Pontoon exposes some of its data via a public API endpoint. The API is
+[GraphQL](http://graphql.org/)-based and available at ``/graphql``.
 
 
 ## Production Deployments

--- a/pontoon/api/urls.py
+++ b/pontoon/api/urls.py
@@ -1,8 +1,6 @@
-from csp.decorators import csp_exempt
 from graphene_django.views import GraphQLView
 
 from django.urls import path
-from django.views.decorators.csrf import csrf_exempt
 
 from pontoon.api.schema import schema
 from pontoon.settings import DEV
@@ -12,6 +10,6 @@ urlpatterns = [
     # GraphQL endpoint. In DEV mode it serves the GraphiQL IDE if accessed with Accept: text/html
     path(
         "graphql",
-        csp_exempt(csrf_exempt(GraphQLView.as_view(schema=schema, graphiql=DEV))),
+        GraphQLView.as_view(schema=schema, graphiql=DEV),
     ),
 ]

--- a/pontoon/settings/dev.py
+++ b/pontoon/settings/dev.py
@@ -47,6 +47,7 @@ CSP_SCRIPT_SRC = base.CSP_SCRIPT_SRC + (
     "http://ajax.googleapis.com",
     # Needed for GraphiQL
     "https://cdn.jsdelivr.net",
+    # Needed for GraphiQL (inline script)
     "'sha256-gp1+DqtmqR6gC56O1TE7F+GuoHAHHbXyN+gaBi8gcjo='",
 )
 CSP_STYLE_SRC = base.CSP_STYLE_SRC + (

--- a/pontoon/settings/dev.py
+++ b/pontoon/settings/dev.py
@@ -42,7 +42,16 @@ TEMPLATES[0]["OPTIONS"]["match_regex"] = re.compile(
     re.VERBOSE,
 )
 
-CSP_SCRIPT_SRC = base.CSP_SCRIPT_SRC + ("http://ajax.googleapis.com",)
 CSP_IMG_SRC = base.CSP_IMG_SRC + ("data:",)
+CSP_SCRIPT_SRC = base.CSP_SCRIPT_SRC + (
+    "http://ajax.googleapis.com",
+    # Needed for GraphiQL
+    "https://cdn.jsdelivr.net",
+    "'sha256-gp1+DqtmqR6gC56O1TE7F+GuoHAHHbXyN+gaBi8gcjo='",
+)
+CSP_STYLE_SRC = base.CSP_STYLE_SRC + (
+    # Needed for GraphiQL
+    "https://cdn.jsdelivr.net",
+)
 
 GRAPHENE = {"MIDDLEWARE": ["graphene_django.debug.DjangoDebugMiddleware"]}


### PR DESCRIPTION
Content Security Policy should be only exempt if it absolutely cannot be used. It doesn't seem like this is the case for our GraphQL endpoint. The same goes for CSRF.