### PR TITLE
Use document.activeElement rather than custom redux value to track SearchBox focus

### DIFF
--- a/translate/src/modules/fluenteditor/components/RichTranslationForm.tsx
+++ b/translate/src/modules/fluenteditor/components/RichTranslationForm.tsx
@@ -11,9 +11,9 @@ import {
   extractAccessKeyCandidates,
   isPluralExpression,
 } from '~/core/utils/fluent';
-import { useAppSelector } from '~/hooks';
 import { usePluralExamples } from '~/hooks/usePluralExamples';
 import { useReadonlyEditor } from '~/hooks/useReadonlyEditor';
+import { searchBoxHasFocus } from '~/modules/search/components/SearchBox';
 
 import './RichTranslationForm.css';
 
@@ -228,9 +228,6 @@ function RichPattern({
  * are made directly to that AST.
  */
 export function RichTranslationForm(): null | React.ReactElement<'div'> {
-  const searchInputFocused = useAppSelector(
-    (state) => state.search.searchInputFocused,
-  );
   const { entity } = useContext(EntityView);
   const { activeInput, value: message } = useContext(EditorData);
 
@@ -245,8 +242,8 @@ export function RichTranslationForm(): null | React.ReactElement<'div'> {
     } else {
       activeInput.current ??=
         root.current?.querySelector('textarea:first-of-type') ?? null;
-      if (activeInput.current && !searchInputFocused) {
-        activeInput.current.focus();
+      if (!searchBoxHasFocus()) {
+        activeInput.current?.focus();
       }
     }
   }, [entity, message]);

--- a/translate/src/modules/fluenteditor/components/RichTranslationForm.tsx
+++ b/translate/src/modules/fluenteditor/components/RichTranslationForm.tsx
@@ -229,7 +229,7 @@ function RichPattern({
  */
 export function RichTranslationForm(): null | React.ReactElement<'div'> {
   const { entity } = useContext(EntityView);
-  const { activeInput, value: message } = useContext(EditorData);
+  const { activeInput, machinery, value: message } = useContext(EditorData);
 
   const root = useRef<HTMLTableSectionElement>(null);
   const userInput = useRef(false);
@@ -246,7 +246,7 @@ export function RichTranslationForm(): null | React.ReactElement<'div'> {
         activeInput.current?.focus();
       }
     }
-  }, [entity, message]);
+  }, [entity, machinery, message]);
 
   // message should always be a Message or a Term
   return message instanceof Message || message instanceof Term ? (

--- a/translate/src/modules/genericeditor/components/GenericTranslationForm.tsx
+++ b/translate/src/modules/genericeditor/components/GenericTranslationForm.tsx
@@ -3,8 +3,8 @@ import { EditorActions, EditorData } from '~/context/Editor';
 
 import { Locale } from '~/context/Locale';
 import { useHandleShortcuts } from '~/core/editor';
-import { useAppSelector } from '~/hooks';
 import { useReadonlyEditor } from '~/hooks/useReadonlyEditor';
+import { searchBoxHasFocus } from '~/modules/search/components/SearchBox';
 
 /**
  * Shows a generic translation form, a simple textarea.
@@ -14,19 +14,15 @@ export function GenericTranslationForm(): React.ReactElement<'textarea'> | null 
   const readonly = useReadonlyEditor();
   const { setEditorFromInput } = useContext(EditorActions);
   const { activeInput, value } = useContext(EditorData);
-  const searchInputFocused = useAppSelector(
-    (state) => state.search.searchInputFocused,
-  );
 
   const handleShortcuts = useHandleShortcuts();
 
   // Focus the textarea when something changes.
   useLayoutEffect(() => {
-    const input = activeInput.current;
-    if (input && !searchInputFocused) {
-      input.focus();
+    if (!searchBoxHasFocus()) {
+      activeInput.current?.focus();
     }
-  }, [value, searchInputFocused]);
+  }, [value]);
 
   return typeof value !== 'string' ? null : (
     <textarea

--- a/translate/src/modules/genericeditor/components/GenericTranslationForm.tsx
+++ b/translate/src/modules/genericeditor/components/GenericTranslationForm.tsx
@@ -13,7 +13,7 @@ export function GenericTranslationForm(): React.ReactElement<'textarea'> | null 
   const { code, direction, script } = useContext(Locale);
   const readonly = useReadonlyEditor();
   const { setEditorFromInput } = useContext(EditorActions);
-  const { activeInput, value } = useContext(EditorData);
+  const { activeInput, machinery, value } = useContext(EditorData);
 
   const handleShortcuts = useHandleShortcuts();
 
@@ -22,7 +22,7 @@ export function GenericTranslationForm(): React.ReactElement<'textarea'> | null 
     if (!searchBoxHasFocus()) {
       activeInput.current?.focus();
     }
-  }, [value]);
+  }, [machinery, value]);
 
   return typeof value !== 'string' ? null : (
     <textarea

--- a/translate/src/modules/search/actions.ts
+++ b/translate/src/modules/search/actions.ts
@@ -2,18 +2,12 @@ import { FilterData, fetchFilterData } from '~/api/filter';
 import type { AppDispatch } from '~/store';
 
 export const UPDATE = 'search/UPDATE';
-export const SET_FOCUS = 'search/SET_FOCUS';
 
-export type Action = UpdateAction | SetFocusAction;
+export type Action = UpdateAction;
 
 type UpdateAction = {
   type: typeof UPDATE;
   response: FilterData;
-};
-
-type SetFocusAction = {
-  type: typeof SET_FOCUS;
-  searchInputFocused: boolean;
 };
 
 export const getAuthorsAndTimeRangeData =
@@ -22,10 +16,3 @@ export const getAuthorsAndTimeRangeData =
     const response = await fetchFilterData(locale, project, resource);
     dispatch({ type: UPDATE, response });
   };
-
-export function setFocus(searchInputFocused: boolean): SetFocusAction {
-  return {
-    type: SET_FOCUS,
-    searchInputFocused,
-  };
-}

--- a/translate/src/modules/search/components/SearchBox.tsx
+++ b/translate/src/modules/search/components/SearchBox.tsx
@@ -17,7 +17,7 @@ import type { SearchAndFilters } from '~/modules/search';
 import { SEARCH } from '~/modules/search';
 import type { AppDispatch } from '~/store';
 
-import { getAuthorsAndTimeRangeData, setFocus } from '../actions';
+import { getAuthorsAndTimeRangeData } from '../actions';
 import { FILTERS_EXTRA, FILTERS_STATUS } from '../constants';
 
 import { FiltersPanel } from './FiltersPanel';
@@ -56,6 +56,9 @@ export type FilterAction = {
   filter: FilterType;
   value: string | string[] | null | undefined;
 };
+
+/** If SearchBox has focus, translation form updates should not grab focus for themselves.  */
+export const searchBoxHasFocus = () => document.activeElement?.id === 'search';
 
 /**
  * Shows and controls a search box, used to filter the list of entities.
@@ -253,9 +256,7 @@ export function SearchBoxBase({
         title='Search Strings (Ctrl + Shift + F)'
         type='search'
         value={search}
-        onBlur={() => dispatch(setFocus(false))}
         onChange={(ev) => setSearch(ev.currentTarget.value)}
-        onFocus={() => dispatch(setFocus(true))}
         onKeyDown={(ev) => {
           if (ev.key === 'Enter') {
             applyFilters();

--- a/translate/src/modules/search/index.ts
+++ b/translate/src/modules/search/index.ts
@@ -1,5 +1,5 @@
 export { SearchTerms } from './components/SearchTerms';
 
 export { SEARCH } from './reducer';
-export type { SearchAndFilters } from './reducer';
+export type { SearchFilters as SearchAndFilters } from './reducer';
 export type { TimeRangeType } from './components/SearchBox';

--- a/translate/src/modules/search/reducer.ts
+++ b/translate/src/modules/search/reducer.ts
@@ -1,38 +1,31 @@
 import type { Author } from '~/api/filter';
 
-import { Action, UPDATE, SET_FOCUS } from './actions';
+import { Action, UPDATE } from './actions';
 
 // Name of this module.
 // Used as the key to store this module's reducer.
 export const SEARCH = 'search';
 
-export type SearchAndFilters = {
+export type SearchFilters = {
   readonly authors: Author[];
   readonly countsPerMinute: number[][];
-  readonly searchInputFocused: boolean;
 };
 
-const initial: SearchAndFilters = {
+const initial: SearchFilters = {
   authors: [],
   countsPerMinute: [],
-  searchInputFocused: false,
 };
 
 export function reducer(
-  state: SearchAndFilters = initial,
+  state: SearchFilters = initial,
   action: Action,
-): SearchAndFilters {
+): SearchFilters {
   switch (action.type) {
     case UPDATE:
       return {
         ...state,
         authors: action.response.authors,
         countsPerMinute: action.response.counts_per_minute,
-      };
-    case SET_FOCUS:
-      return {
-        ...state,
-        searchInputFocused: action.searchInputFocused,
       };
     default:
       return state;


### PR DESCRIPTION
Fixes #2572

The timing of redux state updates was a bit off, causing the weird UX. Rather than fix the timing, let's just get rid of the state, and trust the browser to track whether the search box is focused or not.