### PR TITLE
Add project view permission to translator groups

### DIFF
--- a/pontoon/base/admin.py
+++ b/pontoon/base/admin.py
@@ -8,6 +8,7 @@ from django.forms.models import ModelForm
 from django.forms import ChoiceField
 from django.urls import reverse
 from django.utils.html import format_html
+from guardian.admin import GuardedModelAdmin
 
 from pontoon.actionlog.models import ActionLog
 from pontoon.base import models
@@ -221,7 +222,7 @@ class SubpageInline(admin.TabularInline):
     raw_id_fields = ("resources",)
 
 
-class ProjectAdmin(admin.ModelAdmin):
+class ProjectAdmin(GuardedModelAdmin):
     search_fields = ["name", "slug"]
     list_display = (
         "name",
@@ -281,7 +282,7 @@ class ProjectAdmin(admin.ModelAdmin):
     )
 
 
-class ProjectLocaleAdmin(admin.ModelAdmin):
+class ProjectLocaleAdmin(GuardedModelAdmin):
     search_fields = ["project__name", "project__slug", "locale__name", "locale__code"]
     list_display = ("pk", "project", "locale", "readonly", "pretranslation_enabled")
     ordering = ("-pk",)

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -1257,8 +1257,10 @@ class ProjectQuerySet(models.QuerySet):
         """
         if user.is_superuser:
             return self
+        
+        user_projects = get_objects_for_user(user, "base.view_project", accept_global_perms=False).distinct()
 
-        return self.filter(visibility=Project.Visibility.PUBLIC)
+        return (self.filter(visibility=Project.Visibility.PUBLIC).distinct() | user_projects).distinct()
 
     def available(self):
         """


### PR DESCRIPTION
So that private projects can still be accessible by translator groups of the project.