### PR TITLE
Normalise initial FTL values to always end in newline

### DIFF
--- a/translate/src/context/Editor.test.js
+++ b/translate/src/context/Editor.test.js
@@ -88,7 +88,7 @@ describe('<EditorProvider>', () => {
     mountSpy(Spy, 'ftl', 'key = message');
     expect(editor).toMatchObject({
       format: 'ftl',
-      initial: 'key = message',
+      initial: 'key = message\n',
       value: 'message',
       view: 'simple',
     });
@@ -100,7 +100,7 @@ describe('<EditorProvider>', () => {
       editor = useContext(EditorData);
       return null;
     };
-    const initial = 'key = { $var ->\n [one] ONE\n *[other] OTHER\n }';
+    const initial = 'key = { $var ->\n [one] ONE\n *[other] OTHER\n }\n';
     mountSpy(Spy, 'ftl', initial);
 
     const value = parseEntry(initial);
@@ -118,7 +118,7 @@ describe('<EditorProvider>', () => {
       editor = useContext(EditorData);
       return null;
     };
-    const value = '## comment';
+    const value = '## comment\n';
     mountSpy(Spy, 'ftl', value);
 
     expect(editor).toMatchObject({
@@ -172,7 +172,7 @@ describe('useClearEditor', () => {
       clearEditor = useClearEditor();
       return null;
     };
-    const initial = 'key = { $var ->\n [one] ONE\n *[other] OTHER\n }';
+    const initial = 'key = { $var ->\n [one] ONE\n *[other] OTHER\n }\n';
     const wrapper = mountSpy(Spy, 'ftl', initial);
     act(() => clearEditor());
     wrapper.update();

--- a/translate/src/context/Editor.tsx
+++ b/translate/src/context/Editor.tsx
@@ -224,7 +224,7 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
       } else if (!initial.endsWith('\n')) {
         // Some Fluent translations may be stored without a terminal newline.
         // If the data is cleaned up, this conditional may be removed.
-        // https://github.com/mozilla/pontoon/issues/2607
+        // https://github.com/mozilla/pontoon/issues/2216
         initial += '\n';
       }
       const next = getFtlViewAndValue(initial);

--- a/translate/src/context/Editor.tsx
+++ b/translate/src/context/Editor.tsx
@@ -211,23 +211,29 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
   }, [readonly]);
 
   useEffect(() => {
-    let format: 'ftl' | 'simple' = 'simple';
-    let initial = '';
-    let value: string | Entry = '';
-    let view: 'simple' | 'rich' | 'source' = 'simple';
+    let initial = activeTranslation?.string || '';
 
-    initial = activeTranslation?.string || '';
+    let format: 'ftl' | 'simple';
+    let value: string | Entry;
+    let view: 'simple' | 'rich' | 'source';
     if (entity.format === 'ftl') {
       format = 'ftl';
       if (!initial) {
         const entry = parseEntry(entity.original);
         initial = serializeEntry(getEmptyMessage(entry, locale));
+      } else if (!initial.endsWith('\n')) {
+        // Some Fluent translations may be stored without a terminal newline.
+        // If the data is cleaned up, this conditional may be removed.
+        // https://github.com/mozilla/pontoon/issues/2607
+        initial += '\n';
       }
       const next = getFtlViewAndValue(initial);
       value = next.value;
       view = next.view;
     } else {
+      format = 'simple';
       value = initial;
+      view = 'simple';
     }
 
     setState((prev) => ({

--- a/translate/src/core/editor/components/Editor.test.js
+++ b/translate/src/core/editor/components/Editor.test.js
@@ -26,6 +26,7 @@ const NESTED_SELECTORS_STRING = ftl`
           }
           [select] WOW
       }
+
   `;
 
 const RICH_MESSAGE_STRING = ftl`


### PR DESCRIPTION
Fixes #2607 with a workaround

The detected "change" is effectively due to bad data; some FTL strings are stored in the database without the terminal newline that's always included in the output of our Fluent serialiser. I suspect that these may have been entered by editing and submitting strings using the advanced/raw view.

So one way to fix the problem would be to go through the data and normalise all of it to always include a newline, but I've opted here to add that normalisation in the front-end. It's likely that we'll refactor the internal representation of messages further as a part of the MF2 work, at which stage this may be dropped thanks to comparing parsed message structures rather than strings.