### PR TITLE
Do not mark Pretranslated strings with Errors and Warnings as needing sync

### DIFF
--- a/pontoon/pretranslation/tasks.py
+++ b/pontoon/pretranslation/tasks.py
@@ -171,7 +171,12 @@ def pretranslate(self, project_pk, locales=None, entities=None):
     bulk_run_checks(Translation.objects.for_checks().filter(pk__in=translation_pks))
 
     # Mark translations as changed
-    changed_translations = Translation.objects.filter(pk__in=translation_pks)
+    changed_translations = Translation.objects.filter(
+        pk__in=translation_pks,
+        # Do not sync translations with errors and warnings
+        errors__isnull=True,
+        warnings__isnull=True,
+    )
     changed_translations.bulk_mark_changed()
 
     # Update latest activity and stats for changed instances.

--- a/pontoon/pretranslation/tests/test_tasks.py
+++ b/pontoon/pretranslation/tests/test_tasks.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
-from pontoon.base.models import User, Translation
+from pontoon.base.models import ChangedEntityLocale, Translation, User
 from pontoon.pretranslation.tasks import pretranslate
 from pontoon.test.factories import (
     EntityFactory,
@@ -53,6 +53,8 @@ def test_pretranslate(gt_mock, project_a, locale_a, resource_a, locale_b):
 
     # Total pretranslations = 2(tr_ax) + 2(tr_bx) + 2(tr_ay)
     assert len(translations) == 6
+
+    assert ChangedEntityLocale.objects.all().count() == 6
 
     # pretranslated count == total pretranslations.
     assert project_a.pretranslated_strings == 6

--- a/pontoon/pretranslation/tests/test_tasks.py
+++ b/pontoon/pretranslation/tests/test_tasks.py
@@ -44,12 +44,12 @@ def test_pretranslate(gt_mock, project_a, locale_a, resource_a, locale_b):
         pretranslation_enabled=True,
     )
 
-    tm_user = User.objects.get(email="pontoon-tm@example.com")
-    gt_mock.return_value = [("pretranslation", None, tm_user)]
+    gt_user = User.objects.get(email="pontoon-gt@example.com")
+    gt_mock.return_value = [("pretranslation", None, gt_user)]
 
     pretranslate(project_a.pk)
     project_a.refresh_from_db()
-    translations = Translation.objects.filter(user=tm_user)
+    translations = Translation.objects.filter(user=gt_user)
 
     # Total pretranslations = 2(tr_ax) + 2(tr_bx) + 2(tr_ay)
     assert len(translations) == 6


### PR DESCRIPTION
Fix #2691.

The patch keeps translations with failed checks stored as Errors in Warnings in Pontoon DB and treats them as such in stats and dashboards, but it doesn't send them to VCS. 

That way Errors and Warnings remain easy to spot, exposing potential further improvements to pretranslation logic, but at the same time no longer break products, which is the core issue we're solving in #2691.