### PR TITLE
Keep editor context fields value updated on relevant changes

### DIFF
--- a/translate/src/context/Editor.test.js
+++ b/translate/src/context/Editor.test.js
@@ -178,13 +178,13 @@ describe('<EditorProvider>', () => {
               [one] ONE
              *[other] OTHER
           }
-
       `;
     const wrapper = mountSpy(Spy, 'ftl', source);
     act(() => actions.clearEditor());
     wrapper.update();
 
     expect(editor).toMatchObject({
+      fields: [{ current: null }, { current: null }],
       sourceView: false,
       value: [
         {
@@ -198,6 +198,100 @@ describe('<EditorProvider>', () => {
           labels: [{ label: 'other', plural: true }],
           name: '',
           value: '',
+        },
+      ],
+    });
+  });
+
+  it('sets editor from history', () => {
+    let editor;
+    let actions;
+    const Spy = () => {
+      editor = useContext(EditorData);
+      actions = useContext(EditorActions);
+      return null;
+    };
+    const wrapper = mountSpy(Spy, 'ftl', `key = VALUE\n`);
+
+    expect(editor).toMatchObject({
+      fields: [{ current: null }],
+      sourceView: false,
+      value: [{ keys: [], labels: [], name: '', value: 'VALUE' }],
+    });
+
+    const source = ftl`
+      key =
+          { $var ->
+              [one] ONE
+             *[other] OTHER
+          }
+      `;
+    act(() => actions.setEditorFromHistory(source));
+    wrapper.update();
+
+    expect(editor).toMatchObject({
+      fields: [{ current: null }, { current: null }],
+      sourceView: false,
+      value: [
+        {
+          keys: [{ type: 'nmtoken', value: 'one' }],
+          labels: [{ label: 'one', plural: true }],
+          name: '',
+          value: 'ONE',
+        },
+        {
+          keys: [{ type: '*', value: 'other' }],
+          labels: [{ label: 'other', plural: true }],
+          name: '',
+          value: 'OTHER',
+        },
+      ],
+    });
+  });
+
+  it('toggles Fluent source view', () => {
+    let editor;
+    let actions;
+    const Spy = () => {
+      editor = useContext(EditorData);
+      actions = useContext(EditorActions);
+      return null;
+    };
+    const source = ftl`
+      key =
+          { $var ->
+              [one] ONE
+             *[other] OTHER
+          }
+      `;
+    const wrapper = mountSpy(Spy, 'ftl', source);
+    act(() => actions.toggleSourceView());
+    wrapper.update();
+
+    expect(editor).toMatchObject({
+      fields: [{ current: null }],
+      sourceView: true,
+      value: [{ keys: [], labels: [], name: '', value: source }],
+    });
+
+    act(() => actions.toggleSourceView());
+    wrapper.update();
+
+    expect(editor).toMatchObject({
+      fields: [{ current: null }, { current: null }],
+      sourceView: false,
+      value: [
+        {
+          keys: [{ type: 'nmtoken', value: 'one' }],
+          labels: [{ label: 'one', plural: true }],
+          name: '',
+          value: 'ONE',
+        },
+        {
+          keys: [{ type: '*', value: 'other' }],
+          labels: [{ label: 'other', plural: true }],
+          name: '',
+          value: 'OTHER',
         },
       ],
     });

--- a/translate/src/context/Editor.tsx
+++ b/translate/src/context/Editor.tsx
@@ -232,6 +232,7 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
               next.value = editSource(str);
               next.sourceView = true;
             }
+            next.fields = next.value.map(() => ({ current: null }));
           } else {
             next.value = setEditorMessage(prev.initial, null, str);
           }
@@ -281,13 +282,20 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
             const entry = parseEntryFromFluentSource(prev.entry, source);
             if (entry && !requiresSourceView(entry)) {
               const value = editMessageEntry(entry);
-              return { ...prev, entry, sourceView: false, value };
+              return {
+                ...prev,
+                entry,
+                fields: value.map(() => ({ current: null })),
+                sourceView: false,
+                value,
+              };
             }
           } else if (entity.format === 'ftl') {
             const entry = buildMessageEntry(prev.entry, prev.value);
             const source = serializeEntry('ftl', entry);
             return {
               ...prev,
+              fields: [{ current: null }],
               sourceView: true,
               value: editSource(source),
             };

--- a/translate/src/modules/translationform/components/TranslationForm.tsx
+++ b/translate/src/modules/translationform/components/TranslationForm.tsx
@@ -104,7 +104,7 @@ export function TranslationForm(): React.ReactElement<'div'> {
           return;
         }
       }
-      focusField.current = 0;
+      focusField.current = -1;
     },
     [focusField, fields],
   );


### PR DESCRIPTION
Fixes the field entry bug part of #2780.

When the shape of a message changes, the Editor context's `fields` array was not being updated like it should be. This manifested in the reported issue as copying the source changed the count 1 -> 2, and editing the second variant broke things.