### PR TITLE
Speed up project dashboard

### DIFF
--- a/pontoon/localizations/templates/localizations/localization.html
+++ b/pontoon/localizations/templates/localizations/localization.html
@@ -72,12 +72,12 @@
           icon = 'file',
         )
       }}
-      {% if project.tags_enabled and tags %}
+      {% if project.tags_enabled and tags_count %}
          {{ Menu.item(
            'Tags',
            url('pontoon.localizations.tags', locale.code, project.slug),
            is_active = (current_page == 'tags'),
-           count = tags,
+           count = tags_count,
            icon = 'tag',
          )
       }}

--- a/pontoon/localizations/views.py
+++ b/pontoon/localizations/views.py
@@ -41,8 +41,8 @@ def localization(request, code, slug):
             "project": project,
             "project_locale": project_locale,
             "resource_count": resource_count,
-            "tags": (
-                len(TagsTool(projects=[project], locales=[locale], priority=True))
+            "tags_count": (
+                project.tag_set.filter(resources__isnull=False).distinct().count()
                 if project.tags_enabled
                 else None
             ),

--- a/pontoon/projects/templates/projects/project.html
+++ b/pontoon/projects/templates/projects/project.html
@@ -68,12 +68,12 @@
           icon = 'folder',
         )
       }}
-      {% if project.tags_enabled and tags %}
+      {% if project.tags_enabled and tags_count %}
          {{ Menu.item(
            'Tags',
            url('pontoon.projects.tags', project.slug),
            is_active = (current_page == 'tags'),
-           count = tags,
+           count = tags_count,
            icon = 'tag',
          )
       }}

--- a/pontoon/projects/views.py
+++ b/pontoon/projects/views.py
@@ -64,8 +64,8 @@ def project(request, slug):
             "chart": chart,
             "count": project_locales.count(),
             "project": project,
-            "tags": (
-                len(TagsTool(projects=[project], priority=True))
+            "tags_count": (
+                project.tag_set.filter(resources__isnull=False).distinct().count()
                 if project.tags_enabled
                 else None
             ),


### PR DESCRIPTION
Currently, the page load time of the Firefox dashboard is pretty bad.

In this patch, we speed that up by only loading _Tag count_ (needed in the Tag tab) on page load, rather than _all Tag data_.

The same logic is applied to the localization dashboard, where the impact is less visible.

PROD:
https://pontoon.mozilla.org/projects/firefox/

STAGE:
https://mozilla-pontoon-staging.herokuapp.com/projects/firefox/