### PR TITLE
Serialize pretranslated translations to VCS and downloaded files

### DIFF
--- a/pontoon/base/utils.py
+++ b/pontoon/base/utils.py
@@ -18,7 +18,7 @@ from xml.sax.saxutils import escape, quoteattr
 
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
-from django.db.models import Prefetch
+from django.db.models import Prefetch, Q
 from django.db.models.query import QuerySet
 from django.http import HttpResponseBadRequest
 from django.shortcuts import get_object_or_404
@@ -291,8 +291,8 @@ def get_download_content(slug, code, part):
 
         for e in entities_qs:
             entities_dict[e.key] = e.translation_set.filter(
-                approved=True, locale=locale
-            )
+                Q(approved=True) | Q(pretranslated=True)
+            ).filter(locale=locale)
 
         for vcs_translation in resource_file.translations:
             key = vcs_translation.key

--- a/pontoon/sync/changeset.py
+++ b/pontoon/sync/changeset.py
@@ -3,7 +3,7 @@ import logging
 from collections import defaultdict
 from django.contrib.auth.models import User
 from django.db import connection
-from django.db.models import Prefetch
+from django.db.models import Prefetch, Q
 from django.template.defaultfilters import pluralize
 from notifications.signals import notify
 
@@ -167,8 +167,8 @@ class ChangeSet:
             changed_resources.add(resources[db_entity.resource.path])
             vcs_translation = vcs_entity.translations[locale_code]
             db_translations = db_entity.translation_set.filter(
-                approved=True, locale__code=locale_code
-            )
+                Q(approved=True) | Q(pretranslated=True)
+            ).filter(locale__code=locale_code)
             vcs_translation.update_from_db(db_translations)
 
             # Track which translators were involved.


### PR DESCRIPTION
Along with Approved strings, Pretranslated strings need to be serialized into localization files when generated for sync and file download.