### PR TITLE
Use POST requests for social login endpoints

### DIFF
--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -728,16 +728,21 @@ header nav .right .sign-in-header {
   float: left;
 }
 
-header nav .right .sign-in-header .button {
+header nav .right .sign-in-header button {
+  background: transparent;
   border: 1.5px solid #7bc176;
-  color: white;
   border-radius: 2px;
+  color: white;
+  font-size: 14px;
+  font-weight: 300;
+  height: 40px;
+  line-height: 17px;
   padding: 10px 25px;
   text-align: center;
   margin: 10px 5px 0 0;
 }
 
-header nav .right .sign-in-header .button:hover {
+header nav .right .sign-in-header button:hover {
   background-color: #7bc176;
 }
 

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -277,17 +277,6 @@ $(function () {
     return window.location.pathname + window.location.search;
   }
 
-  // Sign in button action
-  $('#fxa-sign-in, #standalone-signin a, #sidebar-signin').on(
-    'click',
-    function () {
-      var $this = $(this);
-      var loginUrl = $this.prop('href'),
-        startSign = loginUrl.match(/\?/) ? '&' : '?';
-      $this.prop('href', loginUrl + startSign + 'next=' + getRedirectUrl());
-    },
-  );
-
   // Sign out button action
   $('.sign-out a, #sign-out a').on('click', function (ev) {
     var $this = $(this),

--- a/pontoon/base/templates/django/base.html
+++ b/pontoon/base/templates/django/base.html
@@ -84,13 +84,19 @@
                     {% if user.is_authenticated %}
                       <li id="standalone-sign-out"><a href="{% url 'standalone_logout' %}" title="{{ user.email|nospam }}"><i class="fa fa-sign-out-alt fa-fw"></i>Sign out</a></li>
                     {% else %}
-                      <li id="standalone-signin"><a href="{% url 'standalone_login' %}"><i class="fa fa-sign-in-alt fa-fw"></i>Sign in</a></li>
+                      <li id="standalone-signin"><a href="{% url 'standalone_login' %}?next={{ request.get_full_path|urlencode }}"><i class="fa fa-sign-in-alt fa-fw"></i>Sign in</a></li>
                     {% endif %}
                   {% else %}
                     {% if user.is_authenticated %}
                       <li id="sign-out"><a href="{% url 'account_logout' %}" title="{{ user.email|nospam }}">{{ SignOut.csrf_form }}<i class="fa fa-sign-out-alt fa-fw"></i>Sign out</a></li>
                     {% else %}
-                      <li id="sign-in"><a id="fxa-sign-in" href="{{ provider_login_url }}"><i class="fa fa-sign-in-alt fa-fw"></i>Sign in</a></li>
+                      <li id="sign-in">
+                        <form action="{{ provider_login_url }}?next={{ request.get_full_path|urlencode }}" method="post">
+                          {% csrf_token %}
+                          <i class="fa fa-sign-in-alt fa-fw"></i>
+                          <button type="submit">Sign in</button>
+                        </form>
+                      </li>
                     {% endif %}
                   {% endif %}
                 </ul>

--- a/pontoon/base/templates/django/socialaccount/authentication_error.html
+++ b/pontoon/base/templates/django/socialaccount/authentication_error.html
@@ -5,5 +5,11 @@
 {% block content %}
 <h1 id="title">Sign In Failure</h1>
 <h2 id="subtitle">An error occurred while attempting to sign in.</h2>
-<p id="action"><a href="{{ provider_login_url }}">Try again</a></p>
+<div id="action">
+    <form action="{{ provider_login_url }}?next={{ request.get_full_path|urlencode }}" method="post">
+        {% csrf_token %}
+        <i class="fa fa-sign-in-alt fa-fw"></i>
+        <button type="submit">Try again</button>
+      </form>
+</div>
 {% endblock %}

--- a/pontoon/base/templates/header.html
+++ b/pontoon/base/templates/header.html
@@ -1,3 +1,4 @@
+{% import "widgets/signin.html" as SignIn with context %}
 {% import "widgets/signout.html" as SignOut with context %}
 {% import "widgets/profile.html" as Profile with context %}
 {% import "contributors/widgets/notifications_menu.html" as Notifications with context %}
@@ -25,11 +26,7 @@
 
         {% if not user.is_authenticated %}
         <div class="sign-in-header">
-          {% if settings.AUTHENTICATION_METHOD == 'django' %}
-          <a href="{{ url('standalone_login') }}" class="button">Sign in</a>
-          {% else %}
-          <a id="fxa-sign-in" href="{{ provider_login_url(request) }}" class="button">Sign in</a>
-          {% endif %}
+          {{ SignIn.button() }}
         </div>
         {% endif %}
 

--- a/pontoon/base/templates/widgets/signin.html
+++ b/pontoon/base/templates/widgets/signin.html
@@ -1,0 +1,11 @@
+{% macro button(title="Sign in") %}
+{% if settings.AUTHENTICATION_METHOD == 'django' %}
+    {% set login_url = url('standalone_login') %}
+{% else %}
+    {% set login_url = provider_login_url(request) %}
+{% endif %}
+<form action="{{ login_url }}?next={{ request.get_full_path()|urlencode }}" method="post">
+    {% csrf_token %}
+    <button type="submit">{{ title }}</button>
+</form>
+{% endmacro %}

--- a/pontoon/contributors/static/css/profile.css
+++ b/pontoon/contributors/static/css/profile.css
@@ -2,6 +2,19 @@
   padding-top: 20px;
 }
 
+#heading .info form {
+  display: inline-block;
+}
+
+#heading .info form button {
+  background: transparent;
+  border: none;
+  color: #7bc876;
+  padding: 0;
+  font-size: 16px;
+  font-weight: 100;
+}
+
 #middle .container {
   padding: 1em 0;
 }
@@ -108,9 +121,6 @@
   content: '';
   display: table;
   clear: both;
-}
-
-#main .content h4 {
 }
 
 #main .content h4 > div {

--- a/pontoon/contributors/templates/contributors/profile.html
+++ b/pontoon/contributors/templates/contributors/profile.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% import "widgets/signin.html" as SignIn with context %}
+
 {% block title %}{{ contributor.name_or_email }}{% endblock %}
 
 {% block class %}user{% endblock %}
@@ -35,12 +37,7 @@
           <span>Email address visible to users with translator rights</span>
         {% endif %}
       {% else %}
-      {% if settings.AUTHENTICATION_METHOD == 'django' %}
-        {% set login_url = url('standalone_login') %}
-      {% else %}
-        {% set login_url = provider_login_url(request) %}
-      {% endif %}
-      <a id="sidebar-signin" href="{{ login_url }}">Sign in to see email address</a>
+        {{ SignIn.button(title="Sign in to see email address") }}
       {% endif %}
     </li>
     <li>

--- a/translate/public/locale/en-US/translate.ftl
+++ b/translate/public/locale/en-US/translate.ftl
@@ -111,7 +111,7 @@ comments-CommentsList--all-comments = ALL COMMENTS
 ## Editor Menu
 ## Allows contributors to modify or propose a translation
 
-editor-EditorMenu--sign-in-to-translate = <a>Sign in</a> to translate.
+editor-EditorMenu--sign-in-to-translate = <form>Sign in</form> to translate.
 editor-EditorMenu--read-only-localization = This is a read-only localization.
 editor-EditorMenu--button-copy = COPY
     .title = Copy From Source (Ctrl + Shift + C)

--- a/translate/public/locale/fr/translate.ftl
+++ b/translate/public/locale/fr/translate.ftl
@@ -9,7 +9,7 @@
 ## Editor Menu
 ## Allows contributors to modify or propose a translation
 
-editor-EditorMenu--sign-in-to-translate = <a>Connectez-vous</a> pour traduire.
+editor-EditorMenu--sign-in-to-translate = <form>Connectez-vous</form> pour traduire.
 editor-EditorMenu--read-only-localization = Cette traduction est en lecture seule.
 editor-EditorMenu--button-copy = COPIER
 editor-EditorMenu--button-clear = EFFACER

--- a/translate/src/core/editor/components/EditorMenu.css
+++ b/translate/src/core/editor/components/EditorMenu.css
@@ -51,6 +51,14 @@
   line-height: 40px;
 }
 
-.editor-menu .banner a {
+.editor-menu .banner form {
+  display: inline-block;
+}
+
+.editor-menu .banner button {
+  background: none;
+  border: none;
   color: #7bc876;
+  font-style: inherit;
+  padding: 0;
 }

--- a/translate/src/core/editor/components/EditorMenu.tsx
+++ b/translate/src/core/editor/components/EditorMenu.tsx
@@ -55,9 +55,9 @@ function MenuContent() {
     return (
       <Localized
         id='editor-EditorMenu--sign-in-to-translate'
-        elems={{ a: <user.SignInLink url={signInURL} /> }}
+        elems={{ form: <user.SignInForm url={signInURL} /> }}
       >
-        <p className='banner'>{'<a>Sign in</a> to translate.'}</p>
+        <div className='banner'>{'<form>Sign in</form> to translate.'}</div>
       </Localized>
     );
   }
@@ -65,7 +65,7 @@ function MenuContent() {
   if (entity.readonly) {
     return (
       <Localized id='editor-EditorMenu--read-only-localization'>
-        <p className='banner'>This is a read-only localization.</p>
+        <div className='banner'>This is a read-only localization.</div>
       </Localized>
     );
   }

--- a/translate/src/core/user/components/FileUpload.tsx
+++ b/translate/src/core/user/components/FileUpload.tsx
@@ -2,6 +2,7 @@ import { Localized } from '@fluent/react';
 import React, { useCallback, useRef } from 'react';
 
 import type { Location } from '~/context/Location';
+import { CSRFToken } from '~/core/utils';
 
 import './FileUpload.css';
 
@@ -19,10 +20,6 @@ export function FileUpload({ parameters }: Props): React.ReactElement<'form'> {
     uploadForm.current?.submit();
   }, []);
 
-  /* TODO: Refactor core.api.base and reuse getCSRFToken() here */
-  const rootElt = document.getElementById('root');
-  const csrfToken = rootElt?.dataset.csrfToken ?? '';
-
   return (
     <form
       action='/upload/'
@@ -31,7 +28,7 @@ export function FileUpload({ parameters }: Props): React.ReactElement<'form'> {
       method='POST'
       ref={uploadForm}
     >
-      <input name='csrfmiddlewaretoken' type='hidden' value={csrfToken} />
+      <CSRFToken />
       <input name='code' type='hidden' value={parameters.locale} />
       <input name='slug' type='hidden' value={parameters.project} />
       <input name='part' type='hidden' value={parameters.resource} />

--- a/translate/src/core/user/components/SignIn.css
+++ b/translate/src/core/user/components/SignIn.css
@@ -1,16 +1,20 @@
-.user-signin a {
+.user-signin {
+  display: inline-block;
+}
+
+.user-signin button {
+  background: transparent;
   border: 1.5px solid #7bc176;
   border-radius: 2px;
   color: white;
-  display: inline-block;
   font-size: 14px;
-  height: 17px;
-  line-height: 16px;
+  font-weight: 300;
+  height: 40px;
+  line-height: 17px;
   padding: 10px 25px;
-  text-align: center;
   margin: 10px 5px 0 0;
 }
 
-.user-signin a:hover {
+.user-signin button:hover {
   background-color: #7bc176;
 }

--- a/translate/src/core/user/components/SignIn.tsx
+++ b/translate/src/core/user/components/SignIn.tsx
@@ -2,7 +2,7 @@ import { Localized } from '@fluent/react';
 import React from 'react';
 
 import './SignIn.css';
-import { SignInLink } from './SignInLink';
+import { SignInForm } from './SignInForm';
 
 type Props = {
   url: string;
@@ -15,7 +15,7 @@ export function SignIn({ url }: Props): React.ReactElement<'span'> {
   return (
     <span className='user-signin'>
       <Localized id='user-SignIn--sign-in'>
-        <SignInLink url={url}>Sign in</SignInLink>
+        <SignInForm url={url}>Sign in</SignInForm>
       </Localized>
     </span>
   );

--- a/translate/src/core/user/components/SignInForm.tsx
+++ b/translate/src/core/user/components/SignInForm.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { CSRFToken } from '~/core/utils';
+
 type Props = {
   children?: React.ReactNode;
   url: string;
@@ -8,9 +10,16 @@ type Props = {
 /*
  * Render a link to the Sign In process.
  */
-export function SignInLink({ children, url }: Props): React.ReactElement<'a'> {
+export function SignInForm({ children, url }: Props): React.ReactElement<'a'> {
   const { origin, pathname, search } = window.location;
+
   const parsedUrl = new URL(url, origin);
   parsedUrl.searchParams.set('next', pathname + search);
-  return <a href={parsedUrl.toString()}>{children}</a>;
+
+  return (
+    <form action={parsedUrl.toString()} method='post'>
+      <CSRFToken />
+      <button type='submit'>{children}</button>
+    </form>
+  );
 }

--- a/translate/src/core/user/index.ts
+++ b/translate/src/core/user/index.ts
@@ -1,4 +1,4 @@
-export { SignInLink } from './components/SignInLink';
+export { SignInForm } from './components/SignInForm';
 export { UserAvatar } from './components/UserAvatar';
 
 export { USER } from './reducer';

--- a/translate/src/core/utils/components/CSRFToken.tsx
+++ b/translate/src/core/utils/components/CSRFToken.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import { getCSRFToken } from '~/api/utils/csrfToken';
+
+/*
+ * Render element with CSRF token needed in POST forms.
+ */
+export function CSRFToken(): React.ReactElement<'input'> {
+  return (
+    <input name='csrfmiddlewaretoken' type='hidden' value={getCSRFToken()} />
+  );
+}

--- a/translate/src/core/utils/index.ts
+++ b/translate/src/core/utils/index.ts
@@ -3,5 +3,6 @@ export { getOptimizedContent } from './getOptimizedContent';
 export { asLocaleString } from './asLocaleString';
 
 // Components, HOC, and Hooks
+export { CSRFToken } from './components/CSRFToken';
 export { withActionsDisabled } from './components/withActionsDisabled';
 export { useOnDiscard } from './hooks/useOnDiscard';


### PR DESCRIPTION
With the recent upgrade of `django-allauth`, when you try to log into Pontoon, you get first redirected to a log in page, on which you need to click on a button and then get redirected to the actual Firefox Accounts login page.

That's because POST requests are now required by default to initiate the handshake:
https://django-allauth.readthedocs.io/en/latest/release-notes.html#section-5

The following patch removes that extra step during the log in process by replacing sign in links with buttons, which submit a POST form.