### PR TITLE
Add wrapper component for ProjectInfoDialog to satisfy useOnDiscard

### DIFF
--- a/translate/src/core/utils/hooks/useOnDiscard.ts
+++ b/translate/src/core/utils/hooks/useOnDiscard.ts
@@ -1,5 +1,11 @@
 import { useEffect } from 'react';
 
+/**
+ * Calls `onDiscard` when clicking anywhere outside the `ref` element
+ *
+ * @param ref - Must be the top-level element rendered by a component,
+ *   or this hook will misbehave.
+ */
 export function useOnDiscard(
   ref: React.RefObject<unknown>,
   onDiscard: () => void,

--- a/translate/src/modules/projectinfo/components/ProjectInfo.tsx
+++ b/translate/src/modules/projectinfo/components/ProjectInfo.tsx
@@ -6,6 +6,28 @@ import { useOnDiscard } from '~/core/utils';
 
 import './ProjectInfo.css';
 
+function ProjectInfoDialog({
+  info,
+  onDiscard,
+}: {
+  info: string;
+  onDiscard: () => void;
+}): React.ReactElement<'aside'> {
+  const ref = useRef<HTMLElement>(null);
+  useOnDiscard(ref, onDiscard);
+
+  // We can safely use project.info because it is validated by bleach
+  // before being saved into the database.
+  return (
+    <aside ref={ref} className='panel'>
+      <Localized id='projectinfo-ProjectInfo--project-info-title'>
+        <h2>PROJECT INFO</h2>
+      </Localized>
+      <p dangerouslySetInnerHTML={{ __html: info }} />
+    </aside>
+  );
+}
+
 /**
  * Show a panel with the information provided for the current project.
  */
@@ -14,24 +36,13 @@ export function ProjectInfo(): React.ReactElement<'div'> | null {
   const [visible, setVisible] = useState(false);
   const toggleVisible = useCallback(() => setVisible((prev) => !prev), []);
   const handleDiscard = useCallback(() => setVisible(false), []);
-  const ref = useRef<HTMLElement>(null);
-  useOnDiscard(ref, handleDiscard);
 
   return fetching || !info ? null : (
     <div className='project-info'>
       <div className='button' onClick={toggleVisible}>
         <span className='fa fa-info'></span>
       </div>
-      {visible && (
-        <aside ref={ref} className='panel'>
-          <Localized id='projectinfo-ProjectInfo--project-info-title'>
-            <h2>PROJECT INFO</h2>
-          </Localized>
-          {/* We can safely use project.info because it is validated
-          by bleach before being saved into the database. */}
-          <p dangerouslySetInnerHTML={{ __html: info }} />
-        </aside>
-      )}
+      {visible && <ProjectInfoDialog info={info} onDiscard={handleDiscard} />}
     </div>
   );
 }


### PR DESCRIPTION
Fixes #2563

The `useOnDiscard()` hook was mis-used in the ProjectInfo component. Its code documentation is improved to note a requirement for its `ref` to be a top-level element.

The other uses of the hook have also been reviewed to ensure that this same issue should not be present elsewhere.