### PR TITLE
Permissions fixes

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -226,14 +226,18 @@ def user_role(self, managers=None, translators=None):
             return "Manager for " + ", ".join(managers[self])
     else:
         if self.managed_locales:
-            return "Manager for " + ", ".join(self.managed_locales)
+            return "Manager for " + ", ".join(
+                self.managed_locales.values_list("code", flat=True)
+            )
 
     if translators is not None:
         if self in translators:
             return "Translator for " + ", ".join(translators[self])
     else:
         if self.translated_locales:
-            return "Translator for " + ", ".join(self.translated_locales)
+            return "Translator for " + ", ".join(
+                self.translated_locales.values_list("code", flat=True)
+            )
 
     return "Contributor"
 
@@ -274,7 +278,7 @@ def can_translate(self, locale, project):
     """Check if user has suitable permissions to translate in given locale or project/locale."""
 
     # Locale managers can translate all projects
-    if locale.code in self.managed_locales:
+    if locale in self.managed_locales:
         return True
 
     project_locale = ProjectLocale.objects.get(project=project, locale=locale)

--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -103,20 +103,6 @@ def comma_or_prefix(source):
 
 
 @library.filter
-def display_permissions(self):
-    output = "Can make suggestions"
-
-    if self.translated_locales:
-        if self.is_superuser:
-            locales = "all locales"
-        else:
-            locales = ", ".join(self.translated_locales)
-        output = "Can submit and approve translations for " + locales
-
-    return output
-
-
-@library.filter
 def date_status(value, complete):
     """Get date status relative to today."""
     if isinstance(value, datetime.date):


### PR DESCRIPTION
In https://github.com/mozilla/pontoon/commit/327962edb5a32c267ab4ed5a5d73b5fac7301c96#diff-4ebc5e9888b2962aecd470dd76f7d410b4e246f2d8323df57ed7dd0c8d5e3ade we changed `User.managed_locales` and `User.translated_locales` API, which broke `User.can_translate` among other things. As a consequence, some users were unable to review translations.

The `User` model extensions implemented using the `add_to_class()` method are not tested. We should fix this in a separate patch.