### PR TITLE
Remove all default exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "enzyme": "^3.11.0",
         "enzyme-adapter-react-16": "^1.15.6",
         "eslint": "^8.9.0",
+        "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-react": "^7.22.0",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^27.5.1",
@@ -3059,6 +3060,12 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
     },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
     "node_modules/@types/linkify-it": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
@@ -5152,6 +5159,168 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
+      "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^3.2.7",
+        "resolve": "^1.20.0"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz",
+      "integrity": "sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^3.2.7",
+        "find-up": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/find-up": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
+      "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
+      "dev": true,
+      "dependencies": {
+        "array-includes": "^3.1.4",
+        "array.prototype.flat": "^1.2.5",
+        "debug": "^2.6.9",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.6",
+        "eslint-module-utils": "^2.7.3",
+        "has": "^1.0.3",
+        "is-core-module": "^2.8.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.values": "^1.1.5",
+        "resolve": "^1.22.0",
+        "tsconfig-paths": "^3.14.1"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "node_modules/eslint-plugin-react": {
       "version": "7.29.4",
@@ -9056,6 +9225,12 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
+    },
     "node_modules/moo": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
@@ -11053,6 +11228,39 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
+      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/json5": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/tslib": {
@@ -13811,6 +14019,12 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
     },
+    "@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true
+    },
     "@types/linkify-it": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
@@ -15490,6 +15704,144 @@
           "version": "0.20.2",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
+      "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.2.7",
+        "resolve": "^1.20.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.3.tgz",
+      "integrity": "sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==",
+      "dev": true,
+      "requires": {
+        "debug": "^3.2.7",
+        "find-up": "^2.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
+      "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.4",
+        "array.prototype.flat": "^1.2.5",
+        "debug": "^2.6.9",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.6",
+        "eslint-module-utils": "^2.7.3",
+        "has": "^1.0.3",
+        "is-core-module": "^2.8.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.values": "^1.1.5",
+        "resolve": "^1.22.0",
+        "tsconfig-paths": "^3.14.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "doctrine": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
       }
@@ -18333,6 +18685,12 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
+    },
     "moo": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
@@ -19901,6 +20259,35 @@
           "requires": {
             "lru-cache": "^6.0.0"
           }
+        }
+      }
+    },
+    "tsconfig-paths": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
+      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
+      "dev": true,
+      "requires": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.6",
     "eslint": "^8.9.0",
+    "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-react": "^7.22.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^27.5.1",

--- a/translate/.eslintrc.js
+++ b/translate/.eslintrc.js
@@ -3,7 +3,7 @@
 module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint'],
+  plugins: ['@typescript-eslint', 'import'],
   extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
   env: {
     browser: true,
@@ -20,5 +20,6 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 0,
     '@typescript-eslint/no-inferrable-types': 0,
     '@typescript-eslint/prefer-as-const': 0,
+    'import/no-default-export': 'error',
   },
 };

--- a/translate/rollup.config.js
+++ b/translate/rollup.config.js
@@ -45,4 +45,5 @@ const config = {
   },
 };
 
+// eslint-disable-next-line import/no-default-export
 export default config;

--- a/translate/src/App.test.js
+++ b/translate/src/App.test.js
@@ -4,8 +4,9 @@
 // import { shallow } from 'enzyme';
 // import sinon from 'sinon';
 
