### PR TITLE
Fix issues copying strings from Machinery & OtherLocales to editor using key shortcut

### DIFF
--- a/translate/src/context/HelperSelection.tsx
+++ b/translate/src/context/HelperSelection.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useEffect, useState } from 'react';
 
 import { useActiveTranslation } from './EntityView';
 
-export type HelperSelection = Readonly<{
+type HelperSelection = Readonly<{
   /**
    * Index of selected tab in the helpers box. Assumes the following:
    * - `0`: Machinery

--- a/translate/src/core/editor/hooks/useHandleShortcuts.ts
+++ b/translate/src/core/editor/hooks/useHandleShortcuts.ts
@@ -6,6 +6,7 @@ import { HelperSelection } from '~/context/HelperSelection';
 import { MachineryTranslations } from '~/context/MachineryTranslations';
 import { SearchData } from '~/context/SearchData';
 import { UnsavedActions, UnsavedChanges } from '~/context/UnsavedChanges';
+import { getSimplePreview } from '~/core/utils/fluent';
 import { useAppSelector } from '~/hooks';
 import { useReadonlyEditor } from '~/hooks/useReadonlyEditor';
 
@@ -137,7 +138,7 @@ export function useHandleShortcuts(): (
             setEditorFromHelpers(translation, sources, true);
           } else {
             const { translation } = otherLocaleTranslations[nextIdx];
-            setEditorFromHelpers(translation, [], true);
+            setEditorFromHelpers(getSimplePreview(translation), [], true);
           }
         }
         break;

--- a/translate/src/modules/machinery/components/Translation.tsx
+++ b/translate/src/modules/machinery/components/Translation.tsx
@@ -1,12 +1,6 @@
 import { Localized } from '@fluent/react';
 import classNames from 'classnames';
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useContext, useEffect, useRef } from 'react';
 
 import type { MachineryTranslation } from '~/api/machinery';
 import { EditorActions } from '~/context/Editor';
@@ -41,13 +35,11 @@ export function Translation({
 }: Props): React.ReactElement<React.ElementType> {
   const { setEditorFromHelpers } = useContext(EditorActions);
   const { element, setElement } = useContext(HelperSelection);
-  const [isCopied, setCopied] = useState(false);
   const isSelected = element === index;
 
   const copyTranslationIntoEditor = useCallback(() => {
     if (window.getSelection()?.isCollapsed !== false) {
       setElement(index);
-      setCopied(true);
       setEditorFromHelpers(translation.translation, translation.sources, true);
     }
   }, [index, setEditorFromHelpers, translation]);
@@ -55,7 +47,7 @@ export function Translation({
   const className = classNames(
     'translation',
     useReadonlyEditor() && 'cannot-copy',
-    isSelected && isCopied && 'selected',
+    isSelected && 'selected',
   );
 
   const translationRef = useRef<HTMLLIElement>(null);

--- a/translate/src/modules/otherlocales/components/Translation.tsx
+++ b/translate/src/modules/otherlocales/components/Translation.tsx
@@ -1,12 +1,6 @@
 import { Localized } from '@fluent/react';
 import classNames from 'classnames';
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useContext, useEffect, useRef } from 'react';
 
 import type { Entity } from '~/api/entity';
 import type { OtherLocaleTranslation } from '~/api/other-locales';
@@ -40,13 +34,11 @@ export function Translation({
 }: Props): React.ReactElement<React.ElementType> {
   const { setEditorFromHelpers } = useContext(EditorActions);
   const { element, setElement } = useContext(HelperSelection);
-  const [isCopied, setCopied] = useState(false);
   const isSelected = element === index;
 
   const copyTranslationIntoEditor = useCallback(() => {
     if (window.getSelection()?.isCollapsed !== false) {
       setElement(index);
-      setCopied(true);
       const value =
         format === 'ftl'
           ? getSimplePreview(translation.translation)
@@ -58,7 +50,7 @@ export function Translation({
   const className = classNames(
     'translation',
     useReadonlyEditor() && 'cannot-copy',
-    isSelected && isCopied && 'selected',
+    isSelected && 'selected',
   );
 
   const translationRef = useRef<HTMLLIElement>(null);


### PR DESCRIPTION
Fixes #2582 

Fixing the `key = value` part was missed in #2568, which made the same thing work for mouse interactions.

The selection highlight was a separate bug; an unneeded part of state was not fully dropped during the earlier Redux -> React Context migration, and it hid the highlight when using key shortcuts.