### PR TITLE
Default contributors limit

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -3246,7 +3246,7 @@ class TranslationQuerySet(models.QuerySet):
                 "translation_count": user.translations_count,
                 "role": user.user_role,
             }
-            for user in users_with_translations_counts(None, Q(id__in=self), limit=100)
+            for user in users_with_translations_counts(None, Q(id__in=self))
         ]
 
     def counts_per_minute(self):

--- a/pontoon/base/tests/managers/test_user.py
+++ b/pontoon/base/tests/managers/test_user.py
@@ -69,7 +69,7 @@ def test_mgr_user_contributors_limit(
             user=contrib,
             entity=entities[i],
         )
-    top_contributors = users_with_translations_counts()
+    top_contributors = users_with_translations_counts(limit=100)
     assert len(top_contributors) == 100
 
 

--- a/pontoon/contributors/utils.py
+++ b/pontoon/contributors/utils.py
@@ -31,7 +31,7 @@ from pontoon.base.utils import convert_to_unix_time
 
 
 def users_with_translations_counts(
-    start_date=None, query_filters=None, locale=None, limit=100
+    start_date=None, query_filters=None, locale=None, limit=None
 ):
     """
     Returns contributors list, sorted by count of their translations. Every user instance has

--- a/pontoon/contributors/views.py
+++ b/pontoon/contributors/views.py
@@ -423,6 +423,7 @@ class ContributorsMixin:
             & Q(user__isnull=False)
             & Q(user__profile__system_user=False),
             kwargs.get("locale"),
+            100,
         )
         context["period"] = period
         return context


### PR DESCRIPTION
The default output of `users_with_translations_counts()` is limited to 100 entries. That's because historically we've used this method on contributor dashboards only and didn't want to make the page (load) to big (slow).

Now that we use it in other places, including in pontoon-scripts, it doesn't make sense for the limit to be on by default.