### PR TITLE
Silence failures in ReactEditor.toDOMRange() for MentionList position

### DIFF
--- a/translate/src/core/comments/components/AddComment.tsx
+++ b/translate/src/core/comments/components/AddComment.tsx
@@ -254,10 +254,11 @@ export function AddComment({
           </Localized>
           {mentionTarget && suggestedUsers.length > 0 && (
             <MentionList
+              editor={editor}
               index={mentionIndex}
               onSelect={handleSelectMention}
-              range={ReactEditor.toDOMRange(editor, mentionTarget)}
               suggestedUsers={suggestedUsers}
+              target={mentionTarget}
             />
           )}
         </Slate>


### PR DESCRIPTION
Workaround-y fix for https://github.com/mozilla/pontoon/issues/2298#issuecomment-1155742194, which is a slightly different bug from the originally reported issue.

The source of this problem appears to be a timing issue internal to `slate` or `slate-react`. Rather than trying to really figure out and fix the root cause there, let's just patch this so that the comment editor doesn't blow up.