### PR TITLE
Avoid throwing errors in editor

### DIFF
--- a/translate/src/context/Editor.tsx
+++ b/translate/src/context/Editor.tsx
@@ -409,9 +409,10 @@ function updateRichValue(
       }
     }
     if (!pattern || path.length > 0) {
-      throw new Error(
-        `Invalid rich editor path ${input.id} for entry ${next.id}`,
+      console.error(
+        new Error(`Invalid rich editor path ${input.id} for entry ${next.id}`),
       );
+      return null;
     }
 
     let start: number;

--- a/translate/src/utils/message/getReconstructedMessage.ts
+++ b/translate/src/utils/message/getReconstructedMessage.ts
@@ -3,16 +3,21 @@ import type { MessageEntry } from '.';
 import { parseEntry } from './parseEntry';
 
 /**
- * Return a reconstructed Fluent message from the original message and some
- * translated content.
+ * Return a reconstructed Fluent message from the `original` message and some
+ * `translation` content.
+ *
+ * @returns `null` if either the original or reconstructed message is not valid
  */
 export function getReconstructedMessage(
   original: string,
   translation: string,
-): MessageEntry {
+): MessageEntry | null {
   const message = parseEntry(original);
   if (!message) {
-    throw new Error(`Error parsing '${original}' in getReconstructedMessage`);
+    console.error(
+      new Error(`Error parsing '${original}' in getReconstructedMessage`),
+    );
+    return null;
   }
   let key = message.id;
 
@@ -33,9 +38,5 @@ export function getReconstructedMessage(
     content += ' { "" }';
   }
 
-  const res = parseEntry(content);
-  if (!res) {
-    throw new Error(`Error parsing '${content}' in getReconstructedMessage`);
-  }
-  return res;
+  return parseEntry(content);
 }


### PR DESCRIPTION
Fixes #2707, a regression from #2684

During editing, input will not always parse as valid Fluent. One of the code paths used from the history view was throwing an error in this situation, when it should have just accepted that the translation was not currently valid.

Another similar point of potential failure is also patched, pre-emptively.