### PR TITLE
Update MS Terminology Request / Response according to the new API version

### DIFF
--- a/pontoon/machinery/templates/machinery/microsoft_terminology.jinja
+++ b/pontoon/machinery/templates/machinery/microsoft_terminology.jinja
@@ -6,9 +6,10 @@
             <text>{{ text }}</text>
             <from>en-US</from>
             <to>{{ to }}</to>
-            <sources>
-                <TranslationSource>Terms</TranslationSource>
-                <TranslationSource>UiStrings</TranslationSource>
+            <sources xmlns:a="https://api.terminology.microsoft.com/terminology"
+                xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+                <a:TranslationSource>Terms</a:TranslationSource>
+                <a:TranslationSource>UiStrings</a:TranslationSource>
             </sources>
             <maxTranslations>{{ max_result }}</maxTranslations>
         </GetTranslations>

--- a/pontoon/machinery/views.py
+++ b/pontoon/machinery/views.py
@@ -312,16 +312,20 @@ def microsoft_terminology(request):
         r.raise_for_status()
 
         translations = []
-        xpath = ".//{http://api.terminology.microsoft.com/terminology}"
+        namespaces = {"a": "https://api.terminology.microsoft.com/terminology"}
         root = ET.fromstring(r.content)
-        results = root.find(xpath + "GetTranslationsResult")
+        results = root.find(
+            ".//{http://api.terminology.microsoft.com/terminology}GetTranslationsResult"
+        )
 
         if results is not None:
             for translation in results:
                 translations.append(
                     {
-                        "source": translation.find(xpath + "OriginalText").text,
-                        "target": translation.find(xpath + "TranslatedText").text,
+                        "source": translation.find("a:OriginalText", namespaces).text,
+                        "target": translation.find(
+                            ".//a:TranslatedText", namespaces
+                        ).text,
                     }
                 )
 


### PR DESCRIPTION
Fixes #2447 and makes Microsoft Terminology Service work again.

Note that this is the only external service that doesn't require authentication, so it also works (and can be tested) locally.