### PR TITLE
Always return an array from EntityAPI#getHistory()

### DIFF
--- a/translate/src/core/api/base.ts
+++ b/translate/src/core/api/base.ts
@@ -75,10 +75,12 @@ export default class APIBase {
       return await response.json();
     } catch (e) {
       // Catch non-JSON responses
-      /* eslint-disable no-console */
-      console.error('The response content is not JSON-compatible');
-      console.error(`URL: ${url} - Method: ${method}`);
-      console.error(e);
+      if (!(e instanceof Error) || e.name !== 'AbortError') {
+        /* eslint-disable no-console */
+        console.error('The response content is not JSON-compatible');
+        console.error(`URL: ${url} - Method: ${method}`);
+        console.error(e);
+      }
 
       return {};
     }

--- a/translate/src/core/api/entity.ts
+++ b/translate/src/core/api/entity.ts
@@ -118,7 +118,7 @@ export default class EntityAPI extends APIBase {
     entity: number,
     locale: string,
     pluralForm: number = -1,
-  ): Promise<any> {
+  ): Promise<unknown[]> {
     const payload = new URLSearchParams();
     payload.append('entity', entity.toString());
     payload.append('locale', locale);
@@ -129,7 +129,8 @@ export default class EntityAPI extends APIBase {
 
     const results = await this.fetch('/get-history/', 'GET', payload, headers);
 
-    return this.keysToCamelCase(results);
+    // On error or abort, fetch() returns an empty object
+    return Array.isArray(results) ? this.keysToCamelCase(results) : [];
   }
 
   async getSiblingEntities(entity: number, locale: string): Promise<any> {

--- a/translate/src/modules/history/actions.ts
+++ b/translate/src/modules/history/actions.ts
@@ -81,7 +81,7 @@ export function get(entity: number, locale: string, pluralForm: number) {
 
     const content = await api.entity.getHistory(entity, locale, pluralForm);
 
-    dispatch(receive(content));
+    dispatch(receive(content as HistoryTranslation[]));
   };
 }
 


### PR DESCRIPTION
Fixes #2474 

When a request is aborted, `fetch()` may still return a valid object (TIL). Calling then the response's `json()` method will throw an error with `name: 'AbortError'`. The APIBase class's `fetch()` wrapper will then log the error with `console.error()`, and return an empty object `{}`.

This probably breaks assumptions all over the place in the `translate` front-end as API results are never actually validated. In this particular instance, the assumption it's breaking is that the history will be an array. An empty object, on the other hand, has `undefined` length and no `find()` method, and thereby triggers the reported error condition.

This is a fix for this specific endpoint, rather than the general case.