### PR TITLE
Render attribute names in plural string labels

### DIFF
--- a/translate/src/modules/fluenteditor/components/RichTranslationForm.test.js
+++ b/translate/src/modules/fluenteditor/components/RichTranslationForm.test.js
@@ -162,6 +162,45 @@ describe('<RichTranslationForm>', () => {
     ).toEqual({ plural: 'other', example: 2 });
   });
 
+  it('renders plural string in attributes properly', () => {
+    const [wrapper] = mountForm(ftl`
+      my-entry =
+        .label =
+            { $num ->
+                [one] Hello!
+               *[other] World!
+            }
+      `);
+
+    expect(wrapper.find('textarea')).toHaveLength(2);
+
+    expect(wrapper.find('textarea').at(0).html()).toContain('Hello!');
+
+    expect(wrapper.find('label .attribute-label').at(0).html()).toContain(
+      'label',
+    );
+
+    expect(
+      wrapper
+        .find('#fluenteditor-RichTranslationForm--plural-example')
+        .at(0)
+        .prop('vars'),
+    ).toEqual({ plural: 'one', example: 1 });
+
+    expect(wrapper.find('textarea').at(1).html()).toContain('World!');
+
+    expect(wrapper.find('label .attribute-label').at(1).html()).toContain(
+      'label',
+    );
+
+    expect(
+      wrapper
+        .find('#fluenteditor-RichTranslationForm--plural-example')
+        .at(1)
+        .prop('vars'),
+    ).toEqual({ plural: 'other', example: 2 });
+  });
+
   it('renders access keys properly', () => {
     const [wrapper] = mountForm(ftl`
       title = Title

--- a/translate/src/modules/fluenteditor/components/RichTranslationForm.tsx
+++ b/translate/src/modules/fluenteditor/components/RichTranslationForm.tsx
@@ -19,6 +19,22 @@ import './RichTranslationForm.css';
 
 type MessagePath = Array<string | number>;
 
+function RichLabel({ label, example }: { label: string; example?: number }) {
+  return typeof example === 'number' ? (
+    <Localized
+      id='fluenteditor-RichTranslationForm--plural-example'
+      vars={{ example, plural: label }}
+      elems={{ stress: <span className='stress' /> }}
+    >
+      <span className='example'>
+        {'{ $plural } (e.g. <stress>{ $example }</stress>)'}
+      </span>
+    </Localized>
+  ) : (
+    <span className='label'>{label}</span>
+  );
+}
+
 function RichItem({
   activeInput,
   attributeName,
@@ -68,24 +84,14 @@ function RichItem({
     <tr className={className}>
       <td>
         <label htmlFor={id}>
-          {typeof example === 'number' ? (
-            <Localized
-              id='fluenteditor-RichTranslationForm--plural-example'
-              vars={{ example, plural: label }}
-              elems={{ stress: <span className='stress' /> }}
-            >
-              <span className='example'>
-                {'{ $plural } (e.g. <stress>{ $example }</stress>)'}
-              </span>
-            </Localized>
-          ) : attributeName ? (
+          {attributeName ? (
             <span>
               <span className='attribute-label'>{attributeName}</span>
               <span className='divider'>&middot;</span>
-              <span className='label'>{label}</span>
+              <RichLabel label={label} example={example} />
             </span>
           ) : (
-            <span>{label}</span>
+            <RichLabel label={label} example={example} />
           )}
         </label>
       </td>


### PR DESCRIPTION
Fix #2692.

If Fluent string contains plurals in attributes, prepend rich editor labels with attribute names, same as for other selec expressions in attributes.