### PR TITLE
Automatically fill editor for missing values with a perfect TM match

### DIFF
--- a/translate/public/locale/en-US/translate.ftl
+++ b/translate/public/locale/en-US/translate.ftl
@@ -206,6 +206,12 @@ editor-KeyboardShortcuts--copy-from-next-helper = Copy From Next Helper
 editor-KeyboardShortcuts--copy-from-next-helper-shortcut = <mod1>Ctrl</mod1> + <mod2>Shift</mod2> + <accel>Down</accel>
 
 
+## Editor machinery source indicator
+## Shown when a perfect match is provided automatically from translation memory
+
+editor-MachinerySourceIndicator--text = Perfect match from translation memory
+
+
 ## Editor New Contributor Tooltip
 ## Renders the guidelines for new contributors
 

--- a/translate/public/locale/en-US/translate.ftl
+++ b/translate/public/locale/en-US/translate.ftl
@@ -209,7 +209,7 @@ editor-KeyboardShortcuts--copy-from-next-helper-shortcut = <mod1>Ctrl</mod1> + <
 ## Editor machinery source indicator
 ## Shown when a perfect match is provided automatically from translation memory
 
-editor-MachinerySourceIndicator--text = Perfect match from translation memory
+editor-MachinerySourceIndicator--text = <stress>100%</stress> MATCH FROM TRANSLATION MEMORY
 
 
 ## Editor New Contributor Tooltip

--- a/translate/src/core/editor/components/Editor.tsx
+++ b/translate/src/core/editor/components/Editor.tsx
@@ -8,6 +8,7 @@ import { PluralSelector } from '~/modules/genericeditor/components/PluralSelecto
 import './Editor.css';
 import { EditorMenu } from './EditorMenu';
 import { NewContributorTooltip } from './NewContributorTooltip';
+import { MachinerySourceIndicator } from './MachinerySourceIndicator';
 
 export function Editor(): React.ReactElement<'div'> {
   const { view } = useContext(EditorData);
@@ -17,6 +18,7 @@ export function Editor(): React.ReactElement<'div'> {
       <PluralSelector />
       <NewContributorTooltip />
       {view === 'rich' ? <RichTranslationForm /> : <GenericTranslationForm />}
+      <MachinerySourceIndicator />
       <EditorMenu />
     </div>
   );

--- a/translate/src/core/editor/components/MachinerySourceIndicator.css
+++ b/translate/src/core/editor/components/MachinerySourceIndicator.css
@@ -1,7 +1,13 @@
 .tm-source {
-  color: #aaa;
-  height: 0;
-  margin: 0 auto -4px;
-  padding-top: 4px;
-  pointer-events: none;
+  font-size: 11px;
+  padding: 10px 0;
+  border-top: 1px solid #5e6475;
+  width: 100%;
+  text-align: center;
+  background: #4d5967;
+  color: #ccc;
+}
+
+.tm-source .stress {
+  color: #7bc876;
 }

--- a/translate/src/core/editor/components/MachinerySourceIndicator.css
+++ b/translate/src/core/editor/components/MachinerySourceIndicator.css
@@ -1,0 +1,7 @@
+.tm-source {
+  color: #aaa;
+  height: 0;
+  margin: 0 auto -4px;
+  padding-top: 4px;
+  pointer-events: none;
+}

--- a/translate/src/core/editor/components/MachinerySourceIndicator.tsx
+++ b/translate/src/core/editor/components/MachinerySourceIndicator.tsx
@@ -18,8 +18,13 @@ export function MachinerySourceIndicator() {
   }
 
   return (
-    <Localized id='editor-MachinerySourceIndicator--text'>
-      <div className='tm-source'>Perfect match from translation memory</div>
+    <Localized
+      id='editor-MachinerySourceIndicator--text'
+      elems={{ stress: <span className='stress' /> }}
+    >
+      <div className='tm-source'>
+        {'<stress>100%</stress> MATCH FROM TRANSLATION MEMORY'}
+      </div>
     </Localized>
   );
 }

--- a/translate/src/core/editor/components/MachinerySourceIndicator.tsx
+++ b/translate/src/core/editor/components/MachinerySourceIndicator.tsx
@@ -1,0 +1,25 @@
+import { Localized } from '@fluent/react';
+import React, { useContext } from 'react';
+
+import { EditorData } from '~/context/Editor';
+
+import './MachinerySourceIndicator.css';
+
+export function MachinerySourceIndicator() {
+  const { machinery, value, view } = useContext(EditorData);
+
+  if (
+    !machinery ||
+    machinery.manual ||
+    machinery.translation !== value ||
+    view !== 'simple'
+  ) {
+    return null;
+  }
+
+  return (
+    <Localized id='editor-MachinerySourceIndicator--text'>
+      <div className='tm-source'>Perfect match from translation memory</div>
+    </Localized>
+  );
+}

--- a/translate/src/core/editor/hooks/useHandleShortcuts.ts
+++ b/translate/src/core/editor/hooks/useHandleShortcuts.ts
@@ -134,10 +134,10 @@ export function useHandleShortcuts(): (
               nextIdx < len
                 ? machineryTranslations[nextIdx]
                 : concordanceSearchResults[nextIdx - len];
-            setEditorFromMachinery(translation, sources);
+            setEditorFromMachinery(translation, sources, true);
           } else {
             const { translation } = otherLocaleTranslations[nextIdx];
-            setEditorFromMachinery(translation, []);
+            setEditorFromMachinery(translation, [], true);
           }
         }
         break;

