### PR TITLE
Fix Missing Strings in Downloaded XLIFF Files

### DIFF
--- a/pontoon/base/utils.py
+++ b/pontoon/base/utils.py
@@ -295,11 +295,15 @@ def get_download_content(slug, code, part):
             ).filter(locale=locale)
 
         print(resource_file.translations)
-        for key, vcs_translation in resource_file.translations.items():
-            entity_key = vcs_translation.key
-            if entity_key in entities_dict:
-                entity = entities_dict[entity_key]
-                vcs_translation.update_from_db(entity)
+        # for key, vcs_translation in resource_file.translations.items():
+        #     entity_key = vcs_translation.key
+        #     if entity_key in entities_dict:
+        #         entity = entities_dict[entity_key]
+        #         vcs_translation.update_from_db(entity)
+        for vcs_translation in resource_file.translations:
+            key = vcs_translation.key
+            if key in entities_dict:
+                entity = entities_dict[key]
 
 
         resource_file.save(locale)

--- a/pontoon/base/utils.py
+++ b/pontoon/base/utils.py
@@ -298,6 +298,7 @@ def get_download_content(slug, code, part):
             key = vcs_translation.key
             if key in entities_dict:
                 entity = entities_dict[key]
+                vcs_translation.update_from_db(entity)
 
 
         resource_file.save(locale)

--- a/pontoon/base/utils.py
+++ b/pontoon/base/utils.py
@@ -294,12 +294,6 @@ def get_download_content(slug, code, part):
                 Q(approved=True) | Q(pretranslated=True)
             ).filter(locale=locale)
 
-        print(resource_file.translations)
-        # for key, vcs_translation in resource_file.translations.items():
-        #     entity_key = vcs_translation.key
-        #     if entity_key in entities_dict:
-        #         entity = entities_dict[entity_key]
-        #         vcs_translation.update_from_db(entity)
         for vcs_translation in resource_file.translations:
             key = vcs_translation.key
             if key in entities_dict:

--- a/pontoon/base/utils.py
+++ b/pontoon/base/utils.py
@@ -260,7 +260,7 @@ def get_download_content(slug, code, part):
 
         # Get source file if needed
         source_path = None
-        if resource.is_asymmetric:
+        if resource.is_asymmetric or resource.format == "xliff":
             dirnames = VCSProject.SOURCE_DIR_NAMES
             source_path = _download_file(
                 source_prefixes, dirnames, vcs_project, resource.path

--- a/pontoon/base/utils.py
+++ b/pontoon/base/utils.py
@@ -300,7 +300,6 @@ def get_download_content(slug, code, part):
                 entity = entities_dict[key]
                 vcs_translation.update_from_db(entity)
 
-
         resource_file.save(locale)
 
         if not locale_path:

--- a/pontoon/base/utils.py
+++ b/pontoon/base/utils.py
@@ -294,11 +294,13 @@ def get_download_content(slug, code, part):
                 Q(approved=True) | Q(pretranslated=True)
             ).filter(locale=locale)
 
-        for vcs_translation in resource_file.translations:
-            key = vcs_translation.key
-            if key in entities_dict:
-                entity = entities_dict[key]
+        print(resource_file.translations)
+        for key, vcs_translation in resource_file.translations.items():
+            entity_key = vcs_translation.key
+            if entity_key in entities_dict:
+                entity = entities_dict[entity_key]
                 vcs_translation.update_from_db(entity)
+
 
         resource_file.save(locale)
 

--- a/pontoon/sync/formats/xliff.py
+++ b/pontoon/sync/formats/xliff.py
@@ -128,10 +128,6 @@ class XLIFFResource(ParsedResource):
                     # Store updated nodes
                     xml = unit.xmlelement
                     target = xml.find(unit.namespaced("target"))
-
-                    # If there's no existing target, create a new one
-                    if target is None:
-                        target = etree.SubElement(xml, unit.namespaced("target"))
                     unit.settarget(entity.strings[None])
 
                 else:

--- a/pontoon/sync/formats/xliff.py
+++ b/pontoon/sync/formats/xliff.py
@@ -71,12 +71,12 @@ class XLIFFResource(ParsedResource):
                 # Get the unit's ID and source string
                 key = unit.getid()
                 context = unit.xmlelement.get("id")
-                source_string = unit.rich_source[0]
+                source_string = str(unit.rich_source[0])
                 source_string_plural = ""
 
                 # Get the translated string for the unit. If there's no target string, this will be an empty dictionary
                 target_string = (
-                    unit.get_rich_target()[0] if unit.get_rich_target() else None
+                    str(unit.get_rich_target()[0]) if unit.get_rich_target() else None
                 )
                 strings = {None: target_string} if target_string else {}
 
@@ -93,7 +93,6 @@ class XLIFFResource(ParsedResource):
                     comments,
                     order,
                 )
-                print(f"Adding entity with key {entity.key} to entities")
                 # Add the entity to the entities dictionary using its key as the dictionary key
                 self.entities[entity.key] = entity
 

--- a/pontoon/sync/formats/xliff.py
+++ b/pontoon/sync/formats/xliff.py
@@ -28,6 +28,7 @@ class XLIFFEntity(VCSTranslation):
         strings,
         comments=None,
         order=None,
+        unit=None
     ):
         super().__init__(
             key=key,
@@ -39,6 +40,7 @@ class XLIFFEntity(VCSTranslation):
             fuzzy=False,
             order=order,
         )
+        self.unit = unit
 
     def __repr__(self):
         return "<XLIFFEntity {key}>".format(key=self.key)
@@ -150,7 +152,7 @@ class XLIFFResource(ParsedResource):
                 source_string_plural = ""
 
                 # Get the translated string for the unit. If there's no target string, this will be an empty dictionary
-                target_string = str(unit.get_rich_target()[0]) if unit.get_rich_target() else None
+                target_string = unit.get_rich_target()[0] if unit.get_rich_target() else None
                 strings = {None: target_string} if target_string else {}
 
 
@@ -165,7 +167,9 @@ class XLIFFResource(ParsedResource):
                     strings,
                     comments,
                     order,
+                    unit
                 )
+                print(f"Adding entity with key {entity.key} to entities")
                 # Add the entity to the entities dictionary using its key as the dictionary key
                 self.entities[entity.key] = entity
 
@@ -182,10 +186,10 @@ class XLIFFResource(ParsedResource):
         return self.entities
 
     def save(self, locale):
-        for entity in self.entities:
-            entity.sync_changes()
+        # for entity in self.entities:
+        #     entity.sync_changes()
 
-        locale_code = locale.code
+        # locale_code = locale.code
 
         # TODO: should be made iOS specific
         # Map locale codes for iOS: http://www.ibabbleon.com/iOS-Language-Codes-ISO-639.html
@@ -196,7 +200,7 @@ class XLIFFResource(ParsedResource):
             "nn-NO": "nn",
             "sv-SE": "sv",
         }
-
+        locale_code = locale.code
         if locale_code in locale_mapping:
             locale_code = locale_mapping[locale_code]
 
@@ -205,9 +209,14 @@ class XLIFFResource(ParsedResource):
         for node in self.xliff_file.document.getroot().iterchildren(file_node):
             if not node.get("target-language"):
                 node.set("target-language", locale_code)
+        
+        for entity in self.entities.values():
+            entity.sync_changes()
 
         with open(self.path, "wb") as f:
             f.write(bytes(self.xliff_file))
+        
+        return
 
 # OLD PARSE FUNCTION
 # def parse(path, source_path=None, locale=None):

--- a/pontoon/sync/formats/xliff.py
+++ b/pontoon/sync/formats/xliff.py
@@ -26,7 +26,7 @@ class XLIFFEntity(VCSTranslation):
     ):
         super().__init__(
             key=key,
-            context=key,
+            context=context,
             source_string=source_string,
             source_string_plural=source_string_plural,
             strings=strings,

--- a/pontoon/sync/formats/xliff.py
+++ b/pontoon/sync/formats/xliff.py
@@ -126,13 +126,9 @@ class XLIFFResource(ParsedResource):
                 entity = self.entities.get(key)
                 if None in entity.strings:
                     # Store updated nodes
+                    unit.settarget(entity.strings[None])
                     xml = unit.xmlelement
                     target = xml.find(unit.namespaced("target"))
-
-                    unit.settarget(entity.strings[None])
-                    # If there's no existing target, create a new one
-                    if target is None:
-                        target = etree.SubElement(xml, unit.namespaced("target"))
 
                 else:
                     # Read stored nodes

--- a/pontoon/sync/formats/xliff.py
+++ b/pontoon/sync/formats/xliff.py
@@ -128,7 +128,11 @@ class XLIFFResource(ParsedResource):
                     # Store updated nodes
                     xml = unit.xmlelement
                     target = xml.find(unit.namespaced("target"))
+
                     unit.settarget(entity.strings[None])
+                    # If there's no existing target, create a new one
+                    if target is None:
+                        target = etree.SubElement(xml, unit.namespaced("target"))
 
                 else:
                     # Read stored nodes

--- a/pontoon/sync/formats/xliff.py
+++ b/pontoon/sync/formats/xliff.py
@@ -14,12 +14,6 @@ class XLIFFEntity(VCSTranslation):
     """
     Interface for modifying a single entity in an xliff file.
     """
-    # OLD CODE
-    # def __init__(self, order, unit):
-    #     self.order = order
-    #     self.unit = unit
-    #     self.strings = {None: self.target_string} if self.target_string else {}
-
     def __init__(
         self,
         key,
@@ -44,47 +38,6 @@ class XLIFFEntity(VCSTranslation):
 
     def __repr__(self):
         return "<XLIFFEntity {key}>".format(key=self.key)
-
-    # @property
-    # def key(self):
-    #     return self.unit.getid()
-
-    # @property
-    # def context(self):
-    #     return self.unit.xmlelement.get("id") or ""
-
-    # @property
-    # def source_string(self):
-    #     return str(self.unit.rich_source[0])
-
-    # @property
-    # def source_string_plural(self):
-    #     return ""
-
-    # @property
-    # def comments(self):
-    #     notes = self.unit.getnotes()
-    #     return notes.split("\n") if notes else []
-
-    # @property
-    # def fuzzy(self):
-    #     return False
-
-    # @fuzzy.setter
-    # def fuzzy(self, fuzzy):
-    #     pass  # We don't use fuzzy in XLIFF
-
-    # @property
-    # def source(self):
-    #     return []
-
-    # @property
-    # def target_string(self):
-    #     return str(self.unit.get_rich_target()[0])
-
-    # @target_string.setter
-    # def target_string(self, value):
-    #     self.unit.settarget(value)
 
     def sync_changes(self):
         """
@@ -174,24 +127,11 @@ class XLIFFResource(ParsedResource):
                 # Add the entity to the entities dictionary using its key as the dictionary key
                 self.entities[entity.key] = entity
 
-
-        # OLD CODE
-        # self.path = path
-        # self.xliff_file = xliff_file
-        # self.entities = [
-        #     XLIFFEntity(order, unit) for order, unit in enumerate(self.xliff_file.units)
-        # ]
-
     @property
     def translations(self):
         return self.entities
 
     def save(self, locale):
-        # for entity in self.entities:
-        #     entity.sync_changes()
-
-        # locale_code = locale.code
-
         # TODO: should be made iOS specific
         # Map locale codes for iOS: http://www.ibabbleon.com/iOS-Language-Codes-ISO-639.html
         locale_mapping = {
@@ -218,18 +158,6 @@ class XLIFFResource(ParsedResource):
             f.write(bytes(self.xliff_file))
         
         return
-
-# OLD PARSE FUNCTION
-# def parse(path, source_path=None, locale=None):
-#     with open(path) as f:
-#         xml = f.read().encode("utf-8")
-
-#         try:
-#             xliff_file = xliff.xlifffile(xml)
-#         except etree.XMLSyntaxError as err:
-#             raise ParseError(f"Failed to parse {path}: {err}")
-
-#     return XLIFFResource(path, xliff_file)
 
 def parse(path, source_path=None, locale=None):
     if source_path is not None:

--- a/pontoon/sync/formats/xliff.py
+++ b/pontoon/sync/formats/xliff.py
@@ -129,7 +129,6 @@ class XLIFFResource(ParsedResource):
 
     @property
     def translations(self):
-        # return self.entities
         return sorted(self.entities.values(), key=lambda e: e.order)
 
     def save(self, locale):

--- a/pontoon/sync/formats/xliff.py
+++ b/pontoon/sync/formats/xliff.py
@@ -130,6 +130,7 @@ class XLIFFResource(ParsedResource):
                     {},
                     copy.copy(entity.comments),
                     entity.order,
+                    entity.unit
                 )
 
         # Open the file at the provided path

--- a/pontoon/sync/tests/formats/test_xliff.py
+++ b/pontoon/sync/tests/formats/test_xliff.py
@@ -138,7 +138,9 @@ class XLIFFTests(FormatTestsMixin, TestCase):
             attr=attr,
         )
 
-        super().run_save_basic(input_string, expected_string)
+        super().run_save_basic(
+            input_string, expected_string, source_string=input_string
+        )
 
     def test_save_preserve_target_language(self):
         """
@@ -172,7 +174,9 @@ class XLIFFTests(FormatTestsMixin, TestCase):
             attr=attr,
         )
 
-        super().run_save_basic(input_string, expected_string)
+        super().run_save_basic(
+            input_string, expected_string, source_string=input_string
+        )
 
     def test_save_remove(self):
         attr = f'target-language="{self.locale.code}"'
@@ -201,4 +205,6 @@ class XLIFFTests(FormatTestsMixin, TestCase):
             attr=attr,
         )
 
-        super().run_save_remove(input_string, expected_string)
+        super().run_save_remove(
+            input_string, expected_string, source_string=input_string
+        )


### PR DESCRIPTION
Fixes #2239 

This Pull Request addresses the issue of missing strings in downloaded XLIFF files.

The problem surfaced when a new string was added to the reference file and subsequently translated. Despite the string being present in the Pontoon interface, it was missing in the downloaded XLIFF file.

This PR fixes the issue by ensuring that all new strings and their corresponding translations are correctly parsed and written into the downloaded XLIFF file. Now, when a user adds a new string to the reference file, translates it, and downloads the translated file, they will find the new string and its translation present as expected.

Details of main changes:
* Rewrote the `XLIFFEntity` and `XLIFFResource` classes
* Adjusted the writing logic in the `save` function to ensure all translations are included in the downloaded file
* Modified the parsing logic in the `parse` function to correctly register new strings.

Testing strategy:
* Added new strings to the reference file, translated them and downloaded the XLIFF file to verify the correct behaviour
* Ran existing unit tests to ensure no changes in other functionalities
