### PR TITLE
Switch pretranslated/fuzzy checkbox colors

### DIFF
--- a/translate/src/modules/history/components/Translation.css
+++ b/translate/src/modules/history/components/Translation.css
@@ -136,11 +136,11 @@
 }
 
 .history .translation.pretranslated .content > header button.approve:before {
-  color: #fed271;
+  color: #c0ff00;
 }
 
 .history .translation.fuzzy .content > header button.approve:before {
-  color: #c0ff00;
+  color: #fed271;
 }
 
 .history .translation .content > header button.approve:before,


### PR DESCRIPTION
Checkbox colors in the History panel are off.