### PR TITLE
Correctly set types of ApiFailedChecks members as optional

### DIFF
--- a/translate/src/api/translation.ts
+++ b/translate/src/api/translation.ts
@@ -6,11 +6,11 @@ import type { SourceType } from './machinery';
 export type ChangeOperation = 'approve' | 'unapprove' | 'reject' | 'unreject';
 
 export type ApiFailedChecks = {
-  readonly clErrors: string[];
-  readonly pErrors: string[];
-  readonly clWarnings: string[];
-  readonly pndbWarnings: string[];
-  readonly ttWarnings: string[];
+  readonly clErrors?: string[];
+  readonly pErrors?: string[];
+  readonly clWarnings?: string[];
+  readonly pndbWarnings?: string[];
+  readonly ttWarnings?: string[];
 };
 
 /**

--- a/translate/src/context/FailedChecksData.tsx
+++ b/translate/src/context/FailedChecksData.tsx
@@ -51,11 +51,15 @@ export function FailedChecksProvider({
     },
 
     setFailedChecks(data, source) {
-      const errors = data.clErrors.concat(data.pErrors);
-      const warnings = data.clWarnings.concat(
-        data.pndbWarnings,
-        data.ttWarnings,
-      );
+      let errors: string[] = [];
+      let warnings: string[] = [];
+      for (const [key, value] of Object.entries(data)) {
+        if (key.includes('Errors')) {
+          errors = errors.concat(value);
+        } else if (key.includes('Warnings')) {
+          warnings = warnings.concat(value);
+        }
+      }
       setState((prev) => ({ ...prev, errors, warnings, source }));
     },
   }));


### PR DESCRIPTION
Fixes #2543, which was failing due to not validating that the API response matches the declared TS type; that lead to code making invalid assumptions, and failing to display the proceed-anyway dialog.

It wasn't only failing for approvals, but also submissions of messages with warnings.

Sorry, this one was my fault.