### PR TITLE
Properly serialize FTL messages coming from TM

### DIFF
--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -8,7 +8,7 @@ from allauth.socialaccount import providers
 from allauth.utils import get_request_param
 from bleach.linkifier import Linker
 from django_jinja import library
-from fluent.syntax import FluentParser, FluentSerializer, ast
+from fluent.syntax import FluentParser, ast
 from fluent.syntax.serializer import serialize_expression
 
 from django import template
@@ -22,7 +22,6 @@ from django.utils.http import url_has_allowed_host_and_scheme
 
 register = template.Library()
 parser = FluentParser()
-serializer = FluentSerializer()
 
 
 @library.global_function
@@ -396,7 +395,7 @@ def get_reconstructed_message(original, translation):
     else:
         content += ' { "" }'
 
-    return content
+    return parser.parse_entry(content)
 
 
 @library.filter

--- a/pontoon/base/tests/test_helpers.py
+++ b/pontoon/base/tests/test_helpers.py
@@ -16,10 +16,12 @@ from pontoon.base.templatetags.helpers import (
     get_reconstructed_message,
 )
 
-from fluent.syntax import FluentParser
+from fluent.syntax import FluentParser, FluentSerializer
+
 from pontoon.base.utils import aware_datetime
 
 parser = FluentParser()
+serializer = FluentSerializer()
 
 MULTILINE_SOURCE = """key =
     Simple String
@@ -188,7 +190,7 @@ GET_RECONSTRUCTED_MESSAGE_TESTS = test_cases = OrderedDict(
             {
                 "original": "title = Marvel Cinematic Universe",
                 "translation": "Univers cinématographique Marvel",
-                "expected": "title = Univers cinématographique Marvel",
+                "expected": "title = Univers cinématographique Marvel\n",
             },
         ),
         (
@@ -196,7 +198,7 @@ GET_RECONSTRUCTED_MESSAGE_TESTS = test_cases = OrderedDict(
             {
                 "original": "spoilers =\n    .who-dies = Who dies?",
                 "translation": "Qui meurt ?",
-                "expected": "spoilers =\n    .who-dies = Qui meurt ?",
+                "expected": "spoilers =\n    .who-dies = Qui meurt ?\n",
             },
         ),
         (
@@ -204,7 +206,7 @@ GET_RECONSTRUCTED_MESSAGE_TESTS = test_cases = OrderedDict(
             {
                 "original": "time-travel = They discovered Time Travel",
                 "translation": "Ils ont inventé le\nvoyage temporel",
-                "expected": "time-travel =\n    Ils ont inventé le\n    voyage temporel",
+                "expected": "time-travel =\n    Ils ont inventé le\n    voyage temporel\n",
             },
         ),
         (
@@ -212,7 +214,7 @@ GET_RECONSTRUCTED_MESSAGE_TESTS = test_cases = OrderedDict(
             {
                 "original": "slow-walks =\n    .title = They walk in slow motion",
                 "translation": "Ils se déplacent\nen mouvement lents",
-                "expected": "slow-walks =\n    .title =\n        Ils se déplacent\n        en mouvement lents",
+                "expected": "slow-walks =\n    .title =\n        Ils se déplacent\n        en mouvement lents\n",
             },
         ),
         (
@@ -220,7 +222,7 @@ GET_RECONSTRUCTED_MESSAGE_TESTS = test_cases = OrderedDict(
             {
                 "original": "-my-term = MyTerm",
                 "translation": "Mon Terme",
-                "expected": "-my-term = Mon Terme",
+                "expected": "-my-term = Mon Terme\n",
             },
         ),
         (
@@ -228,7 +230,7 @@ GET_RECONSTRUCTED_MESSAGE_TESTS = test_cases = OrderedDict(
             {
                 "original": "stark = Tony Stark\n    .hero = IronMan\n    .hair = black",
                 "translation": "Anthony Stark",
-                "expected": "stark = Anthony Stark",
+                "expected": "stark = Anthony Stark\n",
             },
         ),
         (
@@ -236,7 +238,7 @@ GET_RECONSTRUCTED_MESSAGE_TESTS = test_cases = OrderedDict(
             {
                 "original": "with-term = I am { -term }",
                 "translation": "Je suis { -term }",
-                "expected": "with-term = Je suis { -term }",
+                "expected": "with-term = Je suis { -term }\n",
             },
         ),
     ]
@@ -334,4 +336,7 @@ def test_get_reconstructed_message(k):
         GET_RECONSTRUCTED_MESSAGE_TESTS[k]["original"],
         GET_RECONSTRUCTED_MESSAGE_TESTS[k]["translation"],
     )
-    assert result == GET_RECONSTRUCTED_MESSAGE_TESTS[k]["expected"]
+    assert (
+        serializer.serialize_entry(result)
+        == GET_RECONSTRUCTED_MESSAGE_TESTS[k]["expected"]
+    )

--- a/pontoon/pretranslation/pretranslate.py
+++ b/pontoon/pretranslation/pretranslate.py
@@ -1,5 +1,7 @@
-from functools import reduce
 import operator
+
+from fluent.syntax import FluentSerializer
+from functools import reduce
 
 from django.db.models import CharField, Value as V
 from django.db.models.functions import Concat
@@ -15,6 +17,9 @@ from pontoon.base.templatetags.helpers import (
     is_single_input_ftl_string,
     get_reconstructed_message,
 )
+
+
+serializer = FluentSerializer()
 
 
 def get_translations(entity, locale):
@@ -54,7 +59,9 @@ def get_translations(entity, locale):
             translation = tm_response[0]["target"]
 
             if entity.string != entity_string:
-                translation = get_reconstructed_message(entity.string, translation)
+                translation = serializer.serialize_entry(
+                    get_reconstructed_message(entity.string, translation)
+                )
 
             strings = [(translation, None, tm_user)]
         else:


### PR DESCRIPTION
Fix #2710.

This patch aligns the return value of `get_reconstructed_message` with frontend - the generated messages is returned as ASP and needs to be serialized with the default serializer settings before being used for pretranslated messages coming from TM.