### PR TITLE
Correct Redirection for New String Notifications

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -351,7 +351,7 @@ def serialized_notifications(self):
         is_comment = False
 
         if hasattr(notification.actor, "slug"):
-            if "new string" in notification.verb and self.profile.custom_homepage:
+            if "new string" in notification.verb:
                 actor = {
                     "anchor": notification.actor.name,
                     "url": reverse(

--- a/pontoon/contributors/templates/contributors/widgets/notifications_menu.html
+++ b/pontoon/contributors/templates/contributors/widgets/notifications_menu.html
@@ -33,7 +33,7 @@
 
         {% if notification.actor.slug %}
           {% set actor_anchor = notification.actor %}
-          {% if "new string" in notification.verb and user.profile.custom_homepage %}
+          {% if "new string" in notification.verb %}
             {% set actor_url = url('pontoon.translate.locale.agnostic', notification.actor.slug, "all-resources") + '?status=missing,pretranslated' %}
           {% else %}
             {% set actor_url = url('pontoon.projects.project', notification.actor.slug) %}


### PR DESCRIPTION
Addresses #2726 

Previously, the redirection was dependent on whether the 'new string' was present in the user's custom homepage. This check was implemented in both the template and the models. However, this was found to be redundant and led to incorrect redirections because the [translate_locale_agnostic](https://github.com/mozilla/pontoon/blob/master/pontoon/base/views.py#L57) function already handles the redirection based on the user's custom homepage.

This change simplifies the code and ensures that users are correctly redirected when they click on a notification about a new string. 