### PR TITLE
fix(docker): copy using chown for package.json and .env

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,10 +43,10 @@ USER pontoon
 # Install the server's Node.js requirements
 ENV YUGLIFY_BINARY /app/node_modules/.bin/yuglify
 ENV TERSER_BINARY /app/node_modules/.bin/terser
-COPY pontoon/package.json .
+COPY --chown=pontoon:pontoon pontoon/package.json .
 RUN npm install
 
-COPY ./docker/config/server.env .env
+COPY --chown=pontoon:pontoon ./docker/config/server.env .env
 COPY --chown=pontoon:pontoon . /app/
 
 RUN python manage.py collectstatic


### PR DESCRIPTION
Setup as described [here](https://mozilla-pontoon.readthedocs.io/en/latest/dev/setup.html) does not work as file permissions are wrong, using `COPY` with `--chown=pontoon:pontoon` fixes this.