-// import App from './App';
-// import store from '~/store';
+// import { App } from './App';
+// import { App } from './App';
+// import { store } from '~/store';
 
 describe('<App>', () => {
   it('renders without crashing', () => {

--- a/translate/src/App.tsx
+++ b/translate/src/App.tsx
@@ -7,11 +7,11 @@ import { initLocale, Locale, updateLocale } from './context/locale';
 import { Location } from './context/location';
 
 import { WaveLoader } from './core/loaders';
-import { NAME as NOTIFICATION, NotificationPanel } from './core/notification';
+import { NOTIFICATION, NotificationPanel } from './core/notification';
 import { addRawNotification } from './core/notification/actions';
 import { getProject } from './core/project/actions';
 import { getResource } from './core/resource/actions';
-import { UserControls } from './core/user';
+import { UserControls } from './core/user/components/UserControls';
 import { getUsersList } from './core/user/actions';
 
 import { useAppDispatch, useAppSelector } from './hooks';
@@ -25,7 +25,7 @@ import { InteractiveTour } from './modules/interactivetour/components/Interactiv
 import { Navigation } from './modules/navbar/components/Navigation';
 import { ProjectInfo } from './modules/projectinfo/components/ProjectInfo';
 import { ResourceProgress } from './modules/resourceprogress';
-import { SearchBox } from './modules/search';
+import { SearchBox } from './modules/search/components/SearchBox';
 
 /**
  * Main entry point to the application. Will render the structure of the page.

--- a/translate/src/core/comments/actions.ts
+++ b/translate/src/core/comments/actions.ts
@@ -2,7 +2,7 @@ import NProgress from 'nprogress';
 
 import { addComment } from '~/api/comment';
 import { addNotification } from '~/core/notification/actions';
-import notificationMessages from '~/core/notification/messages';
+import { notificationMessages } from '~/core/notification/messages';
 import { get as getHistory } from '~/modules/history/actions';
 import { get as getTeamComments } from '~/modules/teamcomments/actions';
 import type { AppDispatch } from '~/store';
@@ -29,7 +29,3 @@ export function addComment_(
     NProgress.done();
   };
 }
-
-export default {
-  addComment: addComment_,
-};

--- a/translate/src/core/comments/components/AddComment.test.js
+++ b/translate/src/core/comments/components/AddComment.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
 
-import AddComment from './AddComment';
+import { AddComment } from './AddComment';
 
 const USER = {
   user: {

--- a/translate/src/core/comments/components/AddComment.tsx
+++ b/translate/src/core/comments/components/AddComment.tsx
@@ -56,7 +56,7 @@ declare module 'slate' {
   }
 }
 
-export default function AddComment(props: Props): React.ReactElement<'div'> {
+export function AddComment(props: Props): React.ReactElement<'div'> {
   const {
     parameters,
     translation,

--- a/translate/src/core/comments/components/Comment.test.js
+++ b/translate/src/core/comments/components/Comment.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
 
-import Comment from './Comment';
+import { Comment } from './Comment';
 
 describe('<Comment>', () => {
   const DEFAULT_COMMENT = {

--- a/translate/src/core/comments/components/Comment.tsx
+++ b/translate/src/core/comments/components/Comment.tsx
@@ -16,7 +16,7 @@ type Props = {
   togglePinnedStatus?: (status: boolean, id: number) => void;
 };
 
-export default function Comment(props: Props): null | React.ReactElement<'li'> {
+export function Comment(props: Props): null | React.ReactElement<'li'> {
   const { comment, canPin, togglePinnedStatus } = props;
 
   if (!comment) {

--- a/translate/src/core/comments/components/CommentsList.test.js
+++ b/translate/src/core/comments/components/CommentsList.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import CommentsList from './CommentsList';
+import { CommentsList } from './CommentsList';
 
 describe('<CommentsList>', () => {
   const DEFAULT_USER = 'AnnPerkins';

--- a/translate/src/core/comments/components/CommentsList.tsx
+++ b/translate/src/core/comments/components/CommentsList.tsx
@@ -4,7 +4,8 @@ import React from 'react';
 import type { TranslationComment } from '~/api/comment';
 import type { HistoryTranslation } from '~/api/translation';
 import type { LocationType } from '~/context/location';
-import { AddComment, Comment } from '~/core/comments';
+import { AddComment } from '~/core/comments/components/AddComment';
+import { Comment } from '~/core/comments/components/Comment';
 import type { UserState } from '~/core/user';
 
 import './CommentsList.css';
@@ -22,7 +23,7 @@ type Props = {
   resetContactPerson?: () => void;
 };
 
-export default function CommentsList(props: Props): React.ReactElement<'div'> {
+export function CommentsList(props: Props): React.ReactElement<'div'> {
   const {
     comments,
     parameters,

--- a/translate/src/core/comments/index.ts
+++ b/translate/src/core/comments/index.ts
@@ -1,5 +1,0 @@
-export { default as actions } from './actions';
-
-export { default as AddComment } from './components/AddComment';
-export { default as Comment } from './components/Comment';
-export { default as CommentsList } from './components/CommentsList';

--- a/translate/src/core/editor/actions.ts
+++ b/translate/src/core/editor/actions.ts
@@ -10,7 +10,7 @@ import { PluralFormType } from '~/context/pluralForm';
 import type { UnsavedChanges } from '~/context/unsavedChanges';
 import { updateEntityTranslation } from '~/core/entities/actions';
 import { addNotification } from '~/core/notification/actions';
-import notificationMessages from '~/core/notification/messages';
+import { notificationMessages } from '~/core/notification/messages';
 import { updateResource } from '~/core/resource/actions';
 import { updateStats } from '~/core/stats/actions';
 import { AppThunk } from '~/store';
@@ -42,6 +42,21 @@ export const UPDATE_MACHINERY_SOURCES: 'editor/UPDATE_MACHINERY_SOURCES' =
 
 export type Translation = string | Entry;
 
+export type Action =
+  | EndUpdateTranslationAction
+  | InitialTranslationAction
+  | ResetEditorAction
+  | ResetHelperElementIndexAction
+  | ResetFailedChecksAction
+  | ResetSelectionAction
+  | SelectHelperElementIndexAction
+  | SelectHelperTabIndexAction
+  | StartUpdateTranslationAction
+  | UpdateAction
+  | UpdateFailedChecksAction
+  | UpdateSelectionAction
+  | UpdateMachinerySourcesAction;
+
 /**
  * Update the current translation of the selected entity.
  */
@@ -50,7 +65,7 @@ export type UpdateAction = {
   readonly translation: Translation;
   readonly changeSource: string;
 };
-export function update(
+export function updateTranslation(
   translation: Translation,
   changeSource?: string,
 ): UpdateAction {
@@ -135,7 +150,9 @@ export type SelectHelperTabIndexAction = {
   readonly type: typeof SELECT_HELPER_TAB_INDEX;
   readonly index: number;
 };
-function selectHelperTabIndex(index: number): SelectHelperTabIndexAction {
+export function selectHelperTabIndex(
+  index: number,
+): SelectHelperTabIndexAction {
   return {
     type: SELECT_HELPER_TAB_INDEX,
     index,
@@ -196,7 +213,7 @@ export function resetSelection(): ResetSelectionAction {
 export type ResetEditorAction = {
   readonly type: typeof RESET_EDITOR;
 };
-export function reset(): ResetEditorAction {
+export function resetEditor(): ResetEditorAction {
   return {
     type: RESET_EDITOR,
   };
@@ -293,7 +310,7 @@ export function sendTranslation_(
         } else if (nextEntity.pk !== entity.pk) {
           location.push({ entity: nextEntity.pk });
         }
-        dispatch(reset());
+        dispatch(resetEditor());
       }
     } else if (content.failedChecks) {
       dispatch(updateFailedChecks(content.failedChecks, 'submitted'));
@@ -307,19 +324,3 @@ export function sendTranslation_(
     NProgress.done();
   };
 }
-
-export default {
-  endUpdateTranslation,
-  reset,
-  resetFailedChecks,
-  resetHelperElementIndex,
-  resetSelection,
-  selectHelperElementIndex,
-  selectHelperTabIndex,
-  setInitialTranslation,
-  startUpdateTranslation,
-  update,
-  updateFailedChecks,
-  updateSelection,
-  updateMachinerySources,
-};

--- a/translate/src/core/editor/components/EditorMainAction.test.js
+++ b/translate/src/core/editor/components/EditorMainAction.test.js
@@ -10,7 +10,7 @@ import {
 
 import * as editorActions from '../actions';
 import * as ExistingTranslation from '../hooks/useExistingTranslation';
-import EditorMainAction from './EditorMainAction';
+import { EditorMainAction } from './EditorMainAction';
 
 beforeAll(() => {
   sinon.stub(Translator, 'useTranslator');

--- a/translate/src/core/editor/components/EditorMainAction.tsx
+++ b/translate/src/core/editor/components/EditorMainAction.tsx
@@ -5,7 +5,7 @@ import { useAppSelector } from '~/hooks';
 import { useTranslator } from '~/hooks/useTranslator';
 
 import { useExistingTranslation } from '../hooks/useExistingTranslation';
-import { useUpdateTranslationStatus } from '../index';
+import { useUpdateTranslationStatus } from '../hooks/useUpdateTranslationStatus';
 
 type Props = {
   sendTranslation: (ignoreWarnings?: boolean) => void;
@@ -22,7 +22,7 @@ type Props = {
  * Otherwise, if the "force suggestion" user setting is on, it renders "Suggest".
  * Otherwise, it renders "Save".
  */
-export default function EditorMainAction({
+export function EditorMainAction({
   sendTranslation,
 }: Props): React.ReactElement<React.ElementType> {
   const isRunningRequest = useAppSelector(

--- a/translate/src/core/editor/components/EditorMenu.test.js
+++ b/translate/src/core/editor/components/EditorMenu.test.js
@@ -10,10 +10,10 @@ import { RECEIVE_ENTITIES } from '~/core/entities/actions';
 import { createDefaultUser, createReduxStore } from '~/test/store';
 import { MockLocalizationProvider } from '~/test/utils';
 
-import EditorMenu from './EditorMenu';
-import EditorSettings from './EditorSettings';
-import KeyboardShortcuts from './KeyboardShortcuts';
-import TranslationLength from './TranslationLength';
+import { EditorMenu } from './EditorMenu';
+import { EditorSettings } from './EditorSettings';
+import { KeyboardShortcuts } from './KeyboardShortcuts';
+import { TranslationLength } from './TranslationLength';
 
 const SELECTED_ENTITY = {
   pk: 1,

--- a/translate/src/core/editor/components/EditorMenu.tsx
+++ b/translate/src/core/editor/components/EditorMenu.tsx
@@ -1,5 +1,5 @@
 import { Localized } from '@fluent/react';
-import * as React from 'react';
+import React from 'react';
 
 import { useSelectedEntity } from '~/core/entities/hooks';
 import * as user from '~/core/user';
@@ -7,11 +7,11 @@ import { saveSetting } from '~/core/user/actions';
 import { useAppDispatch, useAppSelector } from '~/hooks';
 import { UnsavedChangesPopup } from '~/modules/unsavedchanges/components/UnsavedChangesPopup';
 
-import EditorMainAction from './EditorMainAction';
+import { EditorMainAction } from './EditorMainAction';
 import './EditorMenu.css';
-import EditorSettings from './EditorSettings';
-import FailedChecks from './FailedChecks';
-import KeyboardShortcuts from './KeyboardShortcuts';
+import { EditorSettings } from './EditorSettings';
+import { FailedChecks } from './FailedChecks';
+import { KeyboardShortcuts } from './KeyboardShortcuts';
 
 type Props = {
   firstItemHook?: React.ReactNode;
@@ -28,7 +28,7 @@ type Props = {
  * If the entity is read-only, shows a read-only notification.
  * Otherise, shows the various tools to control the editor.
  */
-export default function EditorMenu(props: Props): React.ReactElement<'menu'> {
+export function EditorMenu(props: Props): React.ReactElement<'menu'> {
   return (
     <menu className='editor-menu'>
       {props.firstItemHook}

--- a/translate/src/core/editor/components/EditorSettings.test.js
+++ b/translate/src/core/editor/components/EditorSettings.test.js
@@ -2,12 +2,12 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
 
-import EditorSettingsBase, { EditorSettings } from './EditorSettings';
+import { EditorSettings, EditorSettingsDialog } from './EditorSettings';
 
-function createEditorSettings() {
+function createEditorSettingsDialog() {
   const toggleSettingMock = sinon.stub();
   const wrapper = shallow(
-    <EditorSettings
+    <EditorSettingsDialog
       settings={{
         runQualityChecks: false,
         forceSuggestions: false,
@@ -18,9 +18,9 @@ function createEditorSettings() {
   return [wrapper, toggleSettingMock];
 }
 
-describe('<EditorSettings>', () => {
+describe('<EditorSettingsDialog>', () => {
   it('toggles the runQualityChecks setting', () => {
-    const [wrapper, toggleSettingMock] = createEditorSettings();
+    const [wrapper, toggleSettingMock] = createEditorSettingsDialog();
 
     // Do it once to turn it on.
     wrapper.find('.menu li').at(0).simulate('click');
@@ -36,7 +36,7 @@ describe('<EditorSettings>', () => {
   });
 
   it('toggles the forceSuggestions setting', () => {
-    const [wrapper, toggleSettingMock] = createEditorSettings();
+    const [wrapper, toggleSettingMock] = createEditorSettingsDialog();
 
     // Do it once to turn it on.
     wrapper.find('.menu li').at(1).simulate('click');
@@ -52,15 +52,15 @@ describe('<EditorSettings>', () => {
   });
 });
 
-describe('<EditorSettingsBase>', () => {
+describe('<EditorSettings>', () => {
   it('toggles the settings menu when clicking the gear icon', () => {
-    const wrapper = shallow(<EditorSettingsBase />);
-    expect(wrapper.find('EditorSettings')).toHaveLength(0);
+    const wrapper = shallow(<EditorSettings />);
+    expect(wrapper.find('EditorSettingsDialog')).toHaveLength(0);
 
     wrapper.find('.selector').simulate('click');
-    expect(wrapper.find('EditorSettings')).toHaveLength(1);
+    expect(wrapper.find('EditorSettingsDialog')).toHaveLength(1);
 
     wrapper.find('.selector').simulate('click');
-    expect(wrapper.find('EditorSettings')).toHaveLength(0);
+    expect(wrapper.find('EditorSettingsDialog')).toHaveLength(0);
   });
 });

--- a/translate/src/core/editor/components/EditorSettings.tsx
+++ b/translate/src/core/editor/components/EditorSettings.tsx
@@ -17,7 +17,7 @@ type EditorSettingsProps = {
   onDiscard: () => void;
 };
 
-export function EditorSettings({
+export function EditorSettingsDialog({
   settings,
   toggleSetting,
   onDiscard,
@@ -72,7 +72,7 @@ export function EditorSettings({
 /*
  * Renders settings to be used to customize interactions with the Editor.
  */
-export default function EditorSettingsBase({
+export function EditorSettings({
   settings,
   updateSetting,
 }: Props): React.ReactElement<'div'> {
@@ -97,7 +97,7 @@ export default function EditorSettingsBase({
       />
 
       {visible && (
-        <EditorSettings
+        <EditorSettingsDialog
           settings={settings}
           toggleSetting={toggleSetting}
           onDiscard={handleDiscard}

--- a/translate/src/core/editor/components/FailedChecks.test.js
+++ b/translate/src/core/editor/components/FailedChecks.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import sinon from 'sinon';
 
 import { Locale } from '~/context/locale';
-import * as editor from '~/core/editor';
+import { updateFailedChecks } from '~/core/editor/actions';
 
 import {
   createDefaultUser,
@@ -10,7 +10,7 @@ import {
   mountComponentWithStore,
 } from '~/test/store';
 
-import FailedChecks from './FailedChecks';
+import { FailedChecks } from './FailedChecks';
 
 function createFailedChecks(user) {
   const store = createReduxStore({ project: { slug: 'firefox', tags: [] } });
@@ -37,7 +37,7 @@ describe('<FailedChecks>', () => {
     const [wrapper, store] = createFailedChecks();
 
     store.dispatch(
-      editor.actions.updateFailedChecks(
+      updateFailedChecks(
         {
           clErrors: ['one error'],
           pndbWarnings: ['a warning', 'two warnings'],
@@ -60,10 +60,7 @@ describe('<FailedChecks>', () => {
     });
 
     store.dispatch(
-      editor.actions.updateFailedChecks(
-        { pndbWarnings: ['a warning'] },
-        'submitted',
-      ),
+      updateFailedChecks({ pndbWarnings: ['a warning'] }, 'submitted'),
     );
     wrapper.update();
 
@@ -76,10 +73,7 @@ describe('<FailedChecks>', () => {
     });
 
     store.dispatch(
-      editor.actions.updateFailedChecks(
-        { pndbWarnings: ['a warning'] },
-        'submitted',
-      ),
+      updateFailedChecks({ pndbWarnings: ['a warning'] }, 'submitted'),
     );
     wrapper.update();
 
@@ -90,10 +84,7 @@ describe('<FailedChecks>', () => {
     const [wrapper, store] = createFailedChecks({ manager_for_locales: [] });
 
     store.dispatch(
-      editor.actions.updateFailedChecks(
-        { pndbWarnings: ['a warning'] },
-        'submitted',
-      ),
+      updateFailedChecks({ pndbWarnings: ['a warning'] }, 'submitted'),
     );
     wrapper.update();
 
@@ -103,9 +94,7 @@ describe('<FailedChecks>', () => {
   it('renders approve anyway button if translation with warnings approved', () => {
     const [wrapper, store] = createFailedChecks();
 
-    store.dispatch(
-      editor.actions.updateFailedChecks({ pndbWarnings: ['a warning'] }, ''),
-    );
+    store.dispatch(updateFailedChecks({ pndbWarnings: ['a warning'] }, ''));
     wrapper.update();
 
     expect(wrapper.find('.approve.anyway')).toHaveLength(1);

--- a/translate/src/core/editor/components/FailedChecks.tsx
+++ b/translate/src/core/editor/components/FailedChecks.tsx
@@ -6,7 +6,8 @@ import type { UserState } from '~/core/user';
 import { useAppDispatch, useAppSelector } from '~/hooks';
 import { useTranslator } from '~/hooks/useTranslator';
 
-import { actions, useUpdateTranslationStatus } from '..';
+import { resetFailedChecks } from '../actions';
+import { useUpdateTranslationStatus } from '../hooks/useUpdateTranslationStatus';
 
 import './FailedChecks.css';
 
@@ -18,7 +19,7 @@ type FailedChecksProps = {
  * Shows a list of failed checks (errors and warnings) and a button to ignore
  * those checks and proceed anyway.
  */
-export default function FailedChecks(
+export function FailedChecks(
   props: FailedChecksProps,
 ): null | React.ReactElement<'div'> {
   const dispatch = useAppDispatch();
@@ -35,7 +36,7 @@ export default function FailedChecks(
   }
 
   function resetChecks() {
-    dispatch(actions.resetFailedChecks());
+    dispatch(resetFailedChecks());
   }
 
   function approveAnyway() {

--- a/translate/src/core/editor/components/KeyboardShortcuts.tsx
+++ b/translate/src/core/editor/components/KeyboardShortcuts.tsx
@@ -9,7 +9,7 @@ type KeyboardShortcutsProps = {
   onDiscard: () => void;
 };
 
-function KeyboardShortcuts({ onDiscard }: KeyboardShortcutsProps) {
+function KeyboardShortcutsDialog({ onDiscard }: KeyboardShortcutsProps) {
   const ref = React.useRef(null);
   useOnDiscard(ref, onDiscard);
   return (
@@ -200,7 +200,7 @@ function KeyboardShortcuts({ onDiscard }: KeyboardShortcutsProps) {
 /*
  * Shows a list of keyboard shortcuts.
  */
-export default function KeyboardShortcutsBase(): React.ReactElement<'div'> {
+export function KeyboardShortcuts(): React.ReactElement<'div'> {
   const [visible, setVisible] = useState(false);
   const toggleVisible = useCallback(() => setVisible((prev) => !prev), []);
   const handleDiscard = useCallback(() => setVisible(false), []);
@@ -215,7 +215,7 @@ export default function KeyboardShortcutsBase(): React.ReactElement<'div'> {
         />
       </Localized>
 
-      {visible && <KeyboardShortcuts onDiscard={handleDiscard} />}
+      {visible && <KeyboardShortcutsDialog onDiscard={handleDiscard} />}
     </div>
   );
 }

--- a/translate/src/core/editor/components/TranslationLength.test.js
+++ b/translate/src/core/editor/components/TranslationLength.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import TranslationLength from './TranslationLength';
+import { TranslationLength } from './TranslationLength';
 
 describe('<TranslationLength>', () => {
   const LENGTH_ENTITY = {

--- a/translate/src/core/editor/components/TranslationLength.tsx
+++ b/translate/src/core/editor/components/TranslationLength.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import './TranslationLength.css';
 
@@ -16,7 +16,7 @@ type Props = {
  * syntax in the comment to define maximum translation length. MAX_LENGTH
  * is provided for strings without HTML tags, so they need to be stripped.
  */
-export default function TranslationLength({
+export function TranslationLength({
   comment,
   format,
   original,

--- a/translate/src/core/editor/hooks/useAddTextToTranslation.ts
+++ b/translate/src/core/editor/hooks/useAddTextToTranslation.ts
@@ -1,12 +1,12 @@
 import { useCallback } from 'react';
 
 import { useAppDispatch } from '~/hooks';
-import { actions } from '..';
+import { updateSelection } from '../actions';
 
 /**
  * Return a function to add text to the content of the editor.
  */
-export default function useAddTextToTranslation(): (
+export function useAddTextToTranslation(): (
   content: string,
   changeSource?: string,
 ) => void {
@@ -14,7 +14,7 @@ export default function useAddTextToTranslation(): (
 
   return useCallback(
     (content: string, changeSource?: string) => {
-      dispatch(actions.updateSelection(content, changeSource));
+      dispatch(updateSelection(content, changeSource));
     },
     [dispatch],
   );

--- a/translate/src/core/editor/hooks/useClearEditor.ts
+++ b/translate/src/core/editor/hooks/useClearEditor.ts
@@ -1,9 +1,9 @@
-import useUpdateTranslation from './useUpdateTranslation';
+import { useUpdateTranslation } from './useUpdateTranslation';
 
 /**
  * Return a function to clear the content of the editor.
  */
-export default function useClearEditor(): () => void {
+export function useClearEditor(): () => void {
   const updateTranslation = useUpdateTranslation();
 
   return () => {

--- a/translate/src/core/editor/hooks/useCopyMachineryTranslation.ts
+++ b/translate/src/core/editor/hooks/useCopyMachineryTranslation.ts
@@ -1,29 +1,27 @@
 import { useCallback } from 'react';
 
 import type { MachineryTranslation, SourceType } from '~/api/machinery';
-import { NAME as EDITOR } from '~/core/editor';
+import { EDITOR } from '../reducer';
 import { useAppDispatch, useAppSelector } from '~/hooks';
 import { useReadonlyEditor } from '~/hooks/useReadonlyEditor';
 
-import actions from '../actions';
-import useAddTextToTranslation from './useAddTextToTranslation';
-import useUpdateTranslation from './useUpdateTranslation';
+import { updateMachinerySources } from '../actions';
+import { useAddTextToTranslation } from './useAddTextToTranslation';
+import { useUpdateTranslation } from './useUpdateTranslation';
 
 /**
  * Return a function to copy the original translation into the editor.
  */
-export default function useCopyMachineryTranslation(
+export function useCopyMachineryTranslation(
   entity?: number | null,
 ): (translation: MachineryTranslation) => void {
   const dispatch = useAppDispatch();
 
   const addTextToTranslation = useAddTextToTranslation();
   const updateTranslation = useUpdateTranslation();
-  const updateMachinerySources = useCallback(
+  const updateMachinerySources_ = useCallback(
     (machinerySources: Array<SourceType>, machineryTranslation: string) => {
-      dispatch(
-        actions.updateMachinerySources(machinerySources, machineryTranslation),
-      );
+      dispatch(updateMachinerySources(machinerySources, machineryTranslation));
     },
     [dispatch],
   );
@@ -57,7 +55,7 @@ export default function useCopyMachineryTranslation(
       else {
         updateTranslation(translation.translation, 'machinery');
       }
-      updateMachinerySources(translation.sources, translation.translation);
+      updateMachinerySources_(translation.sources, translation.translation);
     },
     [
       isFluentTranslationMessage,
@@ -65,7 +63,7 @@ export default function useCopyMachineryTranslation(
       entity,
       addTextToTranslation,
       updateTranslation,
-      updateMachinerySources,
+      updateMachinerySources_,
     ],
   );
 }

--- a/translate/src/core/editor/hooks/useCopyOriginalIntoEditor.ts
+++ b/translate/src/core/editor/hooks/useCopyOriginalIntoEditor.ts
@@ -1,12 +1,12 @@
 import { useSelectedEntity } from '~/core/entities/hooks';
 import { usePluralForm } from '~/context/pluralForm';
 
-import useUpdateTranslation from './useUpdateTranslation';
+import { useUpdateTranslation } from './useUpdateTranslation';
 
 /**
  * Return a function to copy the original translation into the editor.
  */
-export default function useCopyOriginalIntoEditor(): () => void {
+export function useCopyOriginalIntoEditor(): () => void {
   const updateTranslation = useUpdateTranslation();
 
   const entity = useSelectedEntity();

--- a/translate/src/core/editor/hooks/useCopyOtherLocaleTranslation.ts
+++ b/translate/src/core/editor/hooks/useCopyOtherLocaleTranslation.ts
@@ -3,12 +3,12 @@ import { useCallback } from 'react';
 import type { OtherLocaleTranslation } from '~/api/other-locales';
 import { useReadonlyEditor } from '~/hooks/useReadonlyEditor';
 
-import useUpdateTranslation from './useUpdateTranslation';
+import { useUpdateTranslation } from './useUpdateTranslation';
 
 /**
  * Return a function to copy the other locale translation into the editor.
  */
-export default function useCopyOtherLocaleTranslation(): (
+export function useCopyOtherLocaleTranslation(): (
   translation: OtherLocaleTranslation,
 ) => void {
   const updateTranslation = useUpdateTranslation();

--- a/translate/src/core/editor/hooks/useExistingTranslation.test.js
+++ b/translate/src/core/editor/hooks/useExistingTranslation.test.js
@@ -1,7 +1,7 @@
 import sinon from 'sinon';
 import * as PluralForm from '~/context/pluralForm';
-import fluentParser from '~/core/utils/fluent/parser';
-import flattenMessage from '~/core/utils/fluent/flattenMessage';
+import { parser as fluentParser } from '~/core/utils/fluent/parser';
+import { flattenMessage } from '~/core/utils/fluent/flattenMessage';
 import * as Hooks from '~/hooks';
 import * as SelectedEntity from '~/core/entities/hooks';
 

--- a/translate/src/core/editor/hooks/useExistingTranslation.ts
+++ b/translate/src/core/editor/hooks/useExistingTranslation.ts
@@ -1,12 +1,12 @@
 import { useTranslationForEntity } from '~/context/pluralForm';
 import { useSelectedEntity } from '~/core/entities/hooks';
-import getReconstructedMessage from '~/core/utils/fluent/getReconstructedMessage';
-import fluentParser from '~/core/utils/fluent/parser';
-import fluentSerializer from '~/core/utils/fluent/serializer';
+import { getReconstructedMessage } from '~/core/utils/fluent/getReconstructedMessage';
+import { parser as fluentParser } from '~/core/utils/fluent/parser';
+import { serializer as fluentSerializer } from '~/core/utils/fluent/serializer';
 import { useAppSelector } from '~/hooks';
-import { NAME as HISTORY } from '~/modules/history';
+import { HISTORY } from '~/modules/history';
 
-import { NAME as EDITOR } from '../index';
+import { EDITOR } from '../reducer';
 
 /**
  * Return a Translation identical to the one currently in the Editor.

--- a/translate/src/core/editor/hooks/useHandleShortcuts.ts
+++ b/translate/src/core/editor/hooks/useHandleShortcuts.ts
@@ -5,17 +5,17 @@ import { useAppDispatch, useAppSelector } from '~/hooks';
 import { useReadonlyEditor } from '~/hooks/useReadonlyEditor';
 
 import { resetFailedChecks, selectHelperElementIndex } from '../actions';
-import useClearEditor from './useClearEditor';
-import useCopyMachineryTranslation from './useCopyMachineryTranslation';
-import useCopyOriginalIntoEditor from './useCopyOriginalIntoEditor';
-import useCopyOtherLocaleTranslation from './useCopyOtherLocaleTranslation';
+import { useClearEditor } from './useClearEditor';
+import { useCopyMachineryTranslation } from './useCopyMachineryTranslation';
+import { useCopyOriginalIntoEditor } from './useCopyOriginalIntoEditor';
+import { useCopyOtherLocaleTranslation } from './useCopyOtherLocaleTranslation';
 import { useExistingTranslation } from './useExistingTranslation';
-import useUpdateTranslationStatus from './useUpdateTranslationStatus';
+import { useUpdateTranslationStatus } from './useUpdateTranslationStatus';
 
 /**
  * Return a function to handle shortcuts in a translation form.
  */
-export default function useHandleShortcuts(): (
+export function useHandleShortcuts(): (
   event: React.KeyboardEvent<HTMLTextAreaElement>,
   sendTranslation: (ignoreWarnings?: boolean, translation?: string) => void,
   clearEditorCustom?: () => void,

--- a/translate/src/core/editor/hooks/useReplaceSelectionContent.ts
+++ b/translate/src/core/editor/hooks/useReplaceSelectionContent.ts
@@ -1,9 +1,9 @@
-import * as React from 'react';
+import React from 'react';
 
 import { useAppDispatch, useAppSelector } from '~/hooks';
-import * as editor from '~/core/editor';
+import { resetSelection } from '../actions';
 
-export default function useReplaceSelectionContent(
+export function useReplaceSelectionContent(
   updateTranslationSelectionWith: (content: string, source: string) => void,
 ) {
   const dispatch = useAppDispatch();
@@ -20,7 +20,7 @@ export default function useReplaceSelectionContent(
     // must use this hook and pass it a function specific to its needs.
     if (selectionReplacementContent) {
       updateTranslationSelectionWith(selectionReplacementContent, changeSource);
-      dispatch(editor.actions.resetSelection());
+      dispatch(resetSelection());
     }
   }, [
     changeSource,

--- a/translate/src/core/editor/hooks/useSendTranslation.ts
+++ b/translate/src/core/editor/hooks/useSendTranslation.ts
@@ -12,7 +12,7 @@ import { sendTranslation_ } from '../actions';
 /**
  * Return a function to send a translation to the server.
  */
-export default function useSendTranslation(): (
+export function useSendTranslation(): (
   ignoreWarnings?: boolean,
   content?: string,
 ) => void {

--- a/translate/src/core/editor/hooks/useUpdateTranslation.ts
+++ b/translate/src/core/editor/hooks/useUpdateTranslation.ts
@@ -1,14 +1,14 @@
 import { useCallback } from 'react';
 
-import { actions } from '..';
-
 import type { Translation } from '~/core/editor';
 import { useAppDispatch } from '~/hooks';
+
+import { updateTranslation } from '../actions';
 
 /**
  * Return a function to update the content of the editor.
  */
-export default function useUpdateTranslation(): (
+export function useUpdateTranslation(): (
   translation: Translation,
   changeSource?: string,
 ) => void {
@@ -16,7 +16,7 @@ export default function useUpdateTranslation(): (
 
   return useCallback(
     (translation: Translation, changeSource?: string) => {
-      dispatch(actions.update(translation, changeSource));
+      dispatch(updateTranslation(translation, changeSource));
     },
     [dispatch],
   );

--- a/translate/src/core/editor/hooks/useUpdateTranslationStatus.ts
+++ b/translate/src/core/editor/hooks/useUpdateTranslationStatus.ts
@@ -13,7 +13,7 @@ import { startUpdateTranslation, endUpdateTranslation } from '../actions';
 /**
  * Return a function to update the status (approved, rejected... ) of a translation.
  */
-export default function useUpdateTranslationStatus(): (
+export function useUpdateTranslationStatus(): (
   translationId: number,
   change: ChangeOperation,
   ignoreWarnings: boolean,

--- a/translate/src/core/editor/hooks/useUpdateUnsavedChanges.ts
+++ b/translate/src/core/editor/hooks/useUpdateUnsavedChanges.ts
@@ -3,7 +3,7 @@ import { UnsavedChanges } from '~/context/unsavedChanges';
 
 import { useAppSelector } from '~/hooks';
 
-export default function useUpdateUnsavedChanges(richEditor: boolean) {
+export function useUpdateUnsavedChanges(richEditor: boolean) {
   const translation = useAppSelector((state) => state.editor.translation);
   const initialTranslation = useAppSelector(
     (state) => state.editor.initialTranslation,

--- a/translate/src/core/editor/index.ts
+++ b/translate/src/core/editor/index.ts
@@ -1,27 +1,21 @@
-export { default as actions } from './actions';
-export { default as reducer } from './reducer';
+export { EditorMenu } from './components/EditorMenu';
+export { EditorSettings } from './components/EditorSettings';
+export { FailedChecks } from './components/FailedChecks';
+export { KeyboardShortcuts } from './components/KeyboardShortcuts';
+export { TranslationLength } from './components/TranslationLength';
 
-export { default as EditorMenu } from './components/EditorMenu';
-export { default as EditorSettings } from './components/EditorSettings';
-export { default as FailedChecks } from './components/FailedChecks';
-export { default as KeyboardShortcuts } from './components/KeyboardShortcuts';
-export { default as TranslationLength } from './components/TranslationLength';
+export { useAddTextToTranslation } from './hooks/useAddTextToTranslation';
+export { useClearEditor } from './hooks/useClearEditor';
+export { useCopyMachineryTranslation } from './hooks/useCopyMachineryTranslation';
+export { useCopyOriginalIntoEditor } from './hooks/useCopyOriginalIntoEditor';
+export { useCopyOtherLocaleTranslation } from './hooks/useCopyOtherLocaleTranslation';
+export { useHandleShortcuts } from './hooks/useHandleShortcuts';
+export { useSendTranslation } from './hooks/useSendTranslation';
+export { useReplaceSelectionContent } from './hooks/useReplaceSelectionContent';
+export { useUpdateTranslation } from './hooks/useUpdateTranslation';
+export { useUpdateTranslationStatus } from './hooks/useUpdateTranslationStatus';
+export { useUpdateUnsavedChanges } from './hooks/useUpdateUnsavedChanges';
 
-export { default as useAddTextToTranslation } from './hooks/useAddTextToTranslation';
-export { default as useClearEditor } from './hooks/useClearEditor';
-export { default as useCopyMachineryTranslation } from './hooks/useCopyMachineryTranslation';
-export { default as useCopyOriginalIntoEditor } from './hooks/useCopyOriginalIntoEditor';
-export { default as useCopyOtherLocaleTranslation } from './hooks/useCopyOtherLocaleTranslation';
-export { default as useHandleShortcuts } from './hooks/useHandleShortcuts';
-export { default as useSendTranslation } from './hooks/useSendTranslation';
-export { default as useReplaceSelectionContent } from './hooks/useReplaceSelectionContent';
-export { default as useUpdateTranslation } from './hooks/useUpdateTranslation';
-export { default as useUpdateTranslationStatus } from './hooks/useUpdateTranslationStatus';
-export { default as useUpdateUnsavedChanges } from './hooks/useUpdateUnsavedChanges';
-
+export { EDITOR } from './reducer';
 export type { EditorState } from './reducer';
 export type { Translation } from './actions';
-
-// Name of this module.
-// Used as the key to store this module's reducer.
-export const NAME = 'editor';

--- a/translate/src/core/editor/reducer.ts
+++ b/translate/src/core/editor/reducer.ts
@@ -2,6 +2,8 @@ import type { SourceType } from '~/api/machinery';
 import type { FailedChecks } from '~/api/translation';
 
 import {
+  Action,
+  Translation,
   END_UPDATE_TRANSLATION,
   RESET_FAILED_CHECKS,
   RESET_SELECTION,
@@ -17,37 +19,9 @@ import {
   UPDATE_MACHINERY_SOURCES,
 } from './actions';
 
-import type {
-  EndUpdateTranslationAction,
-  InitialTranslationAction,
-  ResetEditorAction,
-  ResetHelperElementIndexAction,
-  ResetFailedChecksAction,
-  ResetSelectionAction,
-  SelectHelperElementIndexAction,
-  SelectHelperTabIndexAction,
-  StartUpdateTranslationAction,
-  Translation,
-  UpdateAction,
-  UpdateFailedChecksAction,
-  UpdateSelectionAction,
-  UpdateMachinerySourcesAction,
-} from './actions';
-
-type Action =
-  | EndUpdateTranslationAction
-  | InitialTranslationAction
-  | ResetEditorAction
-  | ResetHelperElementIndexAction
-  | ResetFailedChecksAction
-  | ResetSelectionAction
-  | SelectHelperElementIndexAction
-  | SelectHelperTabIndexAction
-  | StartUpdateTranslationAction
-  | UpdateAction
-  | UpdateFailedChecksAction
-  | UpdateSelectionAction
-  | UpdateMachinerySourcesAction;
+// Name of this module.
+// Used as the key to store this module's reducer.
+export const EDITOR = 'editor';
 
 export type EditorState = {
   readonly translation: Translation;
@@ -128,7 +102,7 @@ const initial: EditorState = {
   selectedHelperTabIndex: 0,
 };
 
-export default function reducer(
+export function reducer(
   state: EditorState = initial,
   action: Action,
 ): EditorState {

--- a/translate/src/core/entities/hooks.ts
+++ b/translate/src/core/entities/hooks.ts
@@ -4,7 +4,7 @@ import type { Entity } from '~/api/entity';
 import { Location } from '~/context/location';
 import { useAppSelector } from '~/hooks';
 
-import { NAME as ENTITIES } from './reducer';
+import { ENTITIES } from './reducer';
 
 export const useEntities = () => useAppSelector((state) => state[ENTITIES]);
 

--- a/translate/src/core/entities/reducer.ts
+++ b/translate/src/core/entities/reducer.ts
@@ -12,7 +12,7 @@ import {
 
 // Name of this module.
 // Used as the key to store this module's reducer.
-export const NAME = 'entities';
+export const ENTITIES = 'entities';
 
 type EntitiesState = {
   readonly entities: Entity[];

--- a/translate/src/core/loaders/components/SkeletonLoader.tsx
+++ b/translate/src/core/loaders/components/SkeletonLoader.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import './SkeletonLoader.css';
 
-export default function SkeletonLoader({
+export function SkeletonLoader({
   sentryRef,
   items,
 }: {

--- a/translate/src/core/loaders/components/WaveLoader.tsx
+++ b/translate/src/core/loaders/components/WaveLoader.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import './WaveLoader.css';
 
@@ -19,5 +19,3 @@ export const WaveLoader = (): React.ReactElement<any> => (
     </div>
   </div>
 );
-
-export default WaveLoader;

--- a/translate/src/core/loaders/index.ts
+++ b/translate/src/core/loaders/index.ts
@@ -1,2 +1,2 @@
-export { default as WaveLoader } from './components/WaveLoader';
-export { default as SkeletonLoader } from './components/SkeletonLoader';
+export { WaveLoader } from './components/WaveLoader';
+export { SkeletonLoader } from './components/SkeletonLoader';

--- a/translate/src/core/notification/actions.ts
+++ b/translate/src/core/notification/actions.ts
@@ -13,6 +13,8 @@ export type NotificationMessage = {
   readonly key?: string;
 };
 
+export type Action = AddAction;
+
 /**
  * Add a localized notification to display.
  *

--- a/translate/src/core/notification/index.ts
+++ b/translate/src/core/notification/index.ts
@@ -1,9 +1,4 @@
-export { default as reducer } from './reducer';
-
 export { NotificationPanel } from './components/NotificationPanel';
 
+export { NOTIFICATION } from './reducer';
 export type { NotificationState } from './reducer';
-
-// Name of this module.
-// Used as the key to store this module's reducer.
-export const NAME = 'notification';

--- a/translate/src/core/notification/messages.tsx
+++ b/translate/src/core/notification/messages.tsx
@@ -1,8 +1,8 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 import type { NotificationMessage } from './actions';
 
-const messages: Record<string, NotificationMessage> = {
+export const notificationMessages: Record<string, NotificationMessage> = {
   TRANSLATION_APPROVED: {
     content: (
       <Localized id='notification--translation-approved'>
@@ -162,5 +162,3 @@ const messages: Record<string, NotificationMessage> = {
     type: 'info',
   },
 };
-
-export default messages;

--- a/translate/src/core/notification/reducer.ts
+++ b/translate/src/core/notification/reducer.ts
@@ -1,8 +1,10 @@
 import { ADD } from './actions';
 
-import type { AddAction, NotificationMessage } from './actions';
+import type { Action, NotificationMessage } from './actions';
 
-type Action = AddAction;
+// Name of this module.
+// Used as the key to store this module's reducer.
+export const NOTIFICATION = 'notification';
 
 export type NotificationState = {
   readonly message: NotificationMessage | null | undefined;
@@ -12,7 +14,7 @@ const initial: NotificationState = {
   message: null,
 };
 
-export default function reducer(
+export function reducer(
   state: NotificationState = initial,
   action: Action,
 ): NotificationState {

--- a/translate/src/core/placeable/components/WithPlaceables.test.js
+++ b/translate/src/core/placeable/components/WithPlaceables.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import WithPlaceables from './WithPlaceables';
+import { WithPlaceables } from './WithPlaceables';
 
 describe('Test parser order', () => {
   it('matches JSON placeholder', () => {

--- a/translate/src/core/placeable/components/WithPlaceables.ts
+++ b/translate/src/core/placeable/components/WithPlaceables.ts
@@ -2,35 +2,35 @@ import createMarker from 'react-content-marker';
 
 import './WithPlaceables.css';
 
-import altAttribute from '../parsers/altAttribute';
-import camelCaseString from '../parsers/camelCaseString';
-import emailPattern from '../parsers/emailPattern';
-import escapeSequence from '../parsers/escapeSequence';
-import filePattern from '../parsers/filePattern';
-import javaFormattingVariable from '../parsers/javaFormattingVariable';
-import jsonPlaceholder from '../parsers/jsonPlaceholder';
-import leadingSpace from '../parsers/leadingSpace';
-import multipleSpaces from '../parsers/multipleSpaces';
-import narrowNonBreakingSpace from '../parsers/narrowNonBreakingSpace';
-import newlineCharacter from '../parsers/newlineCharacter';
-import newlineEscape from '../parsers/newlineEscape';
-import nonBreakingSpace from '../parsers/nonBreakingSpace';
-import nsisVariable from '../parsers/nsisVariable';
-import numberString from '../parsers/numberString';
-import optionPattern from '../parsers/optionPattern';
-import punctuation from '../parsers/punctuation';
-import pythonFormatNamedString from '../parsers/pythonFormatNamedString';
-import pythonFormatString from '../parsers/pythonFormatString';
-import pythonFormattingVariable from '../parsers/pythonFormattingVariable';
-import qtFormatting from '../parsers/qtFormatting';
-import shortCapitalNumberString from '../parsers/shortCapitalNumberString';
-import stringFormattingVariable from '../parsers/stringFormattingVariable';
-import tabCharacter from '../parsers/tabCharacter';
-import thinSpace from '../parsers/thinSpace';
-import unusualSpace from '../parsers/unusualSpace';
-import uriPattern from '../parsers/uriPattern';
-import xmlEntity from '../parsers/xmlEntity';
-import xmlTag from '../parsers/xmlTag';
+import { altAttribute } from '../parsers/altAttribute';
+import { camelCaseString } from '../parsers/camelCaseString';
+import { emailPattern } from '../parsers/emailPattern';
+import { escapeSequence } from '../parsers/escapeSequence';
+import { filePattern } from '../parsers/filePattern';
+import { javaFormattingVariable } from '../parsers/javaFormattingVariable';
+import { jsonPlaceholder } from '../parsers/jsonPlaceholder';
+import { leadingSpace } from '../parsers/leadingSpace';
+import { multipleSpaces } from '../parsers/multipleSpaces';
+import { narrowNonBreakingSpace } from '../parsers/narrowNonBreakingSpace';
+import { newlineCharacter } from '../parsers/newlineCharacter';
+import { newlineEscape } from '../parsers/newlineEscape';
+import { nonBreakingSpace } from '../parsers/nonBreakingSpace';
+import { nsisVariable } from '../parsers/nsisVariable';
+import { numberString } from '../parsers/numberString';
+import { optionPattern } from '../parsers/optionPattern';
+import { punctuation } from '../parsers/punctuation';
+import { pythonFormatNamedString } from '../parsers/pythonFormatNamedString';
+import { pythonFormatString } from '../parsers/pythonFormatString';
+import { pythonFormattingVariable } from '../parsers/pythonFormattingVariable';
+import { qtFormatting } from '../parsers/qtFormatting';
+import { shortCapitalNumberString } from '../parsers/shortCapitalNumberString';
+import { stringFormattingVariable } from '../parsers/stringFormattingVariable';
+import { tabCharacter } from '../parsers/tabCharacter';
+import { thinSpace } from '../parsers/thinSpace';
+import { unusualSpace } from '../parsers/unusualSpace';
+import { uriPattern } from '../parsers/uriPattern';
+import { xmlEntity } from '../parsers/xmlEntity';
+import { xmlTag } from '../parsers/xmlTag';
 
 // Note: the order of these MATTERS!
 export const rules = [
@@ -82,6 +82,4 @@ export const rules = [
 /**
  * Component that marks placeables in a string.
  */
-const WithPlaceables: any = createMarker(rules);
-
-export default WithPlaceables;
+export const WithPlaceables: any = createMarker(rules);

--- a/translate/src/core/placeable/components/WithPlaceablesForFluent.test.js
+++ b/translate/src/core/placeable/components/WithPlaceablesForFluent.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import each from 'jest-each';
 
-import WithPlaceablesForFluent from './WithPlaceablesForFluent';
+import { WithPlaceablesForFluent } from './WithPlaceablesForFluent';
 
 describe('<WithPlaceablesForFluent>', () => {
   each([

--- a/translate/src/core/placeable/components/WithPlaceablesForFluent.ts
+++ b/translate/src/core/placeable/components/WithPlaceablesForFluent.ts
@@ -4,11 +4,11 @@ import type { Parser } from 'react-content-marker';
 import './WithPlaceables.css';
 
 import { rules } from './WithPlaceables';
-import fluentFunction from '../parsers/fluentFunction';
-import fluentParametrizedTerm from '../parsers/fluentParametrizedTerm';
-import fluentString from '../parsers/fluentString';
-import fluentTerm from '../parsers/fluentTerm';
-import multipleSpaces from '../parsers/multipleSpaces';
+import { fluentFunction } from '../parsers/fluentFunction';
+import { fluentParametrizedTerm } from '../parsers/fluentParametrizedTerm';
+import { fluentString } from '../parsers/fluentString';
+import { fluentTerm } from '../parsers/fluentTerm';
+import { multipleSpaces } from '../parsers/multipleSpaces';
 
 export function getRulesWithFluent(rules: Array<Parser>): Array<Parser> {
   const newRules = [...rules];
@@ -30,6 +30,6 @@ export function getRulesWithFluent(rules: Array<Parser>): Array<Parser> {
  * The Fluent rules must come right after the space rules, otherwise it
  * generates a lot of false positives.
  */
-const WithPlaceablesForFluent: any = createMarker(getRulesWithFluent(rules));
-
-export default WithPlaceablesForFluent;
+export const WithPlaceablesForFluent: any = createMarker(
+  getRulesWithFluent(rules),
+);

--- a/translate/src/core/placeable/components/WithPlaceablesForFluentNoLeadingSpace.ts
+++ b/translate/src/core/placeable/components/WithPlaceablesForFluentNoLeadingSpace.ts
@@ -12,8 +12,6 @@ import { getRulesWithoutLeadingSpace } from './WithPlaceablesNoLeadingSpace';
  *
  * See ./WithPlaceablesNoLeadingSpace.js for documentation.
  */
-const WithPlaceablesForFluentNoLeadingSpace: any = createMarker(
+export const WithPlaceablesForFluentNoLeadingSpace: any = createMarker(
   getRulesWithFluent(getRulesWithoutLeadingSpace(rules)),
 );
-
-export default WithPlaceablesForFluentNoLeadingSpace;

--- a/translate/src/core/placeable/components/WithPlaceablesNoLeadingSpace.test.js
+++ b/translate/src/core/placeable/components/WithPlaceablesNoLeadingSpace.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import WithPlaceablesNoLeadingSpace from './WithPlaceablesNoLeadingSpace';
+import { WithPlaceablesNoLeadingSpace } from './WithPlaceablesNoLeadingSpace';
 
 describe('<WithPlaceablesNoLeadingSpace>', () => {
   it('matches newlines in a string', () => {

--- a/translate/src/core/placeable/components/WithPlaceablesNoLeadingSpace.ts
+++ b/translate/src/core/placeable/components/WithPlaceablesNoLeadingSpace.ts
@@ -4,8 +4,8 @@ import type { Parser } from 'react-content-marker';
 import './WithPlaceables.css';
 
 import { rules } from './WithPlaceables';
-import leadingSpace from '../parsers/leadingSpace';
-import unusualSpace from '../parsers/unusualSpace';
+import { leadingSpace } from '../parsers/leadingSpace';
+import { unusualSpace } from '../parsers/unusualSpace';
 
 export function getRulesWithoutLeadingSpace(
   rules: Array<Parser>,
@@ -27,8 +27,6 @@ export function getRulesWithoutLeadingSpace(
  * have a special Placeables component without that parser, for use in
  * combination with other parsing tools (like diff).
  */
-const WithPlaceablesNoLeadingSpace: any = createMarker(
+export const WithPlaceablesNoLeadingSpace: any = createMarker(
   getRulesWithoutLeadingSpace(rules),
 );
-
-export default WithPlaceablesNoLeadingSpace;

--- a/translate/src/core/placeable/index.ts
+++ b/translate/src/core/placeable/index.ts
@@ -1,14 +1,10 @@
-export { default as WithPlaceables } from './components/WithPlaceables';
+export { WithPlaceables } from './components/WithPlaceables';
 export { rules } from './components/WithPlaceables';
 
-export { default as WithPlaceablesForFluent } from './components/WithPlaceablesForFluent';
+export { WithPlaceablesForFluent } from './components/WithPlaceablesForFluent';
 export { getRulesWithFluent } from './components/WithPlaceablesForFluent';
 
-export { default as WithPlaceablesNoLeadingSpace } from './components/WithPlaceablesNoLeadingSpace';
+export { WithPlaceablesNoLeadingSpace } from './components/WithPlaceablesNoLeadingSpace';
 export { getRulesWithoutLeadingSpace } from './components/WithPlaceablesNoLeadingSpace';
 
-export { default as WithPlaceablesForFluentNoLeadingSpace } from './components/WithPlaceablesForFluentNoLeadingSpace';
-
-// Name of this module.
-// Used as the key to store this module's reducer.
-export const NAME = 'placeable';
+export { WithPlaceablesForFluentNoLeadingSpace } from './components/WithPlaceablesForFluentNoLeadingSpace';

--- a/translate/src/core/placeable/parsers/altAttribute.test.js
+++ b/translate/src/core/placeable/parsers/altAttribute.test.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 
 import createMarker from 'react-content-marker';
 
-import altAttribute from './altAttribute';
+import { altAttribute } from './altAttribute';
 
 describe('altAttribute', () => {
   it('marks the right parts of a string', () => {

--- a/translate/src/core/placeable/parsers/altAttribute.tsx
+++ b/translate/src/core/placeable/parsers/altAttribute.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import { Localized } from '@fluent/react';
+import React from 'react';
 
 /**
  * Marks `alt` attributes and their values inside XML tags.
@@ -12,7 +12,7 @@ import { Localized } from '@fluent/react';
  * Source:
  * https://github.com/translate/translate/blob/2.3.1/translate/storage/placeables/general.py#L55
  */
-const altAttribute = {
+export const altAttribute = {
   rule: /(alt=".*?")/i as RegExp,
   tag: (x: string): React.ReactElement<React.ElementType> => {
     return (
@@ -28,5 +28,3 @@ const altAttribute = {
     );
   },
 };
-
-export default altAttribute;

--- a/translate/src/core/placeable/parsers/camelCaseString.test.js
+++ b/translate/src/core/placeable/parsers/camelCaseString.test.js
@@ -4,7 +4,7 @@ import each from 'jest-each';
 
 import createMarker from 'react-content-marker';
 
-import camelCaseString from './camelCaseString';
+import { camelCaseString } from './camelCaseString';
 
 describe('camelCaseString', () => {
   each([

--- a/translate/src/core/placeable/parsers/camelCaseString.tsx
+++ b/translate/src/core/placeable/parsers/camelCaseString.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
@@ -13,7 +13,7 @@ import { Localized } from '@fluent/react';
  * Source:
  * https://github.com/translate/translate/blob/2.3.1/translate/storage/placeables/general.py#L274
  */
-const camelCaseString = {
+export const camelCaseString = {
   rule: /(\b([a-z]+[A-Z]|[A-Z]+[a-z]+[A-Z]|[A-Z]{2,}[a-z])[a-zA-Z0-9]*\b)/ as RegExp,
   matchIndex: 0,
   tag: (x: string): React.ReactElement<React.ElementType> => {
@@ -26,5 +26,3 @@ const camelCaseString = {
     );
   },
 };
-
-export default camelCaseString;

--- a/translate/src/core/placeable/parsers/emailPattern.test.js
+++ b/translate/src/core/placeable/parsers/emailPattern.test.js
@@ -4,7 +4,7 @@ import each from 'jest-each';
 
 import createMarker from 'react-content-marker';
 
-import emailPattern from './emailPattern';
+import { emailPattern } from './emailPattern';
 
 describe('emailPattern', () => {
   each([

--- a/translate/src/core/placeable/parsers/emailPattern.tsx
+++ b/translate/src/core/placeable/parsers/emailPattern.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
@@ -13,7 +13,7 @@ import { Localized } from '@fluent/react';
  * Source:
  * https://github.com/translate/translate/blob/2.3.1/translate/storage/placeables/general.py#L220
  */
-const emailPattern = {
+export const emailPattern = {
   rule: /(((mailto:)|)[A-Za-z0-9]+[-a-zA-Z0-9._%]*@(([-A-Za-z0-9]+)\.)+[a-zA-Z]{2,4})/ as RegExp,
   matchIndex: 0,
   tag: (x: string): React.ReactElement<React.ElementType> => {
@@ -26,5 +26,3 @@ const emailPattern = {
     );
   },
 };
-
-export default emailPattern;

--- a/translate/src/core/placeable/parsers/escapeSequence.test.js
+++ b/translate/src/core/placeable/parsers/escapeSequence.test.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 
 import createMarker from 'react-content-marker';
 
-import escapeSequence from './escapeSequence';
+import { escapeSequence } from './escapeSequence';
 
 describe('escapeSequence', () => {
   it('marks the right parts of a string', () => {

--- a/translate/src/core/placeable/parsers/escapeSequence.tsx
+++ b/translate/src/core/placeable/parsers/escapeSequence.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
  * Marks the escape character "\".
  */
-const escapeSequence = {
+export const escapeSequence = {
   rule: '\\',
   tag: (x: string): React.ReactElement<React.ElementType> => {
     return (
@@ -16,5 +16,3 @@ const escapeSequence = {
     );
   },
 };
-
-export default escapeSequence;

--- a/translate/src/core/placeable/parsers/filePattern.test.js
+++ b/translate/src/core/placeable/parsers/filePattern.test.js
@@ -4,7 +4,7 @@ import each from 'jest-each';
 
 import createMarker from 'react-content-marker';
 
-import filePattern from './filePattern';
+import { filePattern } from './filePattern';
 
 describe('filePattern', () => {
   each([

--- a/translate/src/core/placeable/parsers/filePattern.tsx
+++ b/translate/src/core/placeable/parsers/filePattern.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
@@ -13,7 +13,7 @@ import { Localized } from '@fluent/react';
  * Source:
  * https://github.com/translate/translate/blob/2.3.1/translate/storage/placeables/general.py#L208
  */
-const filePattern = {
+export const filePattern = {
   rule: /(^|\s)((~\/|\/|\.\/)([-A-Za-z0-9_$.+!*(),;:@&=?/~#%]|\\){3,})/ as RegExp,
   matchIndex: 2,
   tag: (x: string): React.ReactElement<React.ElementType> => {
@@ -26,5 +26,3 @@ const filePattern = {
     );
   },
 };
-
-export default filePattern;

--- a/translate/src/core/placeable/parsers/fluentFunction.test.js
+++ b/translate/src/core/placeable/parsers/fluentFunction.test.js
@@ -3,7 +3,7 @@ import createMarker from 'react-content-marker';
 import { shallow } from 'enzyme';
 import each from 'jest-each';
 
-import fluentFunction from './fluentFunction';
+import { fluentFunction } from './fluentFunction';
 
 describe('fluentFunction', () => {
   each([

--- a/translate/src/core/placeable/parsers/fluentFunction.tsx
+++ b/translate/src/core/placeable/parsers/fluentFunction.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
@@ -12,7 +12,7 @@ import { Localized } from '@fluent/react';
  *   { DATETIME($date) }
  *   { NUMBER($ratio, minimumFractionDigits: 2) }
  */
-const fluentFunction = {
+export const fluentFunction = {
   rule: /({ ?[A-W0-9\-_]+[^}]* ?})/ as RegExp,
   tag: (x: string): React.ReactElement<React.ElementType> => {
     return (
@@ -24,5 +24,3 @@ const fluentFunction = {
     );
   },
 };
-
-export default fluentFunction;

--- a/translate/src/core/placeable/parsers/fluentParametrizedTerm.test.js
+++ b/translate/src/core/placeable/parsers/fluentParametrizedTerm.test.js
@@ -3,7 +3,7 @@ import createMarker from 'react-content-marker';
 import { shallow } from 'enzyme';
 import each from 'jest-each';
 
-import fluentParametrizedTerm from './fluentParametrizedTerm';
+import { fluentParametrizedTerm } from './fluentParametrizedTerm';
 
 describe('fluentParametrizedTerm', () => {
   each([

--- a/translate/src/core/placeable/parsers/fluentParametrizedTerm.tsx
+++ b/translate/src/core/placeable/parsers/fluentParametrizedTerm.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
@@ -12,7 +12,7 @@ import { Localized } from '@fluent/react';
  *   { -brand(case: "what ever") }
  *   { -brand-name(foo-bar: "now that's a value!") }
  */
-const fluentParametrizedTerm = {
+export const fluentParametrizedTerm = {
   rule: /({ ?-[^}]*([^}]*: ?[^}]*) ?})/ as RegExp,
   matchIndex: 1,
   tag: (x: string): React.ReactElement<React.ElementType> => {
@@ -28,5 +28,3 @@ const fluentParametrizedTerm = {
     );
   },
 };
-
-export default fluentParametrizedTerm;

--- a/translate/src/core/placeable/parsers/fluentString.test.js
+++ b/translate/src/core/placeable/parsers/fluentString.test.js
@@ -3,7 +3,7 @@ import createMarker from 'react-content-marker';
 import { shallow } from 'enzyme';
 import each from 'jest-each';
 
-import fluentString from './fluentString';
+import { fluentString } from './fluentString';
 
 describe('fluentString', () => {
   each([

--- a/translate/src/core/placeable/parsers/fluentString.tsx
+++ b/translate/src/core/placeable/parsers/fluentString.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
@@ -11,7 +11,7 @@ import { Localized } from '@fluent/react';
  *   { "" }
  *   { "Hello, World" }
  */
-const fluentString = {
+export const fluentString = {
   rule: /({ ?"[^}]*" ?})/ as RegExp,
   tag: (x: string): React.ReactElement<React.ElementType> => {
     return (
@@ -23,5 +23,3 @@ const fluentString = {
     );
   },
 };
-
-export default fluentString;

--- a/translate/src/core/placeable/parsers/fluentTerm.test.js
+++ b/translate/src/core/placeable/parsers/fluentTerm.test.js
@@ -3,7 +3,7 @@ import createMarker from 'react-content-marker';
 import { shallow } from 'enzyme';
 import each from 'jest-each';
 
-import fluentTerm from './fluentTerm';
+import { fluentTerm } from './fluentTerm';
 
 describe('fluentTerm', () => {
   each([

--- a/translate/src/core/placeable/parsers/fluentTerm.tsx
+++ b/translate/src/core/placeable/parsers/fluentTerm.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
@@ -12,7 +12,7 @@ import { Localized } from '@fluent/react';
  *   { -brand }
  *   { -brand-name }
  */
-const fluentTerm = {
+export const fluentTerm = {
   rule: /({ ?-[^}]* ?})/ as RegExp,
   tag: (x: string): React.ReactElement<React.ElementType> => {
     return (
@@ -24,5 +24,3 @@ const fluentTerm = {
     );
   },
 };
-
-export default fluentTerm;

--- a/translate/src/core/placeable/parsers/javaFormattingVariable.test.js
+++ b/translate/src/core/placeable/parsers/javaFormattingVariable.test.js
@@ -4,7 +4,7 @@ import each from 'jest-each';
 
 import createMarker from 'react-content-marker';
 
-import javaFormattingVariable from './javaFormattingVariable';
+import { javaFormattingVariable } from './javaFormattingVariable';
 
 describe('javaFormattingVariable', () => {
   each([

--- a/translate/src/core/placeable/parsers/javaFormattingVariable.tsx
+++ b/translate/src/core/placeable/parsers/javaFormattingVariable.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
@@ -21,7 +21,7 @@ import { Localized } from '@fluent/react';
  * Source:
  * https://github.com/translate/translate/blob/2.3.1/translate/storage/placeables/general.py#L127
  */
-const javaFormattingVariable = {
+export const javaFormattingVariable = {
   rule: /({[0-9]+(,\s*(number(,\s*(integer|currency|percent|[-0#.,E;%\u2030\u00a4']+)?)?|(date|time)(,\s*(short|medium|long|full|.+?))?|choice,([^{]+({.+})?)+)?)?})/ as RegExp,
   matchIndex: 0,
   tag: (x: string): React.ReactElement<React.ElementType> => {
@@ -41,5 +41,3 @@ const javaFormattingVariable = {
     );
   },
 };
-
-export default javaFormattingVariable;

--- a/translate/src/core/placeable/parsers/jsonPlaceholder.test.js
+++ b/translate/src/core/placeable/parsers/jsonPlaceholder.test.js
@@ -4,7 +4,7 @@ import each from 'jest-each';
 
 import createMarker from 'react-content-marker';
 
-import jsonPlaceholder from './jsonPlaceholder';
+import { jsonPlaceholder } from './jsonPlaceholder';
 
 describe('jsonPlaceholder', () => {
   each([

--- a/translate/src/core/placeable/parsers/jsonPlaceholder.tsx
+++ b/translate/src/core/placeable/parsers/jsonPlaceholder.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
@@ -12,7 +12,7 @@ import { Localized } from '@fluent/react';
  *   $USER$
  *   $FIRST_NAME$
  */
-const jsonPlaceholder = {
+export const jsonPlaceholder = {
   rule: /(\$[A-Z0-9_]+\$)/ as RegExp,
   tag: (x: string): React.ReactElement<React.ElementType> => {
     return (
@@ -24,5 +24,3 @@ const jsonPlaceholder = {
     );
   },
 };
-
-export default jsonPlaceholder;

--- a/translate/src/core/placeable/parsers/leadingSpace.test.js
+++ b/translate/src/core/placeable/parsers/leadingSpace.test.js
@@ -4,7 +4,7 @@ import each from 'jest-each';
 
 import createMarker from 'react-content-marker';
 
-import leadingSpace from './leadingSpace';
+import { leadingSpace } from './leadingSpace';
 
 describe('leadingSpace', () => {
   each([[' ', ' hello world']]).it('marks `%s` in `%s`', (mark, content) => {

--- a/translate/src/core/placeable/parsers/leadingSpace.tsx
+++ b/translate/src/core/placeable/parsers/leadingSpace.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
@@ -8,7 +8,7 @@ import { Localized } from '@fluent/react';
  *
  *   " Hello, world"
  */
-const leadingSpace = {
+export const leadingSpace = {
   rule: /(^ +)/ as RegExp,
   tag: (x: string): React.ReactElement<React.ElementType> => {
     return (
@@ -20,5 +20,3 @@ const leadingSpace = {
     );
   },
 };
-
-export default leadingSpace;

--- a/translate/src/core/placeable/parsers/multipleSpaces.test.js
+++ b/translate/src/core/placeable/parsers/multipleSpaces.test.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 
 import createMarker from 'react-content-marker';
 
-import multipleSpaces from './multipleSpaces';
+import { multipleSpaces } from './multipleSpaces';
 
 describe('multipleSpaces', () => {
   it('marks the right parts of a string', () => {

--- a/translate/src/core/placeable/parsers/multipleSpaces.tsx
+++ b/translate/src/core/placeable/parsers/multipleSpaces.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
  * Marks multiple consecutive spaces and replaces them with a middle dot.
  */
-const multipleSpaces = {
+export const multipleSpaces = {
   rule: /(  +)/ as RegExp,
   tag: (x: string): React.ReactElement<React.ElementType> => {
     return (
@@ -22,5 +22,3 @@ const multipleSpaces = {
     );
   },
 };
-
-export default multipleSpaces;

--- a/translate/src/core/placeable/parsers/narrowNonBreakingSpace.test.js
+++ b/translate/src/core/placeable/parsers/narrowNonBreakingSpace.test.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 
 import createMarker from 'react-content-marker';
 
-import narrowNonBreakingSpace from './narrowNonBreakingSpace';
+import { narrowNonBreakingSpace } from './narrowNonBreakingSpace';
 
 describe('narrowNonBreakingSpace', () => {
   it('marks the right parts of a string', () => {

--- a/translate/src/core/placeable/parsers/narrowNonBreakingSpace.tsx
+++ b/translate/src/core/placeable/parsers/narrowNonBreakingSpace.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
  * Marks the narrow no-break space character (Unicode U+202F).
  */
-const narrowNonBreakingSpace = {
+export const narrowNonBreakingSpace = {
   rule: /([\u202F])/ as RegExp,
   tag: (x: string): React.ReactElement<React.ElementType> => {
     return (
@@ -19,5 +19,3 @@ const narrowNonBreakingSpace = {
     );
   },
 };
-
-export default narrowNonBreakingSpace;

--- a/translate/src/core/placeable/parsers/newlineCharacter.test.js
+++ b/translate/src/core/placeable/parsers/newlineCharacter.test.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 
 import createMarker from 'react-content-marker';
 
-import newlineCharacter from './newlineCharacter';
+import { newlineCharacter } from './newlineCharacter';
 
 describe('newlineCharacter', () => {
   it('marks the right parts of a string', () => {

--- a/translate/src/core/placeable/parsers/newlineCharacter.tsx
+++ b/translate/src/core/placeable/parsers/newlineCharacter.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
  * Marks the newline character "\n".
  */
-const newlineCharacter = {
+export const newlineCharacter = {
   rule: '\n',
   tag: (x: string): React.ReactElement<React.ElementType> => {
     return (
@@ -22,5 +22,3 @@ const newlineCharacter = {
     );
   },
 };
-
-export default newlineCharacter;

--- a/translate/src/core/placeable/parsers/newlineEscape.test.js
+++ b/translate/src/core/placeable/parsers/newlineEscape.test.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 
 import createMarker from 'react-content-marker';
 
-import newlineEscape from './newlineEscape';
+import { newlineEscape } from './newlineEscape';
 
 describe('newlineEscape', () => {
   it('marks the right parts of a string', () => {

--- a/translate/src/core/placeable/parsers/newlineEscape.tsx
+++ b/translate/src/core/placeable/parsers/newlineEscape.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
  * Marks escaped newline characters.
  */
-const newlineEscape = {
+export const newlineEscape = {
   rule: '\\n',
   tag: (x: string): React.ReactElement<React.ElementType> => {
     return (
@@ -16,5 +16,3 @@ const newlineEscape = {
     );
   },
 };
-
-export default newlineEscape;

--- a/translate/src/core/placeable/parsers/nonBreakingSpace.test.js
+++ b/translate/src/core/placeable/parsers/nonBreakingSpace.test.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 
 import createMarker from 'react-content-marker';
 
-import nonBreakingSpace from './nonBreakingSpace';
+import { nonBreakingSpace } from './nonBreakingSpace';
 
 describe('nonBreakingSpace', () => {
   it('marks the right parts of a string', () => {

--- a/translate/src/core/placeable/parsers/nonBreakingSpace.tsx
+++ b/translate/src/core/placeable/parsers/nonBreakingSpace.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
  * Marks the no-break space character (Unicode U+00A0).
  */
-const nonBreakingSpace = {
+export const nonBreakingSpace = {
   rule: '\u00A0',
   tag: (x: string): React.ReactElement<React.ElementType> => {
     return (
@@ -16,5 +16,3 @@ const nonBreakingSpace = {
     );
   },
 };
-
-export default nonBreakingSpace;

--- a/translate/src/core/placeable/parsers/nsisVariable.test.js
+++ b/translate/src/core/placeable/parsers/nsisVariable.test.js
@@ -4,7 +4,7 @@ import each from 'jest-each';
 
 import createMarker from 'react-content-marker';
 
-import nsisVariable from './nsisVariable';
+import { nsisVariable } from './nsisVariable';
 
 describe('nsisVariable', () => {
   each([

--- a/translate/src/core/placeable/parsers/nsisVariable.tsx
+++ b/translate/src/core/placeable/parsers/nsisVariable.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
@@ -9,7 +9,7 @@ import { Localized } from '@fluent/react';
  *   $Brand
  *   $BrandShortName
  */
-const nsisVariable = {
+export const nsisVariable = {
   rule: /(^|\s)(\$[a-zA-Z][\w]*)/ as RegExp,
   matchIndex: 2,
   tag: (x: string): React.ReactElement<React.ElementType> => {
@@ -22,5 +22,3 @@ const nsisVariable = {
     );
   },
 };
-
-export default nsisVariable;

--- a/translate/src/core/placeable/parsers/numberString.test.js
+++ b/translate/src/core/placeable/parsers/numberString.test.js
@@ -4,7 +4,7 @@ import each from 'jest-each';
 
 import createMarker from 'react-content-marker';
 
-import numberString from './numberString';
+import { numberString } from './numberString';
 
 describe('numberString', () => {
   each([

--- a/translate/src/core/placeable/parsers/numberString.tsx
+++ b/translate/src/core/placeable/parsers/numberString.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
@@ -14,7 +14,7 @@ import { Localized } from '@fluent/react';
  * Source:
  * https://github.com/translate/translate/blob/2.3.1/translate/storage/placeables/general.py#L72
  */
-const numberString = {
+export const numberString = {
   rule: /([-+]?[0-9]+([\u00A0.,][0-9]+)*)\b/u as RegExp,
   matchIndex: 0,
   tag: (x: string): React.ReactElement<React.ElementType> => {
@@ -27,5 +27,3 @@ const numberString = {
     );
   },
 };
-
-export default numberString;

--- a/translate/src/core/placeable/parsers/optionPattern.test.js
+++ b/translate/src/core/placeable/parsers/optionPattern.test.js
@@ -4,7 +4,7 @@ import each from 'jest-each';
 
 import createMarker from 'react-content-marker';
 
-import optionPattern from './optionPattern';
+import { optionPattern } from './optionPattern';
 
 describe('optionPattern', () => {
   each([

--- a/translate/src/core/placeable/parsers/optionPattern.tsx
+++ b/translate/src/core/placeable/parsers/optionPattern.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
@@ -12,7 +12,7 @@ import { Localized } from '@fluent/react';
  * Source:
  * https://github.com/translate/translate/blob/2.3.1/translate/storage/placeables/general.py#L317
  */
-const optionPattern = {
+export const optionPattern = {
   rule: /(\B(-[a-zA-Z]|--[a-z-]+)\b)/ as RegExp,
   matchIndex: 0,
   tag: (x: string): React.ReactElement<React.ElementType> => {
@@ -25,5 +25,3 @@ const optionPattern = {
     );
   },
 };
-
-export default optionPattern;

--- a/translate/src/core/placeable/parsers/punctuation.test.js
+++ b/translate/src/core/placeable/parsers/punctuation.test.js
@@ -4,7 +4,7 @@ import each from 'jest-each';
 
 import createMarker from 'react-content-marker';
 
-import punctuation from './punctuation';
+import { punctuation } from './punctuation';
 
 describe('punctuation', () => {
   each([

--- a/translate/src/core/placeable/parsers/punctuation.tsx
+++ b/translate/src/core/placeable/parsers/punctuation.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
@@ -7,7 +7,7 @@ import { Localized } from '@fluent/react';
  * Source:
  * https://github.com/translate/translate/blob/2.3.1/translate/storage/placeables/general.py#L229
  */
-const punctuation = {
+export const punctuation = {
   rule: new RegExp(
     '(' +
       '(' +
@@ -35,5 +35,3 @@ const punctuation = {
     );
   },
 };
-
-export default punctuation;

--- a/translate/src/core/placeable/parsers/pythonFormatNamedString.test.js
+++ b/translate/src/core/placeable/parsers/pythonFormatNamedString.test.js
@@ -4,7 +4,7 @@ import each from 'jest-each';
 
 import createMarker from 'react-content-marker';
 
-import pythonFormatNamedString from './pythonFormatNamedString';
+import { pythonFormatNamedString } from './pythonFormatNamedString';
 
 describe('pythonFormatNamedString', () => {
   each([

--- a/translate/src/core/placeable/parsers/pythonFormatNamedString.tsx
+++ b/translate/src/core/placeable/parsers/pythonFormatNamedString.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
@@ -9,7 +9,7 @@ import { Localized } from '@fluent/react';
  *   %(name)s
  *   %(number)D
  */
-const pythonFormatNamedString = {
+export const pythonFormatNamedString = {
   rule: /(%\([[\w\d!.,[\]%:$<>+\-= ]*\)[+|-|0\d+|#]?[.\d+]?[s|d|e|f|g|o|x|c|%])/i as RegExp,
   tag: (x: string): React.ReactElement<React.ElementType> => {
     return (
@@ -24,5 +24,3 @@ const pythonFormatNamedString = {
     );
   },
 };
-
-export default pythonFormatNamedString;

--- a/translate/src/core/placeable/parsers/pythonFormatString.test.js
+++ b/translate/src/core/placeable/parsers/pythonFormatString.test.js
@@ -4,7 +4,7 @@ import each from 'jest-each';
 
 import createMarker from 'react-content-marker';
 
-import pythonFormatString from './pythonFormatString';
+import { pythonFormatString } from './pythonFormatString';
 
 describe('pythonFormatString', () => {
   each([

--- a/translate/src/core/placeable/parsers/pythonFormatString.tsx
+++ b/translate/src/core/placeable/parsers/pythonFormatString.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
@@ -13,7 +13,7 @@ import { Localized } from '@fluent/react';
  *   {number}
  *   {foo[42]}
  */
-const pythonFormatString = {
+export const pythonFormatString = {
   rule: /(\{{?[\w\d!.,[\]%:$<>+-= ]*\}?})/ as RegExp,
   tag: (x: string): React.ReactElement<React.ElementType> => {
     return (
@@ -28,5 +28,3 @@ const pythonFormatString = {
     );
   },
 };
-
-export default pythonFormatString;

--- a/translate/src/core/placeable/parsers/pythonFormattingVariable.test.js
+++ b/translate/src/core/placeable/parsers/pythonFormattingVariable.test.js
@@ -4,7 +4,7 @@ import each from 'jest-each';
 
 import createMarker from 'react-content-marker';
 
-import pythonFormattingVariable from './pythonFormattingVariable';
+import { pythonFormattingVariable } from './pythonFormattingVariable';
 
 describe('pythonFormattingVariable', () => {
   each([

--- a/translate/src/core/placeable/parsers/pythonFormattingVariable.tsx
+++ b/translate/src/core/placeable/parsers/pythonFormattingVariable.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
@@ -16,7 +16,7 @@ import { Localized } from '@fluent/react';
  * Source:
  * https://github.com/translate/translate/blob/2.3.1/translate/storage/placeables/general.py#L115
  */
-const pythonFormattingVariable = {
+export const pythonFormattingVariable = {
   rule: /(%(%|(\([^)]+\)){0,1}[-+0#]{0,1}(\d+|\*){0,1}(\.(\d+|\*)){0,1}[hlL]{0,1}[diouxXeEfFgGcrs]{1}))/ as RegExp,
   matchIndex: 0,
   tag: (x: string): React.ReactElement<React.ElementType> => {
@@ -36,5 +36,3 @@ const pythonFormattingVariable = {
     );
   },
 };
-
-export default pythonFormattingVariable;

--- a/translate/src/core/placeable/parsers/qtFormatting.test.js
+++ b/translate/src/core/placeable/parsers/qtFormatting.test.js
@@ -4,7 +4,7 @@ import each from 'jest-each';
 
 import createMarker from 'react-content-marker';
 
-import qtFormatting from './qtFormatting';
+import { qtFormatting } from './qtFormatting';
 
 describe('qtFormatting', () => {
   each([

--- a/translate/src/core/placeable/parsers/qtFormatting.tsx
+++ b/translate/src/core/placeable/parsers/qtFormatting.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
@@ -23,7 +23,7 @@ import { Localized } from '@fluent/react';
  * Source:
  * https://github.com/translate/translate/blob/2.3.1/translate/storage/placeables/general.py#L80
  */
-const qtFormatting = {
+export const qtFormatting = {
   rule: /(%L?[1-9]\d{0,1}(?=([^\d]|$)))/ as RegExp,
   matchIndex: 0,
   tag: (x: string): React.ReactElement<React.ElementType> => {
@@ -40,5 +40,3 @@ const qtFormatting = {
     );
   },
 };
-
-export default qtFormatting;

--- a/translate/src/core/placeable/parsers/shortCapitalNumberString.test.js
+++ b/translate/src/core/placeable/parsers/shortCapitalNumberString.test.js
@@ -4,7 +4,7 @@ import each from 'jest-each';
 
 import createMarker from 'react-content-marker';
 
-import shortCapitalNumberString from './shortCapitalNumberString';
+import { shortCapitalNumberString } from './shortCapitalNumberString';
 
 describe('shortCapitalNumberString', () => {
   each([

--- a/translate/src/core/placeable/parsers/shortCapitalNumberString.tsx
+++ b/translate/src/core/placeable/parsers/shortCapitalNumberString.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
@@ -10,7 +10,7 @@ import { Localized } from '@fluent/react';
  *   3D
  *   A4
  */
-const shortCapitalNumberString = {
+export const shortCapitalNumberString = {
   rule: /(\b([A-Z][0-9])|([0-9][A-Z])\b)/ as RegExp,
   tag: (x: string): React.ReactElement<React.ElementType> => {
     return (
@@ -29,5 +29,3 @@ const shortCapitalNumberString = {
     );
   },
 };
-
-export default shortCapitalNumberString;

--- a/translate/src/core/placeable/parsers/stringFormattingVariable.test.js
+++ b/translate/src/core/placeable/parsers/stringFormattingVariable.test.js
@@ -4,7 +4,7 @@ import each from 'jest-each';
 
 import createMarker from 'react-content-marker';
 
-import stringFormattingVariable from './stringFormattingVariable';
+import { stringFormattingVariable } from './stringFormattingVariable';
 
 describe('stringFormattingVariable', () => {
   each([

--- a/translate/src/core/placeable/parsers/stringFormattingVariable.tsx
+++ b/translate/src/core/placeable/parsers/stringFormattingVariable.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
@@ -15,7 +15,7 @@ import { Localized } from '@fluent/react';
  * Source:
  * https://github.com/translate/translate/blob/2.3.1/translate/storage/placeables/general.py#L154
  */
-const stringFormattingVariable = {
+export const stringFormattingVariable = {
   rule: /(%(\d+\$)?[-+0#'I]?((\d+)|[*])?(\.\d+)?[hlI]?[cCdiouxXeEfgGnpsS])/ as RegExp,
   matchIndex: 0,
   tag: (x: string): React.ReactElement<React.ElementType> => {
@@ -35,5 +35,3 @@ const stringFormattingVariable = {
     );
   },
 };
-
-export default stringFormattingVariable;

--- a/translate/src/core/placeable/parsers/tabCharacter.test.js
+++ b/translate/src/core/placeable/parsers/tabCharacter.test.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 
 import createMarker from 'react-content-marker';
 
-import tabCharacter from './tabCharacter';
+import { tabCharacter } from './tabCharacter';
 
 describe('tabCharacter', () => {
   it('marks the right parts of a string', () => {

--- a/translate/src/core/placeable/parsers/tabCharacter.tsx
+++ b/translate/src/core/placeable/parsers/tabCharacter.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
  * Marks the tab character "\t".
  */
-const tabCharacter = {
+export const tabCharacter = {
   rule: '\t',
   tag: (x: string): React.ReactElement<React.ElementType> => {
     return (
@@ -22,5 +22,3 @@ const tabCharacter = {
     );
   },
 };
-
-export default tabCharacter;

--- a/translate/src/core/placeable/parsers/thinSpace.test.js
+++ b/translate/src/core/placeable/parsers/thinSpace.test.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 
 import createMarker from 'react-content-marker';
 
-import thinSpace from './thinSpace';
+import { thinSpace } from './thinSpace';
 
 describe('thinSpace', () => {
   it('marks the right parts of a string', () => {

--- a/translate/src/core/placeable/parsers/thinSpace.tsx
+++ b/translate/src/core/placeable/parsers/thinSpace.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
  * Marks the thin space character (Unicode U+2009).
  */
-const thinSpace = {
+export const thinSpace = {
   rule: /([\u2009])/ as RegExp,
   tag: (x: string): React.ReactElement<React.ElementType> => {
     return (
@@ -16,5 +16,3 @@ const thinSpace = {
     );
   },
 };
-
-export default thinSpace;

--- a/translate/src/core/placeable/parsers/unusualSpace.test.js
+++ b/translate/src/core/placeable/parsers/unusualSpace.test.js
@@ -4,7 +4,7 @@ import each from 'jest-each';
 
 import createMarker from 'react-content-marker';
 
-import unusualSpace from './unusualSpace';
+import { unusualSpace } from './unusualSpace';
 
 describe('unusualSpace', () => {
   each([

--- a/translate/src/core/placeable/parsers/unusualSpace.tsx
+++ b/translate/src/core/placeable/parsers/unusualSpace.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
@@ -13,7 +13,7 @@ import { Localized } from '@fluent/react';
  *   "hello\t world"
  *   "hello  world"
  */
-const unusualSpace = {
+export const unusualSpace = {
   rule: /( +$|[\r\n\t]( +)| {2,})/ as RegExp,
   tag: (x: string): React.ReactElement<React.ElementType> => {
     return (
@@ -25,5 +25,3 @@ const unusualSpace = {
     );
   },
 };
-
-export default unusualSpace;

--- a/translate/src/core/placeable/parsers/uriPattern.test.js
+++ b/translate/src/core/placeable/parsers/uriPattern.test.js
@@ -4,7 +4,7 @@ import each from 'jest-each';
 
 import createMarker from 'react-content-marker';
 
-import uriPattern from './uriPattern';
+import { uriPattern } from './uriPattern';
 
 describe('uriPattern', () => {
   each([

--- a/translate/src/core/placeable/parsers/uriPattern.tsx
+++ b/translate/src/core/placeable/parsers/uriPattern.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
@@ -13,7 +13,7 @@ import { Localized } from '@fluent/react';
  * Source:
  * https://github.com/translate/translate/blob/2.3.1/translate/storage/placeables/general.py#L192
  */
-const uriPattern = {
+export const uriPattern = {
   rule: new RegExp(
     '(' +
       '(' +
@@ -41,5 +41,3 @@ const uriPattern = {
     );
   },
 };
-
-export default uriPattern;

--- a/translate/src/core/placeable/parsers/xmlEntity.test.js
+++ b/translate/src/core/placeable/parsers/xmlEntity.test.js
@@ -4,7 +4,7 @@ import each from 'jest-each';
 
 import createMarker from 'react-content-marker';
 
-import xmlEntity from './xmlEntity';
+import { xmlEntity } from './xmlEntity';
 
 describe('xmlEntity', () => {
   each([

--- a/translate/src/core/placeable/parsers/xmlEntity.tsx
+++ b/translate/src/core/placeable/parsers/xmlEntity.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
@@ -12,7 +12,7 @@ import { Localized } from '@fluent/react';
  * Source:
  * https://github.com/translate/translate/blob/2.3.1/translate/storage/placeables/general.py#L254
  */
-const xmlEntity = {
+export const xmlEntity = {
   rule: /(&(([a-zA-Z][a-zA-Z0-9.-]*)|([#](\d{1,5}|x[a-fA-F0-9]{1,5})+));)/ as RegExp,
   matchIndex: 0,
   tag: (x: string): React.ReactElement<React.ElementType> => {
@@ -25,5 +25,3 @@ const xmlEntity = {
     );
   },
 };
-
-export default xmlEntity;

--- a/translate/src/core/placeable/parsers/xmlTag.test.js
+++ b/translate/src/core/placeable/parsers/xmlTag.test.js
@@ -4,7 +4,7 @@ import each from 'jest-each';
 
 import createMarker from 'react-content-marker';
 
-import xmlTag from './xmlTag';
+import { xmlTag } from './xmlTag';
 
 describe('xmlTag', () => {
   each([

--- a/translate/src/core/placeable/parsers/xmlTag.tsx
+++ b/translate/src/core/placeable/parsers/xmlTag.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
@@ -13,7 +13,7 @@ import { Localized } from '@fluent/react';
  * Source:
  * https://github.com/translate/translate/blob/2.3.1/translate/storage/placeables/general.py#L301
  */
-const xmlTag = {
+export const xmlTag = {
   rule: /(<[\w.:]+(\s([\w.:-]+=((".*?")|('.*?')))?)*\/?>|<\/[\w.]+>)/ as RegExp,
   matchIndex: 0,
   tag: (x: string): React.ReactElement<React.ElementType> => {
@@ -26,5 +26,3 @@ const xmlTag = {
     );
   },
 };
-
-export default xmlTag;

--- a/translate/src/core/project/components/ProjectMenu.test.js
+++ b/translate/src/core/project/components/ProjectMenu.test.js
@@ -9,7 +9,7 @@ import { ProjectMenu, ProjectMenuDialog } from './ProjectMenu';
 beforeAll(() => sinon.stub(React, 'useContext'));
 afterAll(() => React.useContext.restore());
 
-function createShallowProjectMenu({
+function createShallowProjectMenuDialog({
   project = {
     slug: 'project',
     name: 'Project',
@@ -24,7 +24,7 @@ function createShallowProjectMenu({
 
 describe('<ProjectMenu>', () => {
   it('renders properly', () => {
-    const wrapper = createShallowProjectMenu();
+    const wrapper = createShallowProjectMenuDialog();
 
     expect(wrapper.find('.menu .search-wrapper')).toHaveLength(1);
     expect(wrapper.find('.menu > ul')).toHaveLength(1);
@@ -33,7 +33,7 @@ describe('<ProjectMenu>', () => {
 
   it('returns no results for non-matching searches', () => {
     const SEARCH_NO_MATCH = 'bc';
-    const wrapper = createShallowProjectMenu({
+    const wrapper = createShallowProjectMenuDialog({
       project: ALL_PROJECTS,
     });
 
@@ -49,7 +49,7 @@ describe('<ProjectMenu>', () => {
 
   it('searches project items correctly', () => {
     const SEARCH_MATCH = 'roj';
-    const wrapper = createShallowProjectMenu({
+    const wrapper = createShallowProjectMenuDialog({
       project: ALL_PROJECTS,
     });
 
@@ -64,7 +64,7 @@ describe('<ProjectMenu>', () => {
   });
 });
 
-function createShallowProjectMenuBase({
+function createShallowProjectMenu({
   project = {
     slug: 'project',
     name: 'Project',
@@ -94,14 +94,14 @@ const ALL_PROJECTS = {
 
 describe('<ProjectMenuBase>', () => {
   it('shows a link to localization dashboard in regular view', () => {
-    const wrapper = createShallowProjectMenuBase();
+    const wrapper = createShallowProjectMenu();
 
     expect(wrapper.text()).toContain('Project');
     expect(wrapper.find('a').prop('href')).toEqual('/locale/project/');
   });
 
   it('shows project selector in all projects view', () => {
-    const wrapper = createShallowProjectMenuBase({ project: ALL_PROJECTS });
+    const wrapper = createShallowProjectMenu({ project: ALL_PROJECTS });
 
     expect(wrapper.find('.project-menu .selector')).toHaveLength(1);
     expect(wrapper.find('#project-ProjectMenu--all-projects')).toHaveLength(1);
@@ -109,7 +109,7 @@ describe('<ProjectMenuBase>', () => {
   });
 
   it('renders the project menu upon clicking on all projects', () => {
-    const wrapper = createShallowProjectMenuBase({ project: ALL_PROJECTS });
+    const wrapper = createShallowProjectMenu({ project: ALL_PROJECTS });
     wrapper.find('.selector').simulate('click');
 
     expect(wrapper.find('ProjectMenuDialog')).toHaveLength(1);

--- a/translate/src/core/project/hooks.ts
+++ b/translate/src/core/project/hooks.ts
@@ -1,4 +1,4 @@
 import { useAppSelector } from '~/hooks';
-import { NAME } from './reducer';
+import { PROJECT } from './reducer';
 
-export const useProject = () => useAppSelector((state) => state[NAME]);
+export const useProject = () => useAppSelector((state) => state[PROJECT]);

--- a/translate/src/core/project/index.ts
+++ b/translate/src/core/project/index.ts
@@ -1,2 +1,3 @@
 export { useProject } from './hooks';
+export { PROJECT } from './reducer';
 export type { ProjectState } from './reducer';

--- a/translate/src/core/project/reducer.ts
+++ b/translate/src/core/project/reducer.ts
@@ -4,7 +4,7 @@ import { Action, RECEIVE, REQUEST } from './actions';
 
 // Name of this module.
 // Used as the key to store this module's reducer.
-export const NAME = 'project';
+export const PROJECT = 'project';
 
 export type ProjectState = {
   readonly fetching: boolean;

--- a/translate/src/core/resource/hooks.ts
+++ b/translate/src/core/resource/hooks.ts
@@ -1,4 +1,4 @@
 import { useAppSelector } from '~/hooks';
-import { NAME } from './reducer';
+import { RESOURCE } from './reducer';
 
-export const useResource = () => useAppSelector((state) => state[NAME]);
+export const useResource = () => useAppSelector((state) => state[RESOURCE]);

--- a/translate/src/core/resource/reducer.ts
+++ b/translate/src/core/resource/reducer.ts
@@ -7,7 +7,7 @@ import {
 
 // Name of this module.
 // Used as the key to store this module's reducer.
-export const NAME = 'resource';
+export const RESOURCE = 'resource';
 
 type ResourcesState = {
   readonly resources: Resource[];

--- a/translate/src/core/stats/hooks.ts
+++ b/translate/src/core/stats/hooks.ts
@@ -1,4 +1,4 @@
 import { useAppSelector } from '~/hooks';
-import { NAME } from './reducer';
+import { STATS } from './reducer';
 
-export const useStats = () => useAppSelector((state) => state[NAME]);
+export const useStats = () => useAppSelector((state) => state[STATS]);

--- a/translate/src/core/stats/reducer.ts
+++ b/translate/src/core/stats/reducer.ts
@@ -4,7 +4,7 @@ import type { Action, Stats } from './actions';
 
 // Name of this module.
 // Used as the key to store this module's reducer.
-export const NAME = 'stats';
+export const STATS = 'stats';
 
 const initial: Stats = {
   approved: 0,

--- a/translate/src/core/term/actions.ts
+++ b/translate/src/core/term/actions.ts
@@ -4,6 +4,8 @@ import type { AppDispatch } from '~/store';
 export const RECEIVE = 'terms/RECEIVE';
 export const REQUEST = 'terms/REQUEST';
 
+export type Action = ReceiveAction | RequestAction;
+
 export type ReceiveAction = {
   readonly type: typeof RECEIVE;
   readonly terms: Array<TermType>;
@@ -27,8 +29,3 @@ export function get(sourceString: string, locale: string) {
     dispatch({ type: RECEIVE, terms });
   };
 }
-
-export default {
-  get,
-  request,
-};

--- a/translate/src/core/term/components/Term.test.js
+++ b/translate/src/core/term/components/Term.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
 
-import Term from './Term';
+import { Term } from './Term';
 
 describe('<Term>', () => {
   const TERM = {

--- a/translate/src/core/term/components/Term.tsx
+++ b/translate/src/core/term/components/Term.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 import type { TermType } from '~/api/terminology';
@@ -16,9 +16,7 @@ type Props = {
 /**
  * Shows term entry with its metadata.
  */
-export default function Term(
-  props: Props,
-): React.ReactElement<React.ElementType> {
+export function Term(props: Props): React.ReactElement<React.ElementType> {
   const { isReadOnlyEditor, locale, term } = props;
 
   const copyTermIntoEditor = (translation: string) => {

--- a/translate/src/core/term/components/TermsList.test.js
+++ b/translate/src/core/term/components/TermsList.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import Term from './Term';
-import TermsList from './TermsList';
+import { Term } from './Term';
+import { TermsList } from './TermsList';
 
 describe('<TermsList>', () => {
   const TERMS = [

--- a/translate/src/core/term/components/TermsList.tsx
+++ b/translate/src/core/term/components/TermsList.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import type { TermType } from '~/api/terminology';
 import { Locale } from '~/context/locale';
 
-import Term from './Term';
+import { Term } from './Term';
 import './TermsList.css';
 
 type Props = {
@@ -16,7 +16,7 @@ type Props = {
 /**
  * Shows a list of terms.
  */
-export default function TermsList(props: Props): React.ReactElement<'ul'> {
+export function TermsList(props: Props): React.ReactElement<'ul'> {
   const { code } = React.useContext(Locale);
   return (
     <ul className='terms-list'>

--- a/translate/src/core/term/getMarker.test.js
+++ b/translate/src/core/term/getMarker.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import getMarker from './getMarker';
+import { getMarker } from './getMarker';
 
 describe('markTerms', () => {
   it('marks terms properly', () => {

--- a/translate/src/core/term/getMarker.tsx
+++ b/translate/src/core/term/getMarker.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import escapeRegExp from 'lodash.escaperegexp';
 import createMarker from 'react-content-marker';
 
@@ -12,10 +12,7 @@ import type { TermState } from '~/core/term';
 
 let keyCounter = 0;
 
-export default function getMarker(
-  terms: TermState,
-  forFluent: boolean = false,
-): any {
+export function getMarker(terms: TermState, forFluent: boolean = false): any {
   let placeableRules = getRulesWithoutLeadingSpace(rules);
 
   if (forFluent) {

--- a/translate/src/core/term/index.ts
+++ b/translate/src/core/term/index.ts
@@ -1,11 +1,5 @@
-export { default as actions } from './actions';
-export { default as reducer } from './reducer';
+export { TermsList } from './components/TermsList';
+export { getMarker } from './getMarker';
 
-export { default as TermsList } from './components/TermsList';
-export { default as getMarker } from './getMarker';
-
+export { TERM } from './reducer';
 export type { TermState } from './reducer';
-
-// Name of this module.
-// Used as the key to store this module's reducer.
-export const NAME = 'term';

--- a/translate/src/core/term/reducer.ts
+++ b/translate/src/core/term/reducer.ts
@@ -1,8 +1,10 @@
 import type { TermType } from '~/api/terminology';
 
-import { ReceiveAction, RequestAction, RECEIVE, REQUEST } from './actions';
+import { Action, RECEIVE, REQUEST } from './actions';
 
-type Action = ReceiveAction | RequestAction;
+// Name of this module.
+// Used as the key to store this module's reducer.
+export const TERM = 'term';
 
 export type TermState = {
   readonly fetching: boolean;
@@ -16,7 +18,7 @@ const initialState: TermState = {
   terms: [],
 };
 
-export default function reducer(
+export function reducer(
   state: TermState = initialState,
   action: Action,
 ): TermState {

--- a/translate/src/core/translation/components/FluentTranslation.tsx
+++ b/translate/src/core/translation/components/FluentTranslation.tsx
@@ -5,20 +5,20 @@ import {
   WithPlaceablesForFluent,
   WithPlaceablesForFluentNoLeadingSpace,
 } from '~/core/placeable';
-import { fluent } from '~/core/utils';
+import { getSimplePreview } from '~/core/utils/fluent';
 import { SearchTerms } from '~/modules/search';
 
 import type { TranslationProps } from './GenericTranslation';
 
-export default function FluentTranslation({
+export function FluentTranslation({
   content,
   diffTarget,
   search,
 }: TranslationProps): React.ReactElement<React.ElementType> {
-  const preview = fluent.getSimplePreview(content);
+  const preview = getSimplePreview(content);
 
   if (diffTarget) {
-    const fluentTarget = fluent.getSimplePreview(diffTarget);
+    const fluentTarget = getSimplePreview(diffTarget);
     return (
       <WithPlaceablesForFluentNoLeadingSpace>
         <TranslationDiff base={fluentTarget} target={preview} />

--- a/translate/src/core/translation/components/GenericTranslation.tsx
+++ b/translate/src/core/translation/components/GenericTranslation.tsx
@@ -10,7 +10,7 @@ export type TranslationProps = {
   search?: string | null | undefined;
 };
 
-export default function GenericTranslation({
+export function GenericTranslation({
   content,
   diffTarget,
   search,

--- a/translate/src/core/translation/components/TranslationProxy.tsx
+++ b/translate/src/core/translation/components/TranslationProxy.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
+import React from 'react';
 
-import FluentTranslation from './FluentTranslation';
-import GenericTranslation from './GenericTranslation';
+import { FluentTranslation } from './FluentTranslation';
+import { GenericTranslation } from './GenericTranslation';
 
 type Props = {
   content: string | null | undefined;
@@ -10,7 +10,7 @@ type Props = {
   search?: string | null | undefined;
 };
 
-export default function TranslationProxy({
+export function TranslationProxy({
   format,
   ...props
 }: Props): null | React.ReactElement<React.ElementType> {

--- a/translate/src/core/translation/index.ts
+++ b/translate/src/core/translation/index.ts
@@ -1,2 +1,2 @@
-export { default as GenericTranslation } from './components/GenericTranslation';
-export { default as TranslationProxy } from './components/TranslationProxy';
+export { GenericTranslation } from './components/GenericTranslation';
+export { TranslationProxy } from './components/TranslationProxy';

--- a/translate/src/core/user/actions.ts
+++ b/translate/src/core/user/actions.ts
@@ -8,12 +8,14 @@ import {
   UsersList,
 } from '~/api/user';
 import { addNotification } from '~/core/notification/actions';
-import notificationMessages from '~/core/notification/messages';
+import { notificationMessages } from '~/core/notification/messages';
 import type { AppThunk } from '~/store';
 
 export const RECEIVE_USERS = 'users/RECEIVE_USERS';
 export const UPDATE = 'user/UPDATE';
 export const UPDATE_SETTINGS = 'user/UPDATE_SETTINGS';
+
+export type Action = ReceiveAction | UpdateAction | UpdateSettingsAction;
 
 export type ReceiveAction = {
   readonly type: typeof RECEIVE_USERS;

--- a/translate/src/core/user/components/UserAvatar.tsx
+++ b/translate/src/core/user/components/UserAvatar.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 type Props = {
@@ -7,7 +7,7 @@ type Props = {
   imageUrl: string;
 };
 
-export default function UserAvatar(props: Props): React.ReactElement<'div'> {
+export function UserAvatar(props: Props): React.ReactElement<'div'> {
   const { username, title, imageUrl } = props;
 
   return (

--- a/translate/src/core/user/components/UserControls.test.js
+++ b/translate/src/core/user/components/UserControls.test.js
@@ -5,7 +5,7 @@ import { UserControls } from './UserControls';
 
 jest.mock('./UserAutoUpdater', () => ({ UserAutoUpdater: () => null }));
 
-describe('<UserControlsBase>', () => {
+describe('<UserControls>', () => {
   it('shows a Sign in link when user is logged out', () => {
     const store = createReduxStore({
       user: { isAuthenticated: false, notifications: {} },

--- a/translate/src/core/user/components/UserControls.tsx
+++ b/translate/src/core/user/components/UserControls.tsx
@@ -3,16 +3,16 @@ import React from 'react';
 import { useAppDispatch, useAppSelector } from '~/hooks';
 
 import { getUserData, markAllNotificationsAsRead_, signOut_ } from '../actions';
-import { NAME } from '../index';
+import { USER } from '../reducer';
 import { SignIn } from './SignIn';
 import { UserAutoUpdater } from './UserAutoUpdater';
 import './UserControls.css';
-import UserNotificationsMenu from './UserNotificationsMenu';
-import UserMenu from './UserMenu';
+import { UserNotificationsMenu } from './UserNotificationsMenu';
+import { UserMenu } from './UserMenu';
 
 export function UserControls(): React.ReactElement<'div'> {
   const dispatch = useAppDispatch();
-  const user = useAppSelector((state) => state[NAME]);
+  const user = useAppSelector((state) => state[USER]);
 
   return (
     <div className='user-controls'>

--- a/translate/src/core/user/components/UserMenu.test.js
+++ b/translate/src/core/user/components/UserMenu.test.js
@@ -10,9 +10,9 @@ import { findLocalizedById, MockLocalizationProvider } from '~/test/utils';
 
 import { FileUpload } from './FileUpload';
 import { SignOut } from './SignOut';
-import UserMenuBase, { UserMenu } from './UserMenu';
+import { UserMenu, UserMenuDialog } from './UserMenu';
 
-describe('<UserMenu>', () => {
+describe('<UserMenuDialog>', () => {
   beforeAll(() => {
     sinon.stub(Hooks, 'useAppSelector');
     sinon.stub(Translator, 'useTranslator');
@@ -45,7 +45,7 @@ describe('<UserMenu>', () => {
     return mount(
       <Location.Provider value={location}>
         <MockLocalizationProvider>
-          <UserMenu user={{ isAuthenticated, isAdmin }} />
+          <UserMenuDialog user={{ isAuthenticated, isAdmin }} />
         </MockLocalizationProvider>
       </Location.Provider>,
     );
@@ -118,9 +118,9 @@ describe('<UserMenu>', () => {
   });
 });
 
-describe('<UserMenuBase>', () => {
+describe('<UserMenu>', () => {
   function createShallowUserMenuBase({ isAuthenticated = true } = {}) {
-    return shallow(<UserMenuBase user={{ isAuthenticated }} />);
+    return shallow(<UserMenu user={{ isAuthenticated }} />);
   }
 
   it('shows the user avatar when the user is logged in', () => {
@@ -139,12 +139,12 @@ describe('<UserMenuBase>', () => {
 
   it('toggles the user menu when clicking the user avatar', () => {
     const wrapper = createShallowUserMenuBase();
-    expect(wrapper.find('UserMenu')).toHaveLength(0);
+    expect(wrapper.find('UserMenuDialog')).toHaveLength(0);
 
     wrapper.find('.selector').simulate('click');
-    expect(wrapper.find('UserMenu')).toHaveLength(1);
+    expect(wrapper.find('UserMenuDialog')).toHaveLength(1);
 
     wrapper.find('.selector').simulate('click');
-    expect(wrapper.find('UserMenu')).toHaveLength(0);
+    expect(wrapper.find('UserMenuDialog')).toHaveLength(0);
   });
 });

--- a/translate/src/core/user/components/UserMenu.tsx
+++ b/translate/src/core/user/components/UserMenu.tsx
@@ -21,7 +21,7 @@ type UserMenuProps = Props & {
   onDiscard: () => void;
 };
 
-export function UserMenu({
+export function UserMenuDialog({
   onDiscard,
   signOut,
   user,
@@ -202,7 +202,7 @@ export function UserMenu({
   );
 }
 
-export default function UserMenuBase(props: Props): React.ReactElement<'div'> {
+export function UserMenu(props: Props): React.ReactElement<'div'> {
   const [visible, setVisible] = useState(false);
   return (
     <div className='user-menu'>
@@ -222,7 +222,9 @@ export default function UserMenuBase(props: Props): React.ReactElement<'div'> {
         )}
       </div>
 
-      {visible && <UserMenu {...props} onDiscard={() => setVisible(false)} />}
+      {visible && (
+        <UserMenuDialog {...props} onDiscard={() => setVisible(false)} />
+      )}
     </div>
   );
 }

--- a/translate/src/core/user/components/UserNotificationsMenu.test.js
+++ b/translate/src/core/user/components/UserNotificationsMenu.test.js
@@ -5,15 +5,16 @@ import sinon from 'sinon';
 import * as api from '~/api/uxaction';
 
 import { UserNotification } from './UserNotification';
-import UserNotificationsMenuBase, {
+import {
   UserNotificationsMenu,
+  UserNotificationsMenuDialog,
 } from './UserNotificationsMenu';
 
-describe('<UserNotificationsMenu>', () => {
+describe('<UserNotificationsMenuDialog>', () => {
   it('shows empty notifications menu if user has no notifications', () => {
     const notifications = [];
     const wrapper = shallow(
-      <UserNotificationsMenu notifications={notifications} />,
+      <UserNotificationsMenuDialog notifications={notifications} />,
     );
 
     expect(wrapper.find('.notification-list .user-notification')).toHaveLength(
@@ -44,7 +45,7 @@ describe('<UserNotificationsMenu>', () => {
     ];
 
     const wrapper = shallow(
-      <UserNotificationsMenu notifications={notifications} />,
+      <UserNotificationsMenuDialog notifications={notifications} />,
     );
 
     expect(wrapper.find('.notification-list .no')).toHaveLength(0);
@@ -52,7 +53,7 @@ describe('<UserNotificationsMenu>', () => {
   });
 });
 
-describe('<UserNotificationsMenuBase>', () => {
+describe('<UserNotificationsMenu>', () => {
   const sandbox = sinon.createSandbox();
   beforeEach(() => sandbox.spy(api, 'logUXAction'));
   afterEach(() => sandbox.restore());
@@ -64,7 +65,7 @@ describe('<UserNotificationsMenuBase>', () => {
         has_unread: false,
       },
     };
-    const wrapper = shallow(<UserNotificationsMenuBase user={user} />);
+    const wrapper = shallow(<UserNotificationsMenu user={user} />);
 
     expect(wrapper.find('.user-notifications-menu')).toHaveLength(0);
   });
@@ -76,7 +77,7 @@ describe('<UserNotificationsMenuBase>', () => {
         notifications: [],
       },
     };
-    const wrapper = shallow(<UserNotificationsMenuBase user={user} />);
+    const wrapper = shallow(<UserNotificationsMenu user={user} />);
 
     expect(wrapper.find('.user-notifications-menu')).toHaveLength(1);
   });
@@ -90,7 +91,7 @@ describe('<UserNotificationsMenuBase>', () => {
         unread_count: '5',
       },
     };
-    const wrapper = mount(<UserNotificationsMenuBase user={user} />);
+    const wrapper = mount(<UserNotificationsMenu user={user} />);
 
     expect(wrapper.find('.user-notifications-menu .badge').text()).toEqual('5');
     expect(api.logUXAction.called).toEqual(true);
@@ -106,7 +107,7 @@ describe('<UserNotificationsMenuBase>', () => {
       },
     };
     const wrapper = shallow(
-      <UserNotificationsMenuBase
+      <UserNotificationsMenu
         markAllNotificationsAsRead={markAllNotificationsAsRead}
         user={user}
       />,

--- a/translate/src/core/user/components/UserNotificationsMenu.tsx
+++ b/translate/src/core/user/components/UserNotificationsMenu.tsx
@@ -18,7 +18,7 @@ type UserNotificationsMenuProps = {
   onDiscard: () => void;
 };
 
-export function UserNotificationsMenu({
+export function UserNotificationsMenuDialog({
   notifications,
   onDiscard,
 }: UserNotificationsMenuProps): React.ReactElement<'div'> {
@@ -64,7 +64,7 @@ export function UserNotificationsMenu({
 /**
  * Renders user notifications.
  */
-export default function UserNotificationsMenuBase({
+export function UserNotificationsMenu({
   markAllNotificationsAsRead,
   user,
 }: Props): null | React.ReactElement<'div'> {
@@ -104,7 +104,7 @@ export default function UserNotificationsMenuBase({
       </div>
 
       {visible && (
-        <UserNotificationsMenu
+        <UserNotificationsMenuDialog
           notifications={user.notifications.notifications}
           onDiscard={handleDiscard}
         />

--- a/translate/src/core/user/index.ts
+++ b/translate/src/core/user/index.ts
@@ -1,12 +1,6 @@
-export { default as reducer } from './reducer';
-
 export { SignInLink } from './components/SignInLink';
-export { UserControls } from './components/UserControls';
-export { default as UserAvatar } from './components/UserAvatar';
+export { UserAvatar } from './components/UserAvatar';
 
+export { USER } from './reducer';
 export type { Settings } from './actions';
 export type { SettingsState, UserState, Notification } from './reducer';
-
-// Name of this module.
-// Used as the key to store this module's reducer.
-export const NAME = 'user';

--- a/translate/src/core/user/reducer.ts
+++ b/translate/src/core/user/reducer.ts
@@ -1,15 +1,10 @@
 import type { UsersList } from '~/api/user';
 
-import {
-  ReceiveAction,
-  UpdateAction,
-  UpdateSettingsAction,
-  RECEIVE_USERS,
-  UPDATE,
-  UPDATE_SETTINGS,
-} from './actions';
+import { Action, RECEIVE_USERS, UPDATE, UPDATE_SETTINGS } from './actions';
 
-type Action = ReceiveAction | UpdateAction | UpdateSettingsAction;
+// Name of this module.
+// Used as the key to store this module's reducer.
+export const USER = 'user';
 
 export type SettingsState = {
   readonly runQualityChecks: boolean;
@@ -119,10 +114,7 @@ const initial: UserState = {
   users: [],
 };
 
-export default function reducer(
-  state: UserState = initial,
-  action: Action,
-): UserState {
+export function reducer(state: UserState = initial, action: Action): UserState {
   switch (action.type) {
     case RECEIVE_USERS:
       return {

--- a/translate/src/core/utils/asLocaleString.ts
+++ b/translate/src/core/utils/asLocaleString.ts
@@ -6,6 +6,6 @@
  * @param {number} number The number to be formatted.
  * @returns {string} A language-sensitive representation of the number.
  */
-export default function asLocaleString(number: number): string {
+export function asLocaleString(number: number): string {
   return Number(number).toLocaleString('en-GB');
 }

--- a/translate/src/core/utils/components/withActionsDisabled.test.js
+++ b/translate/src/core/utils/components/withActionsDisabled.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import withActionsDisabled from './withActionsDisabled';
+import { withActionsDisabled } from './withActionsDisabled';
 
 describe('withActionsDisabled', () => {
   class FakeComp extends React.Component {}

--- a/translate/src/core/utils/components/withActionsDisabled.tsx
+++ b/translate/src/core/utils/components/withActionsDisabled.tsx
@@ -1,7 +1,7 @@
 // @ts-nocheck
 // https://github.com/mozilla/pontoon/issues/2292
 import { $Diff } from 'utility-types';
-import * as React from 'react';
+import React from 'react';
 
 type Props = {
   isActionDisabled: boolean | void;
@@ -12,7 +12,7 @@ type State = {
   isActionDisabled: boolean;
 };
 
-export default function withActionsDisabled<Config extends {}>(
+export function withActionsDisabled<Config extends {}>(
   WrappedComponent: React.ComponentType<Config>,
 ): React.ComponentType<$Diff<Config, Props>> {
   class WithActionsDisabled extends React.Component<

--- a/translate/src/core/utils/fluent/areSupportedElements.ts
+++ b/translate/src/core/utils/fluent/areSupportedElements.ts
@@ -1,5 +1,6 @@
-import isSimpleElement from './isSimpleElement';
 import type { PatternElement } from '@fluent/syntax';
+
+import { isSimpleElement } from './isSimpleElement';
 
 /**
  * Return true when all elements are supported in rich FTL editor.
@@ -8,9 +9,7 @@ import type { PatternElement } from '@fluent/syntax';
  * - simple elements or
  * - select expressions, whose variants are simple elements
  */
-export default function areSupportedElements(
-  elements: Array<PatternElement>,
-): boolean {
+export function areSupportedElements(elements: Array<PatternElement>): boolean {
   return elements.every((element) => {
     return (
       isSimpleElement(element) ||

--- a/translate/src/core/utils/fluent/convertSyntax.test.js
+++ b/translate/src/core/utils/fluent/convertSyntax.test.js
@@ -5,8 +5,8 @@ import {
   getSimpleFromComplex,
 } from './convertSyntax';
 
-import getEmptyMessage from './getEmptyMessage';
-import parser from './parser';
+import { getEmptyMessage } from './getEmptyMessage';
+import { parser } from './parser';
 
 describe('getComplexFromRich', () => {
   it('converts rich translation to complex', () => {

--- a/translate/src/core/utils/fluent/convertSyntax.ts
+++ b/translate/src/core/utils/fluent/convertSyntax.ts
@@ -1,9 +1,9 @@
-import flattenMessage from './flattenMessage';
-import getEmptyMessage from './getEmptyMessage';
-import getReconstructedMessage from './getReconstructedMessage';
-import getSimplePreview from './getSimplePreview';
-import parser from './parser';
-import serializer from './serializer';
+import { flattenMessage } from './flattenMessage';
+import { getEmptyMessage } from './getEmptyMessage';
+import { getReconstructedMessage } from './getReconstructedMessage';
+import { getSimplePreview } from './getSimplePreview';
+import { parser } from './parser';
+import { serializer } from './serializer';
 
 import type { Entry } from '@fluent/syntax';
 import type { LocaleType } from '~/context/locale';
@@ -118,7 +118,7 @@ export function getComplexFromRich(
  *
  * @returns {[ string | Entry, string ]} The converted current translation and initial translation.
  */
-export default function convertSyntax(
+export function convertSyntax(
   fromSyntax: SyntaxType,
   toSyntax: SyntaxType,
   current: string | Entry,

--- a/translate/src/core/utils/fluent/extractAccessKeyCandidates.test.js
+++ b/translate/src/core/utils/fluent/extractAccessKeyCandidates.test.js
@@ -1,6 +1,6 @@
-import extractAccessKeyCandidates from './extractAccessKeyCandidates';
-import flattenMessage from './flattenMessage';
-import parser from './parser';
+import { extractAccessKeyCandidates } from './extractAccessKeyCandidates';
+import { flattenMessage } from './flattenMessage';
+import { parser } from './parser';
 
 describe('extractAccessKeyCandidates', () => {
   it('returns null if the message has no attributes', () => {

--- a/translate/src/core/utils/fluent/extractAccessKeyCandidates.ts
+++ b/translate/src/core/utils/fluent/extractAccessKeyCandidates.ts
@@ -35,7 +35,7 @@ function getTextElementsRecursively(
  * @param {Entry} message A (flat) Fluent message to extract access key candidates from.
  * @returns {?Array<string>} A list of access key candidates.
  */
-export default function extractAccessKeyCandidates(
+export function extractAccessKeyCandidates(
   message: Entry,
 ): Array<string> | null {
   // Safeguard against non-message Fluent entries

--- a/translate/src/core/utils/fluent/flattenMessage.test.js
+++ b/translate/src/core/utils/fluent/flattenMessage.test.js
@@ -1,5 +1,5 @@
-import flattenMessage from './flattenMessage';
-import parser from './parser';
+import { flattenMessage } from './flattenMessage';
+import { parser } from './parser';
 
 describe('flattenMessage', () => {
   it('does not modify value with single element', () => {

--- a/translate/src/core/utils/fluent/flattenMessage.ts
+++ b/translate/src/core/utils/fluent/flattenMessage.ts
@@ -1,4 +1,4 @@
-import flattenPatternElements from './flattenPatternElements';
+import { flattenPatternElements } from './flattenPatternElements';
 
 import type { Entry } from '@fluent/syntax';
 
@@ -13,7 +13,7 @@ import type { Entry } from '@fluent/syntax';
  * @returns {Entry} A copy of the given Fluent message with flattened
  * value and attributes elements.
  */
-export default function flattenMessage(message: Entry): Entry {
+export function flattenMessage(message: Entry): Entry {
   const flatMessage = message.clone();
   if (flatMessage.type !== 'Message' && flatMessage.type !== 'Term') {
     return flatMessage;

--- a/translate/src/core/utils/fluent/flattenPatternElements.ts
+++ b/translate/src/core/utils/fluent/flattenPatternElements.ts
@@ -14,7 +14,7 @@ import {
  * TextElement (merging serialized values of neighbour simple elements) and
  * Placeable (representing select expressions).
  */
-export default function flattenPatternElements(
+export function flattenPatternElements(
   elements: Array<PatternElement>,
 ): Array<PatternElement> {
   const flatElements: PatternElement[] = [];

--- a/translate/src/core/utils/fluent/getEmptyMessage.test.js
+++ b/translate/src/core/utils/fluent/getEmptyMessage.test.js
@@ -1,5 +1,5 @@
-import getEmptyMessage from './getEmptyMessage';
-import parser from './parser';
+import { getEmptyMessage } from './getEmptyMessage';
+import { parser } from './parser';
 
 const LOCALE = {
   code: 'sl',

--- a/translate/src/core/utils/fluent/getEmptyMessage.ts
+++ b/translate/src/core/utils/fluent/getEmptyMessage.ts
@@ -10,8 +10,8 @@ import {
 import type { LocaleType } from '~/context/locale';
 
 import { CLDR_PLURALS } from '../constants';
-import flattenMessage from './flattenMessage';
-import isPluralExpression from './isPluralExpression';
+import { flattenMessage } from './flattenMessage';
+import { isPluralExpression } from './isPluralExpression';
 
 /**
  * Gather custom (numeric) plural variants
@@ -78,7 +78,7 @@ function withDefaultVariant(variants: Array<Variant>): Array<Variant> {
  * @param {Entry} source A Fluent AST to empty.
  * @returns {Entry} An emptied copy of the source.
  */
-export default function getEmptyMessage(
+export function getEmptyMessage(
   source: Entry,
   { cldrPlurals }: LocaleType,
 ): Entry {

--- a/translate/src/core/utils/fluent/getReconstructedMessage.test.js
+++ b/translate/src/core/utils/fluent/getReconstructedMessage.test.js
@@ -1,6 +1,6 @@
-import getReconstructedMessage from './getReconstructedMessage';
-import parser from './parser';
-import serializer from './serializer';
+import { getReconstructedMessage } from './getReconstructedMessage';
+import { parser } from './parser';
+import { serializer } from './serializer';
 
 describe('getReconstructedMessage', () => {
   it('returns the correct value for a simple message', () => {

--- a/translate/src/core/utils/fluent/getReconstructedMessage.ts
+++ b/translate/src/core/utils/fluent/getReconstructedMessage.ts
@@ -1,12 +1,12 @@
-import parser from './parser';
-
 import type { Entry } from '@fluent/syntax';
+
+import { parser } from './parser';
 
 /**
  * Return a reconstructed Fluent message from the original message and some
  * translated content.
  */
-export default function getReconstructedMessage(
+export function getReconstructedMessage(
   original: string,
   translation: string,
 ): Entry {

--- a/translate/src/core/utils/fluent/getSimplePreview.test.js
+++ b/translate/src/core/utils/fluent/getSimplePreview.test.js
@@ -1,4 +1,4 @@
-import getSimplePreview from './getSimplePreview';
+import { getSimplePreview } from './getSimplePreview';
 
 describe('getSimplePreview', () => {
   it('works for an empty string', () => {

--- a/translate/src/core/utils/fluent/getSimplePreview.ts
+++ b/translate/src/core/utils/fluent/getSimplePreview.ts
@@ -1,6 +1,6 @@
 import { Pattern, serializeExpression } from '@fluent/syntax';
 
-import parser from './parser';
+import { parser } from './parser';
 
 function serialize({ elements }: Pattern): string {
   let result = '';
@@ -48,9 +48,7 @@ function serialize({ elements }: Pattern): string {
  * @returns {string} A simplified version of the Fluent message, or the original
  * content if it isn't a valid Fluent message.
  */
-export default function getSimplePreview(
-  content: string | null | undefined,
-): string {
+export function getSimplePreview(content: string | null | undefined): string {
   if (!content) {
     return '';
   }

--- a/translate/src/core/utils/fluent/getSyntaxType.test.js
+++ b/translate/src/core/utils/fluent/getSyntaxType.test.js
@@ -1,5 +1,5 @@
-import getSyntaxType from './getSyntaxType';
-import parser from './parser';
+import { getSyntaxType } from './getSyntaxType';
+import { parser } from './parser';
 
 describe('getSyntaxType', () => {
   it('returns "simple" for a string with simple value', () => {

--- a/translate/src/core/utils/fluent/getSyntaxType.ts
+++ b/translate/src/core/utils/fluent/getSyntaxType.ts
@@ -1,9 +1,10 @@
-import isSimpleMessage from './isSimpleMessage';
-import isSimpleSingleAttributeMessage from './isSimpleSingleAttributeMessage';
-import isSupportedMessage from './isSupportedMessage';
+import type { Entry } from '@fluent/syntax';
+
+import { isSimpleMessage } from './isSimpleMessage';
+import { isSimpleSingleAttributeMessage } from './isSimpleSingleAttributeMessage';
+import { isSupportedMessage } from './isSupportedMessage';
 
 import type { SyntaxType } from './types';
-import type { Entry } from '@fluent/syntax';
 
 /**
  * Return the syntax type of a given Fluent message.
@@ -15,7 +16,7 @@ import type { Entry } from '@fluent/syntax';
  *      - "rich": can be shown in a rich editor;
  *      - "complex": can only be shown in a source editor.
  */
-export default function getSyntaxType(message: Entry): SyntaxType {
+export function getSyntaxType(message: Entry): SyntaxType {
   if (!isSupportedMessage(message)) {
     return 'complex';
   }

--- a/translate/src/core/utils/fluent/index.ts
+++ b/translate/src/core/utils/fluent/index.ts
@@ -1,35 +1,16 @@
-import areSupportedElements from './areSupportedElements';
-import convertSyntax from './convertSyntax';
-import extractAccessKeyCandidates from './extractAccessKeyCandidates';
-import flattenPatternElements from './flattenPatternElements';
-import flattenMessage from './flattenMessage';
-import getEmptyMessage from './getEmptyMessage';
-import getReconstructedMessage from './getReconstructedMessage';
-import getSimplePreview from './getSimplePreview';
-import getSyntaxType from './getSyntaxType';
-import isPluralExpression from './isPluralExpression';
-import isSimpleElement from './isSimpleElement';
-import isSimpleMessage from './isSimpleMessage';
-import isSimpleSingleAttributeMessage from './isSimpleSingleAttributeMessage';
-import isSupportedMessage from './isSupportedMessage';
-import parser from './parser';
-import serializer from './serializer';
-
-export default {
-  areSupportedElements,
-  convertSyntax,
-  extractAccessKeyCandidates,
-  flattenPatternElements,
-  flattenMessage,
-  getEmptyMessage,
-  getReconstructedMessage,
-  getSimplePreview,
-  getSyntaxType,
-  isPluralExpression,
-  isSimpleElement,
-  isSimpleMessage,
-  isSimpleSingleAttributeMessage,
-  isSupportedMessage,
-  parser,
-  serializer,
-};
+export { areSupportedElements } from './areSupportedElements';
+export { convertSyntax } from './convertSyntax';
+export { extractAccessKeyCandidates } from './extractAccessKeyCandidates';
+export { flattenPatternElements } from './flattenPatternElements';
+export { flattenMessage } from './flattenMessage';
+export { getEmptyMessage } from './getEmptyMessage';
+export { getReconstructedMessage } from './getReconstructedMessage';
+export { getSimplePreview } from './getSimplePreview';
+export { getSyntaxType } from './getSyntaxType';
+export { isPluralExpression } from './isPluralExpression';
+export { isSimpleElement } from './isSimpleElement';
+export { isSimpleMessage } from './isSimpleMessage';
+export { isSimpleSingleAttributeMessage } from './isSimpleSingleAttributeMessage';
+export { isSupportedMessage } from './isSupportedMessage';
+export { parser } from './parser';
+export { serializer } from './serializer';

--- a/translate/src/core/utils/fluent/isPluralExpression.test.js
+++ b/translate/src/core/utils/fluent/isPluralExpression.test.js
@@ -1,5 +1,5 @@
-import isPluralExpression from './isPluralExpression';
-import parser from './parser';
+import { isPluralExpression } from './isPluralExpression';
+import { parser } from './parser';
 
 describe('isPluralExpression', () => {
   it('returns false for elements that are not select expressions', () => {

--- a/translate/src/core/utils/fluent/isPluralExpression.ts
+++ b/translate/src/core/utils/fluent/isPluralExpression.ts
@@ -7,7 +7,7 @@ import { CLDR_PLURALS } from '../constants';
  *
  * Keys of all variants of such elements are either CLDR plurals or numbers.
  */
-export default function isPluralExpression(
+export function isPluralExpression(
   expression: Readonly<SelectExpression>,
 ): boolean {
   if (!expression || expression.type !== 'SelectExpression') {

--- a/translate/src/core/utils/fluent/isSimpleElement.ts
+++ b/translate/src/core/utils/fluent/isSimpleElement.ts
@@ -6,7 +6,7 @@ import type { PatternElement } from '@fluent/syntax';
  * - Placeable with expression type StringLiteral, NumberLiteral,
  *   VariableReference, MessageReference, TermReference, FunctionReference
  */
-export default function isSimpleElement(element: PatternElement): boolean {
+export function isSimpleElement(element: PatternElement): boolean {
   if (element.type === 'TextElement') {
     return true;
   }

--- a/translate/src/core/utils/fluent/isSimpleMessage.test.js
+++ b/translate/src/core/utils/fluent/isSimpleMessage.test.js
@@ -1,5 +1,5 @@
-import isSimpleMessage from './isSimpleMessage';
-import parser from './parser';
+import { isSimpleMessage } from './isSimpleMessage';
+import { parser } from './parser';
 
 describe('isSimpleMessage', () => {
   it('returns true for a string with simple text', () => {

--- a/translate/src/core/utils/fluent/isSimpleMessage.ts
+++ b/translate/src/core/utils/fluent/isSimpleMessage.ts
@@ -1,5 +1,6 @@
-import isSimpleElement from './isSimpleElement';
 import type { Entry } from '@fluent/syntax';
+
+import { isSimpleElement } from './isSimpleElement';
 
 /**
  * Return true when message represents a simple message.
@@ -7,7 +8,7 @@ import type { Entry } from '@fluent/syntax';
  * A simple message has no attributes and all value
  * elements are simple.
  */
-export default function isSimpleMessage(message: Entry): boolean {
+export function isSimpleMessage(message: Entry): boolean {
   if (
     message &&
     (message.type === 'Message' || message.type === 'Term') &&

--- a/translate/src/core/utils/fluent/isSimpleSingleAttributeMessage.test.js
+++ b/translate/src/core/utils/fluent/isSimpleSingleAttributeMessage.test.js
@@ -1,5 +1,5 @@
-import isSimpleSingleAttributeMessage from './isSimpleSingleAttributeMessage';
-import parser from './parser';
+import { isSimpleSingleAttributeMessage } from './isSimpleSingleAttributeMessage';
+import { parser } from './parser';
 
 describe('isSimpleSingleAttributeMessage', () => {
   it('returns true for a string with a single attribute', () => {

--- a/translate/src/core/utils/fluent/isSimpleSingleAttributeMessage.ts
+++ b/translate/src/core/utils/fluent/isSimpleSingleAttributeMessage.ts
@@ -1,13 +1,12 @@
-import isSimpleElement from './isSimpleElement';
 import type { Entry } from '@fluent/syntax';
+
+import { isSimpleElement } from './isSimpleElement';
 
 /**
  * Return true when message has no value and a single attribute with only simple
  * elements.
  */
-export default function isSimpleSingleAttributeMessage(
-  message: Entry,
-): boolean {
+export function isSimpleSingleAttributeMessage(message: Entry): boolean {
   if (
     message.type === 'Message' &&
     !message.value &&

--- a/translate/src/core/utils/fluent/isSupportedMessage.ts
+++ b/translate/src/core/utils/fluent/isSupportedMessage.ts
@@ -1,5 +1,6 @@
-import areSupportedElements from './areSupportedElements';
 import type { Entry } from '@fluent/syntax';
+
+import { areSupportedElements } from './areSupportedElements';
 
 /**
  * Return true when message represents a message, supported in rich FTL editor.
@@ -7,7 +8,7 @@ import type { Entry } from '@fluent/syntax';
  * Message is supported if it's valid and all value elements
  * and all attribute elements are supported.
  */
-export default function isSupportedMessage(message: Entry): boolean {
+export function isSupportedMessage(message: Entry): boolean {
   // Parse error
   if (message.type === 'Junk') {
     return false;

--- a/translate/src/core/utils/fluent/parser.ts
+++ b/translate/src/core/utils/fluent/parser.ts
@@ -1,5 +1,3 @@
 import { FluentParser } from '@fluent/syntax';
 
-const fluentParser: FluentParser = new FluentParser({ withSpans: false });
-
-export default fluentParser;
+export const parser = new FluentParser({ withSpans: false });

--- a/translate/src/core/utils/fluent/serializer.ts
+++ b/translate/src/core/utils/fluent/serializer.ts
@@ -1,5 +1,3 @@
 import { FluentSerializer } from '@fluent/syntax';
 
-const fluentSerializer: any = new FluentSerializer();
-
-export default fluentSerializer;
+export const serializer: any = new FluentSerializer();

--- a/translate/src/core/utils/getOptimizedContent.ts
+++ b/translate/src/core/utils/getOptimizedContent.ts
@@ -1,4 +1,4 @@
-import fluent from './fluent';
+import { getSimplePreview } from './fluent';
 
 /**
  * Return an optimized version of a given translation content.
@@ -8,7 +8,7 @@ import fluent from './fluent';
  * @returns {string} If the format is Fluent ('ftl'), return a simplified
  * version of the translation. Otherwise, return the original translation.
  */
-export default function getOptimizedContent(
+export function getOptimizedContent(
   translation: string | null | undefined,
   format: string,
 ): string {
@@ -16,7 +16,7 @@ export default function getOptimizedContent(
     return '';
   }
   if (format === 'ftl') {
-    return fluent.getSimplePreview(translation);
+    return getSimplePreview(translation);
   }
   return translation;
 }

--- a/translate/src/core/utils/hooks/useOnDiscard.test.js
+++ b/translate/src/core/utils/hooks/useOnDiscard.test.js
@@ -3,7 +3,7 @@ import { render, unmountComponentAtNode } from 'react-dom';
 import { act } from 'react-dom/test-utils';
 import sinon from 'sinon';
 
-import useOnDiscard from './useOnDiscard';
+import { useOnDiscard } from './useOnDiscard';
 
 function TestComponent({ onDiscard }) {
   const ref = React.useRef(null);

--- a/translate/src/core/utils/hooks/useOnDiscard.ts
+++ b/translate/src/core/utils/hooks/useOnDiscard.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-export default function useOnDiscard(
+export function useOnDiscard(
   ref: React.RefObject<unknown>,
   onDiscard: () => void,
 ) {

--- a/translate/src/core/utils/index.ts
+++ b/translate/src/core/utils/index.ts
@@ -1,10 +1,7 @@
-// Fluent
-export { default as fluent } from './fluent';
-
 // Functions
-export { default as getOptimizedContent } from './getOptimizedContent';
-export { default as asLocaleString } from './asLocaleString';
+export { getOptimizedContent } from './getOptimizedContent';
+export { asLocaleString } from './asLocaleString';
 
 // Components, HOC, and Hooks
-export { default as withActionsDisabled } from './components/withActionsDisabled';
-export { default as useOnDiscard } from './hooks/useOnDiscard';
+export { withActionsDisabled } from './components/withActionsDisabled';
+export { useOnDiscard } from './hooks/useOnDiscard';

--- a/translate/src/historyInstance.ts
+++ b/translate/src/historyInstance.ts
@@ -1,3 +1,2 @@
 import { createBrowserHistory } from 'history';
-const history = createBrowserHistory({});
-export default history;
+export const history = createBrowserHistory({});

--- a/translate/src/hooks/useReadonlyEditor.ts
+++ b/translate/src/hooks/useReadonlyEditor.ts
@@ -1,5 +1,5 @@
 import { useSelectedEntity } from '~/core/entities/hooks';
-import { NAME as USER } from '~/core/user';
+import { USER } from '~/core/user';
 import { useAppSelector } from '~/hooks';
 
 export function useReadonlyEditor(): boolean {

--- a/translate/src/hooks/useTranslator.test.js
+++ b/translate/src/hooks/useTranslator.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import sinon from 'sinon';
 
-import { NAME as PROJECT } from '~/core/project/reducer';
-import { NAME as USER } from '~/core/user';
+import { PROJECT } from '~/core/project';
+import { USER } from '~/core/user';
 import * as Hooks from '~/hooks';
 
 import { useTranslator } from './useTranslator';

--- a/translate/src/hooks/useTranslator.ts
+++ b/translate/src/hooks/useTranslator.ts
@@ -2,7 +2,7 @@ import { useContext } from 'react';
 
 import { Locale } from '~/context/locale';
 import { useProject } from '~/core/project';
-import { NAME as USER } from '~/core/user';
+import { USER } from '~/core/user';
 import { useAppSelector } from '~/hooks';
 
 /**

--- a/translate/src/index.tsx
+++ b/translate/src/index.tsx
@@ -9,9 +9,9 @@ import { LocationProvider } from './context/location';
 import { PluralFormProvider } from './context/pluralForm';
 import { UnsavedChangesProvider } from './context/unsavedChanges';
 import { AppLocalizationProvider } from './core/l10n/components/AppLocalizationProvider';
-import history from './historyInstance';
+import { history } from './historyInstance';
 import './index.css';
-import store from './store';
+import { store } from './store';
 
 // TODO: Once we have support for more locales in Pontoon, we should
 // make TimeAgo internationalized and initialize all locales here.

--- a/translate/src/modules/addonpromotion/components/AddonPromotion.tsx
+++ b/translate/src/modules/addonpromotion/components/AddonPromotion.tsx
@@ -1,6 +1,6 @@
 import { Localized } from '@fluent/react';
 import React, { useEffect, useState } from 'react';
-import { NAME as USER } from '~/core/user';
+import { USER } from '~/core/user';
 import { dismissAddonPromotion_ } from '~/core/user/actions';
 import { useAppDispatch, useAppSelector } from '~/hooks';
 import './AddonPromotion.css';

--- a/translate/src/modules/batchactions/actions.ts
+++ b/translate/src/modules/batchactions/actions.ts
@@ -8,7 +8,10 @@ import type { LocationType } from '~/context/location';
 import { updateEntityTranslation } from '~/core/entities/actions';
 import { updateResource } from '~/core/resource/actions';
 import { updateStats } from '~/core/stats/actions';
-import { actions as historyActions } from '~/modules/history';
+import {
+  get as getHistory,
+  request as requestHistory,
+} from '~/modules/history/actions';
 import type { AppDispatch } from '~/store';
 
 export const CHECK_BATCHACTIONS = 'batchactions/CHECK';
@@ -114,8 +117,8 @@ const updateUI =
         dispatch(updateEntityTranslation(entity.pk, pluralForm, translation));
 
         if (entity.pk === selectedEntity) {
-          dispatch(historyActions.request(entity.pk, pluralForm));
-          dispatch(historyActions.get(entity.pk, location.locale, pluralForm));
+          dispatch(requestHistory(entity.pk, pluralForm));
+          dispatch(getHistory(entity.pk, location.locale, pluralForm));
         }
       });
     }

--- a/translate/src/modules/batchactions/components/ApproveAll.test.js
+++ b/translate/src/modules/batchactions/components/ApproveAll.test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 
 import { MockLocalizationProvider } from '~/test/utils';
 
-import ApproveAll from './ApproveAll';
+import { ApproveAll } from './ApproveAll';
 
 const DEFAULT_BATCH_ACTIONS = {
   entities: [],

--- a/translate/src/modules/batchactions/components/ApproveAll.tsx
+++ b/translate/src/modules/batchactions/components/ApproveAll.tsx
@@ -12,7 +12,7 @@ type Props = {
 /**
  * Renders Approve All batch action button.
  */
-export default function ApproveAll({
+export function ApproveAll({
   approveAll,
   batchactions: { response, requestInProgress },
 }: Props): React.ReactElement<'button'> {

--- a/translate/src/modules/batchactions/components/BatchActions.test.js
+++ b/translate/src/modules/batchactions/components/BatchActions.test.js
@@ -4,12 +4,12 @@ import sinon from 'sinon';
 
 import * as Hooks from '~/hooks';
 import * as Actions from '../actions';
-import { NAME as BATCHACTIONS } from '../reducer';
+import { BATCHACTIONS } from '../reducer';
 
-import ApproveAll from './ApproveAll';
+import { ApproveAll } from './ApproveAll';
 import { BatchActions } from './BatchActions';
-import RejectAll from './RejectAll';
-import ReplaceAll from './ReplaceAll';
+import { RejectAll } from './RejectAll';
+import { ReplaceAll } from './ReplaceAll';
 
 const DEFAULT_BATCH_ACTIONS = {
   entities: [],

--- a/translate/src/modules/batchactions/components/BatchActions.tsx
+++ b/translate/src/modules/batchactions/components/BatchActions.tsx
@@ -5,12 +5,12 @@ import { Location } from '~/context/location';
 import { useAppDispatch, useAppSelector } from '~/hooks';
 
 import { performAction, resetSelection, selectAll } from '../actions';
-import { NAME as BATCHACTIONS } from '../reducer';
+import { BATCHACTIONS } from '../reducer';
 
-import ApproveAll from './ApproveAll';
+import { ApproveAll } from './ApproveAll';
 import './BatchActions.css';
-import RejectAll from './RejectAll';
-import ReplaceAll from './ReplaceAll';
+import { RejectAll } from './RejectAll';
+import { ReplaceAll } from './ReplaceAll';
 
 /**
  * Renders batch editor, used for performing mass actions on translations.

--- a/translate/src/modules/batchactions/components/RejectAll.test.js
+++ b/translate/src/modules/batchactions/components/RejectAll.test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 
 import { MockLocalizationProvider } from '~/test/utils';
 
-import RejectAll from './RejectAll';
+import { RejectAll } from './RejectAll';
 
 const DEFAULT_BATCH_ACTIONS = {
   entities: [],

--- a/translate/src/modules/batchactions/components/RejectAll.tsx
+++ b/translate/src/modules/batchactions/components/RejectAll.tsx
@@ -12,7 +12,7 @@ type Props = {
 /**
  * Renders Reject All batch action button.
  */
-export default function RejectAll({
+export function RejectAll({
   batchactions: { response, requestInProgress },
   rejectAll,
 }: Props): React.ReactElement<'button'> {

--- a/translate/src/modules/batchactions/components/ReplaceAll.test.js
+++ b/translate/src/modules/batchactions/components/ReplaceAll.test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 
 import { MockLocalizationProvider } from '~/test/utils';
 
-import ReplaceAll from './ReplaceAll';
+import { ReplaceAll } from './ReplaceAll';
 
 const DEFAULT_BATCH_ACTIONS = {
   entities: [],

--- a/translate/src/modules/batchactions/components/ReplaceAll.tsx
+++ b/translate/src/modules/batchactions/components/ReplaceAll.tsx
@@ -12,7 +12,7 @@ type Props = {
 /**
  * Renders Replace All batch action button.
  */
-export default function ReplaceAll({
+export function ReplaceAll({
   replaceAll,
   batchactions: { response, requestInProgress },
 }: Props): React.ReactElement<'button'> {

--- a/translate/src/modules/batchactions/hooks.ts
+++ b/translate/src/modules/batchactions/hooks.ts
@@ -1,5 +1,5 @@
 import { useAppSelector } from '~/hooks';
-import { NAME as BATCHACTIONS } from './reducer';
+import { BATCHACTIONS } from './reducer';
 
 export const useBatchactions = () =>
   useAppSelector((state) => state[BATCHACTIONS]);

--- a/translate/src/modules/batchactions/reducer.ts
+++ b/translate/src/modules/batchactions/reducer.ts
@@ -12,7 +12,7 @@ import {
 
 // Name of this module.
 // Used as the key to store this module's reducer.
-export const NAME = 'batchactions';
+export const BATCHACTIONS = 'batchactions';
 
 export type BatchActionsState = {
   readonly entities: Array<number>;

--- a/translate/src/modules/entitieslist/components/EntitiesList.tsx
+++ b/translate/src/modules/entitieslist/components/EntitiesList.tsx
@@ -4,7 +4,7 @@ import useInfiniteScroll from 'react-infinite-scroll-hook';
 import type { Entity as EntityType } from '~/api/entity';
 import { Locale } from '~/context/locale';
 import { Location } from '~/context/location';
-import { reset as resetEditor } from '~/core/editor/actions';
+import { resetEditor } from '~/core/editor/actions';
 import {
   getEntities,
   getSiblingEntities,
@@ -13,7 +13,7 @@ import {
 import { useEntities } from '~/core/entities/hooks';
 import { SkeletonLoader } from '~/core/loaders';
 import { addNotification } from '~/core/notification/actions';
-import notificationMessages from '~/core/notification/messages';
+import { notificationMessages } from '~/core/notification/messages';
 import { useAppDispatch, useAppStore } from '~/hooks';
 import { usePrevious } from '~/hooks/usePrevious';
 import { useReadonlyEditor } from '~/hooks/useReadonlyEditor';

--- a/translate/src/modules/entitieslist/index.ts
+++ b/translate/src/modules/entitieslist/index.ts
@@ -1,5 +1,1 @@
 export { EntitiesList } from './components/EntitiesList';
-
-// Name of this module.
-// Used as the key to store this module's reducer.
-export const NAME = 'entitieslist';

--- a/translate/src/modules/entitydetails/components/ContextIssueButton.tsx
+++ b/translate/src/modules/entitydetails/components/ContextIssueButton.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 import './ContextIssueButton.css';
@@ -7,9 +7,7 @@ type Props = {
   openTeamComments: () => void;
 };
 
-export default function ContextIssueButton(
-  props: Props,
-): React.ReactElement<'div'> {
+export function ContextIssueButton(props: Props): React.ReactElement<'div'> {
   return (
     <div className='source-string-comment'>
       <Localized id='entitydetails-ContextIssueButton--context-issue-button'>

--- a/translate/src/modules/entitydetails/components/EditorSelector.tsx
+++ b/translate/src/modules/entitydetails/components/EditorSelector.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import './EditorSelector.css';
 
@@ -9,9 +9,7 @@ type Props = {
   fileFormat: string;
 };
 
-export default function EditorSelector(
-  props: Props,
-): React.ReactElement<'div'> {
+export function EditorSelector(props: Props): React.ReactElement<'div'> {
   if (props.fileFormat === 'ftl') {
     return (
       <div className='editor'>

--- a/translate/src/modules/entitydetails/components/EntityDetails.test.js
+++ b/translate/src/modules/entitydetails/components/EntityDetails.test.js
@@ -9,7 +9,7 @@ import { createReduxStore, mountComponentWithStore } from '~/test/store';
 import * as editorActions from '~/core/editor/actions';
 import * as historyActions from '~/modules/history/actions';
 
-import EntityDetails, { EntityDetailsBase } from './EntityDetails';
+import { EntityDetails, EntityDetailsBase } from './EntityDetails';
 
 const ENTITIES = [
   {

--- a/translate/src/modules/entitydetails/components/EntityDetails.tsx
+++ b/translate/src/modules/entitydetails/components/EntityDetails.tsx
@@ -18,10 +18,10 @@ import {
 import { useCheckUnsavedChanges } from '~/context/unsavedChanges';
 import { addComment_ } from '~/core/comments/actions';
 import {
-  reset as resetEditor,
+  resetEditor,
   resetFailedChecks,
   resetHelperElementIndex,
-  update as updateEditor,
+  updateTranslation,
   updateFailedChecks,
   updateSelection,
 } from '~/core/editor/actions';
@@ -31,10 +31,10 @@ import {
   useSelectedEntity,
 } from '~/core/entities/hooks';
 import { addNotification } from '~/core/notification/actions';
-import notificationMessages from '~/core/notification/messages';
-import { NAME as TERMS, TermState } from '~/core/term';
+import { notificationMessages } from '~/core/notification/messages';
+import { TERM, TermState } from '~/core/term';
 import { get as getTerms } from '~/core/term/actions';
-import { NAME as USER, UserState } from '~/core/user';
+import { USER, UserState } from '~/core/user';
 import { getOptimizedContent } from '~/core/utils';
 import { AppStore, useAppDispatch, useAppSelector, useAppStore } from '~/hooks';
 import { useReadonlyEditor } from '~/hooks/useReadonlyEditor';
@@ -42,7 +42,7 @@ import {
   ChangeOperation,
   History,
   HistoryState,
-  NAME as HISTORY,
+  HISTORY,
 } from '~/modules/history';
 import {
   deleteTranslation_,
@@ -50,19 +50,16 @@ import {
   request as requestHistory,
   updateStatus,
 } from '~/modules/history/actions';
-import { MachineryState, NAME as MACHINERY } from '~/modules/machinery';
+import { MachineryState, MACHINERY } from '~/modules/machinery';
 import {
   get as getMachinery,
   getConcordanceSearchResults,
   resetSearch,
   setEntity,
 } from '~/modules/machinery/actions';
-import { LocalesState, NAME as OTHERLOCALES } from '~/modules/otherlocales';
+import { LocalesState, OTHERLOCALES } from '~/modules/otherlocales';
 import { get as getOtherLocales } from '~/modules/otherlocales/actions';
-import {
-  NAME as TEAM_COMMENTS,
-  TeamCommentState,
-} from '~/modules/teamcomments';
+import { TEAM_COMMENTS, TeamCommentState } from '~/modules/teamcomments';
 import {
   get as getTeamComments,
   request as requestTeamComments,
@@ -70,11 +67,11 @@ import {
 } from '~/modules/teamcomments/actions';
 import type { AppDispatch } from '~/store';
 
-import EditorSelector from './EditorSelector';
+import { EditorSelector } from './EditorSelector';
 import './EntityDetails.css';
 import { EntityNavigation } from './EntityNavigation';
-import Helpers from './Helpers';
-import Metadata from './Metadata';
+import { Helpers } from './Helpers';
+import { Metadata } from './Metadata';
 
 type Props = {
   activeTranslationString: string;
@@ -291,7 +288,7 @@ export function EntityDetailsBase({
 
   const updateEditorTranslation = useCallback(
     (translation: string, changeSource: string) =>
-      dispatch(updateEditor(translation, changeSource)),
+      dispatch(updateTranslation(translation, changeSource)),
     [dispatch],
   );
 
@@ -424,9 +421,7 @@ export function EntityDetailsBase({
   );
 }
 
-export default function EntityDetails(): React.ReactElement<
-  typeof EntityDetailsBase
-> {
+export function EntityDetails(): React.ReactElement<typeof EntityDetailsBase> {
   const entity = useSelectedEntity();
   const state = {
     activeTranslationString: useTranslationForEntity(entity)?.string ?? '',
@@ -437,7 +432,7 @@ export default function EntityDetails(): React.ReactElement<
     previousEntity: usePreviousEntity(),
     otherlocales: useAppSelector((state) => state[OTHERLOCALES]),
     teamComments: useAppSelector((state) => state[TEAM_COMMENTS]),
-    terms: useAppSelector((state) => state[TERMS]),
+    terms: useAppSelector((state) => state[TERM]),
     parameters: useContext(Location),
     pluralForm: usePluralForm(entity),
     selectedEntity: entity,

--- a/translate/src/modules/entitydetails/components/FluentAttribute.tsx
+++ b/translate/src/modules/entitydetails/components/FluentAttribute.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 import type { Entity } from '~/api/entity';
-import { fluent } from '~/core/utils';
+import { isSimpleSingleAttributeMessage, parser } from '~/core/utils/fluent';
 
-import Property from './Property';
+import { Property } from './Property';
 
 type Props = {
   readonly entity: Entity;
@@ -13,21 +13,16 @@ type Props = {
 /**
  * Get attribute of a simple single-attribute Fluent message.
  */
-export default function FluentAttribute(
-  props: Props,
-): null | React.ReactElement<any> {
+export function FluentAttribute(props: Props): null | React.ReactElement<any> {
   const { entity } = props;
 
   if (entity.format !== 'ftl') {
     return null;
   }
 
-  const message = fluent.parser.parseEntry(entity.original);
+  const message = parser.parseEntry(entity.original);
 
-  if (
-    message.type !== 'Message' ||
-    !fluent.isSimpleSingleAttributeMessage(message)
-  ) {
+  if (message.type !== 'Message' || !isSimpleSingleAttributeMessage(message)) {
     return null;
   }
 

--- a/translate/src/modules/entitydetails/components/GenericOriginalString.test.js
+++ b/translate/src/modules/entitydetails/components/GenericOriginalString.test.js
@@ -5,7 +5,7 @@ import { Locale } from '~/context/locale';
 
 import { MockLocalizationProvider } from '~/test/utils';
 
-import GenericOriginalString from './GenericOriginalString';
+import { GenericOriginalString } from './GenericOriginalString';
 
 const ENTITY = {
   pk: 42,

--- a/translate/src/modules/entitydetails/components/GenericOriginalString.tsx
+++ b/translate/src/modules/entitydetails/components/GenericOriginalString.tsx
@@ -20,7 +20,7 @@ type Props = {
  * Based on the plural form, show either the singular or plural version of the
  * string, and also display which form is being rendered.
  */
-export default function GenericOriginalString({
+export function GenericOriginalString({
   entity,
   handleClickOnPlaceable,
   pluralForm,

--- a/translate/src/modules/entitydetails/components/Helpers.tsx
+++ b/translate/src/modules/entitydetails/components/Helpers.tsx
@@ -4,7 +4,10 @@ import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 
 import type { Entity } from '~/api/entity';
 import type { LocationType } from '~/context/location';
-import * as editor from '~/core/editor';
+import {
+  resetHelperElementIndex,
+  selectHelperTabIndex,
+} from '~/core/editor/actions';
 import type { TermState } from '~/core/term';
 import type { UserState } from '~/core/user';
 import { useAppDispatch } from '~/hooks';
@@ -44,7 +47,7 @@ type Props = {
  *
  * Shows the metadata of the entity and an editor for translations.
  */
-export default function Helpers(props: Props): React.ReactElement<any> {
+export function Helpers(props: Props): React.ReactElement<any> {
   const {
     entity,
     isReadOnlyEditor,
@@ -119,8 +122,8 @@ export default function Helpers(props: Props): React.ReactElement<any> {
             if (index === lastIndex) {
               return false;
             }
-            dispatch(editor.actions.selectHelperTabIndex(index));
-            dispatch(editor.actions.resetHelperElementIndex());
+            dispatch(selectHelperTabIndex(index));
+            dispatch(resetHelperElementIndex());
           }}
         >
           <TabList>

--- a/translate/src/modules/entitydetails/components/Metadata.test.js
+++ b/translate/src/modules/entitydetails/components/Metadata.test.js
@@ -6,7 +6,7 @@ import { Locale } from '~/context/locale';
 import { createReduxStore } from '~/test/store';
 import { MockLocalizationProvider } from '~/test/utils';
 
-import Metadata from './Metadata';
+import { Metadata } from './Metadata';
 
 const ENTITY = {
   pk: 42,

--- a/translate/src/modules/entitydetails/components/Metadata.tsx
+++ b/translate/src/modules/entitydetails/components/Metadata.tsx
@@ -18,12 +18,12 @@ import type { TermState } from '~/core/term';
 import type { UserState } from '~/core/user';
 import type { TeamCommentState } from '~/modules/teamcomments';
 
-import ContextIssueButton from './ContextIssueButton';
-import FluentAttribute from './FluentAttribute';
+import { ContextIssueButton } from './ContextIssueButton';
+import { FluentAttribute } from './FluentAttribute';
 import { OriginalStringProxy } from './OriginalStringProxy';
-import Property from './Property';
-import Screenshots from './Screenshots';
-import TermsPopup from './TermsPopup';
+import { Property } from './Property';
+import { Screenshots } from './Screenshots';
+import { TermsPopup } from './TermsPopup';
 
 import './Metadata.css';
 
@@ -186,7 +186,7 @@ function SourceObject({
  *  - a link to the resource
  *  - a link to the project
  */
-export default function Metadata({
+export function Metadata({
   addTextToEditorTranslation,
   commentTabRef,
   entity,

--- a/translate/src/modules/entitydetails/components/OriginalStringProxy.tsx
+++ b/translate/src/modules/entitydetails/components/OriginalStringProxy.tsx
@@ -4,7 +4,7 @@ import type { Entity } from '~/api/entity';
 import type { TermState } from '~/core/term';
 import { FluentOriginalString } from '~/modules/fluentoriginal';
 
-import GenericOriginalString from './GenericOriginalString';
+import { GenericOriginalString } from './GenericOriginalString';
 
 type Props = {
   entity: Entity;

--- a/translate/src/modules/entitydetails/components/Property.tsx
+++ b/translate/src/modules/entitydetails/components/Property.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 type Props = {
   readonly title: string;
@@ -9,7 +9,7 @@ type Props = {
 /**
  * Component to dislay a property of an entity in the Metadata component.
  */
-export default function Property(props: Props): React.ReactElement<'div'> {
+export function Property(props: Props): React.ReactElement<'div'> {
   const { children, className, title } = props;
 
   return (

--- a/translate/src/modules/entitydetails/components/Screenshots.test.js
+++ b/translate/src/modules/entitydetails/components/Screenshots.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import Screenshots from './Screenshots';
+import { Screenshots } from './Screenshots';
 import { mount } from 'enzyme';
 
 describe('<Screenshots>', () => {

--- a/translate/src/modules/entitydetails/components/Screenshots.tsx
+++ b/translate/src/modules/entitydetails/components/Screenshots.tsx
@@ -32,7 +32,7 @@ type Props = {
  * On image click, shows the image in a fullscreen lightbox with a grey background.
  * Click or press a key to close.
  */
-export default function Screenshots({ locale, source }: Props) {
+export function Screenshots({ locale, source }: Props) {
   const [openImage, setOpenImage] = useState<string | null>(null);
 
   useEffect(() => {

--- a/translate/src/modules/entitydetails/components/TermsPopup.tsx
+++ b/translate/src/modules/entitydetails/components/TermsPopup.tsx
@@ -17,7 +17,7 @@ type Props = {
 /**
  * Shows a popup with a list of all terms belonging to the highlighted one.
  */
-export default function TermsPopup(props: Props): React.ReactElement<'div'> {
+export function TermsPopup(props: Props): React.ReactElement<'div'> {
   const ref = useRef(null);
   useOnDiscard(ref, props.hide);
 

--- a/translate/src/modules/entitydetails/index.ts
+++ b/translate/src/modules/entitydetails/index.ts
@@ -1,6 +1,2 @@
-export { default as EntityDetails } from './components/EntityDetails';
-export { default as ContextIssueButton } from './components/ContextIssueButton';
-
-// Name of this module.
-// Used as the key to store this module's reducer.
-export const NAME = 'entitydetails';
+export { EntityDetails } from './components/EntityDetails';
+export { ContextIssueButton } from './components/ContextIssueButton';

--- a/translate/src/modules/fluenteditor/components/FluentEditor.test.js
+++ b/translate/src/modules/fluenteditor/components/FluentEditor.test.js
@@ -5,13 +5,13 @@ import { act } from 'react-dom/test-utils';
 import { Provider } from 'react-redux';
 
 import { LocationProvider } from '~/context/location';
-import * as editor from '~/core/editor';
+import { resetEditor, updateTranslation } from '~/core/editor/actions';
 import { RECEIVE_ENTITIES } from '~/core/entities/actions';
 
 import { createDefaultUser, createReduxStore } from '~/test/store';
 import { MockLocalizationProvider } from '~/test/utils';
 
-import FluentEditor from './FluentEditor';
+import { FluentEditor } from './FluentEditor';
 
 const NESTED_SELECTORS_STRING = `my-message =
     { $thing ->
@@ -85,7 +85,7 @@ function createComponent(entityPk = 1) {
     entities: ENTITIES,
     hasMore: false,
   });
-  store.dispatch(editor.actions.reset());
+  store.dispatch(resetEditor());
   act(() => history.push(`?string=${entityPk}`));
   wrapper.update();
 
@@ -146,7 +146,7 @@ describe('<FluentEditor>', () => {
     expect(wrapper.find('SimpleEditor').exists()).toBeTruthy();
 
     // Change translation to a rich string.
-    store.dispatch(editor.actions.update(RICH_MESSAGE_STRING, 'external'));
+    store.dispatch(updateTranslation(RICH_MESSAGE_STRING, 'external'));
     wrapper.update();
 
     expect(wrapper.find('RichEditor').exists()).toBeTruthy();

--- a/translate/src/modules/fluenteditor/components/FluentEditor.tsx
+++ b/translate/src/modules/fluenteditor/components/FluentEditor.tsx
@@ -6,20 +6,20 @@ import { useTranslationForEntity } from '~/context/pluralForm';
 import { Translation, useUpdateTranslation } from '~/core/editor';
 import {
   setInitialTranslation,
-  update as updateEditor,
+  updateTranslation,
 } from '~/core/editor/actions';
 import { useSelectedEntity } from '~/core/entities/hooks';
 import { addNotification } from '~/core/notification/actions';
-import notificationMessages from '~/core/notification/messages';
-import { fluent } from '~/core/utils';
+import { notificationMessages } from '~/core/notification/messages';
+import * as fluent from '~/core/utils/fluent';
 import type { SyntaxType } from '~/core/utils/fluent/types';
 import { useAppDispatch, useAppSelector } from '~/hooks';
 import { useReadonlyEditor } from '~/hooks/useReadonlyEditor';
 
 import './FluentEditor.css';
-import RichEditor from './rich/RichEditor';
-import SimpleEditor from './simple/SimpleEditor';
-import SourceEditor from './source/SourceEditor';
+import { RichEditor } from './rich/RichEditor';
+import { SimpleEditor } from './simple/SimpleEditor';
+import { SourceEditor } from './source/SourceEditor';
 
 /**
  * Function to analyze a translation and determine what its appropriate syntax is.
@@ -156,7 +156,7 @@ function useForceSource(): [boolean, () => void] {
       locale,
     );
     dispatch(setInitialTranslation(initialContent));
-    dispatch(updateEditor(translationContent));
+    dispatch(updateTranslation(translationContent));
     setForceSource(!forceSource);
   }
 
@@ -168,7 +168,7 @@ function useForceSource(): [boolean, () => void] {
  *
  * Renders the most appropriate type of editor for the current translation.
  */
-export default function FluentEditor(): null | React.ReactElement<React.ElementType> {
+export function FluentEditor(): null | React.ReactElement<React.ElementType> {
   const dispatch = useAppDispatch();
 
   const translation = useAppSelector((state) => state.editor.translation);

--- a/translate/src/modules/fluenteditor/components/rich/RichEditor.tsx
+++ b/translate/src/modules/fluenteditor/components/rich/RichEditor.tsx
@@ -7,10 +7,10 @@ import {
   useUpdateTranslation,
 } from '~/core/editor';
 import { useSelectedEntity } from '~/core/entities/hooks';
-import { fluent } from '~/core/utils';
+import * as fluent from '~/core/utils/fluent';
 import { useAppDispatch, useAppSelector } from '~/hooks';
 
-import RichTranslationForm from './RichTranslationForm';
+import { RichTranslationForm } from './RichTranslationForm';
 
 type Props = {
   ftlSwitch: React.ReactNode;
@@ -24,7 +24,7 @@ type Props = {
  * are made directly to that AST. That is why lots of Editor methods are
  * overwritten, to handle the conversion from AST to string and back.
  */
-export default function RichEditor(props: Props): React.ReactElement<any> {
+export function RichEditor(props: Props): React.ReactElement<any> {
   const dispatch = useAppDispatch();
 
   const sendTranslation = useSendTranslation();

--- a/translate/src/modules/fluenteditor/components/rich/RichTranslationForm.test.js
+++ b/translate/src/modules/fluenteditor/components/rich/RichTranslationForm.test.js
@@ -2,13 +2,17 @@ import sinon from 'sinon';
 import React from 'react';
 
 import { Locale } from '~/context/locale';
-import * as editor from '~/core/editor';
-import { fluent } from '~/core/utils';
+import {
+  setInitialTranslation,
+  updateSelection,
+  updateTranslation,
+} from '~/core/editor/actions';
+import { parser } from '~/core/utils/fluent';
 
 import { createReduxStore, mountComponentWithStore } from '~/test/store';
 import { MockLocalizationProvider } from '~/test/utils';
 
-import RichTranslationForm from './RichTranslationForm';
+import { RichTranslationForm } from './RichTranslationForm';
 
 const DEFAULT_LOCALE = {
   direction: 'ltr',
@@ -17,21 +21,21 @@ const DEFAULT_LOCALE = {
   cldrPlurals: [1, 5],
 };
 
-function createComponent(entityString, updateTranslation) {
-  if (!updateTranslation) {
-    updateTranslation = sinon.fake();
+function createComponent(entityString, updateTranslation_) {
+  if (!updateTranslation_) {
+    updateTranslation_ = sinon.fake();
   }
 
   const store = createReduxStore();
-  const message = fluent.parser.parseEntry(entityString);
-  store.dispatch(editor.actions.update(message));
-  store.dispatch(editor.actions.setInitialTranslation(message));
+  const message = parser.parseEntry(entityString);
+  store.dispatch(updateTranslation(message));
+  store.dispatch(setInitialTranslation(message));
 
   const wrapper = mountComponentWithStore(
     () => (
       <Locale.Provider value={DEFAULT_LOCALE}>
         <MockLocalizationProvider>
-          <RichTranslationForm updateTranslation={updateTranslation} />
+          <RichTranslationForm updateTranslation={updateTranslation_} />
         </MockLocalizationProvider>
       </Locale.Provider>
     ),
@@ -210,13 +214,13 @@ describe('<RichTranslationForm>', () => {
       updateMock,
     );
 
-    await store.dispatch(editor.actions.updateSelection('Add'));
+    await store.dispatch(updateSelection('Add'));
 
     // Force a re-render -- see https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/update.html
     wrapper.setProps({});
 
     expect(updateMock.called).toBeTruthy();
-    const replaceContent = fluent.parser.parseEntry(
+    const replaceContent = parser.parseEntry(
       `title = AddValue
     .label = Something
 `,

--- a/translate/src/modules/fluenteditor/components/simple/SimpleEditor.test.js
+++ b/translate/src/modules/fluenteditor/components/simple/SimpleEditor.test.js
@@ -7,13 +7,14 @@ import sinon from 'sinon';
 
 import { LocationProvider } from '~/context/location';
 import * as editorActions from '~/core/editor/actions';
+import { updateTranslation } from '~/core/editor/actions';
 import { RECEIVE_ENTITIES } from '~/core/entities/actions';
-import { fluent } from '~/core/utils';
+import { parser } from '~/core/utils/fluent';
 
 import { createReduxStore } from '~/test/store';
 import { MockLocalizationProvider } from '~/test/utils';
 
-import SimpleEditor from './SimpleEditor';
+import { SimpleEditor } from './SimpleEditor';
 
 const ENTITIES = [
   {
@@ -61,7 +62,7 @@ describe('<SimpleEditor>', () => {
     const [wrapper, store] = createSimpleEditor();
 
     // Update the content with a non-formatted Fluent string.
-    store.dispatch(editorActions.update('my-message = Coucou', 'external'));
+    store.dispatch(updateTranslation('my-message = Coucou', 'external'));
 
     // Force a re-render -- see https://enzymejs.github.io/enzyme/docs/api/ReactWrapper/update.html
     wrapper.setProps({});
@@ -74,9 +75,7 @@ describe('<SimpleEditor>', () => {
     const [wrapper, store] = createSimpleEditor();
 
     // Update the content with a non-formatted Fluent string.
-    store.dispatch(
-      editorActions.update(fluent.parser.parseEntry('hello = World')),
-    );
+    store.dispatch(updateTranslation(parser.parseEntry('hello = World')));
     wrapper.update();
 
     expect(wrapper.isEmptyRender()).toBeTruthy();
@@ -90,7 +89,7 @@ describe('<SimpleEditor>', () => {
     try {
       const [wrapper, store] = createSimpleEditor();
 
-      store.dispatch(editorActions.update('Coucou'));
+      store.dispatch(updateTranslation('Coucou'));
       wrapper.update();
 
       // Intercept the sendTranslation prop and call it directly.

--- a/translate/src/modules/fluenteditor/components/simple/SimpleEditor.tsx
+++ b/translate/src/modules/fluenteditor/components/simple/SimpleEditor.tsx
@@ -1,8 +1,8 @@
-import * as React from 'react';
+import React from 'react';
 
 import * as editor from '~/core/editor';
 import { useSelectedEntity } from '~/core/entities/hooks';
-import { fluent } from '~/core/utils';
+import * as fluent from '~/core/utils/fluent';
 import { useAppSelector } from '~/hooks';
 import { GenericTranslationForm } from '~/modules/genericeditor';
 
@@ -16,9 +16,7 @@ type Props = {
  * Handles transforming the editor's content back to a valid Fluent message on save.
  * Makes sure the content is correctly formatted when updated.
  */
-export default function SimpleEditor(
-  props: Props,
-): null | React.ReactElement<any> {
+export function SimpleEditor(props: Props): null | React.ReactElement<any> {
   const updateTranslation = editor.useUpdateTranslation();
   const clearEditor = editor.useClearEditor();
   const copyOriginalIntoEditor = editor.useCopyOriginalIntoEditor();

--- a/translate/src/modules/fluenteditor/components/source/SourceEditor.tsx
+++ b/translate/src/modules/fluenteditor/components/source/SourceEditor.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import * as editor from '~/core/editor';
 
@@ -14,7 +14,7 @@ type Props = {
  * Displayed when the Rich Editor cannot handle the translation, or if a user
  * forces showing the Fluent source.
  */
-export default function SourceEditor(props: Props): React.ReactElement<any> {
+export function SourceEditor(props: Props): React.ReactElement<any> {
   const clearEditor = editor.useClearEditor();
   const copyOriginalIntoEditor = editor.useCopyOriginalIntoEditor();
   const sendTranslation = editor.useSendTranslation();

--- a/translate/src/modules/fluenteditor/index.ts
+++ b/translate/src/modules/fluenteditor/index.ts
@@ -1,1 +1,1 @@
-export { default as FluentEditor } from './components/FluentEditor';
+export { FluentEditor } from './components/FluentEditor';

--- a/translate/src/modules/fluentoriginal/components/FluentOriginalString.tsx
+++ b/translate/src/modules/fluentoriginal/components/FluentOriginalString.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react';
+import React from 'react';
 
 import type { Entity } from '~/api/entity';
 import type { TermState } from '~/core/term';
-import { fluent } from '~/core/utils';
+import { getSyntaxType, parser } from '~/core/utils/fluent';
 
-import RichString from './RichString';
-import SimpleString from './SimpleString';
-import SourceString from './SourceString';
+import { RichString } from './RichString';
+import { SimpleString } from './SimpleString';
+import { SourceString } from './SourceString';
 
 type Props = {
   readonly entity: Entity;
@@ -22,11 +22,9 @@ type Props = {
  * Based on the syntax type of the string, render it as a simple string preview,
  * as a rich UI or as the original, untouched string.
  */
-export default function FluentOriginalString(
-  props: Props,
-): React.ReactElement<any> {
-  const message = fluent.parser.parseEntry(props.entity.original);
-  const syntax = fluent.getSyntaxType(message);
+export function FluentOriginalString(props: Props): React.ReactElement<any> {
+  const message = parser.parseEntry(props.entity.original);
+  const syntax = getSyntaxType(message);
 
   if (syntax === 'simple') {
     return (

--- a/translate/src/modules/fluentoriginal/components/RichString.test.js
+++ b/translate/src/modules/fluentoriginal/components/RichString.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
 
-import RichString from './RichString';
+import { RichString } from './RichString';
 
 const ORIGINAL = `
 song-title = Hello

--- a/translate/src/modules/fluentoriginal/components/RichString.tsx
+++ b/translate/src/modules/fluentoriginal/components/RichString.tsx
@@ -1,14 +1,14 @@
-import * as React from 'react';
 import {
   Attribute,
   PatternElement,
   Pattern,
   serializeVariantKey,
 } from '@fluent/syntax';
+import React from 'react';
 
 import type { Entity } from '~/api/entity';
 import { getMarker, TermState } from '~/core/term';
-import { fluent } from '~/core/utils';
+import { flattenMessage, parser } from '~/core/utils/fluent';
 
 import './RichString.css';
 
@@ -123,10 +123,8 @@ function renderAttributes(
 /**
  * Show the original string of a Fluent entity in a rich interface.
  */
-export default function RichString(props: Props): React.ReactElement<'table'> {
-  const message = fluent.flattenMessage(
-    fluent.parser.parseEntry(props.entity.original),
-  );
+export function RichString(props: Props): React.ReactElement<'table'> {
+  const message = flattenMessage(parser.parseEntry(props.entity.original));
   // Safeguard against non-translatable entries
   if (message.type !== 'Message' && message.type !== 'Term') {
     throw new Error(`Unexpected type '${message.type}' in RichString`);

--- a/translate/src/modules/fluentoriginal/components/SimpleString.test.js
+++ b/translate/src/modules/fluentoriginal/components/SimpleString.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
 
-import SimpleString from './SimpleString';
+import { SimpleString } from './SimpleString';
 
 const ORIGINAL = `header = 
             .page-title = Hello

--- a/translate/src/modules/fluentoriginal/components/SimpleString.tsx
+++ b/translate/src/modules/fluentoriginal/components/SimpleString.tsx
@@ -1,8 +1,8 @@
-import * as React from 'react';
+import React from 'react';
 
 import type { Entity } from '~/api/entity';
 import { getMarker, TermState } from '~/core/term';
-import { fluent } from '~/core/utils';
+import { getSimplePreview } from '~/core/utils/fluent';
 
 type Props = {
   readonly entity: Entity;
@@ -15,8 +15,8 @@ type Props = {
 /**
  * Show the original string of a Fluent entity as a simple preview.
  */
-export default function SimpleString(props: Props): React.ReactElement<'p'> {
-  const original = fluent.getSimplePreview(props.entity.original);
+export function SimpleString(props: Props): React.ReactElement<'p'> {
+  const original = getSimplePreview(props.entity.original);
   const TermsAndPlaceablesMarker = getMarker(props.terms, true);
   return (
     <p className='original' onClick={props.handleClickOnPlaceable}>

--- a/translate/src/modules/fluentoriginal/components/SourceString.test.js
+++ b/translate/src/modules/fluentoriginal/components/SourceString.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
 
-import SourceString from './SourceString';
+import { SourceString } from './SourceString';
 
 const ORIGINAL = 'title = Hello From The Other Side';
 

--- a/translate/src/modules/fluentoriginal/components/SourceString.tsx
+++ b/translate/src/modules/fluentoriginal/components/SourceString.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import type { Entity } from '~/api/entity';
 import { getMarker, TermState } from '~/core/term';
@@ -14,7 +14,7 @@ type Props = {
 /**
  * Show the source string of a Fluent entity.
  */
-export default function SourceString(props: Props): React.ReactElement<'p'> {
+export function SourceString(props: Props): React.ReactElement<'p'> {
   const TermsAndPlaceablesMarker = getMarker(props.terms, true);
 
   return (

--- a/translate/src/modules/fluentoriginal/index.ts
+++ b/translate/src/modules/fluentoriginal/index.ts
@@ -1,5 +1,1 @@
-export { default as FluentOriginalString } from './components/FluentOriginalString';
-
-// Name of this module.
-// Used as the key to store this module's reducer.
-export const NAME = 'fluentoriginal';
+export { FluentOriginalString } from './components/FluentOriginalString';

--- a/translate/src/modules/genericeditor/components/GenericEditor.test.js
+++ b/translate/src/modules/genericeditor/components/GenericEditor.test.js
@@ -7,13 +7,13 @@ import { Provider } from 'react-redux';
 import { Locale } from '~/context/locale';
 import { LocationProvider } from '~/context/location';
 import { PluralFormProvider } from '~/context/pluralForm';
-import * as editor from '~/core/editor';
+import { resetEditor, updateTranslation } from '~/core/editor/actions';
 import { RECEIVE_ENTITIES } from '~/core/entities/actions';
 
 import { createDefaultUser, createReduxStore } from '~/test/store';
 import { MockLocalizationProvider } from '~/test/utils';
 
-import GenericEditor from './GenericEditor';
+import { GenericEditor } from './GenericEditor';
 
 const ENTITIES = [
   {
@@ -35,7 +35,7 @@ const ENTITIES = [
 
 function selectEntity(store, history, entityIndex) {
   act(() => history.push(`?string=${entityIndex}`));
-  store.dispatch(editor.actions.reset());
+  store.dispatch(resetEditor());
 }
 
 function createComponent(entityIndex = 0) {
@@ -106,7 +106,7 @@ describe('<Editor>', () => {
     const [, store] = createComponent(1);
     expect(store.getState().editor.initialTranslation).toEqual('quelque chose');
 
-    store.dispatch(editor.actions.update('autre chose'));
+    store.dispatch(updateTranslation('autre chose'));
     expect(store.getState().editor.initialTranslation).toEqual('quelque chose');
   });
 });

--- a/translate/src/modules/genericeditor/components/GenericEditor.tsx
+++ b/translate/src/modules/genericeditor/components/GenericEditor.tsx
@@ -1,12 +1,20 @@
-import * as React from 'react';
+import React from 'react';
 
-import * as editor from '~/core/editor';
+import {
+  EditorMenu,
+  TranslationLength,
+  useClearEditor,
+  useCopyOriginalIntoEditor,
+  useSendTranslation,
+  useUpdateTranslation,
+} from '~/core/editor';
+import { resetEditor, setInitialTranslation } from '~/core/editor/actions';
 import { useSelectedEntity } from '~/core/entities/hooks';
 import { usePluralForm, useTranslationForEntity } from '~/context/pluralForm';
 import { useAppDispatch, useAppSelector } from '~/hooks';
 
-import GenericTranslationForm from './GenericTranslationForm';
-import PluralSelector from './PluralSelector';
+import { GenericTranslationForm } from './GenericTranslationForm';
+import { PluralSelector } from './PluralSelector';
 
 /**
  * Hook to update the editor content whenever the entity changes.
@@ -14,7 +22,7 @@ import PluralSelector from './PluralSelector';
 function useLoadTranslation() {
   const dispatch = useAppDispatch();
 
-  const updateTranslation = editor.useUpdateTranslation();
+  const updateTranslation = useUpdateTranslation();
 
   const changeSource = useAppSelector((state) => state.editor.changeSource);
   const entity = useSelectedEntity();
@@ -24,7 +32,7 @@ function useLoadTranslation() {
   React.useLayoutEffect(() => {
     // We want to run this only when the editor state has been reset.
     if (changeSource === 'reset') {
-      dispatch(editor.actions.setInitialTranslation(activeTranslationString));
+      dispatch(setInitialTranslation(activeTranslationString));
       updateTranslation(activeTranslationString, 'initial');
     }
   }, [
@@ -44,14 +52,14 @@ function useLoadTranslation() {
  *
  * Shows a plural selector, a translation form and a menu.
  */
-export default function GenericEditor(): null | React.ReactElement<any> {
+export function GenericEditor(): null | React.ReactElement<any> {
   const dispatch = useAppDispatch();
 
   useLoadTranslation();
-  const updateTranslation = editor.useUpdateTranslation();
-  const clearEditor = editor.useClearEditor();
-  const copyOriginalIntoEditor = editor.useCopyOriginalIntoEditor();
-  const sendTranslation = editor.useSendTranslation();
+  const updateTranslation = useUpdateTranslation();
+  const clearEditor = useClearEditor();
+  const copyOriginalIntoEditor = useCopyOriginalIntoEditor();
+  const sendTranslation = useSendTranslation();
 
   const translation = useAppSelector((state) => state.editor.translation);
   const entity = useSelectedEntity();
@@ -61,22 +69,18 @@ export default function GenericEditor(): null | React.ReactElement<any> {
     return null;
   }
 
-  function resetEditor() {
-    dispatch(editor.actions.reset());
-  }
-
   const original = pluralForm <= 0 ? entity.original : entity.original_plural;
 
   return (
     <>
-      <PluralSelector resetEditor={resetEditor} />
+      <PluralSelector resetEditor={() => dispatch(resetEditor())} />
       <GenericTranslationForm
         sendTranslation={sendTranslation}
         updateTranslation={updateTranslation}
       />
-      <editor.EditorMenu
+      <EditorMenu
         translationLengthHook={
-          <editor.TranslationLength
+          <TranslationLength
             comment={entity.comment}
             format={entity.format}
             original={original}

--- a/translate/src/modules/genericeditor/components/GenericTranslationForm.test.js
+++ b/translate/src/modules/genericeditor/components/GenericTranslationForm.test.js
@@ -1,17 +1,17 @@
 import sinon from 'sinon';
 
-import { update as updateEditor, updateSelection } from '~/core/editor/actions';
+import { updateSelection, updateTranslation } from '~/core/editor/actions';
 
 import { createReduxStore, mountComponentWithStore } from '~/test/store';
 
-import GenericTranslationForm from './GenericTranslationForm';
+import { GenericTranslationForm } from './GenericTranslationForm';
 
-function createComponent(updateTranslation) {
+function createComponent(updateTranslation_) {
   const store = createReduxStore();
-  store.dispatch(updateEditor('Hello'));
+  store.dispatch(updateTranslation('Hello'));
 
   const wrapper = mountComponentWithStore(GenericTranslationForm, store, {
-    updateTranslation,
+    updateTranslation: updateTranslation_,
   });
 
   return [wrapper, store];

--- a/translate/src/modules/genericeditor/components/GenericTranslationForm.tsx
+++ b/translate/src/modules/genericeditor/components/GenericTranslationForm.tsx
@@ -19,7 +19,7 @@ type Props = {
 /**
  * Shows a generic translation form, a simple textarea.
  */
-export default function GenericTranslationForm({
+export function GenericTranslationForm({
   sendTranslation,
   updateTranslation,
 }: Props): React.ReactElement<'textarea'> | null {

--- a/translate/src/modules/genericeditor/components/PluralSelector.test.js
+++ b/translate/src/modules/genericeditor/components/PluralSelector.test.js
@@ -6,7 +6,7 @@ import { Locale } from '~/context/locale';
 import { PluralForm, PluralFormProvider } from '~/context/pluralForm';
 import { createReduxStore, mountComponentWithStore } from '~/test/store';
 
-import PluralSelector, { PluralSelectorBase } from './PluralSelector';
+import { PluralSelector, PluralSelectorBase } from './PluralSelector';
 
 const createShallowPluralSelector = (pluralForm) =>
   shallow(

--- a/translate/src/modules/genericeditor/components/PluralSelector.tsx
+++ b/translate/src/modules/genericeditor/components/PluralSelector.tsx
@@ -61,7 +61,7 @@ export function PluralSelectorBase({
   );
 }
 
-export default function PluralSelector(
+export function PluralSelector(
   props: Props,
 ): React.ReactElement<typeof PluralSelectorBase> {
   return (

--- a/translate/src/modules/genericeditor/index.ts
+++ b/translate/src/modules/genericeditor/index.ts
@@ -1,2 +1,2 @@
-export { default as GenericEditor } from './components/GenericEditor';
-export { default as GenericTranslationForm } from './components/GenericTranslationForm';
+export { GenericEditor } from './components/GenericEditor';
+export { GenericTranslationForm } from './components/GenericTranslationForm';

--- a/translate/src/modules/history/actions.ts
+++ b/translate/src/modules/history/actions.ts
@@ -10,10 +10,14 @@ import {
 import type { LocaleType } from '~/context/locale';
 import type { LocationType } from '~/context/location';
 import type { PluralFormType } from '~/context/pluralForm';
-import { actions as editorActions } from '~/core/editor';
+import {
+  resetEditor,
+  updateFailedChecks,
+  updateTranslation,
+} from '~/core/editor/actions';
 import { updateEntityTranslation } from '~/core/entities/actions';
 import { addNotification } from '~/core/notification/actions';
-import notificationMessages from '~/core/notification/messages';
+import { notificationMessages } from '~/core/notification/messages';
 import { updateResource } from '~/core/resource/actions';
 import { updateStats } from '~/core/stats/actions';
 import type { AppDispatch } from '~/store';
@@ -21,6 +25,8 @@ import type { AppDispatch } from '~/store';
 export const RECEIVE = 'history/RECEIVE';
 export const REQUEST = 'history/REQUEST';
 export const UPDATE = 'history/UPDATE';
+
+export type Action = ReceiveAction | RequestAction | UpdateAction;
 
 export type ReceiveAction = {
   readonly type: typeof RECEIVE;
@@ -121,10 +127,8 @@ export function updateStatus(
 
     // Update the UI based on the response.
     if (results.failedChecks) {
-      dispatch(editorActions.update(results.string, 'external'));
-      dispatch(
-        editorActions.updateFailedChecks(results.failedChecks, translation),
-      );
+      dispatch(updateTranslation(results.string, 'external'));
+      dispatch(updateFailedChecks(results.failedChecks, translation));
     } else {
       // Show a notification to explain what happened.
       const notif = _getOperationNotif(change, !!results.translation);
@@ -137,7 +141,7 @@ export function updateStatus(
         } else if (nextEntity.pk !== entity.pk) {
           location.push({ entity: nextEntity.pk });
         }
-        dispatch(editorActions.reset());
+        dispatch(resetEditor());
       } else {
         dispatch(get(entity.pk, locale.code, pluralForm));
       }
@@ -189,10 +193,3 @@ export function deleteTranslation_(
     NProgress.done();
   };
 }
-
-export default {
-  get,
-  receive,
-  request,
-  updateStatus,
-};

--- a/translate/src/modules/history/components/History.tsx
+++ b/translate/src/modules/history/components/History.tsx
@@ -6,7 +6,7 @@ import type { UserState } from '~/core/user';
 
 import type { ChangeOperation, HistoryState } from '../index';
 import './History.css';
-import Translation from './Translation';
+import { Translation } from './Translation';
 
 type Props = {
   entity: Entity;

--- a/translate/src/modules/history/components/Translation.tsx
+++ b/translate/src/modules/history/components/Translation.tsx
@@ -6,7 +6,7 @@ import ReactTimeAgo from 'react-time-ago';
 import type { Entity } from '~/api/entity';
 import { HistoryTranslation } from '~/api/translation';
 import { Locale } from '~/context/locale';
-import { CommentsList } from '~/core/comments';
+import { CommentsList } from '~/core/comments/components/CommentsList';
 import { TranslationProxy } from '~/core/translation';
 import { UserAvatar, UserState } from '~/core/user';
 import { withActionsDisabled } from '~/core/utils';
@@ -434,4 +434,4 @@ export function TranslationBase({
   );
 }
 
-export default withActionsDisabled(TranslationBase);
+export const Translation = withActionsDisabled(TranslationBase);

--- a/translate/src/modules/history/index.ts
+++ b/translate/src/modules/history/index.ts
@@ -1,10 +1,5 @@
 export type { ChangeOperation } from '~/api/translation';
 
-export { default as actions } from './actions';
 export { History } from './components/History';
-export { default as reducer } from './reducer';
+export { HISTORY } from './reducer';
 export type { HistoryState } from './reducer';
-
-// Name of this module.
-// Used as the key to store this module's reducer.
-export const NAME = 'history';

--- a/translate/src/modules/history/reducer.ts
+++ b/translate/src/modules/history/reducer.ts
@@ -1,15 +1,10 @@
 import { HistoryTranslation } from '~/api/translation';
 
-import {
-  ReceiveAction,
-  RequestAction,
-  UpdateAction,
-  RECEIVE,
-  REQUEST,
-  UPDATE,
-} from './actions';
+import { Action, RECEIVE, REQUEST, UPDATE } from './actions';
 
-type Action = ReceiveAction | RequestAction | UpdateAction;
+// Name of this module.
+// Used as the key to store this module's reducer.
+export const HISTORY = 'history';
 
 export type HistoryState = {
   readonly fetching: boolean;
@@ -37,7 +32,7 @@ const initialState: HistoryState = {
   translations: [],
 };
 
-export default function reducer(
+export function reducer(
   state: HistoryState = initialState,
   action: Action,
 ): HistoryState {

--- a/translate/src/modules/interactivetour/components/InteractiveTour.test.js
+++ b/translate/src/modules/interactivetour/components/InteractiveTour.test.js
@@ -10,7 +10,7 @@ beforeAll(() => sinon.stub(hookModule, 'useTranslator'));
 beforeEach(() => hookModule.useTranslator.returns(false));
 afterAll(() => hookModule.useTranslator.restore());
 
-describe('<InteractiveTourBase>', () => {
+describe('<InteractiveTour>', () => {
   it('renders correctly on the tutorial page for unauthenticated user', () => {
     const store = createReduxStore({
       project: { slug: 'tutorial' },

--- a/translate/src/modules/interactivetour/components/InteractiveTour.tsx
+++ b/translate/src/modules/interactivetour/components/InteractiveTour.tsx
@@ -5,7 +5,7 @@ import Tour, { ReactourStep } from 'reactour';
 import { updateTourStatus } from '~/api/user';
 import { Locale } from '~/context/locale';
 import { useProject } from '~/core/project';
-import { NAME as USER } from '~/core/user';
+import { USER } from '~/core/user';
 import { useAppSelector } from '~/hooks';
 import { useTranslator } from '~/hooks/useTranslator';
 

--- a/translate/src/modules/machinery/actions.ts
+++ b/translate/src/modules/machinery/actions.ts
@@ -18,6 +18,13 @@ export const REQUEST = 'machinery/REQUEST';
 export const RESET_SEARCH = 'machinery/RESET_SEARCH';
 export const SET_ENTITY = 'machinery/SET_ENTITY';
 
+export type Action =
+  | ConcordanceSearchAction
+  | AddTranslationsAction
+  | RequestAction
+  | ResetSearchAction
+  | SetEntityAction;
+
 /**
  * Indicate that entities are currently being fetched.
  */
@@ -158,10 +165,3 @@ export const get =
       dispatch(addTranslations(results));
     }
   };
-
-export default {
-  addTranslations,
-  get,
-  resetSearch,
-  setEntity,
-};

--- a/translate/src/modules/machinery/components/ConcordanceSearch.tsx
+++ b/translate/src/modules/machinery/components/ConcordanceSearch.tsx
@@ -4,7 +4,7 @@ import type { MachineryTranslation } from '~/api/machinery';
 import { Locale } from '~/context/locale';
 import { GenericTranslation } from '~/core/translation';
 
-import TranslationMemory from './source/TranslationMemory';
+import { TranslationMemory } from './source/TranslationMemory';
 
 type Props = {
   sourceString: string;

--- a/translate/src/modules/machinery/components/MachineryCount.tsx
+++ b/translate/src/modules/machinery/components/MachineryCount.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import type { MachineryState } from '~/modules/machinery';
 

--- a/translate/src/modules/machinery/components/Translation.tsx
+++ b/translate/src/modules/machinery/components/Translation.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useContext, useEffect, useRef } from 'react';
 
 import type { MachineryTranslation } from '~/api/machinery';
 import { Locale } from '~/context/locale';
-import { NAME as EDITOR, useCopyMachineryTranslation } from '~/core/editor';
+import { EDITOR, useCopyMachineryTranslation } from '~/core/editor';
 import { selectHelperElementIndex } from '~/core/editor/actions';
 import { GenericTranslation } from '~/core/translation';
 import { useAppDispatch, useAppSelector } from '~/hooks';

--- a/translate/src/modules/machinery/components/TranslationSource.tsx
+++ b/translate/src/modules/machinery/components/TranslationSource.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 
 import type { MachineryTranslation } from '~/api/machinery';
 
-import GoogleTranslation from './source/GoogleTranslation';
-import MicrosoftTranslation from './source/MicrosoftTranslation';
-import SystranTranslation from './source/SystranTranslation';
-import MicrosoftTerminology from './source/MicrosoftTerminology';
-import CaighdeanTranslation from './source/CaighdeanTranslation';
-import TranslationMemory from './source/TranslationMemory';
+import { GoogleTranslation } from './source/GoogleTranslation';
+import { MicrosoftTranslation } from './source/MicrosoftTranslation';
+import { SystranTranslation } from './source/SystranTranslation';
+import { MicrosoftTerminology } from './source/MicrosoftTerminology';
+import { CaighdeanTranslation } from './source/CaighdeanTranslation';
+import { TranslationMemory } from './source/TranslationMemory';
 
 type Props = {
   translation: MachineryTranslation;

--- a/translate/src/modules/machinery/components/source/CaighdeanTranslation.test.js
+++ b/translate/src/modules/machinery/components/source/CaighdeanTranslation.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import CaighdeanTranslation from './CaighdeanTranslation';
+import { CaighdeanTranslation } from './CaighdeanTranslation';
 
 describe('<CaighdeanTranslation>', () => {
   it('renders the CaighdeanTranslation component properly', () => {

--- a/translate/src/modules/machinery/components/source/CaighdeanTranslation.tsx
+++ b/translate/src/modules/machinery/components/source/CaighdeanTranslation.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
  * Show the translation source from Caighdean Machine Translation.
  */
-export default function CaighdeanTranslation(): React.ReactElement<'li'> {
+export function CaighdeanTranslation(): React.ReactElement<'li'> {
   return (
     <li>
       <Localized

--- a/translate/src/modules/machinery/components/source/GoogleTranslation.test.js
+++ b/translate/src/modules/machinery/components/source/GoogleTranslation.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import GoogleTranslation from './GoogleTranslation';
+import { GoogleTranslation } from './GoogleTranslation';
 
 describe('<GoogleTranslation>', () => {
   it('renders the GoogleTranslation component properly', () => {

--- a/translate/src/modules/machinery/components/source/GoogleTranslation.tsx
+++ b/translate/src/modules/machinery/components/source/GoogleTranslation.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
  * Show the translation source from Google Translate.
  */
-export default function GoogleTranslation(): React.ReactElement<'li'> {
+export function GoogleTranslation(): React.ReactElement<'li'> {
   return (
     <li>
       <Localized

--- a/translate/src/modules/machinery/components/source/MicrosoftTerminology.test.js
+++ b/translate/src/modules/machinery/components/source/MicrosoftTerminology.test.js
@@ -5,7 +5,7 @@ import { Locale } from '~/context/locale';
 
 import { MockLocalizationProvider } from '~/test/utils';
 
-import MicrosoftTerminology from './MicrosoftTerminology';
+import { MicrosoftTerminology } from './MicrosoftTerminology';
 
 const LOCALE = { msTerminologyCode: 'en-US' };
 const PROPS = {

--- a/translate/src/modules/machinery/components/source/MicrosoftTerminology.tsx
+++ b/translate/src/modules/machinery/components/source/MicrosoftTerminology.tsx
@@ -10,7 +10,7 @@ type Props = {
 /**
  * Show the translation source from Microsoft Terminology.
  */
-export default function MicrosoftTerminology({
+export function MicrosoftTerminology({
   original,
 }: Props): React.ReactElement<'li'> {
   const { msTerminologyCode } = useContext(Locale);

--- a/translate/src/modules/machinery/components/source/MicrosoftTranslation.test.js
+++ b/translate/src/modules/machinery/components/source/MicrosoftTranslation.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import MicrosoftTranslation from './MicrosoftTranslation';
+import { MicrosoftTranslation } from './MicrosoftTranslation';
 
 describe('<MicrosoftTranslation>', () => {
   it('renders the MicrosoftTranslation component properly', () => {

--- a/translate/src/modules/machinery/components/source/MicrosoftTranslation.tsx
+++ b/translate/src/modules/machinery/components/source/MicrosoftTranslation.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
  * Show the translation source from Microsoft Translation.
  */
-export default function MicrosoftTranslation(): React.ReactElement<'li'> {
+export function MicrosoftTranslation(): React.ReactElement<'li'> {
   return (
     <li>
       <Localized

--- a/translate/src/modules/machinery/components/source/SystranTranslation.tsx
+++ b/translate/src/modules/machinery/components/source/SystranTranslation.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 /**
  * Show the translation source from Systran.
  */
-export default function SystranTranslation(): React.ReactElement<'li'> {
+export function SystranTranslation(): React.ReactElement<'li'> {
   return (
     <li>
       <Localized

--- a/translate/src/modules/machinery/components/source/TranslationMemory.test.js
+++ b/translate/src/modules/machinery/components/source/TranslationMemory.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import TranslationMemory from './TranslationMemory';
+import { TranslationMemory } from './TranslationMemory';
 
 describe('<TranslationMemory>', () => {
   it('renders the component without number of occurrences properly', () => {

--- a/translate/src/modules/machinery/components/source/TranslationMemory.tsx
+++ b/translate/src/modules/machinery/components/source/TranslationMemory.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Localized } from '@fluent/react';
 
 type Props = {
@@ -8,9 +8,7 @@ type Props = {
 /**
  * Show the translation source from Pontoon's memory.
  */
-export default function TranslationMemory(
-  props: Props,
-): React.ReactElement<'li'> {
+export function TranslationMemory(props: Props): React.ReactElement<'li'> {
   return (
     <li>
       <Localized

--- a/translate/src/modules/machinery/index.ts
+++ b/translate/src/modules/machinery/index.ts
@@ -1,11 +1,5 @@
-export { default as actions } from './actions';
-export { default as reducer } from './reducer';
-
 export { Machinery } from './components/Machinery';
 export { MachineryCount } from './components/MachineryCount';
 
+export { MACHINERY } from './reducer';
 export type { MachineryState } from './reducer';
-
-// Name of this module.
-// Used as the key to store this module's reducer.
-export const NAME = 'machinery';

--- a/translate/src/modules/machinery/reducer.ts
+++ b/translate/src/modules/machinery/reducer.ts
@@ -1,11 +1,7 @@
 import type { MachineryTranslation } from '~/api/machinery';
 
 import {
-  ConcordanceSearchAction,
-  AddTranslationsAction,
-  RequestAction,
-  ResetSearchAction,
-  SetEntityAction,
+  Action,
   ADD_TRANSLATIONS,
   CONCORDANCE_SEARCH,
   REQUEST,
@@ -13,12 +9,9 @@ import {
   SET_ENTITY,
 } from './actions';
 
-type Action =
-  | ConcordanceSearchAction
-  | AddTranslationsAction
-  | RequestAction
-  | ResetSearchAction
-  | SetEntityAction;
+// Name of this module.
+// Used as the key to store this module's reducer.
+export const MACHINERY = 'machinery';
 
 type Translations = Array<MachineryTranslation>;
 
@@ -91,7 +84,7 @@ const initial: MachineryState = {
   hasMore: false,
 };
 
-export default function reducer(
+export function reducer(
   state: MachineryState = initial,
   action: Action,
 ): MachineryState {

--- a/translate/src/modules/otherlocales/actions.ts
+++ b/translate/src/modules/otherlocales/actions.ts
@@ -4,6 +4,8 @@ import type { AppDispatch } from '~/store';
 export const RECEIVE: 'otherlocales/RECEIVE' = 'otherlocales/RECEIVE';
 export const REQUEST: 'otherlocales/REQUEST' = 'otherlocales/REQUEST';
 
+export type Action = ReceiveAction | RequestAction;
+
 export type ReceiveAction = {
   readonly type: typeof RECEIVE;
   readonly translations: OtherLocaleTranslation[];
@@ -27,8 +29,3 @@ export function get(entity: number, locale: string) {
     dispatch({ type: RECEIVE, translations });
   };
 }
-
-export default {
-  get,
-  request,
-};

--- a/translate/src/modules/otherlocales/components/OtherLocales.test.js
+++ b/translate/src/modules/otherlocales/components/OtherLocales.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import OtherLocales from './OtherLocales';
+import { OtherLocales } from './OtherLocales';
 
 describe('<OtherLocales>', () => {
   it('shows the correct number of translations', () => {

--- a/translate/src/modules/otherlocales/components/OtherLocales.tsx
+++ b/translate/src/modules/otherlocales/components/OtherLocales.tsx
@@ -17,7 +17,7 @@ type Props = {
 /**
  * Shows all translations of an entity in locales other than the current one.
  */
-export default function OtherLocales({
+export function OtherLocales({
   entity,
   otherlocales: { fetching, translations },
   parameters,

--- a/translate/src/modules/otherlocales/components/OtherLocalesCount.test.js
+++ b/translate/src/modules/otherlocales/components/OtherLocalesCount.test.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import Count from './Count';
+import { OtherLocalesCount } from './OtherLocalesCount';
 
-describe('<Count>', () => {
+describe('<OtherLocalesCount>', () => {
   it('shows the correct number of preferred translations', () => {
     const otherlocales = {
       translations: [
@@ -21,7 +21,7 @@ describe('<Count>', () => {
         },
       ],
     };
-    const wrapper = shallow(<Count otherlocales={otherlocales} />);
+    const wrapper = shallow(<OtherLocalesCount otherlocales={otherlocales} />);
 
     // There are only preferred results.
     expect(wrapper.find('.count > span')).toHaveLength(1);
@@ -52,7 +52,7 @@ describe('<Count>', () => {
         },
       ],
     };
-    const wrapper = shallow(<Count otherlocales={otherlocales} />);
+    const wrapper = shallow(<OtherLocalesCount otherlocales={otherlocales} />);
 
     // There are only remaining results.
     expect(wrapper.find('.count > span')).toHaveLength(1);
@@ -96,7 +96,7 @@ describe('<Count>', () => {
         },
       ],
     };
-    const wrapper = shallow(<Count otherlocales={otherlocales} />);
+    const wrapper = shallow(<OtherLocalesCount otherlocales={otherlocales} />);
 
     // There are both preferred and remaining, and the '+' sign.
     expect(wrapper.find('.count > span')).toHaveLength(3);

--- a/translate/src/modules/otherlocales/components/OtherLocalesCount.tsx
+++ b/translate/src/modules/otherlocales/components/OtherLocalesCount.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import type { LocalesState } from '..';
 
@@ -6,7 +6,9 @@ type Props = {
   otherlocales: LocalesState;
 };
 
-export default function Count(props: Props): null | React.ReactElement<'span'> {
+export function OtherLocalesCount(
+  props: Props,
+): null | React.ReactElement<'span'> {
   const { otherlocales } = props;
 
   if (otherlocales.fetching || !otherlocales.translations) {

--- a/translate/src/modules/otherlocales/components/Translation.tsx
+++ b/translate/src/modules/otherlocales/components/Translation.tsx
@@ -5,7 +5,7 @@ import React, { useCallback, useEffect, useRef } from 'react';
 import type { Entity } from '~/api/entity';
 import type { OtherLocaleTranslation } from '~/api/other-locales';
 import type { LocationType } from '~/context/location';
-import { NAME as EDITOR, useCopyOtherLocaleTranslation } from '~/core/editor';
+import { EDITOR, useCopyOtherLocaleTranslation } from '~/core/editor';
 import { selectHelperElementIndex } from '~/core/editor/actions';
 import { TranslationProxy } from '~/core/translation';
 import { useAppDispatch, useAppSelector } from '~/hooks';

--- a/translate/src/modules/otherlocales/index.ts
+++ b/translate/src/modules/otherlocales/index.ts
@@ -1,11 +1,5 @@
-export { default as actions } from './actions';
-export { default as reducer } from './reducer';
+export { OtherLocales } from './components/OtherLocales';
+export { OtherLocalesCount } from './components/OtherLocalesCount';
 
-export { default as OtherLocales } from './components/OtherLocales';
-export { default as OtherLocalesCount } from './components/Count';
-
+export { OTHERLOCALES } from './reducer';
 export type { LocalesState } from './reducer';
-
-// Name of this module.
-// Used as the key to store this module's reducer.
-export const NAME = 'otherlocales';

--- a/translate/src/modules/otherlocales/reducer.ts
+++ b/translate/src/modules/otherlocales/reducer.ts
@@ -1,8 +1,10 @@
 import type { OtherLocaleTranslation } from '~/api/other-locales';
 
-import { ReceiveAction, RequestAction, RECEIVE, REQUEST } from './actions';
+import { Action, RECEIVE, REQUEST } from './actions';
 
-type Action = ReceiveAction | RequestAction;
+// Name of this module.
+// Used as the key to store this module's reducer.
+export const OTHERLOCALES = 'otherlocales';
 
 export type LocalesState = {
   readonly fetching: boolean;
@@ -16,7 +18,7 @@ const initialState: LocalesState = {
   translations: [],
 };
 
-export default function reducer(
+export function reducer(
   state: LocalesState = initialState,
   action: Action,
 ): LocalesState {

--- a/translate/src/modules/search/actions.ts
+++ b/translate/src/modules/search/actions.ts
@@ -29,8 +29,3 @@ export function setFocus(searchInputFocused: boolean): SetFocusAction {
     searchInputFocused,
   };
 }
-
-export default {
-  getAuthorsAndTimeRangeData,
-  setFocus,
-};

--- a/translate/src/modules/search/components/FiltersPanel.test.js
+++ b/translate/src/modules/search/components/FiltersPanel.test.js
@@ -4,16 +4,16 @@ import sinon from 'sinon';
 
 import { createReduxStore, mountComponentWithStore } from '~/test/store';
 
-import FiltersPanelBase, { FiltersPanel } from './FiltersPanel';
+import { FiltersPanel, FiltersPanelDialog } from './FiltersPanel';
 import { FILTERS_STATUS, FILTERS_EXTRA } from '../constants';
 
-describe('<FiltersPanel>', () => {
+describe('<FiltersPanelDialog>', () => {
   it('correctly sets filter as selected', () => {
     const statuses = ['warnings', 'missing'];
     const extras = ['rejected'];
 
     const store = createReduxStore();
-    const wrapper = mountComponentWithStore(FiltersPanel, store, {
+    const wrapper = mountComponentWithStore(FiltersPanelDialog, store, {
       filters: { authors: [], extras, statuses, tags: [] },
       authorsData: [],
       tagsData: [],
@@ -38,7 +38,7 @@ describe('<FiltersPanel>', () => {
       it('applies a single filter on click on a filter title', () => {
         const onApplyFilter = sinon.spy();
         const store = createReduxStore();
-        const wrapper = mountComponentWithStore(FiltersPanel, store, {
+        const wrapper = mountComponentWithStore(FiltersPanelDialog, store, {
           filters: { authors: [], extras: [], statuses: [slug], tags: [] },
           onApplyFilter,
           authorsData: [],
@@ -54,7 +54,7 @@ describe('<FiltersPanel>', () => {
       it('toggles a filter on click on a filter status icon', () => {
         const onToggleFilter = sinon.spy();
         const store = createReduxStore();
-        const wrapper = mountComponentWithStore(FiltersPanel, store, {
+        const wrapper = mountComponentWithStore(FiltersPanelDialog, store, {
           filters: { authors: [], extras: [], statuses: [slug], tags: [] },
           onToggleFilter,
           parameters: {},
@@ -75,7 +75,7 @@ describe('<FiltersPanel>', () => {
       it('applies a single filter on click on a filter title', () => {
         const onApplyFilter = sinon.spy();
         const store = createReduxStore();
-        const wrapper = mountComponentWithStore(FiltersPanel, store, {
+        const wrapper = mountComponentWithStore(FiltersPanelDialog, store, {
           filters: { authors: [], extras: [slug], statuses: [], tags: [] },
           onApplyFilter,
           authorsData: [],
@@ -91,7 +91,7 @@ describe('<FiltersPanel>', () => {
       it('toggles a filter on click on a filter status icon', () => {
         const onToggleFilter = sinon.spy();
         const store = createReduxStore();
-        const wrapper = mountComponentWithStore(FiltersPanel, store, {
+        const wrapper = mountComponentWithStore(FiltersPanelDialog, store, {
           filters: { authors: [], extras: [slug], statuses: [], tags: [] },
           onToggleFilter,
           parameters: {},
@@ -109,7 +109,7 @@ describe('<FiltersPanel>', () => {
 
   it('shows the toolbar when some filters are selected', () => {
     const store = createReduxStore();
-    const wrapper = mountComponentWithStore(FiltersPanel, store, {
+    const wrapper = mountComponentWithStore(FiltersPanelDialog, store, {
       filters: { authors: [], extras: [], statuses: [], tags: [] },
       selectedFiltersCount: 1,
       authorsData: [],
@@ -122,7 +122,7 @@ describe('<FiltersPanel>', () => {
 
   it('hides the toolbar when no filters are selected', () => {
     const store = createReduxStore();
-    const wrapper = mountComponentWithStore(FiltersPanel, store, {
+    const wrapper = mountComponentWithStore(FiltersPanelDialog, store, {
       filters: { authors: [], extras: [], statuses: [], tags: [] },
       selectedFiltersCount: 0,
       authorsData: [],
@@ -136,7 +136,7 @@ describe('<FiltersPanel>', () => {
   it('resets selected filters on click on the Clear button', () => {
     const onResetFilters = sinon.spy();
     const store = createReduxStore();
-    const wrapper = mountComponentWithStore(FiltersPanel, store, {
+    const wrapper = mountComponentWithStore(FiltersPanelDialog, store, {
       filters: { authors: [], extras: [], statuses: [], tags: [] },
       onResetFilters,
       selectedFiltersCount: 1,
@@ -153,7 +153,7 @@ describe('<FiltersPanel>', () => {
   it('applies selected filters on click on the Apply button', () => {
     const onApplyFilters = sinon.spy();
     const store = createReduxStore();
-    const wrapper = mountComponentWithStore(FiltersPanel, store, {
+    const wrapper = mountComponentWithStore(FiltersPanelDialog, store, {
       filters: { authors: [], extras: [], statuses: [], tags: [] },
       onApplyFilters,
       selectedFiltersCount: 1,
@@ -168,10 +168,10 @@ describe('<FiltersPanel>', () => {
   });
 });
 
-describe('<FiltersPanelBase>', () => {
+describe('<FiltersPanel>', () => {
   it('shows a panel with filters on click', () => {
     const wrapper = shallow(
-      <FiltersPanelBase
+      <FiltersPanel
         filters={{ authors: [], extras: [], statuses: [], tags: [] }}
         authorsData={[]}
         tagsData={[]}
@@ -182,15 +182,15 @@ describe('<FiltersPanelBase>', () => {
       />,
     );
 
-    expect(wrapper.find('FiltersPanel')).toHaveLength(0);
+    expect(wrapper.find('FiltersPanelDialog')).toHaveLength(0);
     wrapper.find('.visibility-switch').simulate('click');
-    expect(wrapper.find('FiltersPanel')).toHaveLength(1);
+    expect(wrapper.find('FiltersPanelDialog')).toHaveLength(1);
   });
 
   it('has the correct icon based on parameters', () => {
     for (let { slug } of FILTERS_STATUS) {
       const wrapper = shallow(
-        <FiltersPanelBase
+        <FiltersPanel
           filters={{ authors: [], extras: [], statuses: [slug], tags: [] }}
           authorsData={[]}
           tagsData={[]}
@@ -205,7 +205,7 @@ describe('<FiltersPanelBase>', () => {
 
     for (let { slug } of FILTERS_EXTRA) {
       const wrapper = shallow(
-        <FiltersPanelBase
+        <FiltersPanel
           filters={{ authors: [], extras: [slug], statuses: [], tags: [] }}
           authorsData={[]}
           tagsData={[]}

--- a/translate/src/modules/search/components/FiltersPanel.tsx
+++ b/translate/src/modules/search/components/FiltersPanel.tsx
@@ -223,7 +223,7 @@ const FilterToolbar = ({
   </div>
 );
 
-export function FiltersPanel({
+export function FiltersPanelDialog({
   authorsData,
   filters: { authors, extras, statuses, tags },
   project,
@@ -335,7 +335,7 @@ export function FiltersPanel({
  *
  * Changes to the filters will be reflected in the URL.
  */
-export default function FiltersPanelBase({
+export function FiltersPanel({
   filters,
   tagsData,
   timeRangeData,
@@ -425,7 +425,7 @@ export default function FiltersPanelBase({
         <span className='status fa'></span>
       </div>
       {visible ? (
-        <FiltersPanel
+        <FiltersPanelDialog
           authorsData={authorsData}
           filters={filters}
           project={parameters.project}

--- a/translate/src/modules/search/components/SearchBox.test.js
+++ b/translate/src/modules/search/components/SearchBox.test.js
@@ -7,7 +7,7 @@ import sinon from 'sinon';
 import { createReduxStore, mountComponentWithStore } from '~/test/store';
 
 import { FILTERS_EXTRA, FILTERS_STATUS } from '../constants';
-import SearchBox, { SearchBoxBase } from './SearchBox';
+import { SearchBox, SearchBoxBase } from './SearchBox';
 
 const PROJECT = {
   tags: [],
@@ -84,19 +84,14 @@ describe('<SearchBoxBase>', () => {
       />,
     );
 
-    expect(wrapper.find('FiltersPanelBase').prop('filters').statuses).toEqual(
-      [],
-    );
+    expect(wrapper.find('FiltersPanel').prop('filters').statuses).toEqual([]);
 
     act(() => {
-      wrapper.find('FiltersPanelBase').prop('toggleFilter')(
-        'missing',
-        'statuses',
-      );
+      wrapper.find('FiltersPanel').prop('toggleFilter')('missing', 'statuses');
     });
     wrapper.update();
 
-    expect(wrapper.find('FiltersPanelBase').prop('filters').statuses).toEqual([
+    expect(wrapper.find('FiltersPanel').prop('filters').statuses).toEqual([
       'missing',
     ]);
   });
@@ -114,14 +109,14 @@ describe('<SearchBoxBase>', () => {
 
     act(() => {
       const { toggleFilter, applySingleFilter } = wrapper
-        .find('FiltersPanelBase')
+        .find('FiltersPanel')
         .props();
       toggleFilter('missing', 'statuses');
       applySingleFilter('warnings', 'statuses');
     });
     wrapper.update();
 
-    expect(wrapper.find('FiltersPanelBase').prop('filters').statuses).toEqual([
+    expect(wrapper.find('FiltersPanel').prop('filters').statuses).toEqual([
       'warnings',
     ]);
   });
@@ -136,29 +131,29 @@ describe('<SearchBoxBase>', () => {
     );
 
     act(() => {
-      const toggle = wrapper.find('FiltersPanelBase').prop('toggleFilter');
+      const toggle = wrapper.find('FiltersPanel').prop('toggleFilter');
       toggle('warnings', 'statuses');
       toggle('rejected', 'extras');
     });
     wrapper.update();
 
     act(() => {
-      const toggle = wrapper.find('FiltersPanelBase').prop('toggleFilter');
+      const toggle = wrapper.find('FiltersPanel').prop('toggleFilter');
       toggle('errors', 'statuses');
     });
     wrapper.update();
 
-    expect(wrapper.find('FiltersPanelBase').prop('filters')).toMatchObject({
+    expect(wrapper.find('FiltersPanel').prop('filters')).toMatchObject({
       extras: ['rejected'],
       statuses: ['warnings', 'errors'],
     });
 
     act(() => {
-      wrapper.find('FiltersPanelBase').prop('resetFilters')();
+      wrapper.find('FiltersPanel').prop('resetFilters')();
     });
     wrapper.update();
 
-    expect(wrapper.find('FiltersPanelBase').prop('filters')).toMatchObject({
+    expect(wrapper.find('FiltersPanel').prop('filters')).toMatchObject({
       extras: [],
       statuses: [],
     });
@@ -177,7 +172,7 @@ describe('<SearchBoxBase>', () => {
     );
 
     act(() => {
-      const apply = wrapper.find('FiltersPanelBase').prop('applySingleFilter');
+      const apply = wrapper.find('FiltersPanel').prop('applySingleFilter');
       apply('all', 'statuses');
     });
     wrapper.update();
@@ -209,7 +204,7 @@ describe('<SearchBoxBase>', () => {
     );
 
     act(() => {
-      const panel = wrapper.find('FiltersPanelBase');
+      const panel = wrapper.find('FiltersPanel');
       const toggle = panel.prop('toggleFilter');
       const setTimeRange = panel.prop('setTimeRange');
       toggle('missing', 'statuses');
@@ -221,12 +216,12 @@ describe('<SearchBoxBase>', () => {
     wrapper.update();
 
     act(() => {
-      const toggle = wrapper.find('FiltersPanelBase').prop('toggleFilter');
+      const toggle = wrapper.find('FiltersPanel').prop('toggleFilter');
       toggle('warnings', 'statuses');
     });
     wrapper.update();
 
-    const apply = wrapper.find('FiltersPanelBase').prop('applyFilters');
+    const apply = wrapper.find('FiltersPanel').prop('applyFilters');
     apply();
 
     expect(

--- a/translate/src/modules/search/components/SearchBox.tsx
+++ b/translate/src/modules/search/components/SearchBox.tsx
@@ -10,18 +10,18 @@ import React, {
 import { Location, LocationType } from '~/context/location';
 import { useCheckUnsavedChanges } from '~/context/unsavedChanges';
 
-import { reset as resetEditor } from '~/core/editor/actions';
+import { resetEditor } from '~/core/editor/actions';
 import { resetEntities } from '~/core/entities/actions';
 import { ProjectState, useProject } from '~/core/project';
 import { useAppDispatch, useAppSelector } from '~/hooks';
 import type { SearchAndFilters } from '~/modules/search';
-import { NAME as SEARCH } from '~/modules/search';
+import { SEARCH } from '~/modules/search';
 import type { AppDispatch } from '~/store';
 
 import { getAuthorsAndTimeRangeData, setFocus } from '../actions';
 import { FILTERS_EXTRA, FILTERS_STATUS } from '../constants';
 
-import FiltersPanel from './FiltersPanel';
+import { FiltersPanel } from './FiltersPanel';
 import './SearchBox.css';
 
 export type TimeRangeType = {
@@ -282,7 +282,7 @@ export function SearchBoxBase({
   );
 }
 
-export default function SearchBox(): React.ReactElement<typeof SearchBoxBase> {
+export function SearchBox(): React.ReactElement<typeof SearchBoxBase> {
   const state = {
     searchAndFilters: useAppSelector((state) => state[SEARCH]),
     parameters: useContext(Location),

--- a/translate/src/modules/search/index.ts
+++ b/translate/src/modules/search/index.ts
@@ -1,12 +1,5 @@
-export { default as actions } from './actions';
-export { default as reducer } from './reducer';
-
-export { default as SearchBox } from './components/SearchBox';
 export { SearchTerms } from './components/SearchTerms';
 
+export { SEARCH } from './reducer';
 export type { SearchAndFilters } from './reducer';
 export type { TimeRangeType } from './components/SearchBox';
-
-// Name of this module.
-// Used as the key to store this module's reducer.
-export const NAME = 'search';

--- a/translate/src/modules/search/reducer.ts
+++ b/translate/src/modules/search/reducer.ts
@@ -2,6 +2,10 @@ import type { Author } from '~/api/filter';
 
 import { Action, UPDATE, SET_FOCUS } from './actions';
 
+// Name of this module.
+// Used as the key to store this module's reducer.
+export const SEARCH = 'search';
+
 export type SearchAndFilters = {
   readonly authors: Author[];
   readonly countsPerMinute: number[][];
@@ -14,7 +18,7 @@ const initial: SearchAndFilters = {
   searchInputFocused: false,
 };
 
-export default function reducer(
+export function reducer(
   state: SearchAndFilters = initial,
   action: Action,
 ): SearchAndFilters {

--- a/translate/src/modules/teamcomments/actions.ts
+++ b/translate/src/modules/teamcomments/actions.ts
@@ -9,6 +9,8 @@ export const RECEIVE = 'comments/RECEIVE';
 export const REQUEST = 'comments/REQUEST';
 export const TOGGLE_PINNED = 'comments/TOGGLE_PINNED';
 
+export type Action = ReceiveAction | RequestAction | TogglePinnedAction;
+
 export type ReceiveAction = {
   readonly type: typeof RECEIVE;
   readonly comments: Array<TeamComment>;
@@ -57,9 +59,3 @@ export function togglePinnedStatus(pinned: boolean, commentId: number) {
     dispatch(togglePinned(pinned, commentId));
   };
 }
-
-export default {
-  get,
-  request,
-  togglePinnedStatus,
-};

--- a/translate/src/modules/teamcomments/components/CommentCount.test.js
+++ b/translate/src/modules/teamcomments/components/CommentCount.test.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import Count from './Count';
+import { CommentCount } from './CommentCount';
 
-describe('<Count>', () => {
+describe('<CommentCount>', () => {
   it('shows the correct number of pinned comments', () => {
     const teamComments = {
       comments: [
@@ -15,7 +15,7 @@ describe('<Count>', () => {
         },
       ],
     };
-    const wrapper = shallow(<Count teamComments={teamComments} />);
+    const wrapper = shallow(<CommentCount teamComments={teamComments} />);
 
     // There are only pinned results.
     expect(wrapper.find('.count > span')).toHaveLength(1);
@@ -30,7 +30,7 @@ describe('<Count>', () => {
     const teamComments = {
       comments: [{}, {}, {}],
     };
-    const wrapper = shallow(<Count teamComments={teamComments} />);
+    const wrapper = shallow(<CommentCount teamComments={teamComments} />);
 
     // There are only remaining results.
     expect(wrapper.find('.count > span')).toHaveLength(1);
@@ -56,7 +56,7 @@ describe('<Count>', () => {
         {},
       ],
     };
-    const wrapper = shallow(<Count teamComments={teamComments} />);
+    const wrapper = shallow(<CommentCount teamComments={teamComments} />);
 
     // There are both pinned and remaining, and the '+' sign.
     expect(wrapper.find('.count > span')).toHaveLength(3);

--- a/translate/src/modules/teamcomments/components/CommentCount.tsx
+++ b/translate/src/modules/teamcomments/components/CommentCount.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import type { TeamCommentState } from '~/modules/teamcomments';
 
@@ -6,7 +6,7 @@ type Props = {
   teamComments: TeamCommentState;
 };
 
-export default function Count(props: Props): null | React.ReactElement<'span'> {
+export function CommentCount(props: Props): null | React.ReactElement<'span'> {
   const { teamComments } = props;
 
   if (teamComments.fetching || !teamComments.comments) {

--- a/translate/src/modules/teamcomments/components/TeamComments.test.js
+++ b/translate/src/modules/teamcomments/components/TeamComments.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import TeamComments from './TeamComments';
+import { TeamComments } from './TeamComments';
 
 describe('<TeamComments>', () => {
   const DEFAULT_USER = 'AndyDwyer';

--- a/translate/src/modules/teamcomments/components/TeamComments.tsx
+++ b/translate/src/modules/teamcomments/components/TeamComments.tsx
@@ -2,7 +2,7 @@ import { Localized } from '@fluent/react';
 import React from 'react';
 
 import type { LocationType } from '~/context/location';
-import { CommentsList } from '~/core/comments';
+import { CommentsList } from '~/core/comments/components/CommentsList';
 import type { UserState } from '~/core/user';
 import type { TeamCommentState } from '~/modules/teamcomments';
 
@@ -18,7 +18,7 @@ type Props = {
   resetContactPerson: () => void;
 };
 
-export default function TeamComments(
+export function TeamComments(
   props: Props,
 ): null | React.ReactElement<'section'> {
   const {

--- a/translate/src/modules/teamcomments/index.ts
+++ b/translate/src/modules/teamcomments/index.ts
@@ -1,11 +1,5 @@
-export { default as actions } from './actions';
-export { default as reducer } from './reducer';
+export { CommentCount } from './components/CommentCount';
+export { TeamComments } from './components/TeamComments';
 
-export { default as TeamComments } from './components/TeamComments';
-export { default as CommentCount } from './components/Count';
-
+export { TEAM_COMMENTS } from './reducer';
 export type { TeamCommentState } from './reducer';
-
-// Name of this module.
-// Used as the key to store this module's reducer.
-export const NAME = 'teamcomments';

--- a/translate/src/modules/teamcomments/reducer.ts
+++ b/translate/src/modules/teamcomments/reducer.ts
@@ -1,15 +1,10 @@
 import type { TeamComment } from '~/api/comment';
 
-import {
-  ReceiveAction,
-  RequestAction,
-  TogglePinnedAction,
-  RECEIVE,
-  REQUEST,
-  TOGGLE_PINNED,
-} from './actions';
+import { Action, RECEIVE, REQUEST, TOGGLE_PINNED } from './actions';
 
-type Action = ReceiveAction | RequestAction | TogglePinnedAction;
+// Name of this module.
+// Used as the key to store this module's reducer.
+export const TEAM_COMMENTS = 'teamcomments';
 
 export type TeamCommentState = {
   readonly fetching: boolean;
@@ -40,7 +35,7 @@ const initialState: TeamCommentState = {
   comments: [],
 };
 
-export default function reducer(
+export function reducer(
   state: TeamCommentState = initialState,
   action: Action,
 ): TeamCommentState {

--- a/translate/src/modules/terms/components/TermCount.tsx
+++ b/translate/src/modules/terms/components/TermCount.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 
 import type { TermState } from '~/core/term';
 
@@ -6,9 +6,7 @@ type Props = {
   terms: TermState;
 };
 
-export default function TermCount(
-  props: Props,
-): null | React.ReactElement<'span'> {
+export function TermCount(props: Props): null | React.ReactElement<'span'> {
   const { terms } = props;
 
   if (terms.fetching || !terms.terms) {

--- a/translate/src/modules/terms/components/Terms.test.js
+++ b/translate/src/modules/terms/components/Terms.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import Terms from './Terms';
+import { Terms } from './Terms';
 import { TermsList } from '~/core/term';
 
 describe('<Terms>', () => {

--- a/translate/src/modules/terms/components/Terms.tsx
+++ b/translate/src/modules/terms/components/Terms.tsx
@@ -17,9 +17,7 @@ type Props = {
 /**
  * Shows all terms found in the source string.
  */
-export default function Terms(
-  props: Props,
-): null | React.ReactElement<'section'> {
+export function Terms(props: Props): null | React.ReactElement<'section'> {
   const { terms } = props;
 
   if (terms.fetching || !terms.terms) {

--- a/translate/src/modules/terms/index.ts
+++ b/translate/src/modules/terms/index.ts
@@ -1,6 +1,2 @@
-export { default as Terms } from './components/Terms';
-export { default as TermCount } from './components/Count';
-
-// Name of this module.
-// Used as the key to store this module's reducer.
-export const NAME = 'terms';
+export { TermCount } from './components/TermCount';
+export { Terms } from './components/Terms';

--- a/translate/src/rootReducer.ts
+++ b/translate/src/rootReducer.ts
@@ -1,34 +1,34 @@
-import * as editor from '~/core/editor';
+import * as editor from '~/core/editor/reducer';
 import * as entities from '~/core/entities/reducer';
-import * as notification from '~/core/notification';
+import * as notification from '~/core/notification/reducer';
 import * as project from '~/core/project/reducer';
 import * as resource from '~/core/resource/reducer';
 import * as stats from '~/core/stats/reducer';
-import * as term from '~/core/term';
-import * as user from '~/core/user';
+import * as term from '~/core/term/reducer';
+import * as user from '~/core/user/reducer';
 import * as batchactions from '~/modules/batchactions/reducer';
-import * as history from '~/modules/history';
-import * as machinery from '~/modules/machinery';
-import * as otherlocales from '~/modules/otherlocales';
-import * as search from '~/modules/search';
-import * as teamcomments from '~/modules/teamcomments';
+import * as history from '~/modules/history/reducer';
+import * as machinery from '~/modules/machinery/reducer';
+import * as otherlocales from '~/modules/otherlocales/reducer';
+import * as search from '~/modules/search/reducer';
+import * as teamcomments from '~/modules/teamcomments/reducer';
 
 // Combine reducers from all modules, using their NAME constant as key.
 export const reducer = {
   // Core modules
-  [editor.NAME]: editor.reducer,
-  [entities.NAME]: entities.reducer,
-  [notification.NAME]: notification.reducer,
-  [project.NAME]: project.reducer,
-  [resource.NAME]: resource.reducer,
-  [stats.NAME]: stats.reducer,
-  [user.NAME]: user.reducer,
+  [editor.EDITOR]: editor.reducer,
+  [entities.ENTITIES]: entities.reducer,
+  [notification.NOTIFICATION]: notification.reducer,
+  [project.PROJECT]: project.reducer,
+  [resource.RESOURCE]: resource.reducer,
+  [stats.STATS]: stats.reducer,
+  [user.USER]: user.reducer,
   // Application modules
-  [batchactions.NAME]: batchactions.reducer,
-  [history.NAME]: history.reducer,
-  [machinery.NAME]: machinery.reducer,
-  [otherlocales.NAME]: otherlocales.reducer,
-  [search.NAME]: search.reducer,
-  [teamcomments.NAME]: teamcomments.reducer,
-  [term.NAME]: term.reducer,
+  [batchactions.BATCHACTIONS]: batchactions.reducer,
+  [history.HISTORY]: history.reducer,
+  [machinery.MACHINERY]: machinery.reducer,
+  [otherlocales.OTHERLOCALES]: otherlocales.reducer,
+  [search.SEARCH]: search.reducer,
+  [teamcomments.TEAM_COMMENTS]: teamcomments.reducer,
+  [term.TERM]: term.reducer,
 };

--- a/translate/src/store.ts
+++ b/translate/src/store.ts
@@ -3,7 +3,7 @@ import { createLogger } from 'redux-logger';
 
 import { reducer } from './rootReducer';
 
-const store = configureStore({
+export const store = configureStore({
   // @ts-expect-error Here be dragons
   reducer,
 
@@ -31,5 +31,3 @@ export type AppThunk<ReturnType = void> = ThunkAction<
   unknown,
   Action<string>
 >;
-
-export default store;


### PR DESCRIPTION
Built on #2517, will be rebased once that's merged; only the last two commits are actually meant for this PR.

Default exports and in particular re-exports are made of pain. They needlessly complicate dependency graphs and make it harder to find all uses of the re-exported things.

So this PR gets rid of all of them, switching to named exports instead. And it adds an ESLint tule to prevent them from being used at all.

As a side benefit, this allows all of the 15 or so dependency loops to be resolved, which is nice. They weren't horrible, but a bit messy.

Where applicable, nested components are named more clearly as Foo and FooDialog; this still leaves the following four Foo + FooBase component pairs, which should be cleaned up separately:
- `modules/entitydetails/components/EntityDetails`
- `modules/genericeditor/components/PluralSelector`
- `modules/history/components/Translation`
- `modules/search/components/SearchBox`