### PR TITLE
Prevent AttributeError on Tour for AnonymousUsers

### DIFF
--- a/pontoon/tour/views.py
+++ b/pontoon/tour/views.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.decorators import login_required
 from django.http import JsonResponse
 from django.views.decorators.http import require_POST
 
@@ -5,6 +6,7 @@ from pontoon.base.utils import require_AJAX
 from pontoon.tour.forms import UserTourStatusForm
 
 
+@login_required(redirect_field_name="", login_url="/403")
 @require_AJAX
 @require_POST
 def update_tour_status(request):


### PR DESCRIPTION
This fixes the following server error, which occurs for non-authenticated users of Pontoon Tour:

```
[ERROR:django.request] 2022-04-03 19:55:23,337 Internal Server Error: /update-tour-status/
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.9/site-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/app/pontoon/base/utils.py", line 123, in wrap
    return f(request, *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/django/views/decorators/http.py", line 40, in inner
    return func(request, *args, **kwargs)
  File "/app/pontoon/tour/views.py", line 14, in update_tour_status
    instance=request.user.profile,
  File "/usr/local/lib/python3.9/site-packages/django/utils/functional.py", line 247, in inner
    return func(self._wrapped, *args)
AttributeError: 'AnonymousUser' object has no attribute 'profile'
```