### PR TITLE
Replace react-infinite-scroller with react-infinite-scroll-hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9529,17 +9529,6 @@
         "react": ">=16.8.0"
       }
     },
-    "node_modules/react-infinite-scroller": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/react-infinite-scroller/-/react-infinite-scroller-1.2.5.tgz",
-      "integrity": "sha512-2A+SFUliZhVcxr4R2kFBrW/naGSluNMLqT6wfgmXKCggN1u/H4AW7flBLWHcY/5n/KviVLnpQfaMfBb/pG/m7g==",
-      "dependencies": {
-        "prop-types": "^15.5.8"
-      },
-      "peerDependencies": {
-        "react": "^0.14.9 || ^15.3.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/react-intersection-observer-hook": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/react-intersection-observer-hook/-/react-intersection-observer-hook-2.0.3.tgz",
@@ -11386,7 +11375,6 @@
         "react-content-marker": "^2.0.0",
         "react-dom": "^16.14.0",
         "react-infinite-scroll-hook": "^4.0.1",
-        "react-infinite-scroller": "^1.2.4",
         "react-linkify": "^0.2.2",
         "react-redux": "^7.2.6",
         "react-tabs": "^3.0.0",
@@ -18452,14 +18440,6 @@
         "react-intersection-observer-hook": "^2.0.3"
       }
     },
-    "react-infinite-scroller": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/react-infinite-scroller/-/react-infinite-scroller-1.2.5.tgz",
-      "integrity": "sha512-2A+SFUliZhVcxr4R2kFBrW/naGSluNMLqT6wfgmXKCggN1u/H4AW7flBLWHcY/5n/KviVLnpQfaMfBb/pG/m7g==",
-      "requires": {
-        "prop-types": "^15.5.8"
-      }
-    },
     "react-intersection-observer-hook": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/react-intersection-observer-hook/-/react-intersection-observer-hook-2.0.3.tgz",
@@ -19437,7 +19417,6 @@
         "react-content-marker": "^2.0.0",
         "react-dom": "^16.14.0",
         "react-infinite-scroll-hook": "^4.0.1",
-        "react-infinite-scroller": "^1.2.4",
         "react-linkify": "^0.2.2",
         "react-redux": "^7.2.6",
         "react-tabs": "^3.0.0",
@@ -19447,7 +19426,7 @@
         "redux-logger": "^3.0.6",
         "redux-thunk": "^2.3.0",
         "slate": "^0.78.0",
-        "slate-react": "0.77.4",
+        "slate-react": "^0.77.4",
         "styled-components": "^5.3.3",
         "tlds": "^1.218.0"
       }

