### PR TITLE
Replace LOCALE_REQUEST_FROM_EMAIL with DEFAULT_FROM_EMAIL

### DIFF
--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -83,7 +83,7 @@ you create:
 
 ``DEFAULT_FROM_EMAIL``
    Optional. Default email address to send emails from. Default value:
-   ``Pontoon <noreply@hostname>``.
+   ``Pontoon <pontoon@hostname>``.
 
 ``DISABLE_COLLECTSTATIC``
    Disables running ``./manage.py collectstatic`` during the build. Should be
@@ -145,9 +145,6 @@ you create:
 ``GOOGLE_AUTOML_PROJECT_ID``
    Optional. Set your `Google Cloud AutoML Translation`_ model ID to use custom machine
    translation engine by Google.
-
-``LOCALE_REQUEST_FROM_EMAIL``
-   Optional. Requests for new project locales are sent from this email.
 
 ``MAINTENANCE_PAGE_URL``
    Optional. URL to the page displayed to your users when the application is placed

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -49,16 +49,11 @@ def _get_site_url_netloc():
 
 def _default_from_email():
     return os.environ.get(
-        "DEFAULT_FROM_EMAIL", f"Pontoon <noreply@{_get_site_url_netloc()}>"
+        "DEFAULT_FROM_EMAIL", f"Pontoon <pontoon@{_get_site_url_netloc()}>"
     )
 
 
 DEFAULT_FROM_EMAIL = lazy(_default_from_email, str)()
-
-# Email from which new locale requests are sent.
-LOCALE_REQUEST_FROM_EMAIL = os.environ.get(
-    "LOCALE_REQUEST_FROM_EMAIL", "pontoon@example.com"
-)
 
 # VCS identity to be used when committing translations.
 VCS_SYNC_NAME = os.environ.get("VCS_SYNC_NAME", "Pontoon")

--- a/pontoon/teams/views.py
+++ b/pontoon/teams/views.py
@@ -279,7 +279,7 @@ def request_item(request, locale=None):
         EmailMessage(
             subject=mail_subject,
             body=mail_body,
-            from_email=settings.LOCALE_REQUEST_FROM_EMAIL,
+            from_email=settings.DEFAULT_FROM_EMAIL,
             to=settings.PROJECT_MANAGERS,
             cc=cc,
             reply_to=[user.contact_email],


### PR DESCRIPTION
We have a `DEFAULT_FROM_EMAIL` variable, but we use a different setting for the FROM email address when requesting locales to be added to projects. There's no need for two different values, really.

Additionally, this patch changes the `noreply` part of the `DEFAULT_FROM_EMAIL` because such addresses canot be verified and because that's [apparently a bad idea in general](https://mailchimp.com/what-to-know-about-using-no-reply-email/).