### PR TITLE
Add warning for empty Fluent entries

### DIFF
--- a/pontoon/checks/tests/test_pontoon_db.py
+++ b/pontoon/checks/tests/test_pontoon_db.py
@@ -132,6 +132,25 @@ def test_empty_translations(get_entity_mock):
         "pErrors": ["Empty translations are not allowed"]
     }
 
+    assert run_checks(
+        get_entity_mock("ftl", string="key = value"), "", 'key = { "" }'
+    ) == {"pndbWarnings": ["Empty translation"]}
+
+    assert (
+        run_checks(
+            get_entity_mock("ftl", string="key =\n  .attr = value"),
+            "",
+            """key =
+              { $var ->
+                  [a] { "" }
+                 *[b] { "" }
+              }
+              .attr = { "" }
+            """,
+        )
+        == {"pndbWarnings": ["Empty translation"]}
+    )
+
 
 def test_lang_newlines(get_entity_mock):
     """Newlines aren't allowed in lang files"""


### PR DESCRIPTION
**Edit:** Implementation completely changed from the original description; see comments below.

Fixes #2599 ~~using the solution discussed in mozilla/compare-locales#6.~~
CC @flodolo 

~~Adds a Fluent utility function `isEmptyMessage()` and uses it to disable the save action when the simple or rich editor inputs are empty.~~

~~The basic appearance of the button is kept unchanged, but the hover state is affected; the cursor for the disabled state uses a 🚫 indicator and the tooltip notes that saving an empty string is only possible using the advanced editor.~~

~~The label of the button makes more sense to be controlled with CSS `text-transform` rather than being hard-coded, and it doesn't really make sense to duplicate the formatted strings that are provided by FTL.~~