### PR TITLE
Fix empty message generation for be, pl, ru, uk

### DIFF
--- a/translate/src/utils/message/getEmptyMessage.test.js
+++ b/translate/src/utils/message/getEmptyMessage.test.js
@@ -158,12 +158,13 @@ describe('getEmptyMessage', () => {
            *[other] OTHER
         }
       `);
-    const entry = getEmptyMessageEntry(source, { code: 'tg' });
+    const entry = getEmptyMessageEntry(source, { code: 'pl' });
     expect(serializeEntry('ftl', entry)).toBe(ftl`
       selector-multi =
           { $num ->
               [one] { "" }
-             *[other] { "" }
+              [few] { "" }
+             *[many] { "" }
           }
 
       `);

--- a/translate/src/utils/message/getEmptyMessage.ts
+++ b/translate/src/utils/message/getEmptyMessage.ts
@@ -63,7 +63,7 @@ function getEmptyMessage(
       continue;
     }
 
-    let keys: Variant['keys'] = [];
+    const keys: Variant['keys'] = [];
     let catchall: CatchallKey | null = null;
     if (plurals.includes(i)) {
       const exactKeys = new Set<string>();
@@ -75,11 +75,15 @@ function getEmptyMessage(
           exactKeys.add(k.value);
         }
       }
+      for (const key of exactKeys) {
+        keys.push({ type: 'nmtoken', value: key });
+      }
 
       const pc = getPluralCategories(code);
-      keys = Array.from(exactKeys)
-        .concat(pc.filter((cat) => cat !== 'other'))
-        .map((value) => ({ type: 'nmtoken', value }));
+      catchall = { type: '*', value: pc.pop() } as CatchallKey;
+      for (const cat of pc) {
+        keys.push({ type: 'nmtoken', value: cat });
+      }
     } else {
       const keyValues = new Set<string>();
       for (const v of source.variants) {

--- a/translate/src/utils/message/getPluralCategories.ts
+++ b/translate/src/utils/message/getPluralCategories.ts
@@ -13,7 +13,13 @@ export function getPluralCategories(code: string): Intl.LDMLPluralRule[] {
       return ['one', 'other'];
     case 'ltg': // Latgalian
       return ['zero', 'one', 'other'];
+
+    // For the following, deliberately ignore the `other` rule for fractions
+    case 'be': // Belarusian
+    case 'pl': // Polish
+    case 'ru': // Russian
     case 'szl': // Silesian
+    case 'uk': // Ukrainian
       return ['one', 'few', 'many'];
 
     // For the following, deliberately ignore the `many` rule for millions


### PR DESCRIPTION
These locales use `other` only for fractions.