### PR TITLE
Fix CSS import order in index.tsx to maintain expected rule priority

### DIFF
--- a/translate/src/index.tsx
+++ b/translate/src/index.tsx
@@ -4,12 +4,12 @@ import React from 'react';
 import { render } from 'react-dom';
 import { Provider } from 'react-redux';
 
+import './index.css';
 import { App } from './App';
 import { LocationProvider } from './context/Location';
 import { UnsavedChangesProvider } from './context/UnsavedChanges';
 import { AppLocalizationProvider } from './core/l10n/components/AppLocalizationProvider';
 import { history } from './historyInstance';
-import './index.css';
 import { store } from './store';
 
 // TODO: Once we have support for more locales in Pontoon, we should


### PR DESCRIPTION
Fixes #2764 

It looks like some update in tooling changed the ordering of CSS imports to be depth-first rather than breadth-first.