### PR TITLE
Update to compare-locales 9.0.1, fluent-syntax 0.19.0, pip-tools 6.13.0

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -31,7 +31,5 @@ jobs:
         run: make pytest
         env:
           run_opts: --user=root # volumes are only writable by root on gh
-      - name: Install codecov
-        run: pip3 install codecov
-      - name: codecov.io
-        run: python3 -m codecov -F backend
+      - uses: codecov/codecov-action@v3
+        with: { flags: backend }

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -40,11 +40,11 @@ jobs:
         with:
           node-version: '14'
       - name: Install globals
-        run: npm install --global codecov npm@8
+        run: npm install --global npm@8
       - name: Install dependencies
         run: npm ci
       - name: Test
         run: npm test --coverage
         working-directory: translate
-      - name: codecov.io
-        run: codecov -F frontend
+      - uses: codecov/codecov-action@v3
+        with: { flags: frontend }

--- a/.github/workflows/tag-admin.yml
+++ b/.github/workflows/tag-admin.yml
@@ -27,13 +27,13 @@ jobs:
         with:
           node-version: '14'
       - name: Install globals
-        run: npm install --global codecov npm@8
+        run: npm install --global npm@8
       - name: Install dependencies
         run: npm ci
       - name: Test
         run: npm test
         working-directory: tag-admin
-      - name: codecov.io
-        run: codecov -F non-frontend-js
+      - uses: codecov/codecov-action@v3
+        with: { flags: non-frontend-js }
       - name: Build
         run: npm run build

--- a/requirements/default.in
+++ b/requirements/default.in
@@ -17,7 +17,7 @@
 APScheduler==3.9.1.post1
 bleach==3.3.0
 celery==5.2.6
-compare-locales==8.2.0
+compare-locales==9.0.1
 dj-database-url==0.3.0
 Django==3.2.15
 django-ace==1.0.5

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -124,9 +124,9 @@ colorama==0.4.6 \
     --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
     # via sacrebleu
-compare-locales==8.2.0 \
-    --hash=sha256:59b2bba3b8b0b07fd637d5b2bb6b357cbb7caf9f0b7b33b9a1b44cb03db7376c \
-    --hash=sha256:a447d9702cc9d5c891a4ce7f52267357f98748f413bf8252636952ce53617915
+compare-locales==9.0.1 \
+    --hash=sha256:2de0f1d382749fffa6a482d462daff0d70bbc99d48520a0bf8459b22dc7fe9da \
+    --hash=sha256:eda953796841cbfab508ee35f7613a38ae7fbeed48bd26bf5cda9063bd638f06
     # via -r requirements/default.in
 cryptography==36.0.0 \
     --hash=sha256:2049f8b87f449fc6190350de443ee0c1dd631f2ce4fa99efad2984de81031681 \
@@ -216,9 +216,9 @@ django-pipeline==2.0.6 \
     --hash=sha256:3ec726e2bf9f61f213f41ee4513f4191a02ab2f5df86c9e3751a9a607c814031 \
     --hash=sha256:443c560000b3202dafa873cf9b9a49018ded4b2090979dec8e8858b8b1f867c0
     # via -r requirements/default.in
-fluent-syntax==0.18.1 \
-    --hash=sha256:0e63679fa4f1b3042565220a5127b4bab842424f07d6a13c12299e3b3835486a \
-    --hash=sha256:3a55f5e605d1b029a65cc8b6492c86ec4608e15447e73db1495de11fd46c104f
+fluent-syntax==0.19.0 \
+    --hash=sha256:920326d7f46864b9758f0044e9968e3112198bc826acee16ddd8f11d359004fd \
+    --hash=sha256:b352b3475fac6c6ed5f06527921f432aac073d764445508ee5218aeccc7cc5c4
     # via compare-locales
 google-api-core[grpc]==2.10.2 \
     --hash=sha256:10c06f7739fe57781f87523375e8e1a3a4674bf6392cd6131a3222182b971320 \
@@ -660,10 +660,6 @@ python3-openid==3.2.0 \
     --hash=sha256:33fbf6928f401e0b790151ed2b5290b02545e8775f982485205a066f874aaeaf \
     --hash=sha256:6626f771e0417486701e0b4daff762e7212e820ca5b29fcc0d05f6f8736dfa6b
     # via django-allauth
-pytoml==0.1.21 \
-    --hash=sha256:57a21e6347049f73bfb62011ff34cd72774c031b9828cb628a752225136dfc33 \
-    --hash=sha256:8eecf7c8d0adcff3b375b09fe403407aa9b645c499e5ab8cac670ac4a35f61e7
-    # via compare-locales
 pytz==2022.1 \
     --hash=sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7 \
     --hash=sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c
@@ -800,6 +796,10 @@ tabulate==0.9.0 \
     --hash=sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c \
     --hash=sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f
     # via sacrebleu
+toml==0.10.2 \
+    --hash=sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b \
+    --hash=sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f
+    # via compare-locales
 tqdm==4.62.3 \
     --hash=sha256:8dd278a422499cd6b727e6ae4061c40b48fce8b76d1ccbf5d34fca9b7f925b0c \
     --hash=sha256:d359de7217506c9851b7869f3708d8ee53ed70a1b8edbba4dbcb47442592920d
@@ -807,6 +807,10 @@ tqdm==4.62.3 \
 translate-toolkit==3.3.2 \
     --hash=sha256:0795bd3c8668213199550ae4ed8938874083139ec1f8c473dcca1524a206b108
     # via -r requirements/default.in
+typing-extensions==4.5.0 \
+    --hash=sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb \
+    --hash=sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4
+    # via fluent-syntax
 tzdata==2022.7 \
     --hash=sha256:2b88858b0e3120792a3c0635c23daf36a7d7eeeca657c323da299d2094402a0d \
     --hash=sha256:fe5f866eddd8b96e9fcba978f8e503c909b19ea7efda11e52e39494bad3a7bfa

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -20,4 +20,4 @@
 django-debug-toolbar==3.2.1
 django-extensions==3.0.9
 django-sslserver==0.19
-pip-tools==6.8.0
+pip-tools==6.13.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -48,9 +48,9 @@ pep517==0.12.0 \
     --hash=sha256:931378d93d11b298cf511dd634cf5ea4cb249a28ef84160b3247ee9afb4e8ab0 \
     --hash=sha256:dd884c326898e2c6e11f9e0b64940606a93eb10ea022a2e067959f3a110cf161
     # via build
-pip-tools==6.8.0 \
-    --hash=sha256:39e8aee465446e02278d80dbebd4325d1dd8633248f43213c73a25f58e7d8a55 \
-    --hash=sha256:3e5cd4acbf383d19bdfdeab04738b6313ebf4ad22ce49bf529c729061eabfab8
+pip-tools==6.13.0 \
+    --hash=sha256:50943f151d87e752abddec8158622c34ad7f292e193836e90e30d87da60b19d9 \
+    --hash=sha256:61d46bd2eb8016ed4a924e196e6e5b0a268cd3babd79e593048720db23522bb1
     # via -r requirements/dev.in
 pyparsing==3.0.6 \
     --hash=sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4 \

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -107,7 +107,7 @@ tomli==1.2.2 \
     --hash=sha256:c6ce0015eb38820eaf32b5db832dbc26deb3dd427bd5f6556cf0acac2c214fee \
     --hash=sha256:f04066f68f5554911363063a30b108d2b5a5b1a010aa8b6132af78489fe3aade
     # via black
-typing-extensions==4.0.0 \
-    --hash=sha256:2cdf80e4e04866a9b3689a51869016d36db0814d84b8d8a568d22781d45d27ed \
-    --hash=sha256:829704698b22e13ec9eaf959122315eabb370b0884400e9818334d8b677023d9
+typing-extensions==4.5.0 \
+    --hash=sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb \
+    --hash=sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4
     # via black

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -141,7 +141,9 @@ text-unidecode==1.3 \
 toml==0.10.2 \
     --hash=sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b \
     --hash=sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f
-    # via pytest
+    # via
+    #   -c requirements/default.txt
+    #   pytest
 urllib3==1.26.7 \
     --hash=sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece \
     --hash=sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844


### PR DESCRIPTION
Tested this locally, seems to work as intended. Did check that no local code appears to depend on `pytoml`, which is here replaced by `toml`.

The `pip-tools` update is necessary for pip 23.1 compatibility.