### PR TITLE
Fix Pretranslation Locale QuerySet

### DIFF
--- a/pontoon/pretranslation/tasks.py
+++ b/pontoon/pretranslation/tasks.py
@@ -46,12 +46,10 @@ def pretranslate(self, project_pk, locales=None, entities=None):
     else:
         locales = project.locales
 
-    locales = (
-        locales.filter(
-            project_locale__readonly=False, project_locale__pretranslation_enabled=True
-        )
-        .distinct()
-        .prefetch_project_locale(project)
+    locales = locales.filter(
+        project_locale__project=project,
+        project_locale__pretranslation_enabled=True,
+        project_locale__readonly=False,
     )
 
     if not locales:


### PR DESCRIPTION
The QuerySet to select locales to perform pretranslation for a specific project on selects all locales that have pretranslation enabled for at least one project. This patch fixes that to only select locales that have pretranslation enabled for the given project.