### PR TITLE
Refactor accesskey extraction to include more cases

### DIFF
--- a/translate/src/core/utils/fluent/extractAccessKeyCandidates.test.js
+++ b/translate/src/core/utils/fluent/extractAccessKeyCandidates.test.js
@@ -1,69 +1,108 @@
+import ftl from '@fluent/dedent';
 import { extractAccessKeyCandidates } from './extractAccessKeyCandidates';
 import { parseEntry } from './parser';
 
 describe('extractAccessKeyCandidates', () => {
-  it('returns null if the message has no attributes', () => {
-    const message = parseEntry('title = Title');
-    const res = extractAccessKeyCandidates(message);
-
-    expect(res).toEqual(null);
-  });
-
-  it('returns null if the message has no accesskey attribute', () => {
-    const input = 'title =' + '\n    .foo = Bar';
+  it('returns an empty list if the message has no label attribute or value', () => {
+    const input = ftl`
+      title =
+        .foo = Bar
+        .accesskey = B
+      `;
     const message = parseEntry(input);
-    const res = extractAccessKeyCandidates(message);
+    const res = extractAccessKeyCandidates(message, 'accesskey');
 
-    expect(res).toEqual(null);
-  });
-
-  it('returns null if the message has no label attribute or value', () => {
-    const input = 'title =' + '\n    .foo = Bar' + '\n    .accesskey = B';
-    const message = parseEntry(input);
-    const res = extractAccessKeyCandidates(message);
-
-    expect(res).toEqual(null);
+    expect(res).toEqual([]);
   });
 
   it('returns a list of access keys from the message value', () => {
-    const input = 'title = Candidates' + '\n    .accesskey = B';
+    const input = ftl`
+      title = Candidates
+        .accesskey = B
+      `;
     const message = parseEntry(input);
-    const res = extractAccessKeyCandidates(message);
+    const res = extractAccessKeyCandidates(message, 'accesskey');
 
     expect(res).toEqual(['C', 'a', 'n', 'd', 'i', 't', 'e', 's']);
   });
 
   it('returns a list of access keys from the label attribute', () => {
-    const input =
-      'title = Title' + '\n    .label = Candidates' + '\n    .accesskey = B';
+    const input = ftl`
+      title = Title
+        .label = Candidates
+        .accesskey = B
+        .aria-label = Ignore this
+        .value = Ignore this
+      `;
     const message = parseEntry(input);
-    const res = extractAccessKeyCandidates(message);
+    const res = extractAccessKeyCandidates(message, 'accesskey');
+
+    expect(res).toEqual(['C', 'a', 'n', 'd', 'i', 't', 'e', 's']);
+  });
+
+  it('returns a list of access keys from the value attribute', () => {
+    const input = ftl`
+      title =
+        .accesskey = B
+        .aria-label = Ignore this
+        .value = Candidates
+      `;
+    const message = parseEntry(input);
+    const res = extractAccessKeyCandidates(message, 'accesskey');
+
+    expect(res).toEqual(['C', 'a', 'n', 'd', 'i', 't', 'e', 's']);
+  });
+
+  it('returns a list of access keys from the aria-label attribute', () => {
+    const input = ftl`
+      title =
+        .accesskey = B
+        .aria-label = Candidates
+      `;
+    const message = parseEntry(input);
+    const res = extractAccessKeyCandidates(message, 'accesskey');
+
+    expect(res).toEqual(['C', 'a', 'n', 'd', 'i', 't', 'e', 's']);
+  });
+
+  it('returns a list of access keys from the prefixed label attribute', () => {
+    const input = ftl`
+      title = Title
+        .buttonlabel = Candidates
+        .buttonaccesskey = B
+        .label = Ignore this
+        .value = Ignore this
+      `;
+    const message = parseEntry(input);
+    const res = extractAccessKeyCandidates(message, 'buttonaccesskey');
 
     expect(res).toEqual(['C', 'a', 'n', 'd', 'i', 't', 'e', 's']);
   });
 
   it('Does not take Placeables into account when generating candidates', () => {
-    const input =
-      'title = Title' +
-      '\n    .label = Candidates { brand }' +
-      '\n    .accesskey = B';
+    const input = ftl`
+      title = Title
+        .label = Candidates { brand }
+        .accesskey = B
+      `;
     const message = parseEntry(input);
-    const res = extractAccessKeyCandidates(message);
+    const res = extractAccessKeyCandidates(message, 'accesskey');
 
     expect(res).toEqual(['C', 'a', 'n', 'd', 'i', 't', 'e', 's']);
   });
 
   it('returns a list of access keys from all label attribute variants', () => {
-    const input =
-      'title = Title' +
-      '\n    .label =' +
-      '\n        { PLATFORM() ->' +
-      '\n            [windows] Ctrl' +
-      '\n           *[other] Cmd' +
-      '\n        }' +
-      '\n    .accesskey = C';
+    const input = ftl`
+      title = Title' +
+        .label =
+            { PLATFORM() ->
+                [windows] Ctrl
+               *[other] Cmd
+            }
+        .accesskey = C
+      `;
     const message = parseEntry(input);
-    const res = extractAccessKeyCandidates(message);
+    const res = extractAccessKeyCandidates(message, 'accesskey');
 
     expect(res).toEqual(['C', 't', 'r', 'l', 'm', 'd']);
   });

--- a/translate/src/modules/fluenteditor/components/RichTranslationForm.test.js
+++ b/translate/src/modules/fluenteditor/components/RichTranslationForm.test.js
@@ -190,14 +190,14 @@ describe('<RichTranslationForm>', () => {
     expect(wrapper.find('.accesskeys button').at(7).text()).toEqual('s');
   });
 
-  it('does not render the access key UI if no candidates can be generated', () => {
+  it('does not render accesskey buttons if no candidates can be generated', () => {
     const [wrapper] = mountForm(ftl`
       title =
         .label = { reference }
         .accesskey = C
       `);
 
-    expect(wrapper.find('.accesskeys')).toHaveLength(0);
+    expect(wrapper.find('.accesskeys button')).toHaveLength(0);
   });
 
   it('does not render the access key UI if access key is longer than 1 character', () => {

--- a/translate/src/modules/fluenteditor/components/RichTranslationForm.tsx
+++ b/translate/src/modules/fluenteditor/components/RichTranslationForm.tsx
@@ -103,7 +103,7 @@ function RichItem({
           lang={locale.code}
           data-script={locale.script}
         />
-        {isAccessKey && candidates.length > 1 && (
+        {isAccessKey ? (
           <div className='accesskeys'>
             {candidates.map((key) => (
               <button
@@ -115,7 +115,7 @@ function RichItem({
               </button>
             ))}
           </div>
-        )}
+        ) : null}
       </td>
     </tr>
   );

--- a/translate/src/modules/fluenteditor/components/RichTranslationForm.tsx
+++ b/translate/src/modules/fluenteditor/components/RichTranslationForm.tsx
@@ -52,12 +52,10 @@ function RichItem({
     }
   };
 
-  const candidates =
-    typeof message !== 'string' && label === 'accesskey'
-      ? extractAccessKeyCandidates(message)
-      : null;
-
-  const isAccessKey = candidates?.length && value.length < 2;
+  const isAccessKey = label.endsWith('accesskey') && value.length < 2;
+  const candidates = isAccessKey
+    ? extractAccessKeyCandidates(message, label)
+    : [];
 
   const handleAccessKeyClick = readonly
     ? undefined
@@ -105,7 +103,7 @@ function RichItem({
           lang={locale.code}
           data-script={locale.script}
         />
-        {isAccessKey && (
+        {isAccessKey && candidates.length > 1 && (
           <div className='accesskeys'>
             {candidates.map((key) => (
               <button


### PR DESCRIPTION
Fixes #2603

The logic for detecting an accesskey is fixed and expanded to cover more cases. Previously, either the `label` attribute or the message value needed to have non-empty contents for the detection to succeed. Now:
- The input is rendered with accesskey styling independently of the number of candidate keys, but buttons next to it are rendered only if there at least two candidates.
- If a message has no `label` and no value, the `value` and `aria-label` attributes are also inspected.
- All non-letter and non-number candidates are dropped, though they may still be manually entered.
- Prefixed access keys are detected. If e.g. a message has attributes `buttonlabel` and `buttonaccesskey`, the former is used to generate the candidates for the latter.