### PR TITLE
Correct 'unaproved' to 'unapproved' in relevant locations 

### DIFF
--- a/frontend/public/static/locale/en-US/translate.ftl
+++ b/frontend/public/static/locale/en-US/translate.ftl
@@ -501,7 +501,7 @@ machinery-TranslationMemory--number-occurrences =
 ## Messages shown to users after they perform actions.
 
 notification--translation-approved = Translation approved
-notification--translation-unaproved = Translation unaproved
+notification--translation-unapproved = Translation unapproved
 notification--translation-rejected = Translation rejected
 notification--translation-unrejected = Translation unrejected
 notification--translation-deleted = Translation deleted

--- a/frontend/public/static/locale/fr/translate.ftl
+++ b/frontend/public/static/locale/fr/translate.ftl
@@ -164,7 +164,7 @@ machinery-Translation--number-occurrences =
 ## Messages shown to users after they perform actions.
 
 notification--translation-approved = Traduction approuvée
-notification--translation-unaproved = Traduction désapprouvée
+notification--translation-unapproved = Traduction désapprouvée
 notification--translation-rejected = Traduction rejetée
 notification--translation-unrejected = Traduction dérejetée
 notification--translation-deleted = Traduction supprimée

--- a/frontend/src/core/notification/messages.tsx
+++ b/frontend/src/core/notification/messages.tsx
@@ -13,8 +13,8 @@ const messages: Record<string, NotificationMessage> = {
     },
     TRANSLATION_UNAPPROVED: {
         content: (
-            <Localized id='notification--translation-unaproved'>
-                Translation unaproved
+            <Localized id='notification--translation-unapproved'>
+                Translation unapproved
             </Localized>
         ),
         type: 'info',


### PR DESCRIPTION
Fixes #2426