### PR TITLE
Also pretranslate strings that only have rejected suggestions submitted by humans

### DIFF
--- a/pontoon/pretranslation/__init__.py
+++ b/pontoon/pretranslation/__init__.py
@@ -1,0 +1,4 @@
+AUTHORS = {
+    "tm": "pontoon-tm@example.com",
+    "gt": "pontoon-gt@example.com",
+}

--- a/pontoon/pretranslation/pretranslate.py
+++ b/pontoon/pretranslation/pretranslate.py
@@ -14,6 +14,7 @@ from pontoon.machinery.utils import (
     get_google_translate_data,
     get_translation_memory_data,
 )
+from pontoon.pretranslation import AUTHORS
 
 
 log = logging.getLogger(__name__)
@@ -66,10 +67,7 @@ def get_pretranslations(entity, locale):
         - a user (representing TM or GT service)
     """
     source = entity.string
-    services = {
-        "tm": User.objects.get(email="pontoon-tm@example.com"),
-        "gt": User.objects.get(email="pontoon-gt@example.com"),
-    }
+    services = {k: User.objects.get(email=email) for k, email in AUTHORS.items()}
 
     if entity.resource.format == "ftl":
         source_ast = parser.parse_entry(source)

--- a/pontoon/pretranslation/tasks.py
+++ b/pontoon/pretranslation/tasks.py
@@ -8,8 +8,10 @@ from pontoon.base.models import (
     Entity,
     TranslatedResource,
     Translation,
+    User,
 )
 from pontoon.actionlog.models import ActionLog
+from pontoon.pretranslation import AUTHORS
 from pontoon.pretranslation.pretranslate import (
     get_pretranslations,
     update_changed_instances,
@@ -84,15 +86,13 @@ def pretranslate(self, project_pk, locales=None, entities=None):
     )
 
     # Fetch all locale-entity pairs with non-rejected or pretranslated translations
+    pt_authors = [User.objects.get(email=email) for email in AUTHORS.values()]
     translated_entities = (
         Translation.objects.filter(
             locale__in=locales,
             entity__in=entities,
         )
-        .filter(
-            Q(rejected=False)
-            | Q(user__email__in=["pontoon-tm@example.com", "pontoon-gt@example.com"])
-        )
+        .filter(Q(rejected=False) | Q(user__in=pt_authors))
         .annotate(
             locale_entity=Concat(
                 "locale_id", V("-"), "entity_id", output_field=CharField()

--- a/pontoon/pretranslation/tasks.py
+++ b/pontoon/pretranslation/tasks.py
@@ -68,7 +68,7 @@ def pretranslate(self, project_pk, locales=None, entities=None):
 
     entities = entities.prefetch_related("resource")
 
-    # get available TranslatedResource pairs
+    # Fetch all available locale-resource pairs (TranslatedResource objects)
     tr_pairs = (
         TranslatedResource.objects.filter(
             resource__project=project,
@@ -83,11 +83,15 @@ def pretranslate(self, project_pk, locales=None, entities=None):
         .distinct()
     )
 
-    # Fetch all distinct locale-entity pairs for which translation exists
+    # Fetch all locale-entity pairs with non-rejected or pretranslated translations
     translated_entities = (
         Translation.objects.filter(
             locale__in=locales,
             entity__in=entities,
+        )
+        .filter(
+            Q(rejected=False)
+            | Q(user__email__in=["pontoon-tm@example.com", "pontoon-gt@example.com"])
         )
         .annotate(
             locale_entity=Concat(

--- a/pontoon/pretranslation/tests/test_tasks.py
+++ b/pontoon/pretranslation/tests/test_tasks.py
@@ -69,7 +69,7 @@ def test_pretranslate(gt_mock, project_a, locale_a, resource_a, locale_b):
 def test_which_strings_to_pretranslate(gt_mock, project_a, locale_a, resource_a):
     """
     Verify that we only pretranslate:
-    - strings wihtout any translations
+    - strings without any translations
     - strings with only rejected translations, submitted by humans
     """
     project_a.pretranslation_enabled = True


### PR DESCRIPTION
Fix #2813.

Before this patch, we skipped pretranslation for strings that have had any kind of translation.