### PR TITLE
Speed up permission page by removing the ability to select among all users

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -953,8 +953,6 @@ class Locale(AggregatedStats):
             id  - id of project locale
             slug - slug of the project
             name - name of the project
-            all_users - (id, first_name, email) users that aren't translators of given project
-                locale.
             translators - (id, first_name, email) translators assigned to a project locale.
             contributors - (id, first_name, email) people who contributed for a project in
                 current locale.
@@ -1004,17 +1002,6 @@ class Locale(AggregatedStats):
             "groups__pk",
         )
 
-        projects_all_users = defaultdict(set)
-
-        for project_locale in project_locales:
-            projects_all_users[project_locale["translators_group__pk"]] = list(
-                User.objects.exclude(email="")
-                .exclude(groups__projectlocales__pk=project_locale["id"])
-                .values("id", "first_name", "email")
-                .distinct()
-                .order_by("email")
-            )
-
         for project_locale in project_locales:
             group_pk = project_locale["translators_group__pk"]
             locale_projects.append(
@@ -1022,7 +1009,6 @@ class Locale(AggregatedStats):
                     project_locale["id"],
                     project_locale["project__slug"],
                     project_locale["project__name"],
-                    projects_all_users[group_pk],
                     projects_translators[group_pk],
                     project_locale["has_custom_translators"],
                 )

--- a/pontoon/contributors/templates/contributors/widgets/contributor_selector_list.html
+++ b/pontoon/contributors/templates/contributors/widgets/contributor_selector_list.html
@@ -8,7 +8,7 @@
     </div>
     <ul>
       {% for user in choices %}
-      <li class="clearfix{% if user.email in extra %} contributor{% endif %}" data-id="{{ user.id }}" title="{{ user.first_name }}"><span class="arrow fa"></span>{{ user.email }}</li>
+      <li class="clearfix contributor" data-id="{{ user.id }}" title="{{ user.first_name }}"><span class="arrow fa"></span>{{ user.email }}</li>
       {% endfor %}
     </ul>
   </div>

--- a/pontoon/teams/templates/teams/includes/permissions.html
+++ b/pontoon/teams/templates/teams/includes/permissions.html
@@ -1,13 +1,13 @@
 {% import 'contributors/widgets/contributor_selector_list.html' as ContributorSelectorList %}
 
-{% macro user_selector(all_users, index=None) %}
+{% macro user_selector(index=None) %}
     {{ ContributorSelectorList.list(
         'available',
-        choices=all_users,
-        label='<a class="contributors active" href="#">team contributors</a> &middot; <a class="all" href="#">all users</a>',
+        choices=contributors,
+        label='team contributors',
         description="Click on user's email address to move it to the group pointed to by the arrow.",
         index=index,
-        extra=contributors_emails
+        extra=contributors
     ) }}
 {% endmacro %}
 
@@ -18,7 +18,7 @@
         label='translators',
         description=description,
         index=index,
-        extra=contributors_emails
+        extra=contributors
     ) }}
 {% endmacro %}
 
@@ -28,7 +28,7 @@
         choices=managers,
         label='managers',
         description='Managers can change team permissions and edit other settings like team description.',
-        extra=contributors_emails
+        extra=contributors
     ) }}
 {% endmacro %}
 
@@ -38,14 +38,14 @@
     <div class="permissions-groups general clearfix">
         <h3 class="controls">General <span class="small stress">(default team permissions for all projects)</span></h3>
         <div class="selector-wrapper double-list-selector clearfix">
-            {{ user_selector(all_users) }}
+            {{ user_selector() }}
             {{ translator_selector('Translators can submit and approve translations in all projects, unless overridden below.', translators) }}
             {{ manager_selector() }}
         </div>
     </div>
 
     {{ project_locale_form.management_form }}
-    {% for pk, slug, name, all_users, translators, has_custom_translators in locale_projects %}
+    {% for pk, slug, name, translators, has_custom_translators in locale_projects %}
         <div class="permissions-groups project-locale clearfix{% if not has_custom_translators %} hidden{% endif %}"
              data-slug="{{ slug }}"
              data-index="{{ loop.index0 }}">
@@ -60,7 +60,7 @@
                 <a href="#" class="remove-project button" title="Remove custom project permissions"><span class="fa fa-trash"></span>Remove</a>
             </h3>
             <div class="selector-wrapper double-list-selector clearfix">
-                {{ user_selector(all_users, pk) }}
+                {{ user_selector(pk) }}
                 {{ translator_selector('Add or remove Translators to override default team translators set in the General section.', translators, pk) }}
             </div>
         </div>
@@ -76,7 +76,7 @@
                     <input autocomplete="off" autofocus="" type="search">
                 </div>
                 <ul>
-                    {% for pk, slug, name, all_users, translators, has_custom_translators in locale_projects %}
+                    {% for pk, slug, name, translators, has_custom_translators in locale_projects %}
                         <li data-slug="{{ slug }}" data-id="{{ pk }}" class="{% if has_custom_translators %}hidden{% else %}limited{% endif %}">{{ name }}</li>
                     {% endfor %}
                 </ul>

--- a/pontoon/teams/tests/test_views.py
+++ b/pontoon/teams/tests/test_views.py
@@ -116,7 +116,7 @@ def test_ajax_permissions_project_locale_translators_order(
     translators_list = [
         {"id": u.id, "email": u.email, "first_name": u.first_name} for u in translators
     ]
-    assert locale_projects[0][4] == translators_list
+    assert locale_projects[0][3] == translators_list
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This is the first part of fixing the permissions page performance issue tracked in #2289. It removes the ability to assign permissions to any user (not just locale contributors).

It's rarely used feature, but still required. We're dropping it temporarily only, in order to prevent page load timeouts immediately. In the followup patch, we'll restore the feature by loading all users on request rather than on page load.