### PR TITLE
Pretranslate Fluent plural expression with target locale plural forms

### DIFF
--- a/pontoon/base/fluent.py
+++ b/pontoon/base/fluent.py
@@ -189,7 +189,7 @@ def create_locale_plural_variants(node, locale):
         key = variant.key
         if isinstance(key, ast.NumberLiteral):
             numeric.append(variant)
-        elif isinstance(key, ast.Identifier) and key.name in locale.cldr_plurals_list():
+        else:
             source_plurals[key.name] = variant
         if variant.default:
             default = variant

--- a/pontoon/base/fluent.py
+++ b/pontoon/base/fluent.py
@@ -194,7 +194,7 @@ def create_locale_plural_variants(node, locale):
         if variant.default:
             default = variant
 
-    for plural in locale.cldr_plurals_list().split(", "):
+    for plural in locale.cldr_plurals_list():
         if plural in source_plurals.keys():
             variant = source_plurals[plural]
         else:

--- a/pontoon/base/fluent.py
+++ b/pontoon/base/fluent.py
@@ -202,7 +202,7 @@ def create_locale_plural_variants(node, locale):
             variant.key.name = plural
         variants.append(variant)
 
-    if len([v for v in variants if v.default]) == 0:
+    if any(v.default for v in variants):
         variants[-1].default = True
 
     node.variants = variants

--- a/pontoon/base/fluent.py
+++ b/pontoon/base/fluent.py
@@ -158,3 +158,18 @@ def get_simple_preview(content):
         tree = translation_ast.attributes[0]
 
     return serialize_value(tree.value)
+
+
+def is_plural_expression(expression):
+    from pontoon.base.models import Locale
+
+    CLDR_PLURALS = [c for _, c in Locale.CLDR_PLURALS]
+
+    if isinstance(expression, ast.SelectExpression):
+        return all(
+            isinstance(variant.key, ast.NumberLiteral)
+            or variant.key.name in CLDR_PLURALS
+            for variant in expression.variants
+        )
+
+    return False

--- a/pontoon/base/fluent.py
+++ b/pontoon/base/fluent.py
@@ -180,15 +180,14 @@ def create_locale_plural_variants(node, locale):
     if not is_plural_expression(node):
         return
 
-    numeric = []
+    variants = []
     source_plurals = {}
-    locale_plurals = []
     default = None
 
     for variant in node.variants:
         key = variant.key
         if isinstance(key, ast.NumberLiteral):
-            numeric.append(variant)
+            variants.append(variant)
         else:
             source_plurals[key.name] = variant
         if variant.default:
@@ -201,9 +200,7 @@ def create_locale_plural_variants(node, locale):
             variant = copy.deepcopy(default)
             variant.default = False
             variant.key.name = plural
-        locale_plurals.append(variant)
-
-    variants = numeric + locale_plurals
+        variants.append(variant)
 
     if len([v for v in variants if v.default]) == 0:
         variants[-1].default = True

--- a/pontoon/base/fluent.py
+++ b/pontoon/base/fluent.py
@@ -198,11 +198,10 @@ def create_locale_plural_variants(node, locale):
             variant = source_plurals[plural]
         else:
             variant = copy.deepcopy(default)
-            variant.default = False
             variant.key.name = plural
+        variant.default = False
         variants.append(variant)
 
-    if any(v.default for v in variants):
-        variants[-1].default = True
+    variants[-1].default = True
 
     node.variants = variants

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -907,7 +907,7 @@ class Locale(AggregatedStats):
             "pk": self.pk,
             "nplurals": self.nplurals,
             "plural_rule": self.plural_rule,
-            "cldr_plurals": self.cldr_plurals_list(),
+            "cldr_plurals": self.cldr_plurals_list_string(),
             "direction": self.direction,
             "script": self.script,
             "google_translate_code": self.google_translate_code,
@@ -923,7 +923,10 @@ class Locale(AggregatedStats):
             return [int(p) for p in self.cldr_plurals.split(",")]
 
     def cldr_plurals_list(self):
-        return ", ".join(map(Locale.cldr_id_to_plural, self.cldr_id_list()))
+        return map(Locale.cldr_id_to_plural, self.cldr_id_list())
+
+    def cldr_plurals_list_string(self):
+        return ", ".join(self.cldr_plurals_list())
 
     @classmethod
     def cldr_plural_to_id(self, cldr_plural):

--- a/pontoon/base/tests/test_fluent.py
+++ b/pontoon/base/tests/test_fluent.py
@@ -4,7 +4,11 @@ from collections import OrderedDict
 from fluent.syntax import FluentParser
 from textwrap import dedent
 
-from pontoon.base.fluent import FlatTransformer, get_simple_preview
+from pontoon.base.fluent import (
+    FlatTransformer,
+    get_simple_preview,
+    is_plural_expression,
+)
 
 
 parser = FluentParser()
@@ -193,3 +197,107 @@ def test_flat_transformer_value_and_attributes():
 def test_get_simple_preview(k):
     string, expected = SIMPLE_TRANSLATION_TESTS[k]
     assert get_simple_preview(string) == expected
+
+
+def test_is_plural_expression_not_select_expression():
+    # Return False for elements that are not select expressions
+    input = dedent(
+        """
+        my-entry = Hello!
+    """
+    )
+
+    message = parser.parse_entry(input)
+    element = message.value.elements[0]
+
+    assert is_plural_expression(element) is False
+
+
+def test_is_plural_expression_all_cldr_plurals():
+    # Return True if all variant keys are CLDR plurals
+    input = dedent(
+        """
+        my-entry =
+            { $num ->
+                [one] Hello!
+               *[two] World!
+            }`
+    """
+    )
+
+    message = parser.parse_entry(input)
+    element = message.value.elements[0]
+
+    assert is_plural_expression(element.expression) is True
+
+
+def test_is_plural_expression_all_numbers():
+    # Return True if all variant keys are numbers
+    input = dedent(
+        """
+        my-entry =
+            { $num ->
+                [1] Hello!
+               *[2] World!
+            }`
+    """
+    )
+
+    message = parser.parse_entry(input)
+    element = message.value.elements[0]
+
+    assert is_plural_expression(element.expression) is True
+
+
+def test_is_plural_expression_one_cldr_plural_one_number():
+    # Return True if one variant key is a CLDR plural and the other is a number
+    input = dedent(
+        """
+        my-entry =
+            { $num ->
+                [one] Hello!
+               *[1] World!
+            }`
+    """
+    )
+
+    message = parser.parse_entry(input)
+    element = message.value.elements[0]
+
+    assert is_plural_expression(element.expression) is True
+
+
+def test_is_plural_expression_one_cldr_plural_one_something_else():
+    # Return False if one variant key is a CLDR plural and the other is neither a CLDR plural nor a number
+    input = dedent(
+        """
+        my-entry =
+            { $num ->
+                [one] Hello!
+               *[variant] World!
+            }`
+    """
+    )
+
+    message = parser.parse_entry(input)
+    element = message.value.elements[0]
+
+    assert is_plural_expression(element.expression) is False
+
+
+def test_is_plural_expression_neither_cldr_plural_nor_number():
+    # Return False if neither variant key is a CLDR plural nor a number
+    input = dedent(
+        """
+        my-entry =
+            { $num ->
+                [variant] Hello!
+               *[another-variant] World!
+            }`
+    """
+    )
+
+    message = parser.parse_entry(input)
+    element = message.value.elements[0]
+
+    assert is_plural_expression(element.expression) is False

--- a/pontoon/pretranslation/pretranslate.py
+++ b/pontoon/pretranslation/pretranslate.py
@@ -9,7 +9,7 @@ from fluent.syntax import FluentParser, FluentSerializer
 from functools import reduce
 
 from pontoon.base.models import User, TranslatedResource
-from pontoon.base.fluent import FlatTransformer
+from pontoon.base.fluent import FlatTransformer, create_locale_plural_variants
 from pontoon.machinery.utils import (
     get_google_translate_data,
     get_translation_memory_data,
@@ -26,6 +26,10 @@ class PretranslationTransformer(FlatTransformer):
     def __init__(self, locale):
         self.services = []
         self.locale = locale
+
+    def visit_SelectExpression(self, node):
+        create_locale_plural_variants(node, self.locale)
+        return self.generic_visit(node)
 
     def visit_TextElement(self, node):
         pretranslation, service = get_pretranslated_data(node.value, self.locale)

--- a/pontoon/teams/templates/teams/team.html
+++ b/pontoon/teams/templates/teams/team.html
@@ -36,7 +36,7 @@
       {{ HeadingInfo.details_item(
         title='Plural forms',
         class='plural-forms',
-        value=locale.cldr_plurals_list(),
+        value=locale.cldr_plurals_list_string(),
         title_link='http://cldr.unicode.org/index/cldr-spec/plural-rules')
       }}
 


### PR DESCRIPTION
Fix #2734.

For each plural expression, we change plural forms to match those of the target locale.

The code in `fluent.py` is inspired by the ([legacy](https://github.com/mozilla/pontoon/blob/26c5f709ce9ddec66ec214c4ec8db722196ea24c/translate/src/utils/message/getEmptyMessage.ts#L31)) frontend code.