### PR TITLE
Fix MultipleObjectsReturned in retrieving Locale from GT code

### DIFF
--- a/pontoon/machinery/utils.py
+++ b/pontoon/machinery/utils.py
@@ -19,19 +19,11 @@ log = logging.getLogger(__name__)
 MAX_RESULTS = 5
 
 
-def get_google_translate_data(text, locale_code):
-    try:
-        locale = base.models.Locale.objects.get(google_translate_code=locale_code)
-    except base.models.Locale.DoesNotExist as e:
-        return {
-            "status": False,
-            "message": f"{e}",
-        }
-
+def get_google_translate_data(text, locale):
     if locale.google_automl_model:
         return get_google_automl_translation(text, locale)
 
-    return get_google_generic_translation(text, locale_code)
+    return get_google_generic_translation(text, locale.google_translate_code)
 
 
 def get_google_generic_translation(text, locale_code):

--- a/pontoon/machinery/views.py
+++ b/pontoon/machinery/views.py
@@ -161,13 +161,17 @@ def google_translate(request):
         if not locale_code:
             raise ValueError("Locale code is empty")
 
+        locale = Locale.objects.filter(google_translate_code=locale_code).first()
+        if not locale:
+            raise ValueError("Locale code not supported")
+
     except (MultiValueDictKeyError, ValueError) as e:
         return JsonResponse(
             {"status": False, "message": f"Bad Request: {e}"},
             status=400,
         )
 
-    data = get_google_translate_data(text, locale_code)
+    data = get_google_translate_data(text, locale)
 
     if not data["status"]:
         return JsonResponse(data, status=400)

--- a/pontoon/pretranslation/pretranslate.py
+++ b/pontoon/pretranslation/pretranslate.py
@@ -48,7 +48,7 @@ def get_translations(entity, locale):
     elif locale.google_translate_code:
         gt_response = get_google_translate_data(
             text=entity.string,
-            locale_code=locale.google_translate_code,
+            locale=locale,
         )
 
         if gt_response["status"]:


### PR DESCRIPTION
`Locale.objects.get(google_translate_code=locale_code)` can of course break, because multiple locales (e.g. `es-*`) share the same Google Translate locale code (e.g. `es`).