### PR TITLE
Simplify `Entity.for_project_locale` and `Entity.map_entities`

### DIFF
--- a/pontoon/base/tests/models/test_entity.py
+++ b/pontoon/base/tests/models/test_entity.py
@@ -333,7 +333,6 @@ def test_entity_project_locale_no_paths(
         "original": str(entity_a.string),
         "machinery_original": str(entity_a.string),
         "readonly": False,
-        "visible": False,
         "is_sibling": False,
     }
     assert entities[0] == expected

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -202,7 +202,7 @@ def _get_paginated_entities(locale, preferred_source_locale, project, form, enti
     return JsonResponse(
         {
             "entities": Entity.map_entities(
-                locale, preferred_source_locale, entities_to_map, []
+                locale, preferred_source_locale, entities_to_map
             ),
             "has_next": has_next,
             "stats": TranslatedResource.objects.stats(
@@ -372,15 +372,13 @@ def get_sibling_entities(request):
                 locale,
                 preferred_source_locale,
                 succeeding_entities,
-                [],
-                True,
+                is_sibling=True,
             ),
             "preceding": Entity.map_entities(
                 locale,
                 preferred_source_locale,
                 preceding_entities,
-                [],
-                True,
+                is_sibling=True,
             ),
         },
         safe=False,


### PR DESCRIPTION
While working on #2050, I noticed that there were a couple of minor inefficiencies in `Entities` methods; they're fixed here.

This also drops the unused always-false `visible` field from the JSON output.