### PR TITLE
Add special-case plural handling for some locales

### DIFF
--- a/translate/src/utils/message/getEmptyMessage.test.js
+++ b/translate/src/utils/message/getEmptyMessage.test.js
@@ -134,4 +134,38 @@ describe('getEmptyMessage', () => {
 
       `);
   });
+
+  it('handles plural messages for locales with no plurals', () => {
+    const source = parseEntry(ftl`
+      selector-multi =
+        { $num ->
+            [one] ONE
+           *[other] OTHER
+        }
+      `);
+    const entry = getEmptyMessageEntry(source, { code: 'zh' });
+    expect(serializeEntry('ftl', entry)).toBe(ftl`
+      selector-multi = { "" }
+
+      `);
+  });
+
+  it('handles plural messages for special locales', () => {
+    const source = parseEntry(ftl`
+      selector-multi =
+        { $num ->
+            [one] ONE
+           *[other] OTHER
+        }
+      `);
+    const entry = getEmptyMessageEntry(source, { code: 'tg' });
+    expect(serializeEntry('ftl', entry)).toBe(ftl`
+      selector-multi =
+          { $num ->
+              [one] { "" }
+             *[other] { "" }
+          }
+
+      `);
+  });
 });

--- a/translate/src/utils/message/getEmptyMessage.ts
+++ b/translate/src/utils/message/getEmptyMessage.ts
@@ -8,10 +8,10 @@ import type {
 } from 'messageformat';
 
 import type { Locale } from '~/context/Locale';
-import { CLDR_PLURALS } from '../constants';
 import { pojoCopy } from '../pojo';
 import type { MessageEntry } from '.';
 import { findPluralSelectors } from './findPluralSelectors';
+import { getPluralCategories } from './getPluralCategories';
 
 /**
  * Return a copy of a given MessageEntry with all its patterns empty.
@@ -66,12 +66,6 @@ function getEmptyMessage(
     let keys: Variant['keys'] = [];
     let catchall: CatchallKey | null = null;
     if (plurals.includes(i)) {
-      const pr = new Intl.PluralRules(code);
-      const pc = pr.resolvedOptions().pluralCategories;
-      pc.sort((a, b) =>
-        CLDR_PLURALS.indexOf(a) < CLDR_PLURALS.indexOf(b) ? -1 : 1,
-      );
-
       const exactKeys = new Set<string>();
       for (const v of source.variants) {
         const k = v.keys[i];
@@ -82,6 +76,7 @@ function getEmptyMessage(
         }
       }
 
+      const pc = getPluralCategories(code);
       keys = Array.from(exactKeys)
         .concat(pc.filter((cat) => cat !== 'other'))
         .map((value) => ({ type: 'nmtoken', value }));

--- a/translate/src/utils/message/getPluralCategories.ts
+++ b/translate/src/utils/message/getPluralCategories.ts
@@ -1,0 +1,16 @@
+import { CLDR_PLURALS } from '../constants';
+
+export function getPluralCategories(code: string): Intl.LDMLPluralRule[] {
+  // These special cases should be occasionally pruned on CLDR updates
+  switch (code) {
+    case 'tg': // Tajik
+      return ['one', 'other'];
+  }
+
+  const pr = new Intl.PluralRules(code);
+  const pc = pr.resolvedOptions().pluralCategories;
+  pc.sort((a, b) =>
+    CLDR_PLURALS.indexOf(a) < CLDR_PLURALS.indexOf(b) ? -1 : 1,
+  );
+  return pc;
+}

--- a/translate/src/utils/message/getPluralCategories.ts
+++ b/translate/src/utils/message/getPluralCategories.ts
@@ -3,8 +3,38 @@ import { CLDR_PLURALS } from '../constants';
 export function getPluralCategories(code: string): Intl.LDMLPluralRule[] {
   // These special cases should be occasionally pruned on CLDR updates
   switch (code) {
+    case 'ace': // Acehnese
+    case 'ilo': // Iloko
+    case 'meh': // Mixteco Yucuhiti
+    case 'mix': // Mixtepec Mixtec
+    case 'pai': // Pai pai
+      return ['other'];
     case 'tg': // Tajik
       return ['one', 'other'];
+    case 'ltg': // Latgalian
+      return ['zero', 'one', 'other'];
+    case 'szl': // Silesian
+      return ['one', 'few', 'many'];
+
+    // For the following, deliberately ignore the `many` rule for millions
+    case 'ca': // Catalan
+    case 'ca-valencia': // Catalan (Valencian)
+    case 'es': // Spanish
+    case 'es-AR': // Spanish (Argentina)
+    case 'es-CL': // Spanish (Spain)
+    case 'es-ES': // Spanish (Chile)
+    case 'es-MX': // Spanish (Mexico)
+    case 'fr': // French
+    case 'it': // Italian
+    case 'pt': // Portuguese
+    case 'pt-BR': // Portuguese (Brazil)
+    case 'pt-PT': // Portuguese (Portugal)
+      return ['one', 'other'];
+  }
+
+  const supported = Intl.PluralRules.supportedLocalesOf(code);
+  if (supported.length === 0) {
+    return ['one', 'other'];
   }
 
   const pr = new Intl.PluralRules(code);


### PR DESCRIPTION
Fixes #2780

Adds a wrapper around the `new Intl.PluralRules().resolvedOptions()` call that allows for special handling for individual locales, such as `tg`.