### PR TITLE
Drop redux-logger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,6 @@
         "@types/react-redux": "^7.1.18",
         "@types/react-tabs": "^2.3.4",
         "@types/reactour": "^1.18.1",
-        "@types/redux-logger": "^3.0.9",
         "@types/shortid": "^0.0.29",
         "@types/sinon": "^10.0.1",
         "@types/styled-components": "^5.1.9",
@@ -3218,15 +3217,6 @@
         "@types/react": "*"
       }
     },
-    "node_modules/@types/redux-logger": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@types/redux-logger/-/redux-logger-3.0.9.tgz",
-      "integrity": "sha512-cwYhVbYNgH01aepeMwhd0ABX6fhVB2rcQ9m80u8Fl50ZODhsZ8RhQArnLTkE7/Zrfq4Sz/taNoF7DQy9pCZSKg==",
-      "dev": true,
-      "dependencies": {
-        "redux": "^4.0.0"
-      }
-    },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -4634,11 +4624,6 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
-    },
-    "node_modules/deep-diff": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
-      "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ="
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -10114,14 +10099,6 @@
         "@babel/runtime": "^7.9.2"
       }
     },
-    "node_modules/redux-logger": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-3.0.6.tgz",
-      "integrity": "sha1-91VZZvMJjzyIYExEnPC69XeCdL8=",
-      "dependencies": {
-        "deep-diff": "^0.3.5"
-      }
-    },
     "node_modules/redux-thunk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
@@ -11827,7 +11804,6 @@
         "react-time-ago": "^7.1.3",
         "reactour": "^1.15.1",
         "redux": "^4.1.1",
-        "redux-logger": "^3.0.6",
         "redux-thunk": "^2.3.0",
         "slate": "^0.78.0",
         "slate-react": "^0.77.4",
@@ -14162,15 +14138,6 @@
         "@types/react": "*"
       }
     },
-    "@types/redux-logger": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@types/redux-logger/-/redux-logger-3.0.9.tgz",
-      "integrity": "sha512-cwYhVbYNgH01aepeMwhd0ABX6fhVB2rcQ9m80u8Fl50ZODhsZ8RhQArnLTkE7/Zrfq4Sz/taNoF7DQy9pCZSKg==",
-      "dev": true,
-      "requires": {
-        "redux": "^4.0.0"
-      }
-    },
     "@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -15212,11 +15179,6 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
-    },
-    "deep-diff": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
-      "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ="
     },
     "deep-is": {
       "version": "0.1.4",
@@ -19350,14 +19312,6 @@
         "@babel/runtime": "^7.9.2"
       }
     },
-    "redux-logger": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-3.0.6.tgz",
-      "integrity": "sha1-91VZZvMJjzyIYExEnPC69XeCdL8=",
-      "requires": {
-        "deep-diff": "^0.3.5"
-      }
-    },
     "redux-thunk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
@@ -20198,7 +20152,6 @@
         "react-time-ago": "^7.1.3",
         "reactour": "^1.15.1",
         "redux": "^4.1.1",
-        "redux-logger": "^3.0.6",
         "redux-thunk": "^2.3.0",
         "slate": "^0.78.0",
         "slate-react": "^0.77.4",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "@types/react-redux": "^7.1.18",
     "@types/react-tabs": "^2.3.4",
     "@types/reactour": "^1.18.1",
-    "@types/redux-logger": "^3.0.9",
     "@types/shortid": "^0.0.29",
     "@types/sinon": "^10.0.1",
     "@types/styled-components": "^5.1.9",

--- a/translate/package.json
+++ b/translate/package.json
@@ -29,7 +29,6 @@
     "react-time-ago": "^7.1.3",
     "reactour": "^1.15.1",
     "redux": "^4.1.1",
-    "redux-logger": "^3.0.6",
     "redux-thunk": "^2.3.0",
     "slate": "^0.78.0",
     "slate-react": "^0.77.4",

--- a/translate/src/store.ts
+++ b/translate/src/store.ts
@@ -1,5 +1,4 @@
 import { configureStore, ThunkAction, Action } from '@reduxjs/toolkit';
-import { createLogger } from 'redux-logger';
 
 import { reducer } from './rootReducer';
 
@@ -9,16 +8,10 @@ export const store = configureStore({
 
   // @ts-expect-error Here be dragons
   middleware(getDefaultMiddleware) {
-    const middleware = getDefaultMiddleware({
+    return getDefaultMiddleware({
       serializableCheck: false,
       immutableCheck: false,
     });
-
-    if (process.env.NODE_ENV === 'development') {
-      middleware.push(createLogger());
-    }
-
-    return middleware;
   },
 });
 


### PR DESCRIPTION
As much of the application state is already out of Redux, the verbosity of `redux-logger` is becoming more and more annoying, and less useful. So let's remove it.