### PR TITLE
Add contribution timeline

### DIFF
--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -138,9 +138,9 @@ def format_datetime(value, format="full", default="---"):
         if format == "full":
             format = "%A, %B %d, %Y at %H:%M %Z"
         elif format == "date":
-            format = "%B %d, %Y"
+            format = "%B %-d, %Y"
         elif format == "short_date":
-            format = "%b %d, %Y"
+            format = "%b %-d, %Y"
         elif format == "time":
             format = "%H:%M %Z"
         return value.strftime(format)

--- a/pontoon/contributors/static/css/profile.css
+++ b/pontoon/contributors/static/css/profile.css
@@ -27,9 +27,7 @@ h2 {
   color: #ebebeb;
   font-size: 18px;
   font-weight: bold;
-  letter-spacing: normal;
   line-height: 1.4em;
-  padding-bottom: 10px;
   text-transform: none;
 }
 
@@ -210,7 +208,7 @@ h4.superuser {
 }
 
 #contributions .type-selector {
-  float: left;
+  float: right;
   padding-left: 0;
   width: 260px;
 }
@@ -240,9 +238,18 @@ h4.superuser {
   width: 100%;
 }
 
-#contributions h2 {
-  float: right;
+#contributions h3 {
+  float: left;
   line-height: 32px;
+}
+
+#contributions h3,
+#timeline h3 {
+  color: #ccc;
+  font-size: 16px;
+  font-weight: 400;
+  font-style: normal;
+  letter-spacing: 0;
 }
 
 #contribution-graph rect.day:hover,
@@ -288,7 +295,7 @@ svg.js-calendar-graph-svg {
   margin-top: 40px;
 }
 
-#timeline h2 {
+#timeline h3 {
   padding-bottom: 5px;
 }
 

--- a/pontoon/contributors/static/css/profile.css
+++ b/pontoon/contributors/static/css/profile.css
@@ -202,7 +202,7 @@ h4.superuser {
 /* Contribution Graph */
 
 #contributions {
-  margin-top: 30px;
+  margin-top: 50px;
 }
 
 #contributions .type-selector {
@@ -275,4 +275,54 @@ svg.js-calendar-graph-svg {
   content: ' ';
   border: 5px solid transparent;
   border-top-color: rgba(0, 0, 0, 0.8);
+}
+
+/* Contribution Timeline */
+
+#timeline {
+  color: #ccc;
+  margin-top: 40px;
+}
+
+#timeline h2 {
+  padding-bottom: 20px;
+}
+
+#timeline .contribution-group {
+  border-left: 2px solid #4d5967;
+  margin-left: 20px;
+  padding: 20px 0 20px 20px;
+}
+
+#timeline .heading {
+  font-size: 16px;
+
+  padding-bottom: 5px;
+}
+
+#timeline .localizations {
+  list-style: none;
+  margin: 0;
+}
+
+#timeline .localizations li {
+  line-height: 2em;
+}
+
+#timeline .localizations li:hover {
+  background: #333941;
+}
+
+#timeline .localizations li a {
+  color: #ccc;
+  display: block;
+}
+
+#timeline .localizations li a .stress {
+  color: #7bc876;
+}
+
+#timeline .localizations li a .contribution-count {
+  color: #888;
+  float: right;
 }

--- a/pontoon/contributors/static/css/profile.css
+++ b/pontoon/contributors/static/css/profile.css
@@ -5,11 +5,11 @@
 #main .container .left-column {
   color: #ccc;
   margin-right: 30px;
-  width: 276px;
+  width: 260px;
 }
 
 #main .container .right-column {
-  width: 674px;
+  width: 690px;
 }
 
 /* Sidebar */
@@ -116,7 +116,7 @@ h4.superuser {
 
 #insights {
   float: left;
-  width: 460px;
+  width: 476px;
 }
 
 #insights .block {
@@ -154,7 +154,7 @@ h4.superuser {
 
 #stats > div {
   font-weight: 300;
-  margin-bottom: 46px;
+  margin-bottom: 38px;
 }
 
 #stats > div:last-child {
@@ -184,7 +184,7 @@ h4.superuser {
 
 #stats:first-child {
   text-align: center;
-  width: 674px;
+  width: 100%;
 }
 
 #stats:first-child div {

--- a/pontoon/contributors/static/css/profile.css
+++ b/pontoon/contributors/static/css/profile.css
@@ -283,7 +283,7 @@ svg.js-calendar-graph-svg {
 /* Contribution Timeline */
 
 #timeline {
-  color: #ccc;
+  color: #888;
   margin-top: 40px;
 }
 
@@ -300,6 +300,7 @@ svg.js-calendar-graph-svg {
 #timeline .heading {
   background: #333941;
   border-radius: 6px 6px 0 0;
+  color: #ccc;
   padding: 20px 20px 0;
   position: relative;
 }

--- a/pontoon/contributors/static/css/profile.css
+++ b/pontoon/contributors/static/css/profile.css
@@ -33,6 +33,10 @@ h2 {
   text-transform: none;
 }
 
+.avatar img.rounded {
+  border-color: #333941;
+}
+
 .display-name {
   font-size: 24px;
   padding-bottom: 0;
@@ -264,7 +268,6 @@ svg.js-calendar-graph-svg {
 }
 
 .svg-tip:after {
-  -moz-box-sizing: border-box;
   box-sizing: border-box;
   position: absolute;
   left: 50%;
@@ -285,36 +288,81 @@ svg.js-calendar-graph-svg {
 }
 
 #timeline h2 {
-  padding-bottom: 20px;
-}
-
-#timeline .contribution-group {
-  border-left: 2px solid #4d5967;
-  margin-left: 20px;
-  padding: 20px 0 20px 20px;
-}
-
-#timeline .heading {
-  font-size: 16px;
-
   padding-bottom: 5px;
 }
 
