### PR TITLE
Group Team contributors by role

### DIFF
--- a/pontoon/contributors/templates/contributors/widgets/contributor_list.html
+++ b/pontoon/contributors/templates/contributors/widgets/contributor_list.html
@@ -12,11 +12,11 @@
 {% endmacro %}
 
 {# Widget to display list of contributors. #}
-{% macro list_contributors(contributors) %}
+{% macro list_contributors(contributors, title="Contributors") %}
   <table class="striped">
     <thead>
       <tr>
-        <th>Contributor</th>
+        <th>{{ title }}</th>
         <th>Translations</th>
       </tr>
     </thead>
@@ -28,7 +28,7 @@
             <img class="rounded" src="{{ contributor.gravatar_url(88) }}" width="44" height="44">
             <p class="name">{{ contributor.name_or_email }}</p>
           </a>
-          <p class="role">{{ contributor.user_role }}</p>
+          <p class="role">{{ contributor.user_locale_role or contributor.user_role }}</p>
         </td>
         <td class="stats">
           <div class="details">

--- a/pontoon/contributors/views.py
+++ b/pontoon/contributors/views.py
@@ -332,7 +332,9 @@ class ContributorsMixin:
             start_date = None
 
         context["contributors"] = users_with_translations_counts(
-            start_date, self.contributors_filter(**kwargs) & Q(user__isnull=False)
+            start_date,
+            self.contributors_filter(**kwargs) & Q(user__isnull=False),
+            kwargs.get("locale"),
         )
         context["period"] = period
         return context

--- a/pontoon/teams/static/css/team.css
+++ b/pontoon/teams/static/css/team.css
@@ -1,3 +1,7 @@
+.contributors ~ table {
+  margin-bottom: 30px;
+}
+
 .buglist {
   display: none;
   table-layout: fixed;

--- a/pontoon/teams/templates/teams/includes/contributors.html
+++ b/pontoon/teams/templates/teams/includes/contributors.html
@@ -3,8 +3,18 @@
 <menu class="controls contributors">
   {{ Contributors.select_period(period, url('pontoon.teams.contributors', locale.code)) }}
 </menu>
-{% if contributors %}
-  {{ Contributors.list_contributors(contributors) }}
-{% else %}
+{% if managers %}
+  {{ Contributors.list_contributors(managers, title="Managers") }}
+{% endif %}
+
+{% if translators %}
+  {{ Contributors.list_contributors(translators, title="Translators") }}
+{% endif %}
+
+{% if regular_contributors %}
+  {{ Contributors.list_contributors(regular_contributors) }}
+{% endif %}
+
+{% if not contributors %}
   {{ Contributors.no_contributors() }}
 {% endif %}

--- a/pontoon/teams/views.py
+++ b/pontoon/teams/views.py
@@ -297,6 +297,20 @@ class LocaleContributorsView(ContributorsMixin, DetailView):
     slug_field = "code"
     slug_url_kwarg = "locale"
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(locale=self.object, **kwargs)
+        contributors = context["contributors"]
+        context["managers"] = [
+            c for c in contributors if c.user_locale_role == "manager"
+        ]
+        context["translators"] = [
+            c for c in contributors if c.user_locale_role == "translator"
+        ]
+        context["regular_contributors"] = [
+            c for c in contributors if c.user_locale_role == "contributor"
+        ]
+        return context
+
     def get_context_object_name(self, obj):
         return "locale"
 


### PR DESCRIPTION
This patch groups users on the Locales Contributors page (e.g. https://pontoon.mozilla.org/sl/contributors/) by the role they have within a locale.

Fixes #2157, at least the easy parts of it. Not sure we want to go very far beyond this (e.g. add a contact form). We could however add a Contact/Email button to listed managers.