### PR TITLE
Opt-out of Chrome Auto Dark Theme

### DIFF
--- a/pontoon/base/templates/500.html
+++ b/pontoon/base/templates/500.html
@@ -9,6 +9,7 @@
     <title>Server Error</title>
     <meta name="description" content="Mozilla’s Localization Platform">
     <meta name="author" content="Mozilla">
+    <meta name="color-scheme" content="only light">
 
     <style>
       /* 

--- a/pontoon/base/templates/base.html
+++ b/pontoon/base/templates/base.html
@@ -9,6 +9,7 @@
     <title>{% block title %}Pontoon{% endblock %}</title>
     <meta name="description" content="Mozilla’s Localization Platform">
     <meta name="author" content="Mozilla">
+    <meta name="color-scheme" content="only light">
 
     <!-- Defining a type is a workaround for bug 1422289. -->
     <link rel="icon" href="{{ static('img/logo.svg') }}" type="image/svg+xml">

--- a/pontoon/base/templates/django/base.html
+++ b/pontoon/base/templates/django/base.html
@@ -12,6 +12,7 @@
     <title>{% block title %}Pontoon{% endblock %}</title>
     <meta name="description" content="Mozilla’s Localization Platform">
     <meta name="author" content="Mozilla">
+    <meta name="color-scheme" content="only light">
     <link rel="stylesheet" href="{% static 'css/fontawesome-all.css' %}" title="" type="text/css" />
     <link rel="stylesheet" href="{% static 'css/nprogress.css' %}" title="" type="text/css" />
     <link rel="stylesheet" href="{% static 'css/fonts.css' %}" title="" type="text/css" />

--- a/translate/public/translate.html
+++ b/translate/public/translate.html
@@ -6,6 +6,7 @@
     <meta name="theme-color" content="#000000">
     <meta name="description" content="Mozilla’s Localization Platform">
     <meta name="author" content="Mozilla">
+    <meta name="color-scheme" content="only light">
     <!--
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/


### PR DESCRIPTION
Fixes #2576.

Pontoon color scheme is dark by default, and Chrome breaks it when the experimental
Auto Dark Theme flag is on. This patch opts-out of Chrome Auto Dark Theme.

Resources:
https://developer.chrome.com/blog/auto-dark-theme/#using-a-meta-tag