### PR TITLE
Handle specific Git error during push operation 

### DIFF
--- a/pontoon/sync/vcs/repositories.py
+++ b/pontoon/sync/vcs/repositories.py
@@ -171,16 +171,18 @@ class CommitToGit(CommitToRepository):
 
         push = ["git", "push", self.url, push_target]
         code, output, error = execute(push, path)
+        exception_message = str(error)
+
         if code != 0:
             if (
                 "Updates were rejected because the remote contains work that you do"
                 in error
             ):
-                raise CommitToRepositoryException(
-                    "Remote contains work that you do not have locally." + str(error)
+                exception_message = (
+                    "Remote contains work that you do not have locally. "
+                    + exception_message
                 )
-            else:
-                raise CommitToRepositoryException(str(error))
+            raise CommitToRepositoryException(exception_message)
 
         if "Everything up-to-date" in error:
             return self.nothing_to_commit()

--- a/pontoon/sync/vcs/repositories.py
+++ b/pontoon/sync/vcs/repositories.py
@@ -172,8 +172,13 @@ class CommitToGit(CommitToRepository):
         push = ["git", "push", self.url, push_target]
         code, output, error = execute(push, path)
         if code != 0:
-            if "Updates were rejected because the remote contains work that you do" in error:
-                raise CommitToRepositoryException("Remote contains work that you do not have locally." + str(error))
+            if (
+                "Updates were rejected because the remote contains work that you do"
+                in error
+            ):
+                raise CommitToRepositoryException(
+                    "Remote contains work that you do not have locally." + str(error)
+                )
             else:
                 raise CommitToRepositoryException(str(error))
 

--- a/pontoon/sync/vcs/repositories.py
+++ b/pontoon/sync/vcs/repositories.py
@@ -172,7 +172,10 @@ class CommitToGit(CommitToRepository):
         push = ["git", "push", self.url, push_target]
         code, output, error = execute(push, path)
         if code != 0:
-            raise CommitToRepositoryException(str(error))
+            if "Updates were rejected because the remote contains work that you do" in error:
+                raise CommitToRepositoryException("Remote contains work that you do not have locally." + str(error))
+            else:
+                raise CommitToRepositoryException(str(error))
 
         if "Everything up-to-date" in error:
             return self.nothing_to_commit()


### PR DESCRIPTION
Fixes #2306 

This pull request introduces specific handling for a common Git error that occurs during a push operation. The error message is "Updates were rejected because the remote contains work that you do not have locally...".

Previously, when this error occurred, it was difficult to understand the specific cause of the error and to take appropriate action to resolve it.

This change allows for more precise logging and error handling when this Git error occurs.