### PR TITLE
Workaround for zero-width italic backticks

### DIFF
--- a/pontoon/base/static/css/fonts.css
+++ b/pontoon/base/static/css/fonts.css
@@ -25,3 +25,12 @@
   font-weight: 400;
   src: url('../fonts/OpenSans-Italic.woff2') format('woff2');
 }
+
+/* Workaround for https://github.com/google/fonts/issues/6221 */
+@font-face {
+  font-family: 'Open Sans';
+  font-style: italic;
+  font-weight: 400;
+  src: url('../fonts/OpenSans-Regular.woff2') format('woff2');
+  unicode-range: U+60;
+}


### PR DESCRIPTION
This is a workaround for google/fonts#6221, which shows up for us in some failed-checks warnings.

I'm tracking the upstream issue and will update the font files once it's properly fixed.