--- a/translate/src/core/entities/useTranslationStatus.tsx
+++ b/translate/src/core/entities/useTranslationStatus.tsx
@@ -1,0 +1,52 @@
+import { useMemo } from 'react';
+import { Entity } from '~/api/entity';
+
+type TranslationStatus =
+  | 'errors'
+  | 'warnings'
+  | 'approved'
+  | 'pretranslated'
+  | 'partial'
+  | 'missing';
+
+export function useTranslationStatus({
+  translation,
+}: Entity): TranslationStatus {
+  return useMemo(() => {
+    let errors = false;
+    let warnings = false;
+    let approved = 0;
+    let pretranslated = 0;
+
+    for (const tx of translation) {
+      if (tx.approved || tx.pretranslated || tx.fuzzy) {
+        if (tx.errors.length) {
+          errors = true;
+        } else if (tx.warnings.length) {
+          warnings = true;
+        } else if (tx.approved) {
+          approved += 1;
+        } else if (tx.pretranslated) {
+          pretranslated += 1;
+        }
+      }
+    }
+
+    if (errors) {
+      return 'errors';
+    }
+    if (warnings) {
+      return 'warnings';
+    }
+    if (approved === translation.length) {
+      return 'approved';
+    }
+    if (pretranslated === translation.length) {
+      return 'pretranslated';
+    }
+    if (approved > 0 || pretranslated > 0) {
+      return 'partial';
+    }
+    return 'missing';
+  }, [translation]);
+}

--- a/translate/src/modules/entitieslist/components/Entity.tsx
+++ b/translate/src/modules/entitieslist/components/Entity.tsx
@@ -3,9 +3,9 @@ import classNames from 'classnames';
 import React, { useCallback, useContext, useState } from 'react';
 
 import type { Entity as EntityType } from '~/api/entity';
-import type { EntityTranslation } from '~/api/translation';
 import { Locale } from '~/context/Locale';
 import type { Location } from '~/context/Location';
+import { useTranslationStatus } from '~/core/entities/useTranslationStatus';
 import { TranslationProxy } from '~/core/translation';
 import { useTranslator } from '~/hooks/useTranslator';
 
@@ -100,9 +100,10 @@ export function Entity({
 
   const { code, direction, script } = useContext(Locale);
 
+  const status = useTranslationStatus(entity);
   const cn = classNames(
     'entity',
-    translationStatus(entity.translation),
+    status,
     selected && 'selected',
     isTranslator && !isReadOnlyEditor && 'batch-editable',
     checkedForBatchEditing && 'checked',
@@ -148,42 +149,4 @@ export function Entity({
       </div>
     </li>
   );
-}
-
-function translationStatus(translations: EntityTranslation[]): string {
-  let errors = false;
-  let warnings = false;
-  let approved = 0;
-  let pretranslated = 0;
-
-  for (const tx of translations) {
-    if (tx.approved || tx.pretranslated || tx.fuzzy) {
-      if (tx.errors.length) {
-        errors = true;
-      } else if (tx.warnings.length) {
-        warnings = true;
-      } else if (tx.approved) {
-        approved += 1;
-      } else if (tx.pretranslated) {
-        pretranslated += 1;
-      }
-    }
-  }
-
-  if (errors) {
-    return 'errors';
-  }
-  if (warnings) {
-    return 'warnings';
-  }
-  if (approved === translations.length) {
-    return 'approved';
-  }
-  if (pretranslated === translations.length) {
-    return 'pretranslated';
-  }
-  if (approved > 0 || pretranslated > 0) {
-    return 'partial';
-  }
-  return 'missing';
 }

--- a/translate/src/modules/genericeditor/components/PluralSelector.css
+++ b/translate/src/modules/genericeditor/components/PluralSelector.css
@@ -8,6 +8,7 @@
 .plural-selector ul li {
   background: #4d5967;
   border: 1px solid #5e6475;
+  border-bottom: none;
   border-left: none;
   display: table-cell;
   text-align: center;

--- a/translate/src/modules/machinery/components/Translation.tsx
+++ b/translate/src/modules/machinery/components/Translation.tsx
@@ -48,7 +48,11 @@ export function Translation({
     if (window.getSelection()?.isCollapsed !== false) {
       setElement(index);
       setCopied(true);
-      setEditorFromMachinery(translation.translation, translation.sources);
+      setEditorFromMachinery(
+        translation.translation,
+        translation.sources,
+        true,
+      );
     }
   }, [index, setEditorFromMachinery, translation]);
 

--- a/translate/src/modules/otherlocales/components/Translation.tsx
+++ b/translate/src/modules/otherlocales/components/Translation.tsx
@@ -46,7 +46,7 @@ export function Translation({
     if (window.getSelection()?.isCollapsed !== false) {
       setElement(index);
       setCopied(true);
-      setEditorFromMachinery(translation.translation, []);
+      setEditorFromMachinery(translation.translation, [], true);
     }
   }, [index, setEditorFromMachinery, translation]);
 


### PR DESCRIPTION
~Built on top of #2536, so will need a rebase once it's merged. Actual changes here are the last two commits.~ Edit: Done.

Fixes #2050, so ping its original reporter @tomer.

Screenshot of the editor with the "Perfect match from translation memory" indicator shown:
<img width="722" alt="Screenshot 2022-05-25 at 0 09 02" src="https://user-images.githubusercontent.com/617000/170132792-10e0da83-9cfd-4030-a9ab-846f066ec421.png">

UX is based on discussions with @mathjazz, as a noticeable but discreet indicator that should not move other elements in the view when its shown or hidden. Currently it's only shown for this specific case, but while playing around with it, it seems like it could work for all machinery matches. I'd be very happy to accept suggestions for better/alternative wording for it.

The indicator is only shown when in the "simple" view, and the automatic fill also only happens when the string may be initially shown in that view.