### PR TITLE
Move contact person @mention delay to comment submission

### DIFF
--- a/translate/src/modules/comments/components/AddComment.css
+++ b/translate/src/modules/comments/components/AddComment.css
@@ -77,7 +77,11 @@
   padding-left: 10px;
 }
 
-.comments-list .add-comment .submit-button:hover {
+.comments-list .add-comment .submit-button:hover:not(:disabled) {
   color: #272a2f;
   background: #7bc876;
+}
+
+.comments-list .add-comment .submit-button:disabled {
+  cursor: wait;
 }

--- a/translate/src/modules/comments/components/AddComment.tsx
+++ b/translate/src/modules/comments/components/AddComment.tsx
@@ -303,11 +303,11 @@ function serialize(node: Descendant, users: MentionUser[]): string {
   switch (node.type) {
     case 'paragraph':
       return `<p>${children.trim()}</p>`;
-    case 'mention':
-      node.url ??= users.find((user) => user.name === node.character)?.url;
-      return node.url
-        ? `<a href="${escapeHtml(node.url)}">${children}</a>`
-        : children;
+    case 'mention': {
+      const url =
+        node.url ?? users.find((user) => user.name === node.character)?.url;
+      return url ? `<a href="${escapeHtml(url)}">${children}</a>` : children;
+    }
     default:
       return children;
   }


### PR DESCRIPTION
Fixes #2591 

We don't actually need the `/get-users/` data for the rendering of the `@mention`, but we do ultimately need the URL for comment submission. So let's just insert the mention right away, but block submission (with a `cursor: wait` indicator when hovering on the button) until we have the data.

This still doesn't fix the bad API, but it hides its effects further.