--- a/translate/README.md
+++ b/translate/README.md
@@ -247,7 +247,6 @@ You can read [more about pseudo-localization on Wikipedia](https://en.wikipedia.
 - [create-react-app](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md)
 - [Jest](http://jestjs.io/docs/en/getting-started)
 - [sinon](https://sinonjs.org/releases/v6.0.0/)
-- [Infinite Scroller](https://cassetterocks.github.io/react-infinite-scroller/)
 - [Linkify](https://tasti.github.io/react-linkify/)
 - [ReactTimeAgo](https://github.com/catamphetamine/react-time-ago)
 - [react-tabs](https://github.com/reactjs/react-tabs)

--- a/translate/package.json
+++ b/translate/package.json
@@ -24,7 +24,6 @@
     "react-content-marker": "^2.0.0",
     "react-dom": "^16.14.0",
     "react-infinite-scroll-hook": "^4.0.1",
-    "react-infinite-scroller": "^1.2.4",
     "react-linkify": "^0.2.2",
     "react-redux": "^7.2.6",
     "react-tabs": "^3.0.0",

--- a/translate/src/core/loaders/components/SkeletonLoader.tsx
+++ b/translate/src/core/loaders/components/SkeletonLoader.tsx
@@ -2,13 +2,22 @@ import React from 'react';
 
 import './SkeletonLoader.css';
 
-export default function SkeletonLoader({ items }: { items: unknown[] }) {
+export default function SkeletonLoader({
+  sentryRef,
+  items,
+}: {
+  sentryRef?: React.Ref<HTMLUListElement>;
+  items: unknown[];
+}) {
   const firstLoad = items.length === 0;
   const itemCount = firstLoad ? 30 : 2;
   const list = Array.from(Array(itemCount).keys());
 
   return (
-    <ul className={`skeleton-loader entities ${firstLoad ? null : 'scroll'}`}>
+    <ul
+      className={`skeleton-loader entities ${firstLoad ? null : 'scroll'}`}
+      ref={sentryRef}
+    >
       {list.map((i) => {
         const classes = `entity missing ${
           i === 0 && firstLoad ? 'selected' : null

--- a/translate/src/modules/entitieslist/components/EntitiesList.test.js
+++ b/translate/src/modules/entitieslist/components/EntitiesList.test.js
@@ -1,11 +1,46 @@
+/* global global */
+
 import { createMemoryHistory } from 'history';
+import { act } from 'react-dom/test-utils';
 import sinon from 'sinon';
 
 import * as EntitiesActions from '~/core/entities/actions';
 import * as BatchActions from '~/modules/batchactions/actions';
-import { createReduxStore, mountComponentWithStore } from '~/test/store';
+
+import {
+  createDefaultUser,
+  createReduxStore,
+  mountComponentWithStore,
+} from '~/test/store';
 
 import EntitiesList, { EntitiesListBase } from './EntitiesList';
+
+class MockIntersectionObserver {
+  static map = new Map();
+
+  static set(isIntersecting) {
+    for (let callback of MockIntersectionObserver.map.values()) {
+      callback([{ isIntersecting }]);
+    }
+  }
+
+  constructor(callback) {
+    MockIntersectionObserver.map.set(this, callback);
+  }
+  disconnect() {
+    MockIntersectionObserver.map.delete(this);
+  }
+  observe() {}
+}
+
+let origIntersectionObserver;
+beforeAll(() => {
+  origIntersectionObserver = global.IntersectionObserver;
+  global.IntersectionObserver = MockIntersectionObserver;
+});
+afterAll(() => {
+  global.IntersectionObserver = origIntersectionObserver;
+});
 
 // Entities shared between tests
 const ENTITIES = [
@@ -36,31 +71,25 @@ describe('<EntitiesList>', () => {
   it('shows a loading animation when there are more entities to load', () => {
     const store = createReduxStore();
     store.dispatch(EntitiesActions.receive(ENTITIES, true));
-
     const wrapper = mountComponentWithStore(EntitiesList, store);
-    const scroll = wrapper.find('InfiniteScroll');
 
-    expect(scroll.find('SkeletonLoader')).toHaveLength(1);
+    expect(wrapper.find('SkeletonLoader')).toHaveLength(1);
   });
 
   it("doesn't display a loading animation when there aren't entities to load", () => {
     const store = createReduxStore();
     store.dispatch(EntitiesActions.receive(ENTITIES, false));
-
     const wrapper = mountComponentWithStore(EntitiesList, store);
-    const scroll = wrapper.find('InfiniteScroll');
 
-    expect(scroll.find('SkeletonLoader')).toHaveLength(0);
+    expect(wrapper.find('SkeletonLoader')).toHaveLength(0);
   });
 
   it('shows a loading animation when entities are being fetched from the server', () => {
     const store = createReduxStore();
     store.dispatch(EntitiesActions.request());
-
     const wrapper = mountComponentWithStore(EntitiesList, store);
-    const scroll = wrapper.find('InfiniteScroll');
 
-    expect(scroll.find('SkeletonLoader')).toHaveLength(1);
+    expect(wrapper.find('SkeletonLoader')).toHaveLength(1);
   });
 
   it('shows the correct number of entities', () => {
@@ -70,24 +99,23 @@ describe('<EntitiesList>', () => {
 
     const store = createReduxStore();
     store.dispatch(EntitiesActions.receive(ENTITIES, false));
-
     const wrapper = mountComponentWithStore(EntitiesList, store, {}, history);
 
     expect(wrapper.find('Entity')).toHaveLength(2);
   });
 
-  it.skip('excludes current entities when requesting new entities', () => {
+  it('excludes current entities when requesting new entities', () => {
+    jest.useFakeTimers();
+
     const store = createReduxStore();
+    store.dispatch(EntitiesActions.receive(ENTITIES, true));
+    mountComponentWithStore(EntitiesList, store);
 
-    store.dispatch(EntitiesActions.receive(ENTITIES, false));
+    act(() => MockIntersectionObserver.set(true));
+    jest.advanceTimersByTime(100); // default value for react-infinite-scroll-hook delayInMs
 
-    const wrapper = mountComponentWithStore(EntitiesList, store);
-
-    // No longer available externally, and only called from react-infinite-scroller
-    wrapper.find(EntitiesListBase).instance().getMoreEntities();
-
-    // Verify the 5th argument of `actions.get` is the list of current entities.
-    expect(EntitiesActions.get.args[0][4]).toEqual([1, 2]);
+    const currentEntPks = ENTITIES.map((ent) => ent.pk);
+    expect(EntitiesActions.get.args[0][4]).toEqual(currentEntPks);
   });
 
   it('redirects to the first entity when none is selected', () => {
@@ -112,18 +140,16 @@ describe('<EntitiesList>', () => {
     });
   });
 
-  it.skip('toggles entity for batch editing', () => {
+  it('toggles entity for batch editing', () => {
     const store = createReduxStore();
-
     store.dispatch(EntitiesActions.receive(ENTITIES, false));
+
+    // HACK to get isTranslator === true in Entity
+    createDefaultUser(store, { translator_for_locales: [''] });
 
     const wrapper = mountComponentWithStore(EntitiesList, store);
 
-    // No longer available externally
-    wrapper
-      .find(EntitiesListBase)
-      .instance()
-      .toggleForBatchEditing(ENTITIES[0].pk, false);
+    wrapper.find('.entity .status').first().simulate('click');
 
     expect(BatchActions.toggleSelection.calledOnce).toBeTruthy();
   });

--- a/translate/src/modules/entitieslist/components/EntitiesList.test.js
+++ b/translate/src/modules/entitieslist/components/EntitiesList.test.js
@@ -13,7 +13,7 @@ import {
   mountComponentWithStore,
 } from '~/test/store';
 
-import EntitiesList, { EntitiesListBase } from './EntitiesList';
+import { EntitiesList } from './EntitiesList';
 
 class MockIntersectionObserver {
   static map = new Map();

--- a/translate/src/modules/entitieslist/components/EntitiesList.tsx
+++ b/translate/src/modules/entitieslist/components/EntitiesList.tsx
@@ -2,10 +2,10 @@ import React, { useCallback, useContext, useEffect, useRef } from 'react';
 import useInfiniteScroll from 'react-infinite-scroll-hook';
 
 import { Locale } from '~/context/locale';
-import { Location, LocationType } from '~/context/location';
+import { Location } from '~/context/location';
 import type { Entity as EntityType } from '~/core/api';
 import { reset as resetEditor } from '~/core/editor/actions';
-import { EntitiesState, NAME as ENTITIES } from '~/core/entities';
+import { NAME as ENTITIES } from '~/core/entities';
 import {
   get as getEntities,
   getSiblingEntities,
@@ -14,13 +14,10 @@ import {
 import { SkeletonLoader } from '~/core/loaders';
 import { addNotification } from '~/core/notification/actions';
 import notificationMessages from '~/core/notification/messages';
-import { AppStore, useAppDispatch, useAppSelector, useAppStore } from '~/hooks';
+import { useAppDispatch, useAppSelector, useAppStore } from '~/hooks';
 import { usePrevious } from '~/hooks/usePrevious';
 import { useReadonlyEditor } from '~/hooks/useReadonlyEditor';
-import {
-  BatchActionsState,
-  NAME as BATCHACTIONS,
-} from '~/modules/batchactions';
+import { NAME as BATCHACTIONS } from '~/modules/batchactions';
 import {
   checkSelection,
   resetSelection,
@@ -30,22 +27,9 @@ import {
 } from '~/modules/batchactions/actions';
 import { NAME as UNSAVEDCHANGES } from '~/modules/unsavedchanges';
 import { check as checkUnsavedChanges } from '~/modules/unsavedchanges/actions';
-import type { AppDispatch } from '~/store';
 
 import './EntitiesList.css';
 import { Entity } from './Entity';
-
-type Props = {
-  batchactions: BatchActionsState;
-  entities: EntitiesState;
-  isReadOnlyEditor: boolean;
-  parameters: LocationType;
-};
-
-type InternalProps = Props & {
-  dispatch: AppDispatch;
-  store: AppStore;
-};
 
 /**
  * Displays a list of entities and their current translation.
@@ -54,14 +38,17 @@ type InternalProps = Props & {
  * entities. It interacts with `core/navigation` when an entity is selected.
  *
  */
-export function EntitiesListBase({
-  batchactions,
-  dispatch,
-  entities,
-  isReadOnlyEditor,
-  parameters,
-  store,
-}: InternalProps): React.ReactElement<'div'> {
+export function EntitiesList(): React.ReactElement<'div'> {
+  const dispatch = useAppDispatch();
+  const store = useAppStore();
+
+  const batchactions = useAppSelector((state) => state[BATCHACTIONS]);
+  const { entities, fetchCount, fetching, hasMore } = useAppSelector(
+    (state) => state[ENTITIES],
+  );
+  const isReadOnlyEditor = useReadonlyEditor();
+  const parameters = useContext(Location);
+
   const mounted = useRef(false);
   const list = useRef<HTMLDivElement>(null);
 
@@ -131,15 +118,15 @@ export function EntitiesListBase({
    */
   useEffect(() => {
     const selectedEntity = parameters.entity;
-    const firstEntity = entities.entities[0];
-    const isValid = entities.entities.some(({ pk }) => pk === selectedEntity);
+    const firstEntity = entities[0];
+    const isValid = entities.some(({ pk }) => pk === selectedEntity);
 
     if ((!selectedEntity || !isValid) && firstEntity) {
       // Replace the last history item instead of pushing a new one.
       selectEntity(firstEntity, true);
 
       // Only do this the very first time entities are loaded.
-      if (entities.fetchCount === 1 && selectedEntity && !isValid) {
+      if (fetchCount === 1 && selectedEntity && !isValid) {
         dispatch(addNotification(notificationMessages.ENTITY_NOT_FOUND));
       }
     }
@@ -191,12 +178,12 @@ export function EntitiesListBase({
 
   // Scroll to selected entity when entity changes
   // and when entity list loads for the first time
-  const prevEntityCount = usePrevious(entities.entities.length);
+  const prevEntityCount = usePrevious(entities.length);
   useEffect(() => {
-    if (!prevEntityCount && entities.entities.length > 0) {
+    if (!prevEntityCount && entities.length > 0) {
       scrollToSelected();
     }
-  }, [entities.entities.length]);
+  }, [entities.length]);
   useEffect(scrollToSelected, [parameters.entity]);
 
   const { code } = useContext(Locale);
@@ -216,7 +203,7 @@ export function EntitiesListBase({
           // lastCheckedEntity and the entity if entity not checked. If entity
           // checked, uncheck all entities in-between.
           if (shiftKeyPressed && batchactions.lastCheckedEntity) {
-            const entityListIds = entities.entities.map((e) => e.pk);
+            const entityListIds = entities.map((e) => e.pk);
             const start = entityListIds.indexOf(entity);
             const end = entityListIds.indexOf(batchactions.lastCheckedEntity);
 
@@ -236,18 +223,18 @@ export function EntitiesListBase({
         }),
       );
     },
-    [batchactions, dispatch, entities.entities, store],
+    [batchactions, dispatch, entities, store],
   );
 
   const getMoreEntities = useCallback(() => {
-    if (!entities.fetching) {
+    if (!fetching) {
       dispatch(
         getEntities(
           locale,
           project,
           resource,
           null, // Do not return a specific list of entities defined by their IDs.
-          entities.entities.map((entity) => entity.pk), // Currently shown entities should be excluded from the next results.
+          entities.map((entity) => entity.pk), // Currently shown entities should be excluded from the next results.
           parameters.entity.toString(),
           search,
           status,
@@ -258,17 +245,17 @@ export function EntitiesListBase({
         ),
       );
     }
-  }, [dispatch, entities, parameters]);
+  }, [dispatch, entities, fetching, parameters]);
 
   // Must be after other useEffect() calls, as they are run in order during mount
   useEffect(() => {
     mounted.current = true;
   }, []);
 
-  const hasNextPage = entities.fetching || entities.hasMore;
+  const hasNextPage = fetching || hasMore;
 
   const [sentryRef, { rootRef }] = useInfiniteScroll({
-    loading: entities.fetching,
+    loading: fetching,
     hasNextPage,
     onLoadMore: getMoreEntities,
     rootMargin: '0px 0px 600px 0px',
@@ -277,7 +264,7 @@ export function EntitiesListBase({
     rootRef(list.current);
   });
 
-  if (entities.entities.length === 0 && !hasNextPage) {
+  if (entities.length === 0 && !hasNextPage) {
     // When there are no results for the current search.
     return (
       <div className='entities unselectable' ref={list}>
@@ -292,7 +279,7 @@ export function EntitiesListBase({
   return (
     <div className='entities unselectable' ref={list}>
       <ul>
-        {entities.entities.map((entity) => (
+        {entities.map((entity) => (
           <Entity
             key={entity.pk}
             checkedForBatchEditing={batchactions.entities.includes(entity.pk)}
@@ -308,28 +295,7 @@ export function EntitiesListBase({
           />
         ))}
       </ul>
-      {hasNextPage && (
-        <SkeletonLoader items={entities.entities} sentryRef={sentryRef} />
-      )}
+      {hasNextPage && <SkeletonLoader items={entities} sentryRef={sentryRef} />}
     </div>
-  );
-}
-
-export default function EntitiesList(): React.ReactElement<
-  typeof EntitiesListBase
-> {
-  const state = {
-    batchactions: useAppSelector((state) => state[BATCHACTIONS]),
-    entities: useAppSelector((state) => state[ENTITIES]),
-    isReadOnlyEditor: useReadonlyEditor(),
-    parameters: useContext(Location),
-  };
-
-  return (
-    <EntitiesListBase
-      {...state}
-      dispatch={useAppDispatch()}
-      store={useAppStore()}
-    />
   );
 }

--- a/translate/src/modules/entitieslist/index.ts
+++ b/translate/src/modules/entitieslist/index.ts
@@ -1,4 +1,4 @@
-export { default as EntitiesList } from './components/EntitiesList';
+export { EntitiesList } from './components/EntitiesList';
 
 // Name of this module.
 // Used as the key to store this module's reducer.

--- a/translate/src/modules/machinery/components/Machinery.tsx
+++ b/translate/src/modules/machinery/components/Machinery.tsx
@@ -133,9 +133,10 @@ export const Machinery = ({
           ))}
         </ul>
         {(machinery.fetching || machinery.hasMore) && (
-          <div ref={sentryRef}>
-            <SkeletonLoader key={0} items={machinery.searchResults} />
-          </div>
+          <SkeletonLoader
+            items={machinery.searchResults}
+            sentryRef={sentryRef}
+          />
         )}
       </div>
     </section>


### PR DESCRIPTION
Fixes #2420

The previously skipped EntitiesList tests are now un-skipped. Minimally mocking IntersectionObserver was... interesting.