### PR TITLE
Only machine translate the part that follows Id in fluent string

### DIFF
--- a/pontoon/pretranslation/pretranslate.py
+++ b/pontoon/pretranslation/pretranslate.py
@@ -6,7 +6,7 @@ from functools import reduce
 from django.db.models import CharField, Value as V
 from django.db.models.functions import Concat
 
-from pontoon.base.models import User, TranslatedResource, Resource
+from pontoon.base.models import User, TranslatedResource
 from pontoon.machinery.utils import (
     get_google_translate_data,
     get_translation_memory_data,
@@ -37,9 +37,6 @@ def get_translations(entity, locale):
     """
     tm_user = User.objects.get(email="pontoon-tm@example.com")
     gt_user = User.objects.get(email="pontoon-gt@example.com")
-
-    if entity.resource.format != Resource.Format.FTL:
-        return
 
     strings = []
     plural_forms = range(0, locale.nplurals or 1)
@@ -74,19 +71,19 @@ def get_translations(entity, locale):
 
     # Else fetch from google translate
     elif locale.google_translate_code:
-        entity_string = (
+        key_substituted_string = (
             entity.string.replace(entity.key, UNTRANSLATABLE_KEY, 1)
-            if entity.resource.format == Resource.Format.FTL
+            if entity.resource.format == "ftl"
             else entity.string
         )
 
         gt_response = get_google_translate_data(
-            text=entity_string,
+            text=key_substituted_string,
             locale=locale,
         )
 
         if gt_response["status"]:
-            if entity.string != entity_string:
+            if entity.string != key_substituted_string:
                 gt_response["translation"] = gt_response["translation"].replace(
                     UNTRANSLATABLE_KEY, entity.key
                 )

--- a/pontoon/pretranslation/pretranslate.py
+++ b/pontoon/pretranslation/pretranslate.py
@@ -41,7 +41,7 @@ def get_translations(entity, locale):
     strings = []
     plural_forms = range(0, locale.nplurals or 1)
 
-    entity_string = (
+    tm_input = (
         as_simple_translation(entity.string)
         if is_single_input_ftl_string(entity.string)
         else entity.string
@@ -49,7 +49,7 @@ def get_translations(entity, locale):
 
     # Try to get matches from translation_memory
     tm_response = get_translation_memory_data(
-        text=entity_string,
+        text=tm_input,
         locale=locale,
     )
 
@@ -59,7 +59,7 @@ def get_translations(entity, locale):
         if entity.string_plural == "":
             translation = tm_response[0]["target"]
 
-            if entity.string != entity_string:
+            if entity.string != tm_input:
                 translation = serializer.serialize_entry(
                     get_reconstructed_message(entity.string, translation)
                 )
@@ -71,19 +71,19 @@ def get_translations(entity, locale):
 
     # Else fetch from google translate
     elif locale.google_translate_code:
-        key_substituted_string = (
+        gt_input = (
             entity.string.replace(entity.key, UNTRANSLATABLE_KEY, 1)
             if entity.resource.format == "ftl"
             else entity.string
         )
 
         gt_response = get_google_translate_data(
-            text=key_substituted_string,
+            text=gt_input,
             locale=locale,
         )
 
         if gt_response["status"]:
-            if entity.string != key_substituted_string:
+            if entity.string != gt_input:
                 gt_response["translation"] = gt_response["translation"].replace(
                     UNTRANSLATABLE_KEY, entity.key
                 )


### PR DESCRIPTION
Fixes #2690

I think the same approach can be applied to prevent attribute translation as well. 