### PR TITLE
Base keyboard shortcuts on key values rather than positions

### DIFF
--- a/translate/src/core/editor/hooks/useHandleShortcuts.ts
+++ b/translate/src/core/editor/hooks/useHandleShortcuts.ts
@@ -63,8 +63,7 @@ export default function useHandleShortcuts(): (
     clearEditorCustom?: () => void,
     copyOriginalIntoEditorCustom?: () => void,
   ) => {
-    // FIXME: When updating to react@17, use ev.code
-    switch (ev.nativeEvent.code) {
+    switch (ev.key) {
       // On Enter:
       //   - If unsaved changes popup is shown, proceed.
       //   - If failed checks popup is shown after approving a translation, approve it anyway.
@@ -106,7 +105,7 @@ export default function useHandleShortcuts(): (
         break;
 
       // On Ctrl + Shift + C, copy the original translation.
-      case 'KeyC':
+      case 'C':
         if (ev.ctrlKey && ev.shiftKey && !ev.altKey) {
           ev.preventDefault();
           (copyOriginalIntoEditorCustom || copyOriginalIntoEditor)();
@@ -138,8 +137,7 @@ export default function useHandleShortcuts(): (
           ev.preventDefault();
 
           const nextIdx =
-            // FIXME: When updating to react@17, use ev.code
-            ev.nativeEvent.code === 'ArrowDown'
+            ev.key === 'ArrowDown'
               ? (selectedHelperElementIndex + 1) % numTranslations
               : (selectedHelperElementIndex - 1 + numTranslations) %
                 numTranslations;

--- a/translate/src/modules/search/components/SearchBox.test.js
+++ b/translate/src/modules/search/components/SearchBox.test.js
@@ -300,7 +300,7 @@ describe('<SearchBox>', () => {
     );
     document.dispatchEvent(
       new KeyboardEvent('keydown', {
-        code: 'KeyF',
+        key: 'F',
         ctrlKey: true,
         shiftKey: true,
       }),

--- a/translate/src/modules/search/components/SearchBox.tsx
+++ b/translate/src/modules/search/components/SearchBox.tsx
@@ -103,7 +103,7 @@ export function SearchBoxBase({
   useEffect(() => {
     const handleShortcuts = (ev: KeyboardEvent) => {
       // On Ctrl + Shift + F, set focus on the search input.
-      if (ev.code === 'KeyF' && !ev.altKey && ev.ctrlKey && ev.shiftKey) {
+      if (ev.key === 'F' && !ev.altKey && ev.ctrlKey && ev.shiftKey) {
         ev.preventDefault();
         searchInput.current?.focus();
       }


### PR DESCRIPTION
Fixes #2475 

In #2444, the keyboard shortcuts were switched from using the deprecated KeyboardEvent `keyCode` to `code`, when they should have been switched to using `key`. Both `code` and `key` use string identifiers for the keys, but `code` is concerned with physical keys while `key` with logical ones. This means that `code` has different values for the different return keys; `Enter` and `NumpadEnter`.

@mathjazz Are you able to test if this does anything for #2476, or if that's a different issue?