### PR TITLE
Include pretranslated in completion calculations

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -583,7 +583,11 @@ class AggregatedStats(models.Model):
 
     @property
     def completed_strings(self):
-        return self.approved_strings + self.strings_with_warnings
+        return (
+            self.approved_strings
+            + self.pretranslated_strings
+            + self.strings_with_warnings
+        )
 
     @property
     def complete(self):

--- a/pontoon/base/static/js/progress-chart.js
+++ b/pontoon/base/static/js/progress-chart.js
@@ -28,7 +28,10 @@ $(function () {
           ? stats.missing / stats.all
           : 1 /* Draw "empty" progress if no projects enabled */,
       },
-      number = Math.floor((fraction.translated + fraction.warnings) * 100);
+      number = Math.floor(
+        (fraction.translated + fraction.pretranslated + fraction.warnings) *
+          100,
+      );
 
     // Update graph
     var canvas = this,

--- a/pontoon/base/static/js/table.js
+++ b/pontoon/base/static/js/table.js
@@ -125,16 +125,15 @@ var Pontoon = (function (my) {
               translated =
                 legend.find('.translated .value').data('value') / all || 0,
               pretranslated =
-                legend.find('.pretranslated .value').data('value') / all || 0;
+                legend.find('.pretranslated .value').data('value') / all || 0,
+              warnings =
+                legend.find('.warnings .value').data('value') / all || 0;
 
             if ($(el).find('.progress .not-ready').length) {
               return 'not-ready';
             }
 
-            return {
-              translated: translated,
-              pretranslated: pretranslated,
-            };
+            return translated + pretranslated + warnings;
           }
 
           function getUnreviewed(el) {
@@ -189,7 +188,7 @@ var Pontoon = (function (my) {
           node.addClass(cls);
 
           items.sort(function (a, b) {
-            // Sort by translated, then by pretranslated percentage
+            // Sort by completion
             if (node.is('.progress')) {
               var chartA = getProgress(a),
                 chartB = getProgress(b);
@@ -205,10 +204,7 @@ var Pontoon = (function (my) {
                 return 1 * dir;
               }
 
-              return (
-                (chartA.translated - chartB.translated) * dir ||
-                (chartA.pretranslated - chartB.pretranslated) * dir
-              );
+              return (chartA - chartB) * dir;
 
               // Sort by unreviewed state
             } else if (node.is('.unreviewed-status')) {

--- a/pontoon/localizations/views.py
+++ b/pontoon/localizations/views.py
@@ -131,7 +131,11 @@ def ajax_resources(request, code, slug):
             ),
             "completion_percent": int(
                 math.floor(
-                    (part["approved_strings"] + part["strings_with_warnings"])
+                    (
+                        part["approved_strings"]
+                        + part["pretranslated_strings"]
+                        + part["strings_with_warnings"]
+                    )
                     / part["resource__total_strings"]
                     * 100
                 )

--- a/pontoon/tags/tests/utils/test_tagged.py
+++ b/pontoon/tags/tests/utils/test_tagged.py
@@ -195,4 +195,4 @@ def test_util_tag_chart():
     assert chart.approved_share == 18.0
     assert chart.pretranslated_share == 10.0
     assert chart.unreviewed_share == 32.0
-    assert chart.completion_percent == 17
+    assert chart.completion_percent == 27

--- a/pontoon/tags/utils/chart.py
+++ b/pontoon/tags/utils/chart.py
@@ -15,7 +15,11 @@ class TagChart:
     def completion_percent(self):
         return int(
             math.floor(
-                (self.approved_strings + self.strings_with_warnings)
+                (
+                    self.approved_strings
+                    + self.pretranslated_strings
+                    + self.strings_with_warnings
+                )
                 / float(self.total_strings)
                 * 100
             )

--- a/translate/src/api/resource.ts
+++ b/translate/src/api/resource.ts
@@ -3,6 +3,7 @@ import { GET } from './utils/base';
 type APIResource = {
   readonly title: string;
   readonly approved_strings: number;
+  readonly pretranslated_strings: number;
   readonly strings_with_warnings: number;
   readonly resource__total_strings: number;
 };

--- a/translate/src/core/editor/hooks/useSendTranslation.ts
+++ b/translate/src/core/editor/hooks/useSendTranslation.ts
@@ -86,6 +86,7 @@ export function useSendTranslation(): (ignoreWarnings?: boolean) => void {
           updateResource(
             entity.path,
             content.stats.approved,
+            content.stats.pretranslated,
             content.stats.warnings,
           ),
         );

--- a/translate/src/core/editor/hooks/useUpdateTranslationStatus.ts
+++ b/translate/src/core/editor/hooks/useUpdateTranslationStatus.ts
@@ -90,6 +90,7 @@ export function useUpdateTranslationStatus(
           updateResource(
             entity.path,
             results.stats.approved,
+            results.stats.pretranslated,
             results.stats.warnings,
           ),
         );

--- a/translate/src/core/resource/actions.ts
+++ b/translate/src/core/resource/actions.ts
@@ -7,6 +7,7 @@ export const UPDATE_RESOURCE = 'resource/UPDATE';
 export type Resource = {
   readonly path: string;
   readonly approvedStrings: number;
+  readonly pretranslatedStrings: number;
   readonly stringsWithWarnings: number;
   readonly totalStrings: number;
 };
@@ -15,6 +16,7 @@ type UpdateAction = {
   type: typeof UPDATE_RESOURCE;
   resourcePath: string;
   approvedStrings: number;
+  pretranslatedStrings: number;
   stringsWithWarnings: number;
 };
 
@@ -33,6 +35,7 @@ export const getResource =
     const resources = results.map((resource) => ({
       path: resource.title,
       approvedStrings: resource.approved_strings,
+      pretranslatedStrings: resource.pretranslated_strings,
       stringsWithWarnings: resource.strings_with_warnings,
       totalStrings: resource.resource__total_strings,
     }));
@@ -44,10 +47,12 @@ export const getResource =
 export const updateResource = (
   resourcePath: string,
   approvedStrings: number,
+  pretranslatedStrings: number,
   stringsWithWarnings: number,
 ): UpdateAction => ({
   type: UPDATE_RESOURCE,
   resourcePath,
   approvedStrings,
+  pretranslatedStrings,
   stringsWithWarnings,
 });

--- a/translate/src/core/resource/components/ResourceMenu.tsx
+++ b/translate/src/core/resource/components/ResourceMenu.tsx
@@ -51,7 +51,8 @@ function ResourceMenuDialog({
   };
 
   const getProgress = (res: Resource) => {
-    const completeStrings = res.approvedStrings + res.stringsWithWarnings;
+    const completeStrings =
+      res.approvedStrings + res.pretranslatedStrings + res.stringsWithWarnings;
     const percent = Math.floor((completeStrings / res.totalStrings) * 100);
     return percent;
   };

--- a/translate/src/core/resource/components/ResourcePercent.test.js
+++ b/translate/src/core/resource/components/ResourcePercent.test.js
@@ -6,7 +6,8 @@ import { ResourcePercent } from './ResourcePercent';
 describe('<ResourcePercent>', () => {
   const RESOURCE = {
     approvedStrings: 2,
-    stringsWithWarnings: 3,
+    pretranslatedStrings: 1,
+    stringsWithWarnings: 2,
     totalStrings: 10,
   };
 

--- a/translate/src/core/resource/components/ResourcePercent.tsx
+++ b/translate/src/core/resource/components/ResourcePercent.tsx
@@ -12,10 +12,18 @@ type Props = {
  * Render a resource item percentage.
  */
 export function ResourcePercent({
-  resource: { approvedStrings, stringsWithWarnings, totalStrings },
+  resource: {
+    approvedStrings,
+    pretranslatedStrings,
+    stringsWithWarnings,
+    totalStrings,
+  },
 }: Props): React.ReactElement<'span'> {
   const percent =
-    Math.floor(((approvedStrings + stringsWithWarnings) / totalStrings) * 100) +
-    '%';
+    Math.floor(
+      ((approvedStrings + pretranslatedStrings + stringsWithWarnings) /
+        totalStrings) *
+        100,
+    ) + '%';
   return <span className='percent'>{percent}</span>;
 }

--- a/translate/src/core/resource/reducer.test.js
+++ b/translate/src/core/resource/reducer.test.js
@@ -25,6 +25,7 @@ describe('reducer', () => {
       allResources: {
         path: 'all-resources',
         approvedStrings: 0,
+        pretranslatedStrings: 0,
         stringsWithWarnings: 0,
         totalStrings: 0,
       },

--- a/translate/src/core/resource/reducer.ts
+++ b/translate/src/core/resource/reducer.ts
@@ -55,6 +55,7 @@ const initial: ResourcesState = {
   allResources: {
     path: 'all-resources',
     approvedStrings: 0,
+    pretranslatedStrings: 0,
     stringsWithWarnings: 0,
     totalStrings: 0,
   },

--- a/translate/src/modules/batchactions/actions.ts
+++ b/translate/src/modules/batchactions/actions.ts
@@ -94,6 +94,7 @@ const updateUI =
           updateResource(
             location.resource,
             entitiesData.stats.approved,
+            entitiesData.stats.pretranslated,
             entitiesData.stats.warnings,
           ),
         );

--- a/translate/src/modules/resourceprogress/components/ResourceProgress.tsx
+++ b/translate/src/modules/resourceprogress/components/ResourceProgress.tsx
@@ -120,7 +120,7 @@ export function ResourceProgress(): React.ReactElement<'div'> | null {
     return null;
   }
 
-  const complete = stats.approved + stats.warnings;
+  const complete = stats.approved + stats.pretranslated + stats.warnings;
   const percent = Math.floor((complete / stats.total) * 100);
 
   return (


### PR DESCRIPTION
As of this patch, completion percentage calculations used in dashboards, charts and menus treat pretranslated strings as completed, since they end up being used in product.