### PR TITLE
Revert "Temporarily disable Microsoft Terminology Service (#2525)"

### DIFF
--- a/pontoon/machinery/views.py
+++ b/pontoon/machinery/views.py
@@ -277,11 +277,6 @@ def caighdean(request):
 
 def microsoft_terminology(request):
     """Get translations from Microsoft Terminology Service."""
-    return JsonResponse(
-        {"status": False, "message": "Service Unavailable"},
-        status=503,
-    )
-
     try:
         text = request.GET["text"]
         locale_code = request.GET["locale"]


### PR DESCRIPTION
This reverts commit 83d723ff1b57a12d4b2ca90e2ec83f56355a9b8d, because Microsoft Terminology Service endpoint is no longer down:
https://api.terminology.microsoft.com/Terminology.svc

I don't think we need to block this on https://github.com/mozilla/pontoon/issues/2532.