### PR TITLE
Show bugs in the Bugs tab

### DIFF
--- a/pontoon/teams/static/js/bugzilla.js
+++ b/pontoon/teams/static/js/bugzilla.js
@@ -92,7 +92,8 @@ var Pontoon = (function (my) {
                   '</thead>',
               }).append(tbody);
 
-              container.append(table.show());
+              container.append(table);
+              table.show();
 
               var count = data.bugs.length;
               countCallback(tab, count);


### PR DESCRIPTION
Possibly a regression form jQuery update: Bugs in the Bugs tab are not visible at the moment. This patch fixes that.