### PR TITLE
Re-enable Pretranslated status in dashboards, filters and progress charts

### DIFF
--- a/pontoon/base/static/css/table.css
+++ b/pontoon/base/static/css/table.css
@@ -325,11 +325,11 @@ table.table.project-list.hidden {
   display: inline-block;
   padding: 0;
   text-align: center;
-  width: 60px;
+  width: 51px;
 }
 
 .table .progress .legend li:last-child {
-  width: 60px;
+  width: 54px;
 }
 
 .table .progress .legend li a {

--- a/pontoon/base/templates/widgets/heading_info.html
+++ b/pontoon/base/templates/widgets/heading_info.html
@@ -87,15 +87,12 @@
     value=obj.approved_strings,
     link=(link + '?status=translated') if link else None)
   }}
-  <!-- Pretranslation feature is not ready yet, so we're disabling the Pretranslated status
-       in dashboards to avoid showing unnecessary zeros.
   {{ legend_item(
     title='Pretranslated',
     class='pretranslated',
     value=obj.pretranslated_strings,
     link=(link + '?status=pretranslated') if link else None)
   }}
-  -->
   {{ legend_item(
     title='Warnings',
     class='warnings',

--- a/pontoon/base/templates/widgets/progress_chart.html
+++ b/pontoon/base/templates/widgets/progress_chart.html
@@ -25,15 +25,12 @@
           <div class="value" data-value="{{ chart.approved_strings }}">{{ chart.approved_strings|comma_or_prefix }}</div>
         </a>
       </li>
-      <!-- Pretranslation feature is not ready yet, so we're disabling the Pretranslated status
-           in dashboards to avoid showing unnecessary zeros.
       <li class="pretranslated">
         <a href="{{ link }}{% if link_parameter %}{% if not has_params %}?{% else %}&{% endif %}status=pretranslated{% endif %}">
           <div class="title">Pre</div>
           <div class="value" data-value="{{ chart.pretranslated_strings }}">{{ chart.pretranslated_strings|comma_or_prefix }}</div>
         </a>
       </li>
-      -->
       <li class="warnings">
         <a href="{{ link }}{% if link_parameter %}{% if not has_params %}?{% else %}&{% endif %}status=warnings{% endif %}">
           <div class="title">Wrngs</div>

--- a/translate/public/locale/en-US/translate.ftl
+++ b/translate/public/locale/en-US/translate.ftl
@@ -654,6 +654,7 @@ search-FiltersPanel--heading-extra = EXTRA FILTERS
 search-FiltersPanel--heading-authors = TRANSLATION AUTHORS
 search-FiltersPanel--status-name-all = All
 search-FiltersPanel--status-name-translated = Translated
+search-FiltersPanel--status-name-pretranslated = Pretranslated
 search-FiltersPanel--status-name-warnings = Warnings
 search-FiltersPanel--status-name-errors = Errors
 search-FiltersPanel--status-name-missing = Missing

--- a/translate/src/modules/resourceprogress/components/ResourceProgress.css
+++ b/translate/src/modules/resourceprogress/components/ResourceProgress.css
@@ -96,12 +96,12 @@
   color: #aaaaaa;
   display: inline-block;
   margin-right: 1px;
-  width: 99px;
+  width: 79px;
 }
 
 .progress-chart .menu .details div:last-child {
   margin-right: 0;
-  width: 100px;
+  width: 80px;
 }
 
 .progress-chart .menu .details div.approved {

--- a/translate/src/modules/resourceprogress/components/ResourceProgress.tsx
+++ b/translate/src/modules/resourceprogress/components/ResourceProgress.tsx
@@ -13,7 +13,7 @@ type Props = {
 };
 
 function ResourceProgressDialog({ percent, stats, onDiscard }: Props) {
-  const { approved, warnings, errors, missing, unreviewed, total } = stats;
+  const { approved, pretranslated, warnings, errors, missing, unreviewed, total } = stats;
 
   const ref = React.useRef<HTMLElement>(null);
   useOnDiscard(ref, onDiscard);
@@ -51,8 +51,6 @@ function ResourceProgressDialog({ percent, stats, onDiscard }: Props) {
             </Link>
           </p>
         </div>
-        {/* Pretranslation feature is not ready yet, so we're disabling the
-            Pretranslated filter, which wouldn't catch anything.
         <div className='pretranslated'>
           <span className='title'>
             <Localized id='resourceprogress-ResourceProgress--pretranslated'>
@@ -65,7 +63,6 @@ function ResourceProgressDialog({ percent, stats, onDiscard }: Props) {
             </Link>
           </p>
         </div>
-        */}
         <div className='warnings'>
           <span className='title'>
             <Localized id='resourceprogress-ResourceProgress--warnings'>

--- a/translate/src/modules/resourceprogress/components/ResourceProgress.tsx
+++ b/translate/src/modules/resourceprogress/components/ResourceProgress.tsx
@@ -13,7 +13,15 @@ type Props = {
 };
 
 function ResourceProgressDialog({ percent, stats, onDiscard }: Props) {
-  const { approved, pretranslated, warnings, errors, missing, unreviewed, total } = stats;
+  const {
+    approved,
+    pretranslated,
+    warnings,
+    errors,
+    missing,
+    unreviewed,
+    total,
+  } = stats;
 
   const ref = React.useRef<HTMLElement>(null);
   useOnDiscard(ref, onDiscard);

--- a/translate/src/modules/search/constants.ts
+++ b/translate/src/modules/search/constants.ts
@@ -12,6 +12,11 @@ export const FILTERS_STATUS = [
     stat: 'approved',
   },
   {
+    name: 'Pretranslated',
+    slug: 'pretranslated',
+    stat: 'pretranslated',
+  },
+  {
     name: 'Warnings',
     slug: 'warnings',
   },


### PR DESCRIPTION
Pretranslated status was hidden from the UI as part of #2463, which introduced the Pretranslated status and dropped Fuzzy. Now that we plan to start evaluating pretranslation, it's time to restore it.

This patch essentially reverts https://github.com/mozilla/pontoon/pull/2463/commits/0133d9aa307ff85bc52d87f2ea6076f7838749b5 and https://github.com/mozilla/pontoon/pull/2463/commits/3277af14eb72019a0539bf012061aee357af8dae.