### PR TITLE
Make celery command version 5.x compatible

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: newrelic-admin run-program gunicorn pontoon.wsgi:application -t 120 --log-file -
-worker: newrelic-admin run-program celery worker --app=pontoon.base.celeryapp --loglevel=info --without-gossip --without-mingle --without-heartbeat
+worker: newrelic-admin run-program celery --app=pontoon.base.celeryapp worker --loglevel=info --without-gossip --without-mingle --without-heartbeat

--- a/docs/admin/maintenance.rst
+++ b/docs/admin/maintenance.rst
@@ -30,7 +30,7 @@ First, you need to purge the queue:
 .. code-block:: bash
 
    # Replace my-app-name with your Heroku app's name.
-   celery amqp --broker=`heroku config:get RABBITMQ_URL --app=my-app-name`
+   celery --broker=`heroku config:get RABBITMQ_URL --app=my-app-name` amqp
    # Replace my-queue-name with your queue's name (e.g. celery).
    1> queue.purge my-queue-name
 
@@ -39,4 +39,4 @@ Finally, you need to simply access the worker:
 .. code-block:: bash
 
    # Replace my-app-name with your Heroku app's name.
-   celery worker --broker=`heroku config:get RABBITMQ_URL --app=my-app-name`
+   celery --broker=`heroku config:get RABBITMQ_URL --app=my-app-name` worker


### PR DESCRIPTION
This fixes a regression from #2498.

We upgraded celery from version 4 to version 5, which introduced a breaking change and broke with the following error:
```
You are using `--app` as an option of the worker sub-command:
celery worker --app celeryapp <...>
The support for this usage was removed in Celery 5.0. Instead you should use `--app` as a global option:
celery --app celeryapp worker <...>
Usage: celery worker [OPTIONS]
Try 'celery worker --help' for help.
Error: No such option: --app
```