### PR TITLE
Do not crash when serialising & limit selector function names

### DIFF
--- a/translate/public/locale/en-US/translate.ftl
+++ b/translate/public/locale/en-US/translate.ftl
@@ -547,6 +547,7 @@ notification--tt-checks-enabled = Translate Toolkit Checks enabled
 notification--tt-checks-disabled = Translate Toolkit Checks disabled
 notification--make-suggestions-enabled = Make Suggestions enabled
 notification--make-suggestions-disabled = Make Suggestions disabled
+notification--ftl-not-supported-rich-editor = Translation not supported in rich editor
 notification--entity-not-found = Can’t load specified string
 notification--string-link-copied = Link copied to clipboard
 notification--comment-added = Comment added

--- a/translate/src/utils/message/getSyntaxType.test.js
+++ b/translate/src/utils/message/getSyntaxType.test.js
@@ -187,4 +187,16 @@ my-entry =
 
     expect(getSyntaxType(message)).toEqual('complex');
   });
+
+  it('returns "complex" for a string with an unsupported selector', () => {
+    const input = `
+my-entry =
+    { FOO() ->
+        [foo] FOO
+       *[other] BAR
+    }`;
+    const message = parseEntry(input);
+
+    expect(getSyntaxType(message)).toEqual('complex');
+  });
 });

--- a/translate/src/utils/message/getSyntaxType.ts
+++ b/translate/src/utils/message/getSyntaxType.ts
@@ -3,6 +3,13 @@ import type { MessageEntry } from '.';
 
 const MAX_RICH_VARIANTS = 15;
 
+const VALID_FUNCTIONS = [
+  'DATETIME', // built-in DATETIME()
+  'MESSAGE', // message & term references
+  'NUMBER', // built-in NUMBER()
+  'PLATFORM', // mozilla-central custom PLATFORM() selector
+];
+
 /**
  * Return the syntax type of a given MessageEntry.
  *
@@ -70,6 +77,8 @@ function partContainsJunk(part: PatternElement): boolean {
       return true;
     case 'placeholder':
       return partContainsJunk(part.body);
+    case 'expression':
+      return !VALID_FUNCTIONS.includes(part.name);
     default:
       return false;
   }

--- a/translate/src/utils/message/serialize.ts
+++ b/translate/src/utils/message/serialize.ts
@@ -7,7 +7,7 @@ import {
   Transformer,
 } from '@fluent/syntax';
 import { defaultFunctionMap, resourceToFluent } from '@messageformat/fluent';
-import type { Message, Pattern, Variant } from 'messageformat';
+import type { Message, Pattern } from 'messageformat';
 import type { MessageEntry } from '.';
 
 class SerializeTransformer extends Transformer {
@@ -37,20 +37,42 @@ export function serializeEntry(entry: MessageEntry | null): string {
     return '';
   }
   const data = new Map<string, Message>();
+  const fnMap: typeof defaultFunctionMap = {};
   if (entry.value) {
     data.set('', entry.value);
+    addSelectorExpressions(fnMap, entry.value);
   }
   if (entry.attributes) {
     for (const [name, attr] of entry.attributes) {
       data.set(name, attr);
+      addSelectorExpressions(fnMap, attr);
     }
   }
   const resource = new Map([[entry.id, data]]);
-  const fnMap = { ...defaultFunctionMap, PLATFORM: 'PLATFORM' };
-  const fr = resourceToFluent(resource, undefined, fnMap);
+  Object.assign(fnMap, defaultFunctionMap);
+  try {
+    const fr = resourceToFluent(resource, undefined, fnMap);
+    transformer.visit(fr);
+    return serializer.serialize(fr);
+  } catch {
+    return '';
+  }
+}
 
-  transformer.visit(fr);
-  return serializer.serialize(fr);
+function addSelectorExpressions(
+  fnMap: typeof defaultFunctionMap,
+  msg: Message,
+) {
+  if (msg.type === 'select') {
+    for (let sel of msg.selectors) {
+      if (sel.type === 'placeholder') {
+        sel = sel.body;
+      }
+      if (sel.type === 'expression') {
+        fnMap[sel.name] = sel.name;
+      }
+    }
+  }
 }
 
 export function serializePattern(pattern: Pattern) {


### PR DESCRIPTION
Fixes #2742 

This does three things:
1. Force source view when the message contains an unsupported selector function like `PIATTAFORMA()`.
2. When serialising to Fluent, support all selector functions.
3. When serialisation fails, swallow the error rather than crashing.

It'll still be possible to save a message using `PIATTAFORMA()`, but to fix that we really ought to apply the validation in the backend.

I'll need to rebase #2720 on these changes.