### PR TITLE
Floor TM quality value

### DIFF
--- a/translate/src/api/machinery.ts
+++ b/translate/src/api/machinery.ts
@@ -113,7 +113,7 @@ export async function fetchTranslationMemory(
         itemCount: item.count,
         original: item.source,
         translation: item.target,
-        quality: Math.round(item.quality),
+        quality: Math.floor(item.quality),
       }))
     : [];
 }


### PR DESCRIPTION
Fixes #2680.

We currently round Machinery quality percentage on frontend, which in very long strings results in e.g. 99.6 % matches to appear as perfect matches, which are copied into the editor automatically.

This patch replaces `Math.round()` with `Math.floor()`.