### PR TITLE
Add support for list query parameter

### DIFF
--- a/translate/public/locale/en-US/translate.ftl
+++ b/translate/public/locale/en-US/translate.ftl
@@ -633,6 +633,7 @@ search-FiltersPanel--extra-name-unchanged = Unchanged
 search-FiltersPanel--extra-name-empty = Empty
 search-FiltersPanel--extra-name-fuzzy = Fuzzy
 search-FiltersPanel--extra-name-rejected = Rejected
+search-FiltersPanel--extra-name-missing-without-unreviewed = Missing without Unreviewed
 
 search-FiltersPanel--clear-selection = <glyph></glyph>CLEAR
     .title = Uncheck selected filters

--- a/translate/src/context/location.test.js
+++ b/translate/src/context/location.test.js
@@ -19,7 +19,7 @@ describe('LocationProvider', () => {
     });
   });
 
-  it('correctly parses the query string', () => {
+  it('correctly parses a query string', () => {
     const history = {
       location: {
         pathname: '/kg/waterwolf/path/',
@@ -34,6 +34,25 @@ describe('LocationProvider', () => {
       resource: 'path',
       entity: 42,
       status: 'missing,warnings',
+    });
+  });
+
+  it('correctly parses a query string with a list', () => {
+    const history = {
+      location: {
+        pathname: '/kg/waterwolf/path/',
+        search: '?status=missing,warnings&list=13,42,99&string=42',
+      },
+    };
+    const wrapper = shallow(<LocationProvider history={history} />);
+
+    expect(wrapper.prop('value')).toMatchObject({
+      locale: 'kg',
+      project: 'waterwolf',
+      resource: 'path',
+      entity: 42,
+      list: [13, 42, 99],
+      status: null,
     });
   });
 });

--- a/translate/src/modules/batchactions/actions.ts
+++ b/translate/src/modules/batchactions/actions.ts
@@ -1,8 +1,4 @@
-import {
-  batchEditEntities,
-  fetchEntitiesById,
-  fetchEntityIds,
-} from '~/api/entity';
+import { batchEditEntities, fetchEntities, fetchEntityIds } from '~/api/entity';
 import type { EntityTranslation } from '~/api/translation';
 import type { LocationType } from '~/context/location';
 import { updateEntityTranslation } from '~/core/entities/actions';
@@ -85,7 +81,7 @@ export const checkSelection = (
 const updateUI =
   (location: LocationType, selectedEntity: number, entityIds: number[]) =>
   async (dispatch: AppDispatch) => {
-    const entitiesData = await fetchEntitiesById(location, entityIds);
+    const entitiesData = await fetchEntities({ ...location, list: entityIds });
 
     if (entitiesData.stats) {
       // Update stats in progress chart and filter panel.

--- a/translate/src/modules/search/components/FiltersPanel.tsx
+++ b/translate/src/modules/search/components/FiltersPanel.tsx
@@ -412,9 +412,9 @@ export function FiltersPanel({
       selectedCount += 1;
       filterIcon ??= 'time-range';
     }
-    filterIcon ??= 'all';
+    filterIcon ??= parameters.list ? 'list' : 'all';
     return { filterIcon, selectedCount };
-  }, [filters, tagsData, authorsData]);
+  }, [filters, parameters.list, tagsData, authorsData]);
 
   return (
     <div className='filters-panel'>

--- a/translate/src/modules/search/components/SearchBox.css
+++ b/translate/src/modules/search/components/SearchBox.css
@@ -93,6 +93,10 @@
   font-size: 16px;
 }
 
+.search-box .list .status:before {
+  content: '\f022';
+}
+
 .search-box .unchanged .status:before {
   content: '';
 }

--- a/translate/src/modules/search/components/SearchBox.test.js
+++ b/translate/src/modules/search/components/SearchBox.test.js
@@ -233,6 +233,7 @@ describe('<SearchBoxBase>', () => {
         tag: 'browser',
         time: '111111111111-111111111111',
         entity: 0,
+        list: null,
       }),
     ).toBeTruthy();
   });

--- a/translate/src/modules/search/components/SearchBox.tsx
+++ b/translate/src/modules/search/components/SearchBox.tsx
@@ -197,6 +197,7 @@ export function SearchBoxBase({
           tag: tags.join(','),
           time: timeRange ? `${timeRange.from}-${timeRange.to}` : null,
           entity: 0, // With the new results, the current entity might not be available anymore.
+          list: null,
         });
       }),
     [dispatch, parameters, search, filters],


### PR DESCRIPTION
Built on #2518, will be rebased once that's merged; only the last two commits are actually meant for this PR.

Fixes #2049 by adding support for a `list=13,42,99` URL query parameter. This is then used by the review-notification links, as discussed previously in https://github.com/mozilla/pontoon/pull/2456#discussion_r831972129.

In the UI, the list view is indicated by a custom search-box icon, [`list-alt`](https://fontawesome.com/v5/icons/list-alt?s=solid):

<img width="228" alt="Screenshot 2022-05-07 at 15 02 06" src="https://user-images.githubusercontent.com/617000/167253487-fcbf1323-b54f-4d9c-ae3a-ce01ffa18853.png">

Internally, the argument uses the existing `entity_ids` payload parameter used by batch actions, with which `/get-entities/` returns an unpaginated list of matching entities. It's not possible to use the parameter together with any other filters like `status` or `search`. This allows for re-merging the just-added `fetchEntitiesById()` API wrapper method into `fetchEntities()`.

An errant missing FiltersPanel FTL string is added, as we're meddling here with that code in any case.