### PR TITLE
Add script to generate source-only repos for Thunderbird and Seamonkey

### DIFF
--- a/bin/make_comm_source_repos.py
+++ b/bin/make_comm_source_repos.py
@@ -8,122 +8,137 @@ import datetime
 import os
 import shutil
 import subprocess
+import sys
 
 TARGET_REPOS = {
-    'thunderbird': [
-        'calendar',
-        'chat',
-        'mail',
+    "thunderbird": [
+        "calendar",
+        "chat",
+        "mail",
     ],
-    'seamonkey': [
-        'suite',
+    "seamonkey": [
+        "suite",
     ],
 }
 
 
-def write(text):
-    timestamp = datetime.datetime.now().strftime('[%Y-%m-%d %H:%M:%S] ')
-    print(timestamp + text)
+def logmsg(text):
+    timestamp = datetime.datetime.now().strftime("[%Y-%m-%d %H:%M:%S]")
+    print(f"{timestamp} {text}")
 
 
 def execute(command, cwd=None):
     try:
         st = subprocess.PIPE
-        proc = subprocess.Popen(
-            args=command, stdout=st, stderr=st, stdin=st, cwd=cwd)
+        proc = subprocess.Popen(args=command, stdout=st, stderr=st, stdin=st, cwd=cwd)
 
         (output, error) = proc.communicate()
-        code = proc.returncode
-        return code, output, error
+        return_code = proc.returncode
+        return return_code, output.decode("utf-8"), str(error)
 
     except OSError as error:
-        return -1, '', error
+        return -1, "", error
 
 
-def pull(url, target):
-    # Undo local changes
-    execute(['hg', 'revert', '--all', '--no-backup'], target)
-
-    # Pull
-    code, output, error = execute(['hg', 'pull'], target)
-    code, output, error = execute(['hg', 'update', '-c'], target)
-    if code == 0:
-        write('Repository at ' + url + ' updated.')
-
-    # Clone
+def clone(url, folder):
+    return_code, output, error = execute(["hg", "clone", url, folder])
+    if return_code == 0:
+        logmsg(f"Repository {url} cloned in {folder}.")
     else:
-        write(str(error))
-        write('Clone instead.')
+        logmsg(f"Error: {error}")
 
-        # Clean up target directory on a failed pull, so that it's empty for a clone
-        command = ["rm", "-rf", target]
-        code, output, error = execute(command)
+    return return_code
 
-        code, output, error = execute(['hg', 'clone', url, target])
-        if code == 0:
-            write('Repository at ' + url + ' cloned.')
+
+def pull(url, folder):
+    if os.path.isdir(folder):
+        # Undo local changes and purge extra files
+        execute(["hg", "update", "-C"], folder)
+        execute(["hg", "purge", "--config", "extensions.purge="], folder)
+
+        # Try to pull, or clone if that fails
+        return_code, output, error = execute(["hg", "pull", "-u"], folder)
+        if return_code == 0:
+            logmsg(f"Updating local clone of {url}")
         else:
-            write(str(error))
+            logmsg(f"Error: {error}")
+            logmsg("Pull failed, clone instead.")
 
-    return code
+            # Remove target directory on a failed pull
+            shutil.rmtree(folder)
+            return_code = clone(url, folder)
+    else:
+        logmsg(f"Folder does not exist. Cloning {url}")
+        return_code = clone(url, folder)
+
+    # In case of a non-zero error return code, we need to quit early
+    # (see bug 1475603).
+    if return_code != 0:
+        sys.exit(return_code)
+    else:
+        return return_code
 
 
-def push(path):
-    # Add new and remove missing
-    execute(['hg', 'addremove'], path)
+def commit(folder):
+    logmsg("Check repository status")
+    return_code, output, error = execute(["hg", "status"], folder)
 
-    # Commit
-    code, output, error = execute(['hg', 'commit', '-m', 'Update'], path)
-    if code != 0 and len(error):
-        write(str(error))
+    if output != "":
+        # Add new and remove missing
+        execute(["hg", "addremove"], folder)
 
-    # Push
-    code, output, error = execute(['hg', 'push'], path)
-    if code == 0:
-        write('Repository at ' + path + ' pushed.')
+        # Commit
+        return_code, output, error = execute(["hg", "commit", "-m", "Update"], folder)
+        if return_code != 0 and len(error):
+            logmsg(f"Error: {error}")
+        else:
+            logmsg(f"Committed changes in {folder}")
+
+        return return_code
+    else:
+        logmsg(f"SKIP: Nothing to commit in {folder}")
+        return 1
+
+
+def push(folder):
+    return_code, output, error = execute(["hg", "push"], folder)
+    if return_code == 0:
+        logmsg(f"Pushed repository in {folder}")
     elif len(error):
-        write(str(error))
+        logmsg(f"Error: {error}")
 
 
-def quit_or_pass(code):
-    # In case of a non-zero error code, quit early (bug 1475603)
-    if code != 0:
-        quit(code)
-
-
-# Change working directory to where script is located
-abspath = os.path.abspath(__file__)
-dname = os.path.dirname(abspath)
-os.chdir(dname)
+script_folder = os.path.dirname(os.path.abspath(__file__))
 
 # Clone or update source repository
-url = 'https://hg.mozilla.org/projects/comm-l10n/'
-target = 'source'
-code = pull(url, target)
+source_folder = os.path.join(script_folder, "source")
+pull("https://hg.mozilla.org/projects/comm-l10n/", source_folder)
 
-quit_or_pass(code)
-
-for repo in TARGET_REPOS.keys():
-    url = 'ssh://hg.mozilla.org/users/m_owca.info/' + repo
-    target = os.path.join('target', repo)
-
+for repo, folders in TARGET_REPOS.items():
     # Clone or update target repository
-    code = pull(url, target)
+    target_folder = os.path.join(script_folder, "target", repo)
+    pull(f"ssh://hg.mozilla.org/users/m_owca.info/{repo}", target_folder)
 
-    quit_or_pass(code)
+    # Prune all subdirectories in target folder, so that we can remove
+    # subfolders that were eventually removed.
+    logmsg(f"Clean target folder {target_folder}")
+    for f in os.listdir(target_folder):
+        if os.path.isdir(os.path.join(target_folder, f)) and not f.startswith("."):
+            shutil.rmtree(os.path.join(target_folder, f))
 
-    # Prune all subdirectories in target repository in case they get removed from source
-    for subdir in os.listdir(target):
-        if not subdir.startswith('.'):
-            shutil.rmtree(os.path.join(target, subdir))
+    # Copy relevant folders from source to target.
+    # Source folders for this product are within the en-US subfolder.
+    logmsg(f"Copy folders to {target_folder}")
+    for keep_folder in folders:
+        origin = os.path.join(source_folder, "en-US", keep_folder)
+        destination = os.path.join(target_folder, keep_folder)
 
-    # Copy folders from source to target
-    for folder in TARGET_REPOS[repo]:
-        origin = os.path.join('source', 'en-US', folder)
-        destination = os.path.join('target', repo, folder)
-
-        if os.path.exists(origin):
+        if os.path.isdir(origin):
             shutil.copytree(origin, destination)
+        else:
+            logmsg(f"Folder {keep_folder} does not exist for repo {repo}")
 
     # Commit and push target repositories
-    push(target)
+    return_code = commit(target_folder)
+    if return_code == 0:
+        push(target_folder)

--- a/bin/make_comm_source_repos.py
+++ b/bin/make_comm_source_repos.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+"""
+This script uses https://hg.mozilla.org/projects/comm-l10n/ repository to
+create repositories with source strings only for Thunderbird and Seamonkey.
+"""
+
+import datetime
+import os
+import shutil
+import subprocess
+
+TARGET_REPOS = {
+    'thunderbird': [
+        'calendar',
+        'chat',
+        'mail',
+    ],
+    'seamonkey': [
+        'suite',
+    ],
+}
+
+
+def write(text):
+    timestamp = datetime.datetime.now().strftime('[%Y-%m-%d %H:%M:%S] ')
+    print(timestamp + text)
+
+
+def execute(command, cwd=None):
+    try:
+        st = subprocess.PIPE
+        proc = subprocess.Popen(
+            args=command, stdout=st, stderr=st, stdin=st, cwd=cwd)
+
+        (output, error) = proc.communicate()
+        code = proc.returncode
+        return code, output, error
+
+    except OSError as error:
+        return -1, '', error
+
+
+def pull(url, target):
+    # Undo local changes
+    execute(['hg', 'revert', '--all', '--no-backup'], target)
+
+    # Pull
+    code, output, error = execute(['hg', 'pull'], target)
+    code, output, error = execute(['hg', 'update', '-c'], target)
+    if code == 0:
+        write('Repository at ' + url + ' updated.')
+
+    # Clone
+    else:
+        write(str(error))
+        write('Clone instead.')
+
+        # Clean up target directory on a failed pull, so that it's empty for a clone
+        command = ["rm", "-rf", target]
+        code, output, error = execute(command)
+
+        code, output, error = execute(['hg', 'clone', url, target])
+        if code == 0:
+            write('Repository at ' + url + ' cloned.')
+        else:
+            write(str(error))
+
+    return code
+
+
+def push(path):
+    # Add new and remove missing
+    execute(['hg', 'addremove'], path)
+
+    # Commit
+    code, output, error = execute(['hg', 'commit', '-m', 'Update'], path)
+    if code != 0 and len(error):
+        write(str(error))
+
+    # Push
+    code, output, error = execute(['hg', 'push'], path)
+    if code == 0:
+        write('Repository at ' + path + ' pushed.')
+    elif len(error):
+        write(str(error))
+
+
+def quit_or_pass(code):
+    # In case of a non-zero error code, quit early (bug 1475603)
+    if code != 0:
+        quit(code)
+
+
+# Change working directory to where script is located
+abspath = os.path.abspath(__file__)
+dname = os.path.dirname(abspath)
+os.chdir(dname)
+
+# Clone or update source repository
+url = 'https://hg.mozilla.org/projects/comm-l10n/'
+target = 'source'
+code = pull(url, target)
+
+quit_or_pass(code)
+
+for repo in TARGET_REPOS.keys():
+    url = 'ssh://hg.mozilla.org/users/m_owca.info/' + repo
+    target = os.path.join('target', repo)
+
+    # Clone or update target repository
+    code = pull(url, target)
+
+    quit_or_pass(code)
+
+    # Prune all subdirectories in target repository in case they get removed from source
+    for subdir in os.listdir(target):
+        if not subdir.startswith('.'):
+            shutil.rmtree(os.path.join(target, subdir))
+
+    # Copy folders from source to target
+    for folder in TARGET_REPOS[repo]:
+        origin = os.path.join('source', 'en-US', folder)
+        destination = os.path.join('target', repo, folder)
+
+        if os.path.exists(origin):
+            shutil.copytree(origin, destination)
+
+    # Commit and push target repositories
+    push(target)


### PR DESCRIPTION
This script uses https://hg.mozilla.org/projects/comm-l10n/ repository to create repositories with source strings only for Thunderbird and Seamonkey.

It's a standalone script, rather than being included in [`mozilla-en-US.py`](https://github.com/mozilla/pontoon/blob/60e49bf07d16540a18501c934b310b30f46c067b/bin/mozilla-en-US.py), because the latter will be obsolete and removed soon; mobile has been long gone, Firefox can just use https://hg.mozilla.org/l10n/gecko-strings/, and this script will cover Thunderbird (including Lightning) and Seamonkey.

This is the output of the script:
https://hg.mozilla.org/users/m_owca.info/thunderbird
https://hg.mozilla.org/users/m_owca.info/seamonkey/