### PR TITLE
Always show Age of unreviewed chart

### DIFF
--- a/pontoon/insights/static/css/insights.css
+++ b/pontoon/insights/static/css/insights.css
@@ -60,8 +60,7 @@
   box-sizing: border-box;
 }
 
-#insights .active-users-chart,
-#insights #unreviewed-suggestions-lifespan-chart {
+#insights .active-users-chart {
   height: 160px;
 }
 


### PR DESCRIPTION
On some screen resolutions, the Age of unreviewed suggestions chart,
which is hidden by default, didn't render at all when being switch to.