### PR TITLE
Optimize Thunderbird and Seamonkey sync

### DIFF
--- a/pontoon/sync/core.py
+++ b/pontoon/sync/core.py
@@ -378,9 +378,10 @@ def get_changed_locales(db_project, locales, now):
     """
     repos = db_project.translation_repositories()
 
-    # Requirement: all translation repositories must have API configured.
+    # Requirement: all translation repositories must have API configured
+    # and must be multi-locale repositories.
     for repo in repos:
-        if not repo.api_config:
+        if not repo.api_config and not repo.multi_locale:
             return locales
 
     log.info(f"Fetching latest commit hashes for project {db_project.slug} started.")

--- a/requirements/default.in
+++ b/requirements/default.in
@@ -37,7 +37,7 @@ jsonfield==3.1.0
 jsonschema==2.6.0
 lxml==4.9.1
 markupsafe==2.0.1
-mercurial==5.2.2
+mercurial==6.4.2
 newrelic==6.2.0.156
 parsimonious==0.8.1
 polib==1.0.6

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -500,10 +500,8 @@ markupsafe==2.0.1 \
     # via
     #   -r requirements/default.in
     #   jinja2
-mercurial==5.2.2 \
-    --hash=sha256:2c44ac796d2581414533da4e39f21a07206b362263489307da2c424c47ff92f5 \
-    --hash=sha256:4c5ea34e2eba25b5d1b5712f1c72df0a64ec47ce206c1279419c87a26fca033b \
-    --hash=sha256:ffc5ff47488c7b5dae6ead3d99f08ef469500d6567592a25311838320106c03b
+mercurial==6.4.2 \
+    --hash=sha256:5b9f6a3c35f4e4695c854ef71428cf9461ca1a529f691c06dc6f7b48e7bb3335
     # via -r requirements/default.in
 newrelic==6.2.0.156 \
     --hash=sha256:242a5e901d684f7ffdd621bc58da8fe9a85d5545b4b63e1070589f5ab45c9e1e \


### PR DESCRIPTION
Fix #2809.

Updating hg.mozilla.org repos is relativelly slow due to network latency. It is particularly slow for projects that use per-locale repos (e.g. Firefox), because there's plenty of them.

To mitigate that, we use Mercurial API to quickly collect latest commit hashes, which allows us to detect repos that needs syncing without actually updating them.

However, this optimization is performed on all hg.mozilla.org repositories, including the single-locale one used by Thunderbird and Seamonkey. That causes all locales to be falsely detected as changed. We should refactor the optimization logic, but for now this patch limits it to multi-locale repositories.

This patch also upgrades the `mercurial` package, which should resolve the `pickle` errors and hopefully a few other things (i.e. needing a worker kick occasionally).