### PR TITLE
Hide "Make Suggestions" for Non-Translators

### DIFF
--- a/translate/public/locale/en-US/translate.ftl
+++ b/translate/public/locale/en-US/translate.ftl
@@ -134,13 +134,13 @@ editor-EditorMenu--button-suggesting = <glyph></glyph>SUGGESTING
 ## Editor Settings
 ## Shows options to update user settings regarding the editor.
 
-editor-EditorSettings--toolkit-checks = <glyph></glyph>Translate Toolkit Checks
+editor-EditorSettings--toolkit-checks = <glyph></glyph>Translate Toolkit checks
     .title = Run Translate Toolkit checks before submitting translations
 
-editor-EditorSettings--force-suggestions = <glyph></glyph>Make Suggestions
+editor-EditorSettings--force-suggestions = <glyph></glyph>Make suggestions
     .title = Save suggestions instead of translations
 
-editor-EditorSettings--change-all = Change All Settings
+editor-EditorSettings--change-all = Change all settings
 
 
 ## Editor FTL Source Editor Switch

--- a/translate/src/modules/editor/components/EditorSettings.test.js
+++ b/translate/src/modules/editor/components/EditorSettings.test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
 
-import { USER } from '~/modules/user/reducer';
 import { EditorSettings, EditorSettingsDialog } from './EditorSettings';
 
 jest.mock('react', () => ({

--- a/translate/src/modules/editor/components/EditorSettings.test.js
+++ b/translate/src/modules/editor/components/EditorSettings.test.js
@@ -2,7 +2,30 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
 
+import { USER } from '~/modules/user/reducer';
 import { EditorSettings, EditorSettingsDialog } from './EditorSettings';
+
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useContext: () => ({ code: 'en' }),
+}));
+
+jest.mock('~/modules/project/hooks', () => ({
+  useProject: () => ({ slug: 'test' }),
+}));
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: (selector) =>
+    selector({
+      user: {
+        isAuthenticated: true,
+        managerForLocales: ['en'],
+        translatorForLocales: ['en'],
+        translatorForProjects: { 'en-test': true },
+      },
+    }),
+}));
 
 function createEditorSettingsDialog() {
   const toggleSettingMock = sinon.stub();
@@ -19,6 +42,10 @@ function createEditorSettingsDialog() {
 }
 
 describe('<EditorSettingsDialog>', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   it('toggles the runQualityChecks setting', () => {
     const [wrapper, toggleSettingMock] = createEditorSettingsDialog();
 
@@ -53,6 +80,9 @@ describe('<EditorSettingsDialog>', () => {
 });
 
 describe('<EditorSettings>', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
   it('toggles the settings menu when clicking the gear icon', () => {
     const wrapper = shallow(<EditorSettings />);
     expect(wrapper.find('EditorSettingsDialog')).toHaveLength(0);

--- a/translate/src/modules/editor/components/EditorSettings.test.js
+++ b/translate/src/modules/editor/components/EditorSettings.test.js
@@ -20,11 +20,27 @@ jest.mock('react-redux', () => ({
       user: {
         isAuthenticated: true,
         managerForLocales: ['en'],
-        translatorForLocales: ['en'],
-        translatorForProjects: { 'en-test': true },
       },
     }),
 }));
+
+function createEditorSettingsDialogForNonTranslator() {
+  jest.mock('~/hooks/useTranslator', () => ({
+    useTranslator: () => false,
+  }));
+
+  const toggleSettingMock = sinon.stub();
+  const wrapper = shallow(
+    <EditorSettingsDialog
+      settings={{
+        runQualityChecks: false,
+        forceSuggestions: false,
+      }}
+      toggleSetting={toggleSettingMock}
+    />,
+  );
+  return [wrapper, toggleSettingMock];
+}
 
 function createEditorSettingsDialog() {
   const toggleSettingMock = sinon.stub();
@@ -41,8 +57,12 @@ function createEditorSettingsDialog() {
 }
 
 describe('<EditorSettingsDialog>', () => {
-  afterEach(() => {
-    jest.resetAllMocks();
+  it('does not show the forceSuggestions setting if user is not a translator', () => {
+    const [wrapper] = createEditorSettingsDialogForNonTranslator();
+
+    expect(wrapper.find('.menu li').at(1).text()).not.toContain(
+      'Force suggestions',
+    );
   });
 
   it('toggles the runQualityChecks setting', () => {
@@ -79,9 +99,6 @@ describe('<EditorSettingsDialog>', () => {
 });
 
 describe('<EditorSettings>', () => {
-  afterEach(() => {
-    jest.resetAllMocks();
-  });
   it('toggles the settings menu when clicking the gear icon', () => {
     const wrapper = shallow(<EditorSettings />);
     expect(wrapper.find('EditorSettingsDialog')).toHaveLength(0);

--- a/translate/src/modules/editor/components/EditorSettings.tsx
+++ b/translate/src/modules/editor/components/EditorSettings.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useRef, useState } from 'react';
 
 import type { Settings } from '~/modules/user';
 import { useOnDiscard } from '~/utils';
+import { useTranslator } from '~/hooks/useTranslator';
 
 import './EditorSettings.css';
 
@@ -23,6 +24,7 @@ export function EditorSettingsDialog({
   onDiscard,
 }: EditorSettingsProps): React.ReactElement<'ul'> {
   const ref = useRef(null);
+  const isTranslator = useTranslator();
   useOnDiscard(ref, onDiscard);
 
   return (
@@ -43,21 +45,23 @@ export function EditorSettingsDialog({
         </li>
       </Localized>
 
-      <Localized
-        id='editor-EditorSettings--force-suggestions'
-        attrs={{ title: true }}
-        elems={{ glyph: <i className='fa fa-fw' /> }}
-      >
-        <li
-          className={
-            'check-box' + (settings.forceSuggestions ? ' enabled' : '')
-          }
-          title='Save suggestions instead of translations'
-          onClick={() => toggleSetting('forceSuggestions')}
+      {isTranslator ? ( 
+        <Localized
+          id='editor-EditorSettings--force-suggestions'
+          attrs={{ title: true }}
+          elems={{ glyph: <i className='fa fa-fw' /> }}
         >
-          {'<glyph></glyph>Make Suggestions'}
-        </li>
-      </Localized>
+          <li
+            className={
+              'check-box' + (settings.forceSuggestions ? ' enabled' : '')
+            }
+            title='Save suggestions instead of translations'
+            onClick={() => toggleSetting('forceSuggestions')}
+          >
+            {'<glyph></glyph>Make Suggestions'}
+          </li>
+        </Localized>
+      ) : null}
 
       <li className='horizontal-separator'></li>
       <li>

--- a/translate/src/modules/editor/components/EditorSettings.tsx
+++ b/translate/src/modules/editor/components/EditorSettings.tsx
@@ -41,7 +41,7 @@ export function EditorSettingsDialog({
           title='Run Translate Toolkit checks before submitting translations'
           onClick={() => toggleSetting('runQualityChecks')}
         >
-          {'<glyph></glyph>Translate Toolkit Checks'}
+          {'<glyph></glyph>Translate Toolkit checks'}
         </li>
       </Localized>
 
@@ -58,7 +58,7 @@ export function EditorSettingsDialog({
             title='Save suggestions instead of translations'
             onClick={() => toggleSetting('forceSuggestions')}
           >
-            {'<glyph></glyph>Make Suggestions'}
+            {'<glyph></glyph>Make suggestions'}
           </li>
         </Localized>
       ) : null}
@@ -66,7 +66,7 @@ export function EditorSettingsDialog({
       <li className='horizontal-separator'></li>
       <li>
         <Localized id='editor-EditorSettings--change-all'>
-          <a href='/settings/'>{'Change All Settings'}</a>
+          <a href='/settings/'>{'Change all settings'}</a>
         </Localized>
       </li>
     </ul>

--- a/translate/src/modules/editor/components/EditorSettings.tsx
+++ b/translate/src/modules/editor/components/EditorSettings.tsx
@@ -45,7 +45,7 @@ export function EditorSettingsDialog({
         </li>
       </Localized>
 
-      {isTranslator ? ( 
+      {isTranslator ? (
         <Localized
           id='editor-EditorSettings--force-suggestions'
           attrs={{ title: true }}


### PR DESCRIPTION
Fixes #2848 

This pull request addresses issue #2848, where the "Make Suggestions" setting was visible in the editor menu for contributors, even though it was hidden in their profile settings. 

With this change, the "Make Suggestions" button will only be rendered if the user has translator permissions. If the user does not have translator permissions, the button will not appear.

This ensures a more consistent and less confusing user experience, as the visibility of the "Make Suggestions" setting now correctly reflects the user's permissions.