### PR TITLE
Restore Locales scrolling in Terminology

### DIFF
--- a/translate/src/modules/machinery/components/Machinery.css
+++ b/translate/src/modules/machinery/components/Machinery.css
@@ -1,7 +1,3 @@
-#react-tabs-5 {
-  overflow-y: hidden;
-}
-
 .machinery {
   height: 100%;
   line-height: 22px;


### PR DESCRIPTION
Fixes #2389: Restore scrolling of the Locales panels when used inside the Terminology project.

@abowler2 Do you remember what was the [initial purpose](https://github.com/mozilla/pontoon/pull/1794/commits/f67f084d9f5c934a13d16fdb3bd8fba84a99769c#diff-7900fda55b9eaedcd6f9d31f2c33482e0963a33368fa5f9d4605669f31621872) of this code??

I don't see issues after I remove the given lines.