### PR TITLE
Exclude tutorial from "first contribution" consideration & notifications

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -290,7 +290,11 @@ def can_translate(self, locale, project):
 
 def is_new_contributor(self, locale):
     """Return True if the user hasn't made contributions to the locale yet."""
-    return not self.translation_set.filter(locale=locale).exists()
+    return (
+        not self.translation_set.filter(locale=locale)
+        .exclude(entity__resource__project__slug="tutorial")
+        .exists()
+    )
 
 
 @property

--- a/pontoon/translations/views.py
+++ b/pontoon/translations/views.py
@@ -80,7 +80,7 @@ def create_translation(request):
     # Checks are disabled for the tutorial.
     use_checks = project.slug != "tutorial"
     user = request.user
-    first_contribution = user.is_new_contributor(locale)
+    first_contribution = use_checks and user.is_new_contributor(locale)
 
     failed_checks = None
     if use_checks:


### PR DESCRIPTION
Fixes #2605 

We should not show first-contribution notifications to managers for the tutorial, and exclude them from consideration for later notifications.