### PR TITLE
In the simple view, use an empty string for empty Fluent literals

### DIFF
--- a/translate/src/utils/message/getSimplePreview.test.js
+++ b/translate/src/utils/message/getSimplePreview.test.js
@@ -1,4 +1,6 @@
 import { getSimplePreview } from './getSimplePreview';
+import { parseEntry } from './parser';
+import { serializeEntry } from './serializer';
 
 describe('getSimplePreview', () => {
   it('works for an empty string', () => {
@@ -36,8 +38,9 @@ describe('getSimplePreview', () => {
   });
 
   it('returns an empty string for an empty literal value', () => {
-    const message = 'empty = { "" }';
-    const res = getSimplePreview(message);
+    const entry = parseEntry('empty = { "" }\n')
+    serializeEntry(entry)
+    const res = getSimplePreview(entry);
     expect(res).toEqual('');
   });
 

--- a/translate/src/utils/message/getSimplePreview.test.js
+++ b/translate/src/utils/message/getSimplePreview.test.js
@@ -38,8 +38,8 @@ describe('getSimplePreview', () => {
   });
 
   it('returns an empty string for an empty literal value', () => {
-    const entry = parseEntry('empty = { "" }\n')
-    serializeEntry(entry)
+    const entry = parseEntry('empty = { "" }\n');
+    serializeEntry(entry);
     const res = getSimplePreview(entry);
     expect(res).toEqual('');
   });

--- a/translate/src/utils/message/getSimplePreview.test.js
+++ b/translate/src/utils/message/getSimplePreview.test.js
@@ -35,6 +35,12 @@ describe('getSimplePreview', () => {
     expect(res).toEqual('Avengers');
   });
 
+  it('returns an empty string for an empty literal value', () => {
+    const message = 'empty = { "" }';
+    const res = getSimplePreview(message);
+    expect(res).toEqual('');
+  });
+
   it('returns the attribute when there are no values and an attribute', () => {
     const message = `hawkeye =
             .real-name = Clint Barton

--- a/translate/src/utils/message/getSimplePreview.ts
+++ b/translate/src/utils/message/getSimplePreview.ts
@@ -19,6 +19,7 @@ function serialize({ elements }: Pattern): string {
         } else {
           const expression = serializeExpression(elt.expression);
           // Empty string literals are best represented by their absence.
+          // These may leak in from serializeEntry().
           if (expression !== '""') {
             result += `{ ${expression} }`;
           }

--- a/translate/src/utils/message/getSimplePreview.ts
+++ b/translate/src/utils/message/getSimplePreview.ts
@@ -18,7 +18,10 @@ function serialize({ elements }: Pattern): string {
           result += serialize(dv.value);
         } else {
           const expression = serializeExpression(elt.expression);
-          result += `{ ${expression} }`;
+          // Empty string literals are best represented by their absence.
+          if (expression !== '""') {
+            result += `{ ${expression} }`;
+          }
         }
         break;
     }


### PR DESCRIPTION
Fixes #2685 

We need to use empty literals `{ "" }` on occasion to represent empty messages, but these should not be rendered in the simple view. This change should also allow for automatic 100% TM matches to work for missing terms, as the field value will then be empty by the time we get the TM results.