### PR TITLE
Add workflow_dispatch triggers for all actions

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -17,6 +17,7 @@ on:
       - docker**
       - pontoon/**
       - .github/workflows/backend.yml
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -13,6 +13,7 @@ on:
     paths:
       - frontend/**
       - .github/workflows/frontend.yml
+  workflow_dispatch:
 
 jobs:
   typescript:

--- a/.github/workflows/heroku.yml
+++ b/.github/workflows/heroku.yml
@@ -13,6 +13,7 @@ on:
     paths:
       - app.json
       - .github/workflows/heroku.yml
+  workflow_dispatch:
 
 jobs:
   app-json:

--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -25,6 +25,7 @@ on:
       - '.*eslint*'
       - '.*prettier*'
       - .github/workflows/js-lint.yml
+  workflow_dispatch:
 
 jobs:
   eslint:

--- a/.github/workflows/non-frontend-js.yml
+++ b/.github/workflows/non-frontend-js.yml
@@ -19,6 +19,7 @@ on:
       - package.json
       - webpack.config.js
       - .github/workflows/non-frontend-js.yml
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/py-lint.yml
+++ b/.github/workflows/py-lint.yml
@@ -15,6 +15,7 @@ on:
       - pontoon/**.py
       - .github/workflows/py-lint.yml
       - requirements/lint.txt
+  workflow_dispatch:
 
 jobs:
   flake8:


### PR DESCRIPTION
Sometimes, it's useful to be able to manually start a CI job, e.g. when working on a feature branch. By adding an empty `workflow_dispatch` value to the GitHub actions' `on` object, this becomes possible: https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow