### PR TITLE
Only fetch /get-users/ when adding a comment

### DIFF
--- a/translate/src/App.tsx
+++ b/translate/src/App.tsx
@@ -5,13 +5,14 @@ import './App.css';
 
 import { initLocale, Locale, updateLocale } from './context/Locale';
 import { Location } from './context/Location';
+import { MentionUsersProvider } from './context/MentionUsers';
+import { NotificationProvider } from './context/Notification';
 
 import { WaveLoader } from './core/loaders';
 import { NotificationPanel } from './core/notification/components/NotificationPanel';
 import { getProject } from './core/project/actions';
 import { getResource } from './core/resource/actions';
 import { UserControls } from './core/user/components/UserControls';
-import { getUsersList } from './core/user/actions';
 
 import { useAppDispatch } from './hooks';
 
@@ -25,7 +26,6 @@ import { Navigation } from './modules/navbar/components/Navigation';
 import { ProjectInfo } from './modules/projectinfo/components/ProjectInfo';
 import { ResourceProgress } from './modules/resourceprogress';
 import { SearchBox } from './modules/search/components/SearchBox';
-import { NotificationProvider } from './context/Notification';
 
 /**
  * Main entry point to the application. Will render the structure of the page.
@@ -43,7 +43,6 @@ export function App() {
 
   useEffect(() => {
     updateLocale(locale, location.locale);
-    dispatch(getUsersList());
   }, []);
 
   useEffect(() => {
@@ -60,30 +59,32 @@ export function App() {
   return (
     <Locale.Provider value={locale}>
       <NotificationProvider>
-        <div id='app'>
-          <AddonPromotion />
-          <header>
-            <Navigation />
-            <ResourceProgress />
-            {allProjects ? null : <ProjectInfo />}
-            <NotificationPanel />
-            <UserControls />
-          </header>
-          <section className='main-content'>
-            <section className='panel-list'>
-              <SearchBox />
-              <EntitiesList />
+        <MentionUsersProvider>
+          <div id='app'>
+            <AddonPromotion />
+            <header>
+              <Navigation />
+              <ResourceProgress />
+              {allProjects ? null : <ProjectInfo />}
+              <NotificationPanel />
+              <UserControls />
+            </header>
+            <section className='main-content'>
+              <section className='panel-list'>
+                <SearchBox />
+                <EntitiesList />
+              </section>
+              <section className='panel-content'>
+                {batchactions.entities.length === 0 ? (
+                  <Entity />
+                ) : (
+                  <BatchActions />
+                )}
+              </section>
             </section>
-            <section className='panel-content'>
-              {batchactions.entities.length === 0 ? (
-                <Entity />
-              ) : (
-                <BatchActions />
-              )}
-            </section>
-          </section>
-          <InteractiveTour />
-        </div>
+            <InteractiveTour />
+          </div>
+        </MentionUsersProvider>
       </NotificationProvider>
     </Locale.Provider>
   );

--- a/translate/src/api/user.ts
+++ b/translate/src/api/user.ts
@@ -48,7 +48,7 @@ export type ApiUserData = {
 };
 
 /** All users for use in mentions suggestions within comments */
-export type UsersList = {
+export type MentionUser = {
   gravatar: string;
   name: string;
   url: string;
@@ -62,7 +62,7 @@ export const dismissAddonPromotion = (): Promise<void> =>
 export const fetchUserData = (): Promise<ApiUserData> => GET('/user-data/');
 
 /** Get all users from server. */
-export const fetchUsersList = (): Promise<UsersList[]> => GET('get-users');
+export const fetchUsersList = (): Promise<MentionUser[]> => GET('/get-users/');
 
 /** Mark all notifications of the current user as read. */
 export const markAllNotificationsAsRead = (): Promise<void> =>

--- a/translate/src/context/MentionUsers.tsx
+++ b/translate/src/context/MentionUsers.tsx
@@ -1,0 +1,40 @@
+import React, { createContext, useMemo, useState } from 'react';
+import { fetchUsersList, MentionUser } from '~/api/user';
+
+type MentionUsers = {
+  /**
+   * Fetch list of users for @-mentions.
+   *
+   * May be called multiple times, but data will only be fetched once.
+   */
+  initMentions(): void;
+  mentionUsers: MentionUser[];
+};
+
+export const MentionUsers = createContext<MentionUsers>({
+  initMentions: () => {},
+  mentionUsers: [],
+});
+
+export function MentionUsersProvider({
+  children,
+}: {
+  children: React.ReactElement;
+}) {
+  const [mentionUsers, setUsers] = useState<MentionUser[]>([]);
+  const [initMentions, setInit] = useState(() => () => {
+    setInit(() => () => {});
+    fetchUsersList().then((list) => {
+      if (Array.isArray(list)) {
+        setUsers(list);
+      }
+    });
+  });
+  const value = useMemo(
+    () => ({ initMentions, mentionUsers }),
+    [initMentions, mentionUsers],
+  );
+  return (
+    <MentionUsers.Provider value={value}>{children}</MentionUsers.Provider>
+  );
+}

--- a/translate/src/core/comments/components/AddComment.test.js
+++ b/translate/src/core/comments/components/AddComment.test.js
@@ -1,29 +1,23 @@
-import React from 'react';
 import { shallow } from 'enzyme';
+import React from 'react';
 import sinon from 'sinon';
+
+import { MentionUsers } from '~/context/MentionUsers';
+import { createReduxStore, mountComponentWithStore } from '~/test/store';
 
 import { AddComment } from './AddComment';
 
 const USER = {
-  user: {
-    user: 'RSwanson',
-    username: 'Ron_Swanson',
-    imageURL: '',
-    users: [
-      {
-        name: 'April Ludwig',
-        url: 'aprilL@parksdept.com',
-        display: 'April',
-      },
-    ],
-  },
+  user: 'RSwanson',
+  username: 'Ron_Swanson',
+  imageURL: '',
 };
 
 describe('<AddComment>', () => {
   it('calls submitComment function', () => {
     const submitCommentFn = sinon.spy();
     const wrapper = shallow(
-      <AddComment {...USER} submitComment={submitCommentFn} />,
+      <AddComment submitComment={submitCommentFn} user={USER} />,
     );
 
     const event = {
@@ -32,5 +26,18 @@ describe('<AddComment>', () => {
 
     wrapper.find('button').simulate('onClick', event);
     expect(submitCommentFn.calledOnce).toBeTruthy;
+  });
+
+  it('fetches mentionable users on render', () => {
+    const initMentions = sinon.spy();
+    const store = createReduxStore();
+    const Wrapper = () => (
+      <MentionUsers.Provider value={{ initMentions, mentionUsers: [] }}>
+        <AddComment user={USER} />
+      </MentionUsers.Provider>
+    );
+    mountComponentWithStore(Wrapper, store);
+
+    expect(initMentions.calledOnce).toBeTruthy;
   });
 });

--- a/translate/src/core/comments/components/MentionList.tsx
+++ b/translate/src/core/comments/components/MentionList.tsx
@@ -4,13 +4,13 @@ import { createPortal } from 'react-dom';
 import type { Range } from 'slate';
 import { ReactEditor } from 'slate-react';
 
-import type { UsersList } from '~/api/user';
+import type { MentionUser } from '~/api/user';
 
 type Props = {
   editor: ReactEditor;
   index: number;
-  onSelect(user: UsersList): void;
-  suggestedUsers: UsersList[];
+  onSelect(user: MentionUser): void;
+  suggestedUsers: MentionUser[];
   target: Range;
 };
 

--- a/translate/src/core/user/actions.ts
+++ b/translate/src/core/user/actions.ts
@@ -1,11 +1,9 @@
 import {
   dismissAddonPromotion,
   fetchUserData,
-  fetchUsersList,
   markAllNotificationsAsRead,
   signOut,
   updateUserSetting,
-  UsersList,
 } from '~/api/user';
 import { NotificationMessage } from '~/context/Notification';
 import {
@@ -16,16 +14,10 @@ import {
 } from '~/core/notification/messages';
 import type { AppThunk } from '~/store';
 
-export const RECEIVE_USERS = 'users/RECEIVE_USERS';
 export const UPDATE = 'user/UPDATE';
 export const UPDATE_SETTINGS = 'user/UPDATE_SETTINGS';
 
-export type Action = ReceiveAction | UpdateAction | UpdateSettingsAction;
-
-export type ReceiveAction = {
-  readonly type: typeof RECEIVE_USERS;
-  readonly users: Array<UsersList>;
-};
+export type Action = UpdateAction | UpdateSettingsAction;
 
 /**
  * Update the user data.
@@ -87,10 +79,6 @@ export function saveSetting(
 export const markAllNotificationsAsRead_ = (): AppThunk => async (dispatch) => {
   await markAllNotificationsAsRead();
   dispatch(getUserData());
-};
-
-export const getUsersList = (): AppThunk => async (dispatch) => {
-  dispatch({ type: RECEIVE_USERS, users: await fetchUsersList() });
 };
 
 /**

--- a/translate/src/core/user/reducer.ts
+++ b/translate/src/core/user/reducer.ts
@@ -1,6 +1,4 @@
-import type { UsersList } from '~/api/user';
-
-import { Action, RECEIVE_USERS, UPDATE, UPDATE_SETTINGS } from './actions';
+import { Action, UPDATE, UPDATE_SETTINGS } from './actions';
 
 // Name of this module.
 // Used as the key to store this module's reducer.
@@ -86,7 +84,6 @@ export type UserState = {
   readonly gravatarURLSmall: string;
   readonly gravatarURLBig: string;
   readonly notifications: Notifications;
-  readonly users: Array<UsersList>;
 };
 
 const initial: UserState = {
@@ -113,16 +110,10 @@ const initial: UserState = {
     notifications: [],
     unread_count: '0',
   },
-  users: [],
 };
 
 export function reducer(state: UserState = initial, action: Action): UserState {
   switch (action.type) {
-    case RECEIVE_USERS:
-      return {
-        ...state,
-        users: action.users,
-      };
     case UPDATE:
       return {
         isAuthenticated: action.data.is_authenticated ?? false,
@@ -149,7 +140,6 @@ export function reducer(state: UserState = initial, action: Action): UserState {
           notifications: [],
           unread_count: '0',
         },
-        users: state.users,
       };
     case UPDATE_SETTINGS:
       return {


### PR DESCRIPTION
This is a patch for the bad initial loading behaviour identified in #2548. It's not a fix for the issue, but it's a step in a better direction.

With this change, data for @-mentionable users is only fetched when the first AddComment component is rendered, i.e. when one of the following happens:
- an authenticated user clicks on a "COMMENT" button next to a History translation,
- the "REQUEST CONTEXT or REPORT ISSUE" button is clicked, or
- when then team comments tab is opened.

To effect the change, the relevant data is moved to a new React Context.

This reduces the initial data load of Pontoon by about 35% on pontoon.mozilla.org. As a minor regression, there is now a short delay after clicking "REQUEST CONTEXT or REPORT ISSUE" before the contact person's data is entered into the edit field due to the mention data loading in the background.