### PR TITLE
Fix rich editor focus handling

### DIFF
--- a/pontoon/machinery/views.py
+++ b/pontoon/machinery/views.py
@@ -128,6 +128,7 @@ def microsoft_translator(request):
     }
     body = [{"Text": text}]
 
+    r = None
     try:
         r = requests.post(url, params=payload, headers=headers, json=body)
         r.raise_for_status()
@@ -146,7 +147,7 @@ def microsoft_translator(request):
     except requests.exceptions.RequestException as e:
         return JsonResponse(
             {"status": False, "message": f"{e}"},
-            status=r.status_code,
+            status=r.status_code if r is not None else 500,
         )
 
 
@@ -207,6 +208,7 @@ def systran_translate(request):
         "format": "text",
     }
 
+    r = None
     try:
         r = requests.post(url, params=payload)
         r.raise_for_status()
@@ -225,7 +227,7 @@ def systran_translate(request):
     except requests.exceptions.RequestException as e:
         return JsonResponse(
             {"status": False, "message": f"{e}"},
-            status=r.status_code,
+            status=r.status_code if r is not None else 500,
         )
 
 
@@ -256,6 +258,7 @@ def caighdean(request):
         "foinse": "gd",
     }
 
+    r = None
     try:
         r = requests.post(url, data=data)
         r.raise_for_status()
@@ -271,7 +274,7 @@ def caighdean(request):
     except requests.exceptions.RequestException as e:
         return JsonResponse(
             {"status": False, "message": f"{e}"},
-            status=r.status_code,
+            status=r.status_code if r is not None else 500,
         )
 
 
@@ -307,6 +310,7 @@ def microsoft_terminology(request):
 
     payload = template.render(payload)
 
+    r = None
     try:
         r = requests.post(url, data=payload, headers=headers)
         r.raise_for_status()
@@ -335,5 +339,5 @@ def microsoft_terminology(request):
     except requests.exceptions.RequestException as e:
         return JsonResponse(
             {"status": False, "message": f"{e}"},
-            status=r.status_code,
+            status=r.status_code if r is not None else 500,
         )

--- a/translate/src/context/Editor.tsx
+++ b/translate/src/context/Editor.tsx
@@ -120,7 +120,7 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
       setEditorFromInput: (value) =>
         setState((prev) => {
           if (prev.view === 'rich' && typeof value === 'string') {
-            const next = updateRichValue(prev, value, false);
+            const next = updateRichValue(prev, value, false, false);
             if (next) {
               return { ...prev, value: next };
             }
@@ -136,7 +136,8 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
               value = translation;
               break;
             case 'rich': {
-              value = updateRichValue(prev, translation, false) ?? translation;
+              value =
+                updateRichValue(prev, translation, false, true) ?? translation;
               break;
             }
             case 'source': {
@@ -157,7 +158,7 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
               return { ...prev, value: input.value };
             }
           } else {
-            const next = updateRichValue(prev, content, true);
+            const next = updateRichValue(prev, content, true, true);
             if (next) {
               return { ...prev, value: next };
             }
@@ -318,6 +319,7 @@ function updateRichValue(
   { activeInput, value }: EditorData,
   content: string,
   selectionOnly: boolean,
+  fixFocus: boolean,
 ): Entry | null {
   if (
     typeof value !== 'string' &&
@@ -350,10 +352,12 @@ function updateRichValue(
     }
 
     // Need to let react-dom "fix" the select position before setting it right
-    setTimeout(() => {
-      const end = start + content.length;
-      input.setSelectionRange(end, end);
-    });
+    if (fixFocus) {
+      setTimeout(() => {
+        const end = start + content.length;
+        input.setSelectionRange(end, end);
+      });
+    }
 
     return next;
   } else {


### PR DESCRIPTION
Fixes #2549 by not "fixing" the cursor position during manual edits. Spent ages looking in entirely the wrong place for this.

Python changes are completely separate, and were required to account for errors discovered when running the server locally with no network connectivity.