### PR TITLE
Use HTML format for Google Translate calls of Fluent messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ venv
 .cache/
 coverage/
 
+# Generated during build
+/pontoon/machinery/static/locale-quotes.json
+
 # Docker
 .server-build
 docker/config/server.env

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,6 +11,9 @@ specs/
 /media/
 /static/
 
+# Generated code
+pontoon/machinery/static/locale-quotes.json
+
 # Jinja templates
 pontoon/base/templates/js/pontoon.js
 translate/public/translate.html

--- a/Makefile
+++ b/Makefile
@@ -62,13 +62,16 @@ build-translate: node_modules
 build-tagadmin: node_modules
 	npm run build -w tag-admin
 
-build-server: server-env translate/dist tag-admin/dist
+build-server: server-env pontoon/machinery/static/locale-quotes.json translate/dist tag-admin/dist
 	"${DC}" build --build-arg USER_ID=$(USER_ID) --build-arg GROUP_ID=$(GROUP_ID) server
 	touch .server-build
 
 server-env:
 	sed -e 's/#SITE_URL#/$(subst /,\/,${SITE_URL})/g' \
 	./docker/config/server.env.template > ./docker/config/server.env
+
+pontoon/machinery/static/locale-quotes.json:
+	node bin/build-locale-quotes.cjs $@
 
 setup: .server-build
 	"${DC}" run server //app/docker/server_setup.sh

--- a/bin/build-locale-quotes.cjs
+++ b/bin/build-locale-quotes.cjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+/* eslint-env node */
+/* eslint-disable no-console */
+
+const { readdirSync, writeFileSync } = require('fs');
+const { dirname, join, resolve } = require('path');
+
+/**
+ * Builds a record of the primary start and end quotes for each available locale,
+ * based on CLDR data.
+ *
+ * If this file is executed directly,
+ * writes the output as JSON to the path provided as an argument, or the console.
+ */
+
+function buildLocaleQuotes() {
+  const pkgPath = require.resolve('cldr-misc-full/package.json');
+  const root = join(dirname(pkgPath), 'main');
+
+  /** @type {Record<string, [string, string]} */
+  const res = {};
+  for (const lc of readdirSync(root)) {
+    try {
+      const data = require(`cldr-misc-full/main/${lc}/delimiters.json`);
+      const { delimiters } = data.main[lc];
+      let q0 = delimiters.quotationStart;
+      let q1 = delimiters.quotationEnd;
+
+      // Add narrow no-break space inside guillemets for French, except in Canada & Switzerland
+      // https://en.wikipedia.org/wiki/Quotation_mark#French
+      if (
+        /^fr(-|$)/.test(lc) &&
+        lc !== 'fr-CA' &&
+        lc !== 'fr-CH' &&
+        q0 === '«' &&
+        q1 === '»'
+      ) {
+        q0 = '«\u202f';
+        q1 = '\u202f»';
+      }
+
+      res[lc] = [q0, q1];
+    } catch (err) {
+      console.error(`Data read error for ${lc}`, err);
+    }
+  }
+
+  return res;
+}
+
+module.exports = buildLocaleQuotes;
+
+if (require.main === module) {
+  const res = buildLocaleQuotes();
+  const str = JSON.stringify(res, null, 2);
+  const target = process.argv[2];
+  if (target && target !== '-') {
+    writeFileSync(resolve(target), str);
+  } else {
+    console.log(str);
+  }
+}

--- a/bin/post_compile
+++ b/bin/post_compile
@@ -14,6 +14,9 @@ npm ci
 echo "Building translate & tag-admin..."
 npm run build:prod
 
+echo "Build locale-quotes data..."
+node bin/build-locale-quotes.cjs pontoon/machinery/static/locale-quotes.json
+
 echo "Collecting static files..."
 ./manage.py migrate --noinput
 ./manage.py collectstatic --noinput

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "@types/styled-components": "^5.1.9",
         "@typescript-eslint/eslint-plugin": "^5.11.0",
         "@typescript-eslint/parser": "^5.11.0",
