### PR TITLE
Sort tags on dashboard by priority

### DIFF
--- a/pontoon/localizations/views.py
+++ b/pontoon/localizations/views.py
@@ -170,7 +170,7 @@ def ajax_tags(request, code, slug):
         priority=True,
     )
 
-    tags = sorted(tags_tool, key=attrgetter('priority'), reverse=True)
+    tags = sorted(tags_tool, key=attrgetter("priority"), reverse=True)
 
     return render(
         request,

--- a/pontoon/localizations/views.py
+++ b/pontoon/localizations/views.py
@@ -1,5 +1,5 @@
 import math
-
+from operator import attrgetter
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Q
@@ -170,10 +170,12 @@ def ajax_tags(request, code, slug):
         priority=True,
     )
 
+    tags = sorted(tags_tool, key=attrgetter('priority'), reverse=True)
+
     return render(
         request,
         "localizations/includes/tags.html",
-        {"locale": locale, "project": project, "tags": list(tags_tool)},
+        {"locale": locale, "project": project, "tags": tags},
     )
 
 

--- a/pontoon/projects/views.py
+++ b/pontoon/projects/views.py
@@ -1,5 +1,5 @@
 import uuid
-
+from operator import attrgetter
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
@@ -110,10 +110,12 @@ def ajax_tags(request, slug):
         priority=True,
     )
 
+    tags = sorted(tags_tool, key=attrgetter('priority'), reverse=True)
+
     return render(
         request,
         "projects/includes/tags.html",
-        {"project": project, "tags": list(tags_tool)},
+        {"project": project, "tags": tags},
     )
 
 

--- a/pontoon/projects/views.py
+++ b/pontoon/projects/views.py
@@ -110,7 +110,7 @@ def ajax_tags(request, slug):
         priority=True,
     )
 
-    tags = sorted(tags_tool, key=attrgetter('priority'), reverse=True)
+    tags = sorted(tags_tool, key=attrgetter("priority"), reverse=True)
 
     return render(
         request,

--- a/pontoon/tags/templates/tags/widgets/tag_list.html
+++ b/pontoon/tags/templates/tags/widgets/tag_list.html
@@ -6,8 +6,8 @@
   <table class="table table-sort project-list">
     <thead>
       <tr>
-        <th class="tag asc">Tag<i class="fa"></i></th>
-        <th class="priority inverted">Priority<i class="fa"></i></th>
+        <th class="tag">Tag<i class="fa"></i></th>
+        <th class="priority inverted asc">Priority<i class="fa"></i></th>
         <th class="latest-activity">Latest Activity<i class="fa"></i></th>
         <th class="progress">Progress<i class="fa"></i></th>
         <th class="unreviewed-status inverted" title="Unreviewed suggestions"><span class="fa fa-lightbulb"></span><i class="fa"></i></th>


### PR DESCRIPTION
Fixes #2280 

This pull request addresses the issue identified with the sorting of tags on the dashboard. Previously, the tags on the dashboard were appearing in an arbitrary order, which made it challenging to quickly identify and address high-priority tags.

This update introduces a sorting mechanism that arranges tags according to their priority, with the highest priority (5-star) tags appearing at the top of the list. This change will allow users to quickly identify and focus on high-priority items.