### PR TITLE
Only exclude system users from contributor dashboards and permissions selectors

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -221,6 +221,9 @@ def user_role(self, managers=None, translators=None):
     if self.is_superuser:
         return "Admin"
 
+    if self.pk is None or self.profile.system_user:
+        return "System User"
+
     if managers is not None:
         if self in managers:
             return "Manager for " + ", ".join(managers[self])

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -243,12 +243,16 @@ def user_role(self, managers=None, translators=None):
 
 
 def user_locale_role(self, locale):
+    if self.is_superuser:
+        return "Admin"
+    if self.pk is None or self.profile.system_user:
+        return "System User"
     if self in locale.managers_group.user_set.all():
-        return "manager"
+        return "Manager"
     if self in locale.translators_group.user_set.all():
-        return "translator"
+        return "Translator"
     else:
-        return "contributor"
+        return "Contributor"
 
 
 @property

--- a/pontoon/base/tests/managers/test_user.py
+++ b/pontoon/base/tests/managers/test_user.py
@@ -5,8 +5,6 @@ from django.db.models import Q
 from pontoon.base.utils import aware_datetime
 from pontoon.contributors.utils import users_with_translations_counts
 
-from django.contrib.auth.models import User
-
 from pontoon.test.factories import (
     EntityFactory,
     TranslationFactory,
@@ -325,22 +323,3 @@ def test_mgr_user_query_args_filtering(
     assert top_contribs[0].translations_approved_count == 11
     assert top_contribs[0].translations_rejected_count == 0
     assert top_contribs[0].translations_unapproved_count == 3
-
-
-@pytest.mark.django_db
-def test_mgr_system_user_contributors_excluded(
-    resource_a,
-    locale_a,
-):
-    """
-    Exclude system users contributors
-    """
-    contributor = User.objects.filter(email="pontoon-gt@example.com").first()
-    user_profile = contributor.profile
-    user_profile.system_user = True
-    user_profile.save()
-
-    entity = EntityFactory.create(resource=resource_a)
-    TranslationFactory.create(locale=locale_a, user=contributor, entity=entity)
-
-    assert len(users_with_translations_counts()) == 0

--- a/pontoon/base/tests/models/test_user.py
+++ b/pontoon/base/tests/models/test_user.py
@@ -1,0 +1,58 @@
+import pytest
+
+from collections import defaultdict
+from django.contrib.auth.models import User
+
+
+@pytest.mark.django_db
+def test_user_role(user_a, user_b, user_c, locale_a):
+    # Default role
+    assert user_a.role() == "Contributor"
+
+    # Superuser
+    user_a.is_superuser = True
+    assert user_a.role() == "Admin"
+
+    # Fake user object
+    imported = User(username="Imported")
+    assert imported.role() == "System User"
+
+    # System user
+    user_b.profile.system_user = True
+    assert user_b.role() == "System User"
+
+    # Translator
+    translators = defaultdict(set)
+    translators[user_c].add(locale_a.code)
+    assert user_c.role(translators=translators) == f"Translator for {locale_a.code}"
+
+    # Manager
+    managers = defaultdict(set)
+    managers[user_c].add(locale_a.code)
+    assert user_c.role(managers=managers) == f"Manager for {locale_a.code}"
+
+
+@pytest.mark.django_db
+def test_user_locale_role(user_a, user_b, user_c, locale_a):
+    # Default role
+    assert user_a.locale_role(locale_a) == "Contributor"
+
+    # Superuser
+    user_a.is_superuser = True
+    assert user_a.locale_role(locale_a) == "Admin"
+
+    # Fake user object
+    imported = User(username="Imported")
+    assert imported.locale_role(locale_a) == "System User"
+
+    # System user
+    user_b.profile.system_user = True
+    assert user_b.locale_role(locale_a) == "System User"
+
+    # Translator
+    locale_a.translators_group.user_set.add(user_c)
+    assert user_c.locale_role(locale_a) == "Translator"
+
+    # Manager
+    locale_a.managers_group.user_set.add(user_c)
+    assert user_c.locale_role(locale_a) == "Manager"

--- a/pontoon/contributors/utils.py
+++ b/pontoon/contributors/utils.py
@@ -120,10 +120,7 @@ def users_with_translations_counts(
         contributor.translations_rejected_count = user["rejected"]
         contributor.translations_unapproved_count = user["unreviewed"]
 
-        if contributor.pk is None:
-            contributor.user_role = "System User"
-        else:
-            contributor.user_role = contributor.role(managers, translators)
+        contributor.user_role = contributor.role(managers, translators)
 
         if locale:
             contributor.user_locale_role = contributor.locale_role(locale)

--- a/pontoon/contributors/utils.py
+++ b/pontoon/contributors/utils.py
@@ -104,9 +104,6 @@ def users_with_translations_counts(
     # Assign properties to user objects.
     contributors = User.objects.filter(pk__in=user_stats.keys())
 
-    # Exclude system users.
-    contributors = contributors.filter(profile__system_user=False)
-
     # Exclude deleted users.
     contributors = contributors.filter(is_active=True)
 

--- a/pontoon/contributors/views.py
+++ b/pontoon/contributors/views.py
@@ -415,7 +415,9 @@ class ContributorsMixin:
 
         context["contributors"] = utils.users_with_translations_counts(
             start_date,
-            self.contributors_filter(**kwargs) & Q(user__isnull=False),
+            self.contributors_filter(**kwargs)
+            & Q(user__isnull=False)
+            & Q(user__profile__system_user=False),
             kwargs.get("locale"),
         )
         context["period"] = period

--- a/pontoon/teams/views.py
+++ b/pontoon/teams/views.py
@@ -181,7 +181,11 @@ def ajax_permissions(request, locale):
     contributors_emails = {
         contributor.email
         for contributor in users_with_translations_counts(
-            None, Q(locale=locale) & Q(user__isnull=False), None
+            None,
+            Q(locale=locale)
+            & Q(user__isnull=False)
+            & Q(user__profile__system_user=False),
+            None,
         )
     }
 

--- a/pontoon/teams/views.py
+++ b/pontoon/teams/views.py
@@ -305,13 +305,15 @@ class LocaleContributorsView(ContributorsMixin, DetailView):
         context = super().get_context_data(locale=self.object, **kwargs)
         contributors = context["contributors"]
         context["managers"] = [
-            c for c in contributors if c.user_locale_role == "manager"
+            c for c in contributors if c.user_locale_role == "Manager"
         ]
         context["translators"] = [
-            c for c in contributors if c.user_locale_role == "translator"
+            c for c in contributors if c.user_locale_role == "Translator"
         ]
         context["regular_contributors"] = [
-            c for c in contributors if c.user_locale_role == "contributor"
+            c
+            for c in contributors
+            if c not in context["managers"] and c not in context["translators"]
         ]
         return context
 


### PR DESCRIPTION
This PR returns system users to the Authors filters in translate view.

I've also added a couple of minor tweaks to user role handling.