### PR TITLE
Add limit (15) for fields in rich editor

### DIFF
--- a/translate/src/utils/message/getSyntaxType.test.js
+++ b/translate/src/utils/message/getSyntaxType.test.js
@@ -165,4 +165,26 @@ my-entry =
 
     expect(getSyntaxType(message)).toEqual('rich');
   });
+
+  it('returns "complex" for a string with excessive select expressions', () => {
+    const input = `
+my-entry =
+    { NUMBER($totalHours) ->
+        [one] { $totalHours } hour
+       *[other] { $totalHours } hours
+    } is achievable in just over { NUMBER($periodMonths) ->
+        [one] { $periodMonths } month
+       *[other] { $periodMonths } months
+    } if { NUMBER($people) ->
+        [one] { $people } person
+       *[other] { $people } people
+    } record { NUMBER($clipsPerDay) ->
+        [one] { $clipsPerDay } clip
+       *[other] { $clipsPerDay } clips
+    } a day.
+`;
+    const message = parseEntry(input);
+
+    expect(getSyntaxType(message)).toEqual('complex');
+  });
 });


### PR DESCRIPTION
Fixes #2703 by adding a limit (15) to the number of fields that may be shown either in the original source or the rich editor view.