### PR TITLE
Fix Approval ratio definition in the Profile page spec

### DIFF
--- a/specs/0111-redesign-profile-page.md
+++ b/specs/0111-redesign-profile-page.md
@@ -20,10 +20,10 @@ See the [mockup](#mockup) for the overall view. Each of the following sections p
 
 ## Approval ratio
 
-Displayed in a graph, it’s the ratio between the number of translations approved over the total number of translations submitted, excluding self-approved translations (either submitted directly as translations, or provided as suggestions and later approved by the translator).
+Displayed in a graph, it’s the ratio between the number of translations approved over the total number of translations reviewed, excluding self-approved translations (either submitted directly as translations, or provided as suggestions and later approved by the translator).
 
 Examples:
-* If a person submits 100 translations, but 20 are rejected, the approval ratio will be 80%.
+* If a person submits 100 translations, of which 10 are rejected and 10 unreviewed, the approval ratio will be 80%.
 * If a person submits 100 translations, 20 are rejected, 20 are self-approved, the approval ratio will be 75% (60 over 80).
 
 The graph displays both the specific month’s ratio and the average for the previous 12 months.


### PR DESCRIPTION
When calculating Approval Ratio, we should ignore translations that haven't been reviewed yet.