### PR TITLE
copy translation source content to clipboard

### DIFF
--- a/translate/public/locale/en-US/translate.ftl
+++ b/translate/public/locale/en-US/translate.ftl
@@ -235,6 +235,8 @@ editor-UnsavedChanges--proceed = PROCEED
 
 entitydetails-EntityNavigation--link = <glyph></glyph>COPY LINK
     .title = Copy Link to String
+entitydetails-EntityNavigation--copysource = <glyph></glyph>COPY CONTENT
+    .title = Copy Source to Clipboard
 entitydetails-EntityNavigation--next = <glyph></glyph>NEXT
     .title = Go To Next String (Alt + Down)
 entitydetails-EntityNavigation--previous = <glyph></glyph>PREVIOUS
@@ -550,6 +552,7 @@ notification--make-suggestions-disabled = Make Suggestions disabled
 notification--ftl-not-supported-rich-editor = Translation not supported in rich editor
 notification--entity-not-found = Can’t load specified string
 notification--string-link-copied = Link copied to clipboard
+notification--string-content-copied = Source content copied to clipboard
 notification--comment-added = Comment added
 
 

--- a/translate/src/modules/entitydetails/components/EntityNavigation.css
+++ b/translate/src/modules/entitydetails/components/EntityNavigation.css
@@ -17,6 +17,11 @@
   float: left;
 }
 
+.entity-navigation button.copy-source {
+  float: left;
+  margin-left: 10px;
+}
+
 .entity-navigation button.previous {
   margin-right: 30px;
 }

--- a/translate/src/modules/entitydetails/components/EntityNavigation.tsx
+++ b/translate/src/modules/entitydetails/components/EntityNavigation.tsx
@@ -1,18 +1,19 @@
 import { Localized } from '@fluent/react';
 import React, { useCallback, useContext, useEffect } from 'react';
 
+import { EntityView } from '~/context/EntityView';
 import { Location } from '~/context/Location';
 import { ShowNotification } from '~/context/Notification';
 import { UnsavedActions } from '~/context/UnsavedChanges';
 import { useNextEntity, usePreviousEntity } from '~/modules/entities/hooks';
-import { STRING_LINK_COPIED } from '~/modules/notification/messages';
+import { STRING_LINK_COPIED, STRING_SOURCE_CONTENT_COPIED } from '~/modules/notification/messages';
 
 import './EntityNavigation.css';
 
 /**
  * Component showing entity navigation toolbar.
  *
- * Shows copy link and next/previous buttons.
+ * Shows copy link, copy content and next/previous buttons.
  */
 export function EntityNavigation(): React.ReactElement {
   const location = useContext(Location);
@@ -20,6 +21,7 @@ export function EntityNavigation(): React.ReactElement {
   const nextEntity = useNextEntity();
   const previousEntity = usePreviousEntity();
   const { checkUnsavedChanges } = useContext(UnsavedActions);
+  const { pluralForm, entity: selectedEntity } = useContext(EntityView);
 
   const copyLinkToClipboard = useCallback(async () => {
     const { locale, project, resource, entity } = location;
@@ -33,6 +35,20 @@ export function EntityNavigation(): React.ReactElement {
 
     showNotification(STRING_LINK_COPIED);
   }, [location]);
+
+  const copySourceContentToClipboard = useCallback(async () => {
+    if (!selectedEntity) {
+        return;
+    }
+
+    const original_string = (pluralForm === -1 || pluralForm === 0)
+        ? selectedEntity.original
+        : selectedEntity.original_plural;
+
+    await navigator.clipboard.writeText(String(original_string));
+
+    showNotification(STRING_SOURCE_CONTENT_COPIED);
+  }, [pluralForm, selectedEntity]);
 
   const goToEntity = useCallback(
     (entity: number | undefined) => {
@@ -92,6 +108,19 @@ export function EntityNavigation(): React.ReactElement {
         >
           {'<glyph></glyph>COPY LINK'}
         </button>
+      </Localized>
+      <Localized
+          id='entitydetails-EntityNavigation--copysource'
+          attrs={{ title: true }}
+          elems={{ glyph: <i className='fa fa-clipboard fa-lg' /> }}
+      >
+          <button
+              className='copy-source'
+              title='Copy Source to Clipboard'
+              onClick={copySourceContentToClipboard}
+          >
+              {'<glyph></glyph>COPY CONTENT'}
+          </button>
       </Localized>
       <Localized
         id='entitydetails-EntityNavigation--next'

--- a/translate/src/modules/notification/messages.tsx
+++ b/translate/src/modules/notification/messages.tsx
@@ -174,6 +174,15 @@ export const STRING_LINK_COPIED: NotificationMessage = {
   type: 'info',
 };
 
+export const STRING_SOURCE_CONTENT_COPIED: NotificationMessage = {
+  content: (
+    <Localized id='notification--string-content-copied'>
+      Source content copied to clipboard
+    </Localized>
+  ),
+  type: 'info',
+};
+
 export const COMMENT_ADDED: NotificationMessage = {
   content: (
     <Localized id='notification--comment-added'>Comment added</Localized>


### PR DESCRIPTION
PR adds new button "COPY CONTENT" next to "COPY LINK". Button allow to copy translation source to clipboard.