### PR TITLE
Speed up server stop in development

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,4 +51,5 @@ COPY --chown=pontoon:pontoon . /app/
 
 RUN python manage.py collectstatic
 
+STOPSIGNAL SIGINT
 CMD ["/app/docker/server_run.sh"]

--- a/docker/server_run.sh
+++ b/docker/server_run.sh
@@ -6,4 +6,4 @@ echo ">>> Setting up the db for Django"
 python manage.py migrate
 
 echo ">>> Starting local server"
-python manage.py runserver 0.0.0.0:8000
+exec python manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
I got annoyed always waiting for the 10 second timeout when stopping the dev server. Two things were going wrong, both fixed here:
1. Docker was sending the process its default `SIGTERM` signal, but Django expects `SIGINT`.
2. The `server_run.sh` script was not replacing its process with Django, and not passing on to it any signals.