### PR TITLE
Separate plural-form reset from entity updates in its provider

### DIFF
--- a/translate/src/context/EntityView.tsx
+++ b/translate/src/context/EntityView.tsx
@@ -58,10 +58,18 @@ export function EntityViewProvider({
   const pluralCount = useContext(Locale).cldrPlurals.length;
   const entities = useAppSelector((state) => state[ENTITIES].entities);
 
-  const [state, setState] = useState(initEntityView);
+  const entity = entities.find((entity) => entity.pk === pk) ?? emptyEntity;
+
+  const [state, setState] = useState<EntityView>({
+    entity,
+    hasPluralForms: false,
+    pluralForm: 0,
+    setPluralForm: () => {},
+  });
+
+  useEffect(() => setState((prev) => ({ ...prev, entity })), [entity]);
 
   useEffect(() => {
-    const entity = entities.find((entity) => entity.pk === pk) ?? emptyEntity;
     const hasPluralForms =
       pluralCount > 1 && !!entity.original_plural && entity.format !== 'ftl';
 
@@ -73,8 +81,13 @@ export function EntityViewProvider({
         }
       : () => {};
 
-    setState({ entity, hasPluralForms, pluralForm: 0, setPluralForm });
-  }, [pk, pluralCount, entities]);
+    setState((prev) => ({
+      entity: prev.entity,
+      hasPluralForms,
+      pluralForm: 0,
+      setPluralForm,
+    }));
+  }, [pk, entity.original_plural, entity.format, pluralCount]);
 
   return <EntityView.Provider value={state}>{children}</EntityView.Provider>;
 }


### PR DESCRIPTION
Fixes #2547 

The approval of one variant of a gettext message was causing a change in the entity data (as it should), but this was mistakenly triggering a `useEffect` hook in the EntityView provider that reset the `pluralForm` value. Hence when approving any such variant, the view would not advance to the next variant like it should.

To fix this, the `entity` and `pluralForm` updates are now handled in separate hooks within EntityViewProvider, with appropriate conditions as their triggers.