### PR TITLE
Never include empty literals in simple editor view

### DIFF
--- a/translate/src/utils/message/getSimplePreview.test.js
+++ b/translate/src/utils/message/getSimplePreview.test.js
@@ -37,8 +37,15 @@ describe('getSimplePreview', () => {
     expect(res).toEqual('Avengers');
   });
 
-  it('returns an empty string for an empty literal value', () => {
+  it('returns an empty string for an empty literal value in a message', () => {
     const entry = parseEntry('empty = { "" }\n');
+    serializeEntry(entry);
+    const res = getSimplePreview(entry);
+    expect(res).toEqual('');
+  });
+
+  it('returns an empty string for an empty literal value in a term', () => {
+    const entry = parseEntry('-empty = { "" }\n');
     serializeEntry(entry);
     const res = getSimplePreview(entry);
     expect(res).toEqual('');

--- a/translate/src/utils/message/getSimplePreview.ts
+++ b/translate/src/utils/message/getSimplePreview.ts
@@ -81,7 +81,9 @@ function previewMessage(message: Message): string {
       res += elt.value;
     } else {
       const expression = serializeExpression(elt.expression);
-      res += `{ ${expression} }`;
+      if (expression !== '""') {
+        res += `{ ${expression} }`;
+      }
     }
   }
   return res;


### PR DESCRIPTION
Fixes #2737