### PR TITLE
Exclude locales chosen for pretranslation from available

### DIFF
--- a/pontoon/administration/templates/admin_project.html
+++ b/pontoon/administration/templates/admin_project.html
@@ -320,7 +320,7 @@
       </div>
     </div>
     <div class="locales-pretranslate clearfix">
-      {{ multiple_team_selector.render(locales_selected, locales_pretranslate) }}
+      {{ multiple_team_selector.render(locales_pretranslate_available, locales_pretranslate) }}
       {{ form.locales_pretranslate }}
       {{ form.locales_pretranslate.errors }}
     </div>

--- a/pontoon/administration/views.py
+++ b/pontoon/administration/views.py
@@ -259,11 +259,16 @@ def manage_project(request, slug=None, template="admin_project.html"):
         pk__in=locales_selected
     )
 
+    locales_pretranslate_available = locales_selected.exclude(
+        pk__in=locales_pretranslate
+    )
+
     # Admins reason in terms of locale codes (see bug 1394194)
     locales_readonly = locales_readonly.order_by("code")
     locales_selected = locales_selected.order_by("code")
     locales_available = locales_available.order_by("code")
     locales_pretranslate = locales_pretranslate.order_by("code")
+    locales_pretranslate_available = locales_pretranslate_available.order_by("code")
 
     data = {
         "slug": slug,
@@ -276,6 +281,7 @@ def manage_project(request, slug=None, template="admin_project.html"):
         "locales_selected": locales_selected,
         "locales_available": locales_available,
         "locales_pretranslate": locales_pretranslate,
+        "locales_pretranslate_available": locales_pretranslate_available,
         "subtitle": subtitle,
         "pk": pk,
         "project": project,


### PR DESCRIPTION
Fix #2787.

After you select locales for pretranslation, they are rightfully moved from Available to the Chosen column. After you reload the page, they appear in both columns.