+#timeline .contribution-group {
+  border-left: 2px solid #333941;
+  margin-left: 20px;
+  padding: 20px 0 20px 30px;
+}
+
+#timeline .heading {
+  background: #333941;
+  border-radius: 6px 6px 0 0;
+  padding: 20px 20px 0;
+  position: relative;
+}
+
+#timeline .heading:after {
+  position: absolute;
+  left: -14px;
+  bottom: 2px;
+  content: ' ';
+  border: 7px solid transparent;
+  border-right-color: #333941;
+}
+
+#timeline .heading .icon {
+  background: #333941;
+  border: 2px solid #272a2f;
+  box-sizing: border-box;
+  display: block;
+  height: 36px;
+  width: 36px;
+  border-radius: 50%;
+  padding: 8px;
+  position: absolute;
+  top: 10px;
+  left: -49px;
+}
+
+#timeline .heading .icon:before {
+  color: #888;
+  font-size: 16px;
+}
+
+#timeline .heading .icon.user-translations:before {
+  content: '\f044';
+}
+
+#timeline .heading .icon.user-reviews:before {
+  content: '\f058';
+}
+
+#timeline .heading .icon.peer-reviews:before {
+  content: '\f2b6';
+}
+
 #timeline .localizations {
+  background: #333941;
+  border-radius: 0 0 6px 6px;
   list-style: none;
   margin: 0;
+  padding: 20px 10px;
 }
 
 #timeline .localizations li {
-  line-height: 2em;
+  line-height: 1.8em;
+  padding: 0 10px;
 }
 
 #timeline .localizations li:hover {
-  background: #333941;
+  background: #272a2f;
 }
 
 #timeline .localizations li a {
-  color: #ccc;
+  color: #aaa;
   display: block;
 }
 

--- a/pontoon/contributors/static/css/profile.css
+++ b/pontoon/contributors/static/css/profile.css
@@ -245,7 +245,8 @@ h4.superuser {
   line-height: 32px;
 }
 
-#contribution-graph rect.day:hover {
+#contribution-graph rect.day:hover,
+#contribution-graph rect.day.selected {
   stroke-width: 1;
   stroke: #fff;
 }

--- a/pontoon/contributors/static/css/profile.css
+++ b/pontoon/contributors/static/css/profile.css
@@ -149,6 +149,7 @@ h4.superuser {
 }
 
 #stats > div {
+  font-weight: 300;
   margin-bottom: 46px;
 }
 

--- a/pontoon/contributors/static/js/profile.js
+++ b/pontoon/contributors/static/js/profile.js
@@ -221,7 +221,12 @@ var Pontoon = (function (my) {
 
         // Remove the first incomplete month label
         if (monthPosition[1].x - monthPosition[0].x < 40) {
-          monthPosition.shift(0);
+          monthPosition.shift();
+        }
+
+        // Remove the last incomplete month label
+        if (monthPosition.at(-1).x > 660) {
+          monthPosition.pop();
         }
 
         // Add month labels
@@ -235,13 +240,13 @@ var Pontoon = (function (my) {
 
         // Add day labels
         graphHTML += `
-            <text text-anchor="middle" class="wday" dx="696" dy="23">M<title>Monday</title></text>
-            <text text-anchor="middle" class="wday" dx="696" dy="49">W<title>Wednesday</title></text>
-            <text text-anchor="middle" class="wday" dx="696" dy="75">F<title>Friday</title></text>`;
+            <text text-anchor="middle" class="wday" dx="-10" dy="23">M<title>Monday</title></text>
+            <text text-anchor="middle" class="wday" dx="-10" dy="49">W<title>Wednesday</title></text>
+            <text text-anchor="middle" class="wday" dx="-10" dy="75">F<title>Friday</title></text>`;
 
         graph.html(`
             <svg width="690" height="110" viewBox="0 0 702 110" class="js-calendar-graph-svg">
-              <g transform="translate(0, 20)">${graphHTML}</g>
+              <g transform="translate(16, 20)">${graphHTML}</g>
             </svg>`);
 
         // Handle tooltip

--- a/pontoon/contributors/static/js/profile.js
+++ b/pontoon/contributors/static/js/profile.js
@@ -318,6 +318,29 @@ var Pontoon = (function (my) {
           });
         });
       },
+      handleContributionGraphClick: function () {
+        $('body').on('click', '#contribution-graph .day', function () {
+          const day = $(this).data('date');
+          const type = $('#contributions .type-selector span').data('type');
+          const user = $('#server').data('user');
+
+          // Update contribution timeline
+          $.ajax({
+            url: '/update-contribution-timeline/',
+            data: {
+              day: day,
+              contribution_type: type,
+              user: user,
+            },
+            success: function (data) {
+              $('#timeline').html(data);
+            },
+            error: function () {
+              Pontoon.endLoader('Oops, something went wrong.', 'error');
+            },
+          });
+        });
+      },
     },
   });
 })(Pontoon || {});
@@ -328,3 +351,4 @@ Pontoon.insights.renderCharts();
 
 Pontoon.profile.renderContributionGraph();
 Pontoon.profile.handleContributionTypeSelector();
+Pontoon.profile.handleContributionGraphClick();

--- a/pontoon/contributors/static/js/profile.js
+++ b/pontoon/contributors/static/js/profile.js
@@ -320,6 +320,10 @@ var Pontoon = (function (my) {
       },
       handleContributionGraphClick: function () {
         $('body').on('click', '#contribution-graph .day', function () {
+          // .addClass() and .removeClass() jQuery methods don't work on SVG elements
+          $('#contribution-graph .day').attr('class', 'day');
+          $(this).attr('class', 'day selected');
+
           const day = $(this).data('date');
           const type = $('#contributions .type-selector span').data('type');
           const user = $('#server').data('user');

--- a/pontoon/contributors/static/js/profile.js
+++ b/pontoon/contributors/static/js/profile.js
@@ -230,14 +230,14 @@ var Pontoon = (function (my) {
           const monthName = monthNameFormat.format(
             new Date(2022, item.monthIndex),
           );
-          graphHTML += `<text x="${item.x}" y="-5" class="month">${monthName}</text>`;
+          graphHTML += `<text x="${item.x}" y="-7" class="month">${monthName}</text>`;
         }
 
         // Add day labels
         graphHTML += `
-            <text text-anchor="middle" class="wday" dx="695" dy="22">M<title>Monday</title></text>
-            <text text-anchor="middle" class="wday" dx="695" dy="48">W<title>Wednesday</title></text>
-            <text text-anchor="middle" class="wday" dx="695" dy="74">F<title>Friday</title></text>`;
+            <text text-anchor="middle" class="wday" dx="696" dy="23">M<title>Monday</title></text>
+            <text text-anchor="middle" class="wday" dx="696" dy="49">W<title>Wednesday</title></text>
+            <text text-anchor="middle" class="wday" dx="696" dy="75">F<title>Friday</title></text>`;
 
         graph.html(`
             <svg width="690" height="110" viewBox="0 0 702 110" class="js-calendar-graph-svg">

--- a/pontoon/contributors/static/js/profile.js
+++ b/pontoon/contributors/static/js/profile.js
@@ -285,6 +285,7 @@ var Pontoon = (function (my) {
           const type = $('#contributions .type-selector span').data('type');
           const user = $('#server').data('user');
 
+          // Update contribution graph
           $.ajax({
             url: '/update-contribution-graph/',
             data: {
@@ -295,6 +296,21 @@ var Pontoon = (function (my) {
               $('#contribution-graph').data('contributions', contributions);
               $('#contributions .title').html(title);
               Pontoon.profile.renderContributionGraph();
+            },
+            error: function () {
+              Pontoon.endLoader('Oops, something went wrong.', 'error');
+            },
+          });
+
+          // Update contribution timeline
+          $.ajax({
+            url: '/update-contribution-timeline/',
+            data: {
+              contribution_type: type,
+              user: user,
+            },
+            success: function (data) {
+              $('#timeline').html(data);
             },
             error: function () {
               Pontoon.endLoader('Oops, something went wrong.', 'error');

--- a/pontoon/contributors/templates/contributors/includes/timeline.html
+++ b/pontoon/contributors/templates/contributors/includes/timeline.html
@@ -1,0 +1,25 @@
+<h2>{{ contribution_timeline.title }}</h2>
+
+{% for title, values in contribution_timeline.contributions.items() %}
+<div class="contribution-group">
+    <h4 class="heading">
+        <span class="icon far {{ values.type }}"></span>
+        {{ title }}
+    </h4>
+    <ul class="localizations">
+        {% for _, localization in values.data.items() %}
+        <li>
+            <a href="{{ localization.url }}">
+                <span class="stress">{{ localization.project.name }}</span> &middot; {{
+                localization.locale.name }} <span class="stress">{{ localization.locale.code }}</span>
+                <span class="contribution-count">{{ ", ".join(localization.actions) }}</span>
+            </a>
+        </li>
+        {% endfor %}
+    </ul>
+</div>
+{% endfor %}
+
+{% if contribution_timeline.contributions == {} %}
+<p>No activity in this period.</p>
+{% endif %}

--- a/pontoon/contributors/templates/contributors/includes/timeline.html
+++ b/pontoon/contributors/templates/contributors/includes/timeline.html
@@ -1,4 +1,4 @@
-<h2>{{ contribution_timeline.title }}</h2>
+<h3>{{ contribution_timeline.title }}</h3>
 
 {% for title, values in contribution_timeline.contributions.items() %}
 <div class="contribution-group">

--- a/pontoon/contributors/templates/contributors/profile.html
+++ b/pontoon/contributors/templates/contributors/profile.html
@@ -314,11 +314,14 @@
             <section id="timeline">
                 <h2>{{ contribution_timeline.title }}</h2>
 
-                {% for title, localizations in contribution_timeline.contributions.items() %}
+                {% for title, values in contribution_timeline.contributions.items() %}
                 <div class="contribution-group">
-                    <p class="heading">{{ title }}</p>
+                    <h4 class="heading">
+                        <span class="icon far {{ values.type }}"></span>
+                        {{ title }}
+                    </h4>
                     <ul class="localizations">
-                        {% for _, localization in localizations.items() %}
+                        {% for _, localization in values.data.items() %}
                         <li>
                             <a href="{{ localization.url }}">
                                 <span class="stress">{{localization.project.name }}</span> &middot; {{

--- a/pontoon/contributors/templates/contributors/profile.html
+++ b/pontoon/contributors/templates/contributors/profile.html
@@ -1,4 +1,5 @@
 {% import "insights/widgets/tooltip.html" as Tooltip %}
+{% import "contributors/includes/timeline.html" as Timeline with context %}
 
 {% extends "base.html" %}
 
@@ -312,31 +313,7 @@
             </section>
 
             <section id="timeline">
-                <h2>{{ contribution_timeline.title }}</h2>
-
-                {% for title, values in contribution_timeline.contributions.items() %}
-                <div class="contribution-group">
-                    <h4 class="heading">
-                        <span class="icon far {{ values.type }}"></span>
-                        {{ title }}
-                    </h4>
-                    <ul class="localizations">
-                        {% for _, localization in values.data.items() %}
-                        <li>
-                            <a href="{{ localization.url }}">
-                                <span class="stress">{{localization.project.name }}</span> &middot; {{
-                                localization.locale.name }} <span class="stress">{{ localization.locale.code }}</span>
-                                <span class="contribution-count">{{ ", ".join(localization.actions) }}</span>
-                            </a>
-                        </li>
-                        {% endfor %}
-                    </ul>
-                </div>
-                {% endfor %}
-
-                {% if contribution_timeline.contributions == {} %}
-                <p>No activity in this period.</p>
-                {% endif %}
+            {{ Timeline }}
             </section>
         </div>
     </div>

--- a/pontoon/contributors/templates/contributors/profile.html
+++ b/pontoon/contributors/templates/contributors/profile.html
@@ -284,7 +284,7 @@
 
             <section id="contributions">
                 <div class="header clearfix">
-                    <h2 class="title">{{ contribution_graph.title }}</h2>
+                    <h3 class="title">{{ contribution_graph.title }}</h3>
                     <div class="type-selector controls select">
                         <div class="button selector">
                             <div class="value">

--- a/pontoon/contributors/templates/contributors/profile.html
+++ b/pontoon/contributors/templates/contributors/profile.html
@@ -333,6 +333,10 @@
                     </ul>
                 </div>
                 {% endfor %}
+
+                {% if contribution_timeline.contributions == {} %}
+                <p>No activity in this period.</p>
+                {% endif %}
             </section>
         </div>
     </div>

--- a/pontoon/contributors/templates/contributors/profile.html
+++ b/pontoon/contributors/templates/contributors/profile.html
@@ -310,6 +310,27 @@
                 <div id="contribution-graph" data-contributions="{{ contributor_graph.contributions }}"></div>
                 <div class="svg-tip"></div>
             </section>
+
+            <section id="timeline">
+                <h2>{{ contributor_timeline.title }}</h2>
+
+                {% for title, localizations in contributor_timeline.contributions.items() %}
+                <div class="contribution-group">
+                    <p class="heading">{{ title }}</p>
+                    <ul class="localizations">
+                        {% for _, localization in localizations.items() %}
+                        <li>
+                            <a href="{{ localization.url }}">
+                                <span class="stress">{{localization.project.name }}</span> &middot; {{
+                                localization.locale.name }} <span class="stress">{{ localization.locale.code }}</span>
+                                <span class="contribution-count">{{ ", ".join(localization.actions) }}</span>
+                            </a>
+                        </li>
+                        {% endfor %}
+                    </ul>
+                </div>
+                {% endfor %}
+            </section>
         </div>
     </div>
 </section>

--- a/pontoon/contributors/templates/contributors/profile.html
+++ b/pontoon/contributors/templates/contributors/profile.html
@@ -26,7 +26,7 @@
                 {% if is_my_profile %}
                 <div class="desc">Change your profile picture</div>
                 {% endif %}
-                <img class="rounded" src="{{ contributor.gravatar_url(544) }}" width="272" height="272">
+                <img class="rounded" src="{{ contributor.gravatar_url(512) }}" width="256" height="256">
             </a>
 
             <div class="personal-information">
@@ -212,8 +212,8 @@
                                 id="approval-rate-chart"
                                 data-approval-rates="{{ approvals_charts.approval_rates }}"
                                 data-approval-rates-12-month-avg="{{ approvals_charts.approval_rates_12_month_avg }}"
-                                width="420"
-                                height="{% if self_approval_rate_visibile %}159{% else %}191{% endif %}">
+                                width="436"
+                                height="{% if self_approval_rate_visibile %}143{% else %}175{% endif %}">
                             </canvas>
                         </div>
                         {% endif %}
@@ -237,8 +237,8 @@
                                 id="self-approval-rate-chart"
                                 data-self-approval-rates="{{ approvals_charts.self_approval_rates }}"
                                 data-self-approval-rates-12-month-avg="{{ approvals_charts.self_approval_rates_12_month_avg }}"
-                                width="420"
-                                height="{% if approval_rate_visibile %}159{% else %}191{% endif %}">
+                                width="436"
+                                height="{% if approval_rate_visibile %}143{% else %}175{% endif %}">
                             </canvas>
                         </div>
                         {% endif %}

--- a/pontoon/contributors/templates/contributors/profile.html
+++ b/pontoon/contributors/templates/contributors/profile.html
@@ -278,7 +278,7 @@
 
             <section id="contributions">
                 <div class="header clearfix">
-                    <h2 class="title">{{ contributor_graph.title }}</h2>
+                    <h2 class="title">{{ contribution_graph.title }}</h2>
                     <div class="type-selector controls select">
                         <div class="button selector">
                             <div class="value">
@@ -307,14 +307,14 @@
                         </div>
                     </div>
                 </div>
-                <div id="contribution-graph" data-contributions="{{ contributor_graph.contributions }}"></div>
+                <div id="contribution-graph" data-contributions="{{ contribution_graph.contributions }}"></div>
                 <div class="svg-tip"></div>
             </section>
 
             <section id="timeline">
-                <h2>{{ contributor_timeline.title }}</h2>
+                <h2>{{ contribution_timeline.title }}</h2>
 
-                {% for title, localizations in contributor_timeline.contributions.items() %}
+                {% for title, localizations in contribution_timeline.contributions.items() %}
                 <div class="contribution-group">
                     <p class="heading">{{ title }}</p>
                     <ul class="localizations">

--- a/pontoon/contributors/templates/contributors/profile.html
+++ b/pontoon/contributors/templates/contributors/profile.html
@@ -189,7 +189,7 @@
             {% set approval_rate_visibile = profile.visibility_approval == "Public" or user.translated_locales %}
             {% set self_approval_rate_visibile = profile.user.translated_locales and (profile.visibility_self_approval == "Public" or user.translated_locales) %}
             {% if approval_rate_visibile or self_approval_rate_visibile %}
-            <section id="insights" data-dates="{{ dates }}">
+            <section id="insights" data-dates="{{ approvals_charts.dates }}">
                 <div class="block clearfix">
                     <div class="chart-group">
                         {% if approval_rate_visibile %}
@@ -210,8 +210,8 @@
                             </h3>
                             <canvas
                                 id="approval-rate-chart"
-                                data-approval-rates="{{ approval_rates }}"
-                                data-approval-rates-12-month-avg="{{ approval_rates_12_month_avg }}"
+                                data-approval-rates="{{ approvals_charts.approval_rates }}"
+                                data-approval-rates-12-month-avg="{{ approvals_charts.approval_rates_12_month_avg }}"
                                 width="420"
                                 height="{% if self_approval_rate_visibile %}159{% else %}191{% endif %}">
                             </canvas>
@@ -235,8 +235,8 @@
                             </h3>
                             <canvas
                                 id="self-approval-rate-chart"
-                                data-self-approval-rates="{{ self_approval_rates }}"
-                                data-self-approval-rates-12-month-avg="{{ self_approval_rates_12_month_avg }}"
+                                data-self-approval-rates="{{ approvals_charts.self_approval_rates }}"
+                                data-self-approval-rates-12-month-avg="{{ approvals_charts.self_approval_rates_12_month_avg }}"
                                 width="420"
                                 height="{% if approval_rate_visibile %}159{% else %}191{% endif %}">
                             </canvas>
@@ -262,15 +262,15 @@
             <section id="stats">
                 <div class="total">
                     <span>All translations</span>
-                    <p>{{ translations.count()|intcomma }}</p>
+                    <p>{{ all_time_stats.translations.count()|intcomma }}</p>
                 </div>
                 <div class="translated">
                     <span>Approved</span>
-                    <p>{{ translations.filter(approved=True).count()|intcomma }}</p>
+                    <p>{{ all_time_stats.translations.filter(approved=True).count()|intcomma }}</p>
                 </div>
                 <div class="unreviewed">
                     <span>Unreviewed</span>
-                    <p>{{ translations.exclude(approved=True).exclude(rejected=True).count()|intcomma }}</p>
+                    <p>{{ all_time_stats.translations.exclude(approved=True).exclude(rejected=True).count()|intcomma }}</p>
                 </div>
             </section>
 
@@ -278,7 +278,7 @@
 
             <section id="contributions">
                 <div class="header clearfix">
-                    <h2 class="title">{{ title }}</h2>
+                    <h2 class="title">{{ contributor_graph.title }}</h2>
                     <div class="type-selector controls select">
                         <div class="button selector">
                             <div class="value">
@@ -307,7 +307,7 @@
                         </div>
                     </div>
                 </div>
-                <div id="contribution-graph" data-contributions="{{ contributions }}"></div>
+                <div id="contribution-graph" data-contributions="{{ contributor_graph.contributions }}"></div>
                 <div class="svg-tip"></div>
             </section>
         </div>

--- a/pontoon/contributors/templates/contributors/profile.html
+++ b/pontoon/contributors/templates/contributors/profile.html
@@ -22,6 +22,9 @@
 
             {% set is_my_profile = (user.is_authenticated and user.email == contributor.email) %}
             {% set profile = contributor.profile %}
+            {% set translator_for_locales = contributor.translator_for_locales %}
+            {% set manager_for_locales = contributor.manager_for_locales %}
+            {% set user_is_translator = user.translated_locales %}
 
             <a class="avatar" href="{% if is_my_profile %}https://gravatar.com/{% endif %}">
                 {% if is_my_profile %}
@@ -49,8 +52,8 @@
                 </div>
                 {% endif %}
 
-                {% set is_email_visible = user.is_authenticated and (profile.visibility_email == "Logged in users" or user.translated_locales or contributor.manager_for_locales or contact_for.exists() or contributor.is_superuser) %}
-                {% set are_external_accounts_visible = (profile.visibility_external_accounts == "Public" or user.translated_locales) and (profile.chat or profile.github or profile.bugzilla) %}
+                {% set is_email_visible = user.is_authenticated and (profile.visibility_email == "Logged in users" or user_is_translator or manager_for_locales or contact_for.exists() or contributor.is_superuser) %}
+                {% set are_external_accounts_visible = (profile.visibility_external_accounts == "Public" or user_is_translator) and (profile.chat or profile.github or profile.bugzilla) %}
 
                 {% if is_email_visible or are_external_accounts_visible %}
                 <div class="block">
@@ -133,15 +136,15 @@
                 </div>
             </div>
 
-            {% if contributor.translator_for_locales or contributor.manager_for_locales or contact_for.exists() or contributor.is_superuser %}
+            {% if translator_for_locales or manager_for_locales or contact_for.exists() or contributor.is_superuser %}
             <hr>
             {% endif %}
 
             <div class="permissions">
-                {% if contributor.translator_for_locales %}
+                {% if translator_for_locales %}
                 <div class="block">
                     <h4 class="subtitle">Translator</h4>
-                    {% for locale in contributor.translator_for_locales %}
+                    {% for locale in translator_for_locales %}
                     <div class="item-with-icon">
                         <span class="icon fa fa-language"></span>
                         <span>{{ locale.name }} <span class="stress">{{ locale.code }}</span></span>
@@ -150,10 +153,10 @@
                 </div>
                 {% endif %}
 
-                {% if contributor.manager_for_locales %}
+                {% if manager_for_locales %}
                 <div class="block">
                     <h4 class="subtitle">Team manager</h4>
-                    {% for locale in contributor.manager_for_locales %}
+                    {% for locale in manager_for_locales %}
                     <div class="item-with-icon">
                         <span class="icon fa fa-language"></span>
                         <a href="{{ url('pontoon.teams.team', locale.code) }}">{{ locale.name }} <span class="stress">{{ locale.code }}</span></a>
@@ -185,10 +188,12 @@
 
         <div class="right-column">
 
+            {% set approval_rate_visibile = profile.visibility_approval == "Public" or user_is_translator %}
+            {% set contributor_is_translator = contributor.translated_locales %}
+            {% set self_approval_rate_visibile = contributor_is_translator and (profile.visibility_self_approval == "Public" or user_is_translator) %}
+
             <div class="clearfix">
 
-            {% set approval_rate_visibile = profile.visibility_approval == "Public" or user.translated_locales %}
-            {% set self_approval_rate_visibile = profile.user.translated_locales and (profile.visibility_self_approval == "Public" or user.translated_locales) %}
             {% if approval_rate_visibile or self_approval_rate_visibile %}
             <section id="insights" data-dates="{{ approvals_charts.dates }}">
                 <div class="block clearfix">

--- a/pontoon/contributors/tests/test_utils.py
+++ b/pontoon/contributors/tests/test_utils.py
@@ -216,16 +216,16 @@ def test_get_contributions_map_with_actions(user_a, action_user_a):
 
 
 @pytest.mark.django_db
-def test_get_contributor_graph_data_without_actions(user_a):
-    assert utils.get_contributor_graph_data(user_a) == (
+def test_get_contribution_graph_data_without_actions(user_a):
+    assert utils.get_contribution_graph_data(user_a) == (
         {},
         "0 contributions in the last year",
     )
 
 
 @pytest.mark.django_db
-def test_get_contributor_graph_data_with_actions(user_a, action_user_a, action_user_b):
-    data, title = utils.get_contributor_graph_data(user_a)
+def test_get_contribution_graph_data_with_actions(user_a, action_user_a, action_user_b):
+    data, title = utils.get_contribution_graph_data(user_a)
 
     # Truncate time
     date = action_user_a.created_at.replace(hour=0, minute=0, second=0, microsecond=0)

--- a/pontoon/contributors/tests/test_utils.py
+++ b/pontoon/contributors/tests/test_utils.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from unittest.mock import patch
-from urllib.parse import quote
+from urllib.parse import urlencode
 
 import pytest
 from dateutil.relativedelta import relativedelta
@@ -261,11 +261,13 @@ def test_get_contribution_timeline_data_without_actions(user_a):
 def test_get_contribution_timeline_data_with_actions(
     user_a, yesterdays_action_user_a, action_user_b
 ):
-    reviewer = quote(user_a.email)
     end = timezone.now()
     start = end - relativedelta(months=1)
-    start_ = start.strftime("%Y%m%d%H%M")
-    end_ = end.strftime("%Y%m%d%H%M")
+
+    params = {
+        "reviewer": user_a.email,
+        "review_time": f"{start.strftime('%Y%m%d%H%M')}-{end.strftime('%Y%m%d%H%M')}",
+    }
 
     assert utils.get_contribution_timeline_data(user_a) == (
         {
@@ -282,7 +284,7 @@ def test_get_contribution_timeline_data_with_actions(
                         },
                         "actions": ["1 approved"],
                         "count": 1,
-                        "url": f"/kg/project_a/all-resources/?reviewer={reviewer}&review_time={start_}-{end_}",
+                        "url": f"/kg/project_a/all-resources/?{urlencode(params)}",
                     },
                 },
                 "type": "user-reviews",

--- a/pontoon/contributors/tests/test_utils.py
+++ b/pontoon/contributors/tests/test_utils.py
@@ -162,8 +162,8 @@ def test_get_sublist_averages():
 
 
 @pytest.mark.django_db
-def test_get_approval_rates_without_actions(user_a):
-    data = utils.get_approval_rates(user_a)
+def test_get_approvals_charts_data_without_actions(user_a):
+    data = utils.get_approvals_charts_data(user_a)
 
     assert data["approval_rates"] == [0] * 12
     assert data["approval_rates_12_month_avg"] == [0] * 12
@@ -172,8 +172,8 @@ def test_get_approval_rates_without_actions(user_a):
 
 
 @pytest.mark.django_db
-def test_get_approval_rates_with_actions(user_a, action_user_a, action_user_b):
-    data = utils.get_approval_rates(user_a)
+def test_get_approvals_charts_data_with_actions(user_a, action_user_a, action_user_b):
+    data = utils.get_approvals_charts_data(user_a)
 
     assert data["approval_rates"] == [0] * 11 + [100]
     assert data["approval_rates_12_month_avg"] == [0] * 11 + [8.333333333333334]
@@ -201,14 +201,14 @@ def test_get_daily_action_counts_with_actions(action_a, action_b, action_c):
 
 
 @pytest.mark.django_db
-def test_get_contributions_without_actions(user_a):
-    assert utils.get_contributions(user_a) == (
+def test_get_contributor_graph_data_without_actions(user_a):
+    assert utils.get_contributor_graph_data(user_a) == (
         {},
         "0 contributions in the last year",
     )
 
 
 @pytest.mark.django_db
-def test_get_contributions_with_actions(user_a, action_user_a, action_user_b):
-    _, title = utils.get_contributions(user_a)
+def test_get_contributor_graph_data_with_actions(user_a, action_user_a, action_user_b):
+    _, title = utils.get_contributor_graph_data(user_a)
     assert title == "1 contribution in the last year"

--- a/pontoon/contributors/urls.py
+++ b/pontoon/contributors/urls.py
@@ -92,4 +92,10 @@ urlpatterns = [
         views.update_contribution_graph,
         name="pontoon.contributors.update_contribution_graph",
     ),
+    # AJAX: Update contribution timeline
+    path(
+        "update-contribution-timeline/",
+        views.update_contribution_timeline,
+        name="pontoon.contributors.update_contribution_timeline",
+    ),
 ]

--- a/pontoon/contributors/utils.py
+++ b/pontoon/contributors/utils.py
@@ -452,6 +452,12 @@ def get_contribution_timeline_data(user, contribution_type=None):
         contributions_qs = contributions_map[contribution_type]
         contribution_data = get_project_locale_contribution_counts(contributions_qs)
 
+        c_count = sum([value["count"] for _, value in contribution_data.items()])
+        p_count = len(contribution_data)
+
+        if c_count == 0:
+            continue
+
         # Generate localizaton URL and add it to the data dict
         querystring = querystrings[contribution_type]
         for key, val in contribution_data.items():
@@ -460,9 +466,6 @@ def get_contribution_timeline_data(user, contribution_type=None):
                 args=[val["locale"]["code"], val["project"]["slug"], "all-resources"],
             )
             contribution_data[key]["url"] = f"{url}?{querystring}"
-
-        c_count = sum([value["count"] for _, value in contribution_data.items()])
-        p_count = len(contribution_data)
 
         # Generate title for the localizations belonging to the same contribution type
         if contribution_type == "user_translations":

--- a/pontoon/contributors/utils.py
+++ b/pontoon/contributors/utils.py
@@ -472,7 +472,14 @@ def get_contribution_timeline_data(user, contribution_type=None):
         elif contribution_type == "peer_reviews":
             title = f"Received review for { intcomma(c_count) } suggestion{ pluralize(c_count) } in { intcomma(p_count) } project{ pluralize(p_count) }"
 
-        contributions.update({title: contribution_data})
+        contributions.update(
+            {
+                title: {
+                    "data": contribution_data,
+                    "type": contribution_type.replace("_", "-"),
+                }
+            }
+        )
 
     return (
         contributions,

--- a/pontoon/contributors/utils.py
+++ b/pontoon/contributors/utils.py
@@ -26,7 +26,7 @@ from pontoon.base.models import (
     Locale,
     Translation,
 )
-from pontoon.base.templatetags.helpers import intcomma
+from pontoon.base.templatetags.helpers import format_datetime, intcomma
 from pontoon.base.utils import convert_to_unix_time
 
 
@@ -423,10 +423,13 @@ def get_contribution_timeline_data(user, contribution_type=None, day=None):
     """
     end = timezone.now()
     start = end - relativedelta(months=1)
+    timeline_title = "Contribution activity in the last month"
 
     if day is not None:
         start = datetime.datetime.fromtimestamp(day, tz=timezone.get_current_timezone())
         end = start + relativedelta(days=1)
+        date = format_datetime(start, format="date")
+        timeline_title = f"Contribution activity on { date }"
 
     contribution_period = Q(created_at__gte=start, created_at__lte=end)
     contributions_map = get_contributions_map(user, contribution_period)
@@ -490,5 +493,5 @@ def get_contribution_timeline_data(user, contribution_type=None, day=None):
 
     return (
         contributions,
-        "Contribution activity in the last month",
+        timeline_title,
     )

--- a/pontoon/contributors/utils.py
+++ b/pontoon/contributors/utils.py
@@ -417,12 +417,16 @@ def get_project_locale_contribution_counts(contributions_qs):
     return counts
 
 
-def get_contribution_timeline_data(user, contribution_type=None):
+def get_contribution_timeline_data(user, contribution_type=None, day=None):
     """
     Get data required to render the Contribution timeline on the Profile page
     """
     end = timezone.now()
     start = end - relativedelta(months=1)
+
+    if day is not None:
+        start = datetime.datetime.fromtimestamp(day, tz=timezone.get_current_timezone())
+        end = start + relativedelta(days=1)
 
     contribution_period = Q(created_at__gte=start, created_at__lte=end)
     contributions_map = get_contributions_map(user, contribution_period)

--- a/pontoon/contributors/utils.py
+++ b/pontoon/contributors/utils.py
@@ -242,7 +242,7 @@ def get_sublist_averages(main_list, sublist_len):
     return [mean(main_list[x : x + sublist_len]) for x in range(sublist_len)]
 
 
-def get_approval_rates(user):
+def get_approvals_charts_data(user):
     """
     Get data required to render Approval rate charts on the Profile page
     """
@@ -303,7 +303,7 @@ def get_daily_action_counts(qs):
     }
 
 
-def get_contributions(user, contribution_type=None):
+def get_contributor_graph_data(user, contribution_type=None):
     """
     Get data required to render the Contribution graph on the Profile page
     """

--- a/pontoon/contributors/utils.py
+++ b/pontoon/contributors/utils.py
@@ -4,6 +4,7 @@ import jwt
 from collections import defaultdict
 from dateutil.relativedelta import relativedelta
 from statistics import mean
+from urllib.parse import quote
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -336,7 +337,7 @@ def get_contributions_map(user, contribution_period=None):
     }
 
 
-def get_contributor_graph_data(user, contribution_type=None):
+def get_contribution_graph_data(user, contribution_type=None):
     """
     Get data required to render the Contribution graph on the Profile page
     """
@@ -362,4 +363,118 @@ def get_contributor_graph_data(user, contribution_type=None):
     return (
         contributions_data,
         f"{ intcomma(total) } contribution{ pluralize(total) } in the last year",
+    )
+
+
+def get_project_locale_contribution_counts(contributions_qs):
+    counts = {}
+
+    for item in (
+        contributions_qs.annotate(
+            project_name=F("translation__entity__resource__project__name"),
+            project_slug=F("translation__entity__resource__project__slug"),
+            locale_name=F("translation__locale__name"),
+            locale_code=F("translation__locale__code"),
+        )
+        .values("project_name", "project_slug", "locale_name", "locale_code")
+        .annotate(count=Count("id"))
+        .values(
+            "project_name",
+            "project_slug",
+            "locale_name",
+            "locale_code",
+            "action_type",
+            "count",
+        )
+    ):
+        key = (item["project_slug"], item["locale_code"])
+        count = item["count"]
+
+        if item["action_type"] == "translation:created":
+            action = f"{ intcomma(count) } translation{ pluralize(count) }"
+        elif item["action_type"] == "translation:approved":
+            action = f"{ intcomma(count) } approved"
+        elif item["action_type"] == "translation:rejected":
+            action = f"{ intcomma(count) } rejected"
+
+        if key in counts.keys():
+            counts[key]["actions"].append(action)
+            counts[key]["count"] += count
+        else:
+            counts[key] = {
+                "project": {
+                    "name": item["project_name"],
+                    "slug": item["project_slug"],
+                },
+                "locale": {
+                    "name": item["locale_name"],
+                    "code": item["locale_code"],
+                },
+                "actions": [action],
+                "count": count,
+            }
+
+    return counts
+
+
+def get_contribution_timeline_data(user, contribution_type=None):
+    """
+    Get data required to render the Contribution timeline on the Profile page
+    """
+    end = timezone.now()
+    start = end - relativedelta(months=1)
+
+    contribution_period = Q(created_at__gte=start, created_at__lte=end)
+    contributions_map = get_contributions_map(user, contribution_period)
+
+    # Get a list of explicit contribution types
+    default_contribution_types = ["user_translations", "user_reviews"]
+    if contribution_type not in contributions_map.keys():
+        contribution_types = default_contribution_types
+    elif contribution_type == "all_user_contributions":
+        contribution_types = default_contribution_types
+    elif contribution_type == "all_contributions":
+        contribution_types = default_contribution_types + ["peer_reviews"]
+    else:
+        contribution_types = [contribution_type]
+
+    email = quote(user.email)
+    start_ = start.strftime("%Y%m%d%H%M")
+    end_ = end.strftime("%Y%m%d%H%M")
+    querystrings = {
+        "user_translations": f"author={ email }&time={ start_ }-{ end_ }",
+        "user_reviews": f"reviewer={ email }&review_time={ start_ }-{ end_ }",
+        "peer_reviews": f"author={ email }&review_time={ start_ }-{ end_ }&exclude_self_reviewed",
+    }
+
+    contributions = {}
+    for contribution_type in contribution_types:
+        contributions_qs = contributions_map[contribution_type]
+        contribution_data = get_project_locale_contribution_counts(contributions_qs)
+
+        # Generate localizaton URL and add it to the data dict
+        querystring = querystrings[contribution_type]
+        for key, val in contribution_data.items():
+            url = reverse(
+                "pontoon.translate",
+                args=[val["locale"]["code"], val["project"]["slug"], "all-resources"],
+            )
+            contribution_data[key]["url"] = f"{url}?{querystring}"
+
+        c_count = sum([value["count"] for _, value in contribution_data.items()])
+        p_count = len(contribution_data)
+
+        # Generate title for the localizations belonging to the same contribution type
+        if contribution_type == "user_translations":
+            title = f"Submitted { intcomma(c_count) } translation{ pluralize(c_count) } in { intcomma(p_count) } project{ pluralize(p_count) }"
+        elif contribution_type == "user_reviews":
+            title = f"Reviewed { intcomma(c_count) } suggestion{ pluralize(c_count) } in { intcomma(p_count) } project{ pluralize(p_count) }"
+        elif contribution_type == "peer_reviews":
+            title = f"Received review for { intcomma(c_count) } suggestion{ pluralize(c_count) } in { intcomma(p_count) } project{ pluralize(p_count) }"
+
+        contributions.update({title: contribution_data})
+
+    return (
+        contributions,
+        "Contribution activity in the last month",
     )

--- a/pontoon/contributors/views.py
+++ b/pontoon/contributors/views.py
@@ -63,11 +63,11 @@ def contributor(request, user):
             "translations": user.contributed_translations,
         },
         "approvals_charts": utils.get_approvals_charts_data(user),
-        "contributor_graph": {
+        "contribution_graph": {
             "contributions": json.dumps(graph_data),
             "title": graph_title,
         },
-        "contributor_timeline": {
+        "contribution_timeline": {
             "contributions": timeline_data,
             "title": timeline_title,
         },
@@ -91,7 +91,7 @@ def update_contribution_graph(request):
             status=400,
         )
 
-    contributions, title = utils.get_contributor_graph_data(user, contribution_type)
+    contributions, title = utils.get_contribution_graph_data(user, contribution_type)
     return JsonResponse({"contributions": contributions, "title": title})
 
 

--- a/pontoon/contributors/views.py
+++ b/pontoon/contributors/views.py
@@ -102,13 +102,17 @@ def update_contribution_timeline(request):
     try:
         user = User.objects.get(pk=request.GET["user"])
         contribution_type = request.GET["contribution_type"]
-    except User.DoesNotExist as e:
+        day = request.GET.get("day", None)
+        day = int(day) / 1000 if day else None
+    except (User.DoesNotExist, ValueError) as e:
         return JsonResponse(
             {"status": False, "message": f"Bad Request: {e}"},
             status=400,
         )
 
-    contributions, title = utils.get_contribution_timeline_data(user, contribution_type)
+    contributions, title = utils.get_contribution_timeline_data(
+        user, contribution_type, day
+    )
 
     return render(
         request,

--- a/pontoon/contributors/views.py
+++ b/pontoon/contributors/views.py
@@ -51,20 +51,22 @@ def contributor_username(request, username):
 
 def contributor(request, user):
     """Contributor profile."""
-    contributions, title = utils.get_contributions(user)
+    contributions, title = utils.get_contributor_graph_data(user)
 
-    context = utils.get_approval_rates(user)
-    context.update(
-        {
-            "title": title,
-            "contributor": user,
+    context = {
+        "contributor": user,
+        "contact_for": user.contact_for.filter(
+            disabled=False, system_project=False, visibility="public"
+        ).order_by("-priority"),
+        "all_time_stats": {
             "translations": user.contributed_translations,
-            "contact_for": user.contact_for.filter(
-                disabled=False, system_project=False, visibility="public"
-            ).order_by("-priority"),
+        },
+        "approvals_charts": utils.get_approvals_charts_data(user),
+        "contributor_graph": {
             "contributions": json.dumps(contributions),
-        }
-    )
+            "title": title,
+        },
+    }
 
     return render(
         request,
@@ -84,7 +86,7 @@ def update_contribution_graph(request):
             status=400,
         )
 
-    contributions, title = utils.get_contributions(user, contribution_type)
+    contributions, title = utils.get_contributor_graph_data(user, contribution_type)
     return JsonResponse({"contributions": contributions, "title": title})
 
 

--- a/pontoon/contributors/views.py
+++ b/pontoon/contributors/views.py
@@ -51,7 +51,8 @@ def contributor_username(request, username):
 
 def contributor(request, user):
     """Contributor profile."""
-    contributions, title = utils.get_contributor_graph_data(user)
+    graph_data, graph_title = utils.get_contribution_graph_data(user)
+    timeline_data, timeline_title = utils.get_contribution_timeline_data(user)
 
     context = {
         "contributor": user,
@@ -63,8 +64,12 @@ def contributor(request, user):
         },
         "approvals_charts": utils.get_approvals_charts_data(user),
         "contributor_graph": {
-            "contributions": json.dumps(contributions),
-            "title": title,
+            "contributions": json.dumps(graph_data),
+            "title": graph_title,
+        },
+        "contributor_timeline": {
+            "contributions": timeline_data,
+            "title": timeline_title,
         },
     }
 

--- a/pontoon/contributors/views.py
+++ b/pontoon/contributors/views.py
@@ -80,8 +80,9 @@ def contributor(request, user):
     )
 
 
+@require_AJAX
+@transaction.atomic
 def update_contribution_graph(request):
-    """Contributor profile."""
     try:
         user = User.objects.get(pk=request.GET["user"])
         contribution_type = request.GET["contribution_type"]
@@ -93,6 +94,32 @@ def update_contribution_graph(request):
 
     contributions, title = utils.get_contribution_graph_data(user, contribution_type)
     return JsonResponse({"contributions": contributions, "title": title})
+
+
+@require_AJAX
+@transaction.atomic
+def update_contribution_timeline(request):
+    try:
+        user = User.objects.get(pk=request.GET["user"])
+        contribution_type = request.GET["contribution_type"]
+    except User.DoesNotExist as e:
+        return JsonResponse(
+            {"status": False, "message": f"Bad Request: {e}"},
+            status=400,
+        )
+
+    contributions, title = utils.get_contribution_timeline_data(user, contribution_type)
+
+    return render(
+        request,
+        "contributors/includes/timeline.html",
+        {
+            "contribution_timeline": {
+                "contributions": contributions,
+                "title": title,
+            },
+        },
+    )
 
 
 @login_required(redirect_field_name="", login_url="/403")

--- a/specs/0111-redesign-profile-page.md
+++ b/specs/0111-redesign-profile-page.md
@@ -47,7 +47,7 @@ The contribution graph displays data over time about the following actions:
 
 Only one data point is displayed at a time, and it can be selected using the dropdown list above the graph. The default view is `Submissions and reviews`, since it provides a good picture of the user’s direct activity in Pontoon.
 
-Each square in the graph represents a day, with color changing depending on the amount of contributions. It’s possible to click on a column to select a specific week, or change the year currently displayed using the links in the rightmost column.
+Each square in the graph represents a day, with color changing depending on the amount of contributions. It’s possible to click on a square to select a specific day, or change the year currently displayed using the links in the rightmost column.
 
 When selecting a specific time range, the data displayed below the graph is updated accordingly. This doesn’t affect the approval and self-approval graphs.
 


### PR DESCRIPTION
Fixes #2487 definitively.

The patch implements contribution timeline, which can be filtered by contribution type and day.

It's deployed to stage (which uses ~2 weeks old prod data):
https://mozilla-pontoon-staging.herokuapp.com/contributors/93Rx_ofmgBDhnz4QZD1aHlOg0uY/

TODO:
- [ ] The `exclude_self_reviewed` filter likely needs some tweaking. Still testing.
- [x] File #2619
- [x] Add unit tests for `get_contribution_timeline_data()`
- [x] Update timeline title with the selected date