### PR TITLE
Clarify visibility of data in the profile page

### DIFF
--- a/specs/0111-redesign-profile-page.md
+++ b/specs/0111-redesign-profile-page.md
@@ -18,12 +18,6 @@ Locale managers and administrators should be able to determine the quality of co
 
 See the [mockup](#mockup) for the overall view. Each of the following sections provides more details on different parts of the design.
 
-## Latest activity
-
-*Latest activity* is displayed in the sidebar. A user is considered active when they either submit a suggestion or review someone else’s work. It’s not considered activity:
-* Logging in to Pontoon.
-* Writing a comment.
-
 ## Approval ratio
 
 Displayed in a graph, it’s the ratio between the number of translations approved over the total number of translations submitted, excluding self-approved translations (either submitted directly as translations, or provided as suggestions and later approved by the translator).
@@ -36,7 +30,7 @@ The graph displays both the specific month’s ratio and the average for the pre
 
 ## Self-approval ratio
 
-Displayed in a graph, it’s the ratio between the number of translations submitted directly — or self-approved after submitting them as suggestions — over the total number of translations submitted. This data point is meaningful only for users with translation rights (translators, locale managers), as it will always be 0 for contributors.
+Displayed in a graph, it’s the ratio between the number of translations submitted directly — or self-approved after submitting them as suggestions — over the total number of translations submitted. This data point is meaningful only for users with translator rights (translators, locale managers), as it will always be 0 for contributors.
 
 Example: if a person has 100 approved translations, but 60 are self-approved, the self-approval ratio will be 60%.
 
@@ -57,6 +51,12 @@ Each square in the graph represents a day, with color changing depending on the 
 
 When selecting a specific time range, the data displayed below the graph is updated accordingly. This doesn’t affect the approval and self-approval graphs.
 
+## Latest activity
+
+*Latest activity* is displayed in the sidebar. A user is considered active when they either submit a suggestion or review someone else’s work. It’s not considered activity:
+* Logging in to Pontoon.
+* Writing a comment.
+
 ## Other data in the sidebar
 
 The sidebar displays contact information for the contributor:
@@ -73,23 +73,21 @@ The sidebar displays contact information for the contributor:
 
 ## Visibility of data
 
-Most of the data will be visible by default to all users, including non authenticated visitors (i.e. users not logged in to Pontoon).
+Most of the data will always be visible to all users, including users not logged in to Pontoon.
 
-Visibility for the following fields can be limited by user settings:
-* Email address (default: limited for contributors and translators, public for locale managers and administrators).
-* External accounts (default: limited).
-* Self-approval ratio (default: public).
-* Approval ratio (default: public).
+Visibility of the following fields can be configured by users:
+* Email address (default: users with translator rights only, option: logged in users).
+* External accounts (default: users with translator rights only, option: all users).
+* Self-approval ratio (default: all users, option: users with translator rights only).
+* Approval ratio (default: all users, option: users with translator rights only).
 
-Limited means that non authenticated users, and other contributors, won’t be able to see this information when they visit the profile page. But this information will be always visible to users with translator rights for any locale in Pontoon (translators, locale managers, administrators).
+Note: The email addresses of managers and administrators will always be visible to all logged in users, since contributors need to be able to contact them.
 
 ## Dependencies and other changes
 
 ### Email address
 
-Users should be able to provide a *contact email address* that will be displayed in the profile page (pending personal visibility settings). If not provided, the email address associated to the account used to log in to Pontoon will be displayed.
-
-The email address of managers and administrators will always be public, since contributors need to be able to contact them.
+Users should be able to provide a *contact email address* that will be displayed in the profile page. If not provided, the email address associated to the account used to log in to Pontoon will be displayed.
 
 ### External accounts
 


### PR DESCRIPTION
- Email address should never we visible to all users.
- Replace the term "limited visibility" with more self-explanatory "users with translator rights".
- Move Latest activity section closer to the Other data in the sidebar section.
- Use the term "translator rights" consistently.
- Move email address visibility details from the Email address section to the Visibility section.