+        "cldr-misc-full": "^43.0.0",
         "concurrently": "^7.0.0",
         "enzyme": "^3.11.0",
         "enzyme-adapter-react-16": "^1.15.6",
@@ -4774,6 +4775,22 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
       "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
+    },
+    "node_modules/cldr-core": {
+      "version": "43.0.0",
+      "resolved": "https://registry.npmjs.org/cldr-core/-/cldr-core-43.0.0.tgz",
+      "integrity": "sha512-dPsV6/yTve1tvK2tyOEVkcugOX1MjIWWOlT/IYcHN33IesBykFR5pzUBpKnco7wZxwNGe3+d3tOVQcN+7i9/iA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/cldr-misc-full": {
+      "version": "43.0.0",
+      "resolved": "https://registry.npmjs.org/cldr-misc-full/-/cldr-misc-full-43.0.0.tgz",
+      "integrity": "sha512-Q4jdQc6Q8vl6hFS9pdGD3tJf7+KhjA/p6imJDYoW2nkVV5tmLQSqMMlk7ALHOGB1Cm7Gmhin/j4nL4lPFEgVuQ==",
+      "dev": true,
+      "peerDependencies": {
+        "cldr-core": "43.0.0"
+      }
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -15792,6 +15809,20 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
       "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
+    },
+    "cldr-core": {
+      "version": "43.0.0",
+      "resolved": "https://registry.npmjs.org/cldr-core/-/cldr-core-43.0.0.tgz",
+      "integrity": "sha512-dPsV6/yTve1tvK2tyOEVkcugOX1MjIWWOlT/IYcHN33IesBykFR5pzUBpKnco7wZxwNGe3+d3tOVQcN+7i9/iA==",
+      "dev": true,
+      "peer": true
+    },
+    "cldr-misc-full": {
+      "version": "43.0.0",
+      "resolved": "https://registry.npmjs.org/cldr-misc-full/-/cldr-misc-full-43.0.0.tgz",
+      "integrity": "sha512-Q4jdQc6Q8vl6hFS9pdGD3tJf7+KhjA/p6imJDYoW2nkVV5tmLQSqMMlk7ALHOGB1Cm7Gmhin/j4nL4lPFEgVuQ==",
+      "dev": true,
+      "requires": {}
     },
     "cliui": {
       "version": "8.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9615,6 +9615,11 @@
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
     },
+    "node_modules/make-plural": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-7.3.0.tgz",
+      "integrity": "sha512-/K3BC0KIsO+WK2i94LkMPv3wslMrazrQhfi5We9fMbLlLjzoOSJWr7TAdupLlDWaJcWxwoNosBkhFDejiu5VDw=="
+    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -12301,6 +12306,9 @@
     },
     "pontoon": {
       "name": "server",
+      "dependencies": {
+        "make-plural": "^7.3.0"
+      },
       "devDependencies": {
         "terser": "^5.14.2",
         "yuglify": "^2.0.0"
@@ -19397,6 +19405,11 @@
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
     },
+    "make-plural": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-7.3.0.tgz",
+      "integrity": "sha512-/K3BC0KIsO+WK2i94LkMPv3wslMrazrQhfi5We9fMbLlLjzoOSJWr7TAdupLlDWaJcWxwoNosBkhFDejiu5VDw=="
+    },
     "makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -20455,6 +20468,7 @@
     "server": {
       "version": "file:pontoon",
       "requires": {
+        "make-plural": "^7.3.0",
         "terser": "^5.14.2",
         "yuglify": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@types/styled-components": "^5.1.9",
     "@typescript-eslint/eslint-plugin": "^5.11.0",
     "@typescript-eslint/parser": "^5.11.0",
+    "cldr-misc-full": "^43.0.0",
     "concurrently": "^7.0.0",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.6",

--- a/pontoon/machinery/fix_punctuation.py
+++ b/pontoon/machinery/fix_punctuation.py
@@ -1,0 +1,98 @@
+import json
+import logging
+import re
+from os.path import dirname, join
+
+from pontoon.base.models import Locale
+
+log = logging.getLogger(__name__)
+_quotes: dict[str, list[str]] = None
+
+
+def get_quotes(locale: Locale) -> tuple[str, str]:
+    # Cache data
+    global _quotes
+    if _quotes is None:
+        try:
+            file = open(join(dirname(__file__), "static/locale-quotes.json"))
+            _quotes = json.load(file)
+        except Exception:
+            log.error("Error loading locale-quotes.json")
+            _quotes = {}
+
+    # Exact match
+    lc = locale.code
+    if lc in _quotes:
+        return tuple(_quotes[lc])
+
+    # With or without script identifier
+    res = None
+    lc_parts = lc.split("-")
+    if len(lc_parts) == 3:
+        del lc_parts[1:2]
+    else:
+        # Not all scripts are tested, because data does not vary for all.
+        # `Latn` is used as a fallback; it won't match for invalid cases.
+        script = "Latn"
+        if locale.script == "Arabic":
+            script = "Arab"
+        elif locale.script == "Cyrillic":
+            script = "Cyrl"
+        elif locale.script == "Simplified Chinese":
+            script = "Hans"
+        elif locale.script == "Traditional Chinese":
+            script = "Hant"
+        lc_parts[1:1] = [script]
+    lc = "-".join(lc_parts)
+    if lc in _quotes:
+        res = _quotes[lc]
+
+    # Language with script, no region
+    if res is None and len(lc_parts) == 3:
+        del lc_parts[2:]
+        lc = "-".join(lc_parts)
+        if lc in _quotes:
+            res = _quotes[lc]
+
+    # Main language tag only, with fallback to straight quotes
+    if res is None:
+        lc = lc_parts[0]
+        res = _quotes[lc] if lc in _quotes else ['"', '"']
+
+    _quotes[locale.code] = res
+    return tuple(res)
+
+
+def fix_punctuation(text: str, locale: Locale):
+    """
+    In particular when dealing with HTML content,
+    machine translation may add extra spaces around inline `<elements>`.
+    For punctuation, we can fix that in a locale-appropriate manner.
+    While there is a risk that this may introduce some unwanted side effects,
+    in general the output is improved.
+    """
+    # double quotes
+    def fix_quotes(match: re.Match[str]):
+        start, end = get_quotes(locale)
+        return start + match.group(1).strip() + end
+
+    text = re.sub(r"&quot;(.*?)&quot;", fix_quotes, text)
+    text = re.sub(r"[„“](.*?)[“”]", fix_quotes, text)
+    text = re.sub(r"«(.*?)»", fix_quotes, text)
+
+    # single quote
+    text = text.replace("&#39;", "’")
+
+    # brackets
+    text = re.sub(r"(?s)([\(\[]) *(.*?) *([\)\]])", r"\1\2\3", text)
+
+    # spaces before general punctuation
+    lc = locale.code
+    if lc == "fr" or lc == "fr-BE" or lc == "fr-CA" or lc == "fr-CH" or lc == "fr-FR":
+        # https://fr.wikipedia.org/wiki/Ponctuation#En_français
+        text = re.sub(r"(</\w+>) +([,.])", r"\1\2", text)
+        text = re.sub(r" +([:;!?%#-])", "\u202f\\1", text)
+    else:
+        text = re.sub(r"(</\w+>) +([,.:;·!?~՞؟،%#-])", r"\1\2", text)
+
+    return text

--- a/pontoon/machinery/tests/test_punctuation.py
+++ b/pontoon/machinery/tests/test_punctuation.py
@@ -1,0 +1,39 @@
+import pytest
+
+from pontoon.machinery.fix_punctuation import fix_punctuation
+from pontoon.test.factories import LocaleFactory
+
+
+@pytest.mark.django_db
+def test_quotes_html_english():
+    locale = LocaleFactory(code="en-XX")
+    res = fix_punctuation("&quot; foo &quot;", locale)
+    assert res == "“foo”"
+
+
+@pytest.mark.django_db
+def test_quotes_guillemets_french():
+    locale = LocaleFactory(code="fr-XX")
+    res = fix_punctuation("«foo»", locale)
+    assert res == "«\u202ffoo\u202f»"
+
+
+@pytest.mark.django_db
+def test_parentheses():
+    locale = LocaleFactory(code="en-XX")
+    res = fix_punctuation("( foo )", locale)
+    assert res == "(foo)"
+
+
+@pytest.mark.django_db
+def test_question_english():
+    locale = LocaleFactory(code="en-XX")
+    res = fix_punctuation("</foo> ?", locale)
+    assert res == "</foo>?"
+
+
+@pytest.mark.django_db
+def test_question_french():
+    locale = LocaleFactory(code="fr-FR")
+    res = fix_punctuation("foo ?", locale)
+    assert res == "foo\u202f?"

--- a/pontoon/machinery/utils.py
+++ b/pontoon/machinery/utils.py
@@ -15,6 +15,7 @@ from django.contrib.postgres.aggregates import ArrayAgg
 from django.db.models import Q
 
 import pontoon.base as base
+from .fix_punctuation import fix_punctuation
 
 log = logging.getLogger(__name__)
 MAX_RESULTS = 5
@@ -27,7 +28,7 @@ def get_google_translate_data(text, locale, format="text"):
         else get_google_generic_translation(text, locale.google_translate_code, format)
     )
     if format == "html" and "translation" in res:
-        res["translation"] = unescape(res["translation"])
+        res["translation"] = unescape(fix_punctuation(res["translation"], locale))
 
     return res
 

--- a/pontoon/machinery/views.py
+++ b/pontoon/machinery/views.py
@@ -157,6 +157,7 @@ def google_translate(request):
     try:
         text = request.GET["text"]
         locale_code = request.GET["locale"]
+        format = request.GET["format"] if "format" in request.GET else "text"
 
         if not locale_code:
             raise ValueError("Locale code is empty")
@@ -171,7 +172,7 @@ def google_translate(request):
             status=400,
         )
 
-    data = get_google_translate_data(text, locale)
+    data = get_google_translate_data(text, locale, format)
 
     if not data["status"]:
         return JsonResponse(data, status=400)

--- a/pontoon/package.json
+++ b/pontoon/package.json
@@ -4,5 +4,8 @@
   "devDependencies": {
     "terser": "^5.14.2",
     "yuglify": "^2.0.0"
+  },
+  "dependencies": {
+    "make-plural": "^7.3.0"
   }
 }

--- a/pontoon/pretranslation/plural_examples.py
+++ b/pontoon/pretranslation/plural_examples.py
@@ -1,0 +1,75 @@
+import json
+import logging
+import re
+from typing import Literal
+
+from pontoon.base.models import Locale
+
+log = logging.getLogger(__name__)
+
+PluralCategory = Literal["zero", "one", "two", "few", "many", "other"]
+
+# Locale code -> plural type -> category -> examples
+_data: dict[
+    str,
+    dict[
+        Literal["cardinal", "ordinal"],
+        dict[PluralCategory, list[str]],
+    ],
+] = None
+
+
+def get_plural_examples(locale: Locale):
+    """
+    Loads data from the npm package `make-plural`.
+    """
+    # Cache data
+    global _data
+    if _data is None:
+        try:
+            file = open("node_modules/make-plural/examples.json")
+            _data = json.load(file)
+        except Exception:
+            log.error("Error loading plural examples")
+            _data = {}
+
+    # Exact match
+    lc = locale.code
+    if lc in _data:
+        return _data[lc]["cardinal"]
+
+    # Map to appropriate make-plural key
+    if lc.startswith("pt-PT"):
+        lc = "pt_PT"
+    else:
+        lc = re.sub(r"-.*$", "", lc)
+
+    return _data[lc]["cardinal"] if lc in _data else {}
+
+
+def find_plural_example(locale: Locale, cat: PluralCategory):
+    # Shortcuts; these are valid for all known locales
+    if cat == "zero":
+        return "0"
+    elif cat == "one":
+        return "1"
+    elif cat == "two":
+        return "2"
+
+    examples = get_plural_examples(locale)
+    if cat != "few" and cat != "many":
+        cat = "other"
+    if cat in examples:
+        cat_ex = examples[cat]
+        if len(cat_ex) > 1 and cat_ex[0] == "0":
+            return cat_ex[1]
+        if cat_ex:
+            return cat_ex[0]
+
+    # Fallback; these are the most likely matches in CLDR data
+    if cat == "few":
+        return "3"
+    elif cat == "many":
+        return "11"
+    else:
+        return "14"

--- a/pontoon/pretranslation/pretranslate.py
+++ b/pontoon/pretranslation/pretranslate.py
@@ -61,7 +61,7 @@ def get_pretranslations(entity, locale):
         return [(pretranslation, None, author)]
 
     else:
-        pretranslation, service = get_pretranslated_data(source, locale)
+        pretranslation, service = get_pretranslated_data(source, source, locale)
 
         if pretranslation is None:
             return []
@@ -76,21 +76,22 @@ def get_pretranslations(entity, locale):
             ]
 
 
-def get_pretranslated_data(source, locale):
+def get_pretranslated_data(raw, wrapped, locale):
     # Empty strings do not need translation
-    if re.search("^\\s*$", source):
-        return source, "tm"
+    if re.search("^\\s*$", raw):
+        return raw, "tm"
 
     # Try to get matches from Translation Memory
-    tm_response = get_translation_memory_data(text=source, locale=locale)
+    tm_response = get_translation_memory_data(text=raw, locale=locale)
     tm_perfect = [t for t in tm_response if int(t["quality"]) == 100]
     if tm_perfect:
         return tm_perfect[0]["target"], "tm"
 
     # Fetch from Google Translate
     elif locale.google_translate_code:
+        format = "text" if raw == wrapped else "html"
         gt_response = get_google_translate_data(
-            text=source, locale=locale, format="text"
+            text=wrapped, locale=locale, format=format
         )
         if gt_response["status"]:
             return gt_response["translation"], "gt"

--- a/pontoon/pretranslation/tests/test_transformer.py
+++ b/pontoon/pretranslation/tests/test_transformer.py
@@ -213,7 +213,7 @@ def test_plural_variants(locale_a):
     assert called == [
         ("Yo!", "Yo!"),
         ("Hello!", "Hello!"),
-        ("{ $num } World!", '<span id="pt-0" translate="no">$num</span> World!'),
-        ("{ $num } World!", '<span id="pt-1" translate="no">$num</span> World!'),
-        ("{ $num } World!", '<span id="pt-2" translate="no">$num</span> World!'),
+        ("{ $num } World!", '<span id="pt-0" translate="no">2</span> World!'),
+        ("{ $num } World!", '<span id="pt-1" translate="no">3</span> World!'),
+        ("{ $num } World!", '<span id="pt-2" translate="no">14</span> World!'),
     ]

--- a/pontoon/test/factories.py
+++ b/pontoon/test/factories.py
@@ -104,6 +104,7 @@ class SubpageFactory(DjangoModelFactory):
 class LocaleFactory(DjangoModelFactory):
     code = Sequence(lambda n: f"en-{n}")
     name = Sequence(lambda n: f"English #{n}")
+    script = Sequence(lambda n: "Latin")
 
     class Meta:
         model = Locale

--- a/translate/src/api/machinery.ts
+++ b/translate/src/api/machinery.ts
@@ -124,11 +124,13 @@ export async function fetchTranslationMemory(
 export async function fetchGoogleTranslation(
   original: string,
   locale: Locale,
+  format: 'html' | 'text',
 ): Promise<MachineryTranslation[]> {
   const url = '/google-translate/';
   const params = {
     text: original,
     locale: locale.googleTranslateCode,
+    format,
   };
 
   const { translation } = (await GET_(url, params)) as {

--- a/translate/src/utils/message/index.ts
+++ b/translate/src/utils/message/index.ts
@@ -19,6 +19,7 @@ export { getPlainMessage } from './getPlainMessage';
 export { getSimplePreview } from './getSimplePreview';
 export { editMessageEntry } from './editMessageEntry';
 export { findPluralSelectors } from './findPluralSelectors';
+export { notranslateUnwrap, notranslateWrap } from './notranslate';
 export { parseEntry } from './parseEntry';
 export { requiresSourceView } from './requiresSourceView';
 export { serializeEntry } from './serializeEntry';

--- a/translate/src/utils/message/notranslate.ts
+++ b/translate/src/utils/message/notranslate.ts
@@ -1,0 +1,13 @@
+/**
+ * Adds `<span translate="no">` wrappers around `{braced}` content in `str`
+ */
+export function notranslateWrap(str: string): string {
+  return str.replace(/{[^}]*}/g, '<span translate="no">$&</span>');
+}
+
+/**
+ * Removes `<span translate="no">` wrappers from the input `str`
+ */
+export function notranslateUnwrap(str: string): string {
+  return str.replace(/<span translate="no">(.*?)<\/span>/gs, '$1');
+}


### PR DESCRIPTION
Fixes #2181 
Fixes #2804 

Fluent expressions are wrapped in a `<span translate="no">...</span>` for machinery and pretranslation calls to Google Translate. The wrapping done in the front-end is pretty simplistic, but updating that to e.g. handle plurals right is a whole different job. In the back-end, the wrapping is a bit more sophisticated, as the inserted wrappers carry an `id` parameter that's used in message reconstruction. This allows sanitising the contents that are left within the `translate=no`.

There are now three interconnected transformers working on messages for pretranslation:
- `NotranslateWrapper` replaces inline expressions with `<span id="pt-{idx}" translate="no">{clean}</span>` text elements. Within plural selectors, for references to the plural selector variable, `{clean}` is an example number for the current numerical key or plural category. This uses CLDR data, prepackaged by my `make-plural` npm package. Otherwise, `{clean}` is the serialization of the source, stripped of control characters `{}<>`. The actual serialization is stored in a list for later retrieval according to `{idx}`.
- `PreparePretranslation` flattens select expressions and adjusts the plural selectors for the current locale.
- `ApplyPretranslation` is the public interface, internally calling the other two. Ultimately, it calls `callback(raw, wrapped, locale) -> (translation, service)` for each pattern, and replaces the contents as appropriate.

It looks like `translate=no` contents do affect the resulting translation somewhat, at least for plurals. Hence the replacement with appropriate numbers for plural cases.

I have not added any escaping for HTML or custom elements because that doesn't seem necessary. There's clearly a proper parser at the other end, so feeding in an incomplete or broken fragment will result in something technically less broken, but therefore structurally different from the input. Given Fluent's own expectations, this should not cause any issues for valid messages.

Extra spacing does appear to sometimes get added around elements. To deal with that, spaces are fixed for trailing punctuation in a locale-appropriate manner.

I added locale-aware quote fixing. It's based on data from CLDR, via the `cldr-misc-full` npm package, and uses straight `"quotes"` as an ultimate fallback, though it does try to match the right locale. This requires an additional build step to repackage the data in a more useful format.

The PR includes some refactoring, as some Fluent transforms are only used for pretranslation work and really ought to (eventually) get replaced by MF2 equivalents rather than being further promulgated. I also couldn't help myself and added type hints to the added files.

Because we now need to rewrite variable reference after we've flattened the message, the flattener needs to keep them as variable references. While doing that, it made sense to lift leading/trailing whitespace out of selectors, allowing for the xfail test on that to start passing.

_Edit: The preceding PR #2829 is closed, as we're handling the whole stack here. The name and description of this PR have been updated to reflect these changes._