### PR TITLE
Do not render EntityDetails or EditorMenu while still loading data

### DIFF
--- a/translate/src/core/editor/components/EditorMenu.test.js
+++ b/translate/src/core/editor/components/EditorMenu.test.js
@@ -63,6 +63,11 @@ function expectHiddenSettingsAndActions(wrapper) {
 }
 
 describe('<EditorMenu>', () => {
+  it('does not render while loading', () => {
+    const wrapper = createEditorMenu({ isAuthenticated: null });
+    expect(wrapper.find('EditorMenu').isEmptyRender()).toBeTruthy();
+  });
+
   it('renders correctly', () => {
     const wrapper = createEditorMenu();
 

--- a/translate/src/core/editor/components/EditorMenu.tsx
+++ b/translate/src/core/editor/components/EditorMenu.tsx
@@ -42,13 +42,20 @@ function MenuContent() {
   const copyOriginalIntoEditor = useCopyOriginalIntoEditor();
   const dispatch = useAppDispatch();
   const { entity } = useContext(EntityView);
-  const userState = useAppSelector((state) => state.user);
+  const { isAuthenticated, settings, signInURL, username } = useAppSelector(
+    (state) => state.user,
+  );
 
-  if (!userState.isAuthenticated) {
+  if (isAuthenticated === null) {
+    // No content while loading user data
+    return null;
+  }
+
+  if (!isAuthenticated) {
     return (
       <Localized
         id='editor-EditorMenu--sign-in-to-translate'
-        elems={{ a: <user.SignInLink url={userState.signInURL} /> }}
+        elems={{ a: <user.SignInLink url={signInURL} /> }}
       >
         <p className='banner'>{'<a>Sign in</a> to translate.'}</p>
       </Localized>
@@ -64,15 +71,12 @@ function MenuContent() {
   }
 
   function updateSetting(setting: keyof user.Settings, value: boolean) {
-    dispatch(saveSetting(setting, value, userState.username, showNotification));
+    dispatch(saveSetting(setting, value, username, showNotification));
   }
 
   return (
     <>
-      <EditorSettings
-        settings={userState.settings}
-        updateSetting={updateSetting}
-      />
+      <EditorSettings settings={settings} updateSetting={updateSetting} />
       <KeyboardShortcuts />
       <TranslationLength />
       <div className='actions'>

--- a/translate/src/core/user/reducer.ts
+++ b/translate/src/core/user/reducer.ts
@@ -67,7 +67,7 @@ export type Notifications = {
 };
 
 export type UserState = {
-  readonly isAuthenticated: boolean;
+  readonly isAuthenticated: boolean | null; // null while loading
   readonly isAdmin: boolean;
   readonly id: string;
   readonly displayName: string;
@@ -90,7 +90,7 @@ export type UserState = {
 };
 
 const initial: UserState = {
-  isAuthenticated: false,
+  isAuthenticated: null,
   isAdmin: false,
   id: '',
   displayName: '',
@@ -125,7 +125,7 @@ export function reducer(state: UserState = initial, action: Action): UserState {
       };
     case UPDATE:
       return {
-        isAuthenticated: action.data.is_authenticated ?? false,
+        isAuthenticated: action.data.is_authenticated ?? null,
         isAdmin: action.data.is_admin ?? false,
         id: action.data.id ?? '',
         displayName: action.data.display_name ?? '',

--- a/translate/src/modules/entitydetails/components/EntityDetails.tsx
+++ b/translate/src/modules/entitydetails/components/EntityDetails.tsx
@@ -60,10 +60,6 @@ export function EntityDetails(): React.ReactElement<'section'> | null {
   const { entity, locale: lc, project } = location;
 
   useEffect(() => {
-    if (!selectedEntity) {
-      return;
-    }
-
     const { format, machinery_original, pk } = selectedEntity;
     const source = getOptimizedContent(machinery_original, format);
 
@@ -92,7 +88,8 @@ export function EntityDetails(): React.ReactElement<'section'> | null {
     [dispatch],
   );
 
-  return (
+  // No content while loading entity data
+  return selectedEntity.pk === 0 ? null : (
     <section className='entity-details'>
       <section className='main-column'>
         <EntityNavigation />


### PR DESCRIPTION
Fixes #2561 

While moving data handling from Redux to React Context, some of their default values changed from `null` to objects containing empty/initial values. This meant that checks like `!entity` or `!user` would never actually succeed, and were in fact dropped. Some of these initial values would then bleed through to the UI as e.g. `user.isAuthenticated` would be `false` and `entity.readonly` would be `true` while the relevant data was being fetched from the server, leading to an initial flash of content.

To fix this, a couple of checks are added for `entity.pk === 0` and `user.isAuthenticated === null` (a new state) to not render components while data is still being fetched.