### PR TITLE
Drop `zoom: 1` from CSS clearfix

### DIFF
--- a/pontoon/base/static/css/boilerplate.css
+++ b/pontoon/base/static/css/boilerplate.css
@@ -209,5 +209,3 @@ button {  width: auto; overflow: visible; }
 }
 
 .clearfix:after { clear: both; }
-/* Fix clearfix: blueprintcss.lighthouseapp.com/projects/15318/tickets/5-extra-margin-padding-bottom-of-page */
-.clearfix { zoom: 1; }

--- a/pontoon/base/templates/500.html
+++ b/pontoon/base/templates/500.html
@@ -223,8 +223,6 @@
       } 
 
       .clearfix:after { clear: both; }
-      /* Fix clearfix: blueprintcss.lighthouseapp.com/projects/15318/tickets/5-extra-margin-padding-bottom-of-page */
-      .clearfix { zoom: 1; }
 
       /* End CSS Reset */
 


### PR DESCRIPTION
We don't need to accommodate ancient browsers, esp. as these cause the following console warning:

> This page uses the non standard property “zoom”. Consider using calc() in the relevant property values, or using “transform” along with “transform-origin: 0 0”.