### PR TITLE
Prefetch user profile data to speed up role detection

### DIFF
--- a/pontoon/contributors/utils.py
+++ b/pontoon/contributors/utils.py
@@ -107,6 +107,9 @@ def users_with_translations_counts(
     # Exclude deleted users.
     contributors = contributors.filter(is_active=True)
 
+    # Prefetch user profile.
+    contributors = contributors.prefetch_related("profile")
+
     if None in user_stats.keys():
         contributors = list(contributors)
         contributors.append(


### PR DESCRIPTION
This is not a final fix for #2289. It fixes a more recent performance regression which made an unnecessary DB request for each user listed in the Contributors panel.

I tested on stage with https://mozilla-pontoon-staging.herokuapp.com/fr/permissions/, which remains very slow, but at least loads now. It did not load in 3 out of 3 attempts before deploying the patch.