### PR TITLE
Add missing dependency on initial value to UnsavedChanges update

### DIFF
--- a/translate/src/context/Editor.tsx
+++ b/translate/src/context/Editor.tsx
@@ -292,7 +292,7 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
     if (exist) {
       resetFailedChecks();
     }
-  }, [state.value]);
+  }, [state.value, state.initial]);
 
   return (
     <EditorData.Provider value={state}>


### PR DESCRIPTION
Fixes #2638

When only one entry is visible, submitting a new translation keeps the editor view on the same string. In that situation, the initial value of the string changes; this was not properly included in the dependencies of the `useEffect()` that updates the UnsavedChanges state