### PR TITLE
Fix #2434: Rename Deadline to Target Date

### DIFF
--- a/pontoon/base/templates/widgets/heading_info.html
+++ b/pontoon/base/templates/widgets/heading_info.html
@@ -27,7 +27,7 @@
 
 {% macro details_item_deadline(deadline, complete) %}
 <li class="deadline">
-  <span class="title">Deadline</span>
+  <span class="title">Target Date</span>
   <span class="value">
     {{ Deadline.deadline(deadline, complete) }}
   </span>

--- a/pontoon/contributors/templates/contributors/settings.html
+++ b/pontoon/contributors/templates/contributors/settings.html
@@ -70,7 +70,7 @@
         <h3>Notification subscriptions</h3>
         <ul class="info check-list">
             {{ Checkbox.checkbox('New string notifications', class='new-string-notifications', attribute='new_string_notifications', is_enabled=user.profile.new_string_notifications, title='Get notified when new strings are added to your projects') }}
-            {{ Checkbox.checkbox('Project deadline notifications', class='project-deadline-notifications', attribute='project_deadline_notifications', is_enabled=user.profile.project_deadline_notifications, title='Get notified when project deadline approaches') }}
+            {{ Checkbox.checkbox('Project target date notifications', class='project-deadline-notifications', attribute='project_deadline_notifications', is_enabled=user.profile.project_deadline_notifications, title='Get notified when project target date approaches') }}
             {{ Checkbox.checkbox('Comment notifications', class='comment-notifications', attribute='comment_notifications', is_enabled=user.profile.comment_notifications, title='Get notified when comments are submitted to your strings') }}
             {{ Checkbox.checkbox('Unreviewed suggestion notifications', class='unreviewed-suggestion-notifications', attribute='unreviewed_suggestion_notifications', is_enabled=user.profile.unreviewed_suggestion_notifications, title='Get notified when new suggestions are ready for review') }}
             {{ Checkbox.checkbox('Review notifications', class='review-notifications', attribute='review_notifications', is_enabled=user.profile.review_notifications, title='Get notified when your suggestions are approved or rejected') }}

--- a/pontoon/homepage/templates/homepage_content.html
+++ b/pontoon/homepage/templates/homepage_content.html
@@ -79,7 +79,7 @@
           </div>
           <div class="box">
             <div class="box-image far fa-clock"></div>
-            <p>Deadline and priority info</p>
+            <p>Target dates and priorities</p>
           </div>
         </div>
         <div class="flex">

--- a/pontoon/localizations/templates/localizations/widgets/resource_list.html
+++ b/pontoon/localizations/templates/localizations/widgets/resource_list.html
@@ -10,7 +10,7 @@
         <th class="resource{% if deadline %} with-deadline{% endif %}{% if priority %} with-priority{% endif %} asc">Resource<i class="fa"></i></th>
 
         {% if deadline %}
-        <th class="deadline">Deadline<i class="fa"></i></th>
+        <th class="deadline">Target Date<i class="fa"></i></th>
         {% endif %}
 
         {% if priority %}

--- a/pontoon/projects/management/commands/send_deadline_notifications.py
+++ b/pontoon/projects/management/commands/send_deadline_notifications.py
@@ -8,12 +8,12 @@ from pontoon.base.models import Project
 
 
 class Command(BaseCommand):
-    help = "Notify contributors about the approaching project deadline"
+    help = "Notify contributors about the approaching project target date"
 
     def handle(self, *args, **options):
         """
-        This command sends deadline reminders to contributors of projects that
-        are due in 7 days. If 2 days before the deadline project still isn't
+        This command sends target date reminders to contributors of projects that
+        are due in 7 days. If 2 days before the target date project still isn't
         complete for the contributor's locale, notifications are sent again.
 
         The command is designed to run daily.
@@ -26,7 +26,7 @@ class Command(BaseCommand):
             else:
                 continue
 
-            self.stdout.write(f"Sending deadline notifications for project {project}.")
+            self.stdout.write(f"Sending target date notifications for project {project}.")
 
             is_project_public = project.visibility == Project.Visibility.PUBLIC
             verb = f"due in {days_left} days"
@@ -48,4 +48,4 @@ class Command(BaseCommand):
                 if is_project_public or contributor.is_superuser:
                     notify.send(project, recipient=contributor, verb=verb)
 
-            self.stdout.write(f"Deadline notifications for project {project} sent.")
+            self.stdout.write(f"Target date notifications for project {project} sent.")

--- a/pontoon/projects/management/commands/send_deadline_notifications.py
+++ b/pontoon/projects/management/commands/send_deadline_notifications.py
@@ -26,7 +26,9 @@ class Command(BaseCommand):
             else:
                 continue
 
-            self.stdout.write(f"Sending target date notifications for project {project}.")
+            self.stdout.write(
+                f"Sending target date notifications for project {project}."
+            )
 
             is_project_public = project.visibility == Project.Visibility.PUBLIC
             verb = f"due in {days_left} days"

--- a/pontoon/projects/templates/projects/widgets/project_list.html
+++ b/pontoon/projects/templates/projects/widgets/project_list.html
@@ -8,7 +8,7 @@
     <thead>
       <tr>
         <th class="name asc">Project<i class="fa"></i></th>
-        <th class="deadline">Deadline<i class="fa"></i></th>
+        <th class="deadline">Target Date<i class="fa"></i></th>
         <th class="priority inverted">Priority<i class="fa"></i></th>
         <th class="latest-activity">Latest Activity<i class="fa"></i></th>
         <th class="progress">Progress<i class="fa"></i></th>


### PR DESCRIPTION
Fixes #2434.

I've kept deadline internally. Which means the only end-user facing leftover of "deadline" is in the API schema.