### PR TITLE
Temporarily disable Microsoft Terminology Service

### DIFF
--- a/pontoon/machinery/views.py
+++ b/pontoon/machinery/views.py
@@ -277,6 +277,11 @@ def caighdean(request):
 
 def microsoft_terminology(request):
     """Get translations from Microsoft Terminology Service."""
+    return JsonResponse(
+        {"status": False, "message": "Service Unavailable"},
+        status=503,
+    )
+
     try:
         text = request.GET["text"]
         locale_code = request.GET["locale"]


### PR DESCRIPTION
Microsoft Terminology Service endpoint is down ATM:
https://api.terminology.microsoft.com/Terminology.svc

It is essentially making the translate app unusable, because many other requests get stuck in a queue and time out.

This is just a temporary fix to disable the service. The proper fix, which will prevent external services to affect other requests, will come in a followup.