### PR TITLE
Validate Repository URLs

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -1801,7 +1801,7 @@ def repository_url_validator(url):
     validator = URLValidator(["http", "https", "ftp", "ftps", "ssh", "svn+ssh"])
 
     # Git SCP-like URL
-    pattern = r"(?P<user>git@([\w\.@]+)(/|:))(?P<server>[\w,\-,\_]+)/(?P<project>[\w,\-,\_]+)(.git){0,1}((/){0,1})"
+    pattern = r"git@[\w\.@]+[/:][\w-]+/[\w-]+(.git)?/?"
 
     try:
         validator(url)

--- a/pontoon/base/tests/models/test_repository.py
+++ b/pontoon/base/tests/models/test_repository.py
@@ -4,6 +4,9 @@ from urllib.parse import urlparse
 
 import pytest
 
+from django.core.exceptions import ValidationError
+
+from pontoon.base.models import repository_url_validator
 from pontoon.test.factories import ProjectLocaleFactory
 
 
@@ -222,3 +225,18 @@ def test_repo_commit_multi_locale(repo_git):
             "https://example.com/for_path",
         )
         assert repo_git.url_for_path.call_args[0] == ("path",)
+
+
+def test_repository_url_validator():
+    """
+    The validity of the Repository URL.
+    """
+    regular_url = "https://example.com/"
+    assert repository_url_validator(regular_url) is None
+
+    git_scp_url = "git@github.com:user/repository.git"
+    assert repository_url_validator(git_scp_url) is None
+
+    invalid_url = "--evil=parameter"
+    with pytest.raises(ValidationError):
+        repository_url_validator(invalid_url)


### PR DESCRIPTION
We should validate Repository URLs before they are stored into the DB.

The `repository_url_validator()` has been tested with all Repository URLs on pontoon.mozilla.org. It supports all HTTP(S), FTP(S), SSH and SVN+SSH URLs, as well as Git SCP-like SSH URL.