### PR TITLE
Show contributor, not current user email

### DIFF
--- a/pontoon/contributors/templates/contributors/profile.html
+++ b/pontoon/contributors/templates/contributors/profile.html
@@ -58,7 +58,7 @@
                 {% if is_email_visible or are_external_accounts_visible %}
                 <div class="block">
                     {% if is_email_visible %}
-                    {% set email = user.contact_email %}
+                    {% set email = contributor.contact_email %}
                     <div class="item-with-icon">
                         <span class="icon fa fa-envelope"></span>
                         <a href="mailto:{{ email|nospam }}">{{ email|nospam }}</a>


### PR DESCRIPTION
On profile page, we have a regression, caused by #2770.