### PR TITLE
Control cursor position less, trusting the browser to handle it right

### DIFF
--- a/translate/src/context/Editor.tsx
+++ b/translate/src/context/Editor.tsx
@@ -164,7 +164,12 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
           if (typeof prev.value === 'string') {
             const input = prev.activeInput.current;
             if (input) {
-              input.setRangeText(content);
+              input.setRangeText(
+                content,
+                input.selectionStart,
+                input.selectionEnd,
+                'end',
+              );
               return { ...prev, value: input.value };
             }
           } else {

--- a/translate/src/modules/fluenteditor/components/RichTranslationForm.tsx
+++ b/translate/src/modules/fluenteditor/components/RichTranslationForm.tsx
@@ -247,7 +247,6 @@ export function RichTranslationForm(): null | React.ReactElement<'div'> {
         root.current?.querySelector('textarea:first-of-type') ?? null;
       if (activeInput.current && !searchInputFocused) {
         activeInput.current.focus();
-        activeInput.current.setSelectionRange(0, 0);
       }
     }
   }, [entity, message]);

--- a/translate/src/modules/genericeditor/components/GenericTranslationForm.test.js
+++ b/translate/src/modules/genericeditor/components/GenericTranslationForm.test.js
@@ -74,9 +74,9 @@ describe('<GenericTranslationForm>', () => {
 
   it('updates the translation when setEditorSelection is passed', async () => {
     const [wrapper, actions] = mountForm('Hello');
-    act(() => actions.setEditorSelection('World, '));
+    act(() => actions.setEditorSelection(', World'));
     wrapper.update();
 
-    expect(wrapper.find('textarea').prop('value')).toBe('World, Hello');
+    expect(wrapper.find('textarea').prop('value')).toBe('Hello, World');
   });
 });

--- a/translate/src/modules/genericeditor/components/GenericTranslationForm.tsx
+++ b/translate/src/modules/genericeditor/components/GenericTranslationForm.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useLayoutEffect, useRef } from 'react';
+import React, { useContext, useLayoutEffect } from 'react';
 import { EditorActions, EditorData } from '~/context/Editor';
 
 import { Locale } from '~/context/Locale';
@@ -17,7 +17,6 @@ export function GenericTranslationForm(): React.ReactElement<'textarea'> | null 
   const searchInputFocused = useAppSelector(
     (state) => state.search.searchInputFocused,
   );
-  const userInput = useRef(false);
 
   const handleShortcuts = useHandleShortcuts();
 
@@ -26,11 +25,6 @@ export function GenericTranslationForm(): React.ReactElement<'textarea'> | null 
     const input = activeInput.current;
     if (input && !searchInputFocused) {
       input.focus();
-      if (userInput.current) {
-        userInput.current = false;
-      } else {
-        input.setSelectionRange(0, 0);
-      }
     }
   }, [value, searchInputFocused]);
 
@@ -42,10 +36,7 @@ export function GenericTranslationForm(): React.ReactElement<'textarea'> | null 
       readOnly={readonly}
       ref={activeInput}
       value={value}
-      onKeyDown={(ev) => {
-        userInput.current = true;
-        handleShortcuts(ev);
-      }}
+      onKeyDown={handleShortcuts}
       onChange={(ev) => setEditorFromInput(ev.currentTarget.value)}
       dir={direction}
       lang={code}


### PR DESCRIPTION
Fixes #2557

The editor state refactoring had carried along (and possibly broken?) some prior behaviour where focus handling was actively driven using `input.setSelectionRange()`. When doing certain editing operations, in particular when mixing RTL & LTR content, this lead to surprising/unhelpful results.

The right answer here isn't to add more customisation and more active control, it's to realise that the browser will almost always do the right thing if you let it. So most of said active control is removed here, and the `setEditorSelection()` action is told to always target the "end" of the selection, as that appears to correspond to the right thing even when mixing RTL & LTR content.

Automated testing of this behaviour is not really possible outside of actual browsers, and we don't have any instrumented browser tests. So this has been and needs to be tested manually to determine if there's a sequence of user actions that produces a weird result with input focus.