### PR TITLE
Use Glossary to prevent placeables modifications by machine translation

### DIFF
--- a/pontoon/base/placeables.py
+++ b/pontoon/base/placeables.py
@@ -9,7 +9,7 @@ class PythonFormatNamedString:
 
 
 class PythonFormatString:
-    parser = re.compile(r"({{?[\w!.,[\]%:$<>+\-= ]*}?})")
+    parser = re.compile(r"{{|}}|{[\w!.,[\]%:$<>+\-= ]*}")
 
 
 class PythonFormattingVariable:

--- a/pontoon/base/placeables.py
+++ b/pontoon/base/placeables.py
@@ -1,22 +1,23 @@
 import re
 
 
-class PythonFormatNamedString:
+class PythonPrintfString:
     parser = re.compile(
-        r"(%\([[\w\d!.,[\]%:$<>+\-= ]*\)[+-0\d+#]?[.\d+]?[sdefgoxc%])",
-        re.IGNORECASE,
+        r"""
+            %
+            (?:\(.*?\))?  # mapping key
+            [\#0\-\ +]*   # conversion flags
+            [\d*]*        # minimum field width
+            (?:\.[\d*])?  # precision
+            [hlL]?        # length modifier
+            [acdEeFfGgiorsuXx%]  # conversion type
+        """,
+        re.X,
     )
 
 
 class PythonFormatString:
     parser = re.compile(r"{{|}}|{[\w!.,[\]%:$<>+\-= ]*}")
-
-
-class PythonFormattingVariable:
-    parser = re.compile(
-        r"(%(%|(\([^)]+\))?[-+0#]?(\d+|\*)?(\.(\d+|\*))?[hlL]?[diouxXeEfFgGcrs]))"
-    )
-    match_index = 0
 
 
 class FluentTerm:
@@ -34,9 +35,8 @@ class JsonPlaceholder:
 def get_placeables(text):
     """Return a list of placeables found in the given string."""
     parsers = [
-        PythonFormatNamedString.parser,
+        PythonPrintfString.parser,
         PythonFormatString.parser,
-        PythonFormattingVariable.parser,
         FluentTerm.parser,
         FluentFunction.parser,
         JsonPlaceholder.parser,

--- a/pontoon/base/placeables.py
+++ b/pontoon/base/placeables.py
@@ -3,7 +3,7 @@ import re
 
 class PythonFormatNamedString:
     parser = re.compile(
-        r"(%\([[\w\d!.,[\]%:$<>+\-= ]*\)[+|-|0\d+|#]?[.\d+]?[s|d|e|f|g|o|x|c|%])",
+        r"(%\([[\w\d!.,[\]%:$<>+\-= ]*\)[+-0\d+#]?[.\d+]?[sdefgoxc%])",
         re.IGNORECASE,
     )
 

--- a/pontoon/base/placeables.py
+++ b/pontoon/base/placeables.py
@@ -14,7 +14,7 @@ class PythonFormatString:
 
 class PythonFormattingVariable:
     parser = re.compile(
-        r"(%(%|(\([^)]+\)){0,1}[-+0#]{0,1}(\d+|\*){0,1}(\.(\d+|\*)){0,1}[hlL]{0,1}[diouxXeEfFgGcrs]{1}))"
+        r"(%(%|(\([^)]+\))?[-+0#]?(\d+|\*)?(\.(\d+|\*))?[hlL]?[diouxXeEfFgGcrs]))"
     )
     match_index = 0
 

--- a/pontoon/base/placeables.py
+++ b/pontoon/base/placeables.py
@@ -2,7 +2,10 @@ import re
 
 
 class PythonFormatNamedString:
-    parser = r"(%\([[\w\d!.,[\]%:$<>+\-= ]*\)[+|-|0\d+|#]?[.\d+]?[s|d|e|f|g|o|x|c|%])"
+    parser = re.compile(
+        r"(%\([[\w\d!.,[\]%:$<>+\-= ]*\)[+|-|0\d+|#]?[.\d+]?[s|d|e|f|g|o|x|c|%])",
+        re.IGNORECASE,
+    )
 
 
 class PythonFormatString:

--- a/pontoon/base/placeables.py
+++ b/pontoon/base/placeables.py
@@ -31,9 +31,9 @@ def get_placeables(text):
     parsers = [
         PythonFormatNamedString.parser,
         PythonFormatString.parser,
-        # PythonFormattingVariable.parser,
+        PythonFormattingVariable.parser,
         FluentTerm.parser,
-        # FluentParametrizedTerm.parser,
+        FluentParametrizedTerm.parser,
         FluentFunction.parser,
     ]
 

--- a/pontoon/base/placeables.py
+++ b/pontoon/base/placeables.py
@@ -1,0 +1,45 @@
+import re
+
+
+class PythonFormatNamedString:
+    parser = r"(%\([[\w\d!.,[\]%:$<>+\-= ]*\)[+|-|0\d+|#]?[.\d+]?[s|d|e|f|g|o|x|c|%])"
+
+
+class PythonFormatString:
+    parser = r"(\{{?[\w\d!.,[\]%:$<>+-= ]*\}?})"
+
+
+class PythonFormattingVariable:
+    parser = r"(%(%|(\([^)]+\)){0,1}[-+0#]{0,1}(\d+|\*){0,1}(\.(\d+|\*)){0,1}[hlL]{0,1}[diouxXeEfFgGcrs]{1}))"
+    match_index = 0
+
+
+class FluentTerm:
+    parser = r"({ ?-[^}]* ?})"
+
+
+class FluentParametrizedTerm:
+    parser = r"({ ?-[^}]*([^}]*: ?[^}]*) ?})"
+
+
+class FluentFunction:
+    parser = r"({ ?[A-W0-9\-_]+[^}]* ?})"
+
+
+def get_placeables(text):
+    """Return a list of placeables found in the given string."""
+    parsers = [
+        PythonFormatNamedString.parser,
+        PythonFormatString.parser,
+        # PythonFormattingVariable.parser,
+        FluentTerm.parser,
+        # FluentParametrizedTerm.parser,
+        FluentFunction.parser,
+    ]
+
+    placeables = []
+
+    for parser in parsers:
+        placeables += re.findall(parser, text)
+
+    return list(dict.fromkeys(placeables))

--- a/pontoon/base/placeables.py
+++ b/pontoon/base/placeables.py
@@ -9,7 +9,7 @@ class PythonFormatNamedString:
 
 
 class PythonFormatString:
-    parser = re.compile(r"(\{{?[\w\d!.,[\]%:$<>+-= ]*\}?})")
+    parser = re.compile(r"({{?[\w!.,[\]%:$<>+\-= ]*}?})")
 
 
 class PythonFormattingVariable:

--- a/pontoon/base/placeables.py
+++ b/pontoon/base/placeables.py
@@ -1,6 +1,10 @@
 import re
 
 
+class MozillaPrintfString:
+    parser = re.compile(r"%(?:[1-9]\$)?[S@]")
+
+
 class PythonPrintfString:
     parser = re.compile(
         r"""
@@ -35,6 +39,7 @@ class JsonPlaceholder:
 def get_placeables(text):
     """Return a list of placeables found in the given string."""
     parsers = [
+        MozillaPrintfString.parser,
         PythonPrintfString.parser,
         PythonFormatString.parser,
         FluentTerm.parser,

--- a/pontoon/base/placeables.py
+++ b/pontoon/base/placeables.py
@@ -9,24 +9,26 @@ class PythonFormatNamedString:
 
 
 class PythonFormatString:
-    parser = r"(\{{?[\w\d!.,[\]%:$<>+-= ]*\}?})"
+    parser = re.compile(r"(\{{?[\w\d!.,[\]%:$<>+-= ]*\}?})")
 
 
 class PythonFormattingVariable:
-    parser = r"(%(%|(\([^)]+\)){0,1}[-+0#]{0,1}(\d+|\*){0,1}(\.(\d+|\*)){0,1}[hlL]{0,1}[diouxXeEfFgGcrs]{1}))"
+    parser = re.compile(
+        r"(%(%|(\([^)]+\)){0,1}[-+0#]{0,1}(\d+|\*){0,1}(\.(\d+|\*)){0,1}[hlL]{0,1}[diouxXeEfFgGcrs]{1}))"
+    )
     match_index = 0
 
 
 class FluentTerm:
-    parser = r"({ ?-[^}]* ?})"
+    parser = re.compile(r"({ ?-[^}]* ?})")
 
 
 class FluentParametrizedTerm:
-    parser = r"({ ?-[^}]*([^}]*: ?[^}]*) ?})"
+    parser = re.compile(r"({ ?-[^}]*([^}]*: ?[^}]*) ?})")
 
 
 class FluentFunction:
-    parser = r"({ ?[A-W0-9\-_]+[^}]* ?})"
+    parser = re.compile(r"({ ?[A-W0-9\-_]+[^}]* ?})")
 
 
 def get_placeables(text):

--- a/pontoon/base/placeables.py
+++ b/pontoon/base/placeables.py
@@ -35,12 +35,11 @@ class JsonPlaceholder:
 def get_placeables(text):
     """Return a list of placeables found in the given string."""
     parsers = [
+        JsonPlaceholder.parser,
         MozillaPrintfString.parser,
         PythonPrintfString.parser,
         PythonFormatString.parser,
-        FluentTerm.parser,
-        FluentFunction.parser,
-        JsonPlaceholder.parser,
+        FluentPlaceable.parser,
     ]
 
     placeables = get_placeables_recursively(text, parsers)

--- a/pontoon/base/placeables.py
+++ b/pontoon/base/placeables.py
@@ -24,12 +24,8 @@ class PythonFormatString:
     parser = re.compile(r"{{|}}|{[\w!.,[\]%:$<>+\-= ]*}")
 
 
-class FluentTerm:
-    parser = re.compile(r"({ *-[^}]*})")
-
-
-class FluentFunction:
-    parser = re.compile(r"({ *[A-W0-9\-_]+[^}]*})")
+class FluentPlaceable:
+    parser = re.compile(r"{ *[A-Z0-9\-_][^}]*}")
 
 
 class JsonPlaceholder:

--- a/pontoon/base/placeables.py
+++ b/pontoon/base/placeables.py
@@ -31,6 +31,16 @@ class FluentFunction:
     parser = re.compile(r"({ ?[A-W0-9\-_]+[^}]* ?})")
 
 
+class JavaFormattingVariable:
+    parser = re.compile(
+        r"(?x){[0-9]+(,\s*(number(,\s*(integer|currency|percent|[-0#.,E;%\u2030\u00a4']+)?)?|(date|time)(,\s*(short|medium|long|full|.+?))?|choice,([^{]+({.+})?)+)?)?}"
+    )
+
+
+class JsonPlaceholder:
+    parser = re.compile(r"(\$[A-Z0-9_]+\$)")
+
+
 def get_placeables(text):
     """Return a list of placeables found in the given string."""
     parsers = [
@@ -40,6 +50,8 @@ def get_placeables(text):
         FluentTerm.parser,
         FluentParametrizedTerm.parser,
         FluentFunction.parser,
+        JavaFormattingVariable.parser,
+        JsonPlaceholder.parser,
     ]
 
     placeables = get_placeables_recursively(text, parsers)

--- a/pontoon/base/placeables.py
+++ b/pontoon/base/placeables.py
@@ -37,9 +37,18 @@ def get_placeables(text):
         FluentFunction.parser,
     ]
 
-    placeables = []
-
-    for parser in parsers:
-        placeables += re.findall(parser, text)
-
+    placeables = get_placeables_recursively(text, parsers)
     return list(dict.fromkeys(placeables))
+
+
+def get_placeables_recursively(text, parsers):
+    if not parsers:
+        return []
+
+    parser = parsers.pop(0)
+    placeables = re.findall(parser, text)
+
+    for part in re.split(parser, text):
+        placeables += get_placeables_recursively(part, parsers)
+
+    return placeables

--- a/pontoon/base/placeables.py
+++ b/pontoon/base/placeables.py
@@ -31,22 +31,6 @@ class FluentFunction:
     parser = re.compile(r"({ *[A-W0-9\-_]+[^}]*})")
 
 
-class JavaFormattingVariable:
-    parser = re.compile(
-        r"""
-        {
-          [0-9]+
-          (,\s*(
-            number(,\s*(integer | currency | percent | [-0#.,E;%\u2030\u00a4']+)?)?
-            | (date | time)(,\s*(short | medium | long | full | .+?))?
-            | choice,([^{]+({.+})?)+
-          )?)?
-        }
-        """,
-        re.X,
-    )
-
-
 class JsonPlaceholder:
     parser = re.compile(r"(\$[A-Z0-9_]+\$)")
 
@@ -60,7 +44,6 @@ def get_placeables(text):
         FluentTerm.parser,
         FluentParametrizedTerm.parser,
         FluentFunction.parser,
-        JavaFormattingVariable.parser,
         JsonPlaceholder.parser,
     ]
 

--- a/pontoon/base/placeables.py
+++ b/pontoon/base/placeables.py
@@ -23,10 +23,6 @@ class FluentTerm:
     parser = re.compile(r"({ *-[^}]*})")
 
 
-class FluentParametrizedTerm:
-    parser = re.compile(r"({ ?-[^}]*([^}]*: ?[^}]*) ?})")
-
-
 class FluentFunction:
     parser = re.compile(r"({ *[A-W0-9\-_]+[^}]*})")
 
@@ -42,7 +38,6 @@ def get_placeables(text):
         PythonFormatString.parser,
         PythonFormattingVariable.parser,
         FluentTerm.parser,
-        FluentParametrizedTerm.parser,
         FluentFunction.parser,
         JsonPlaceholder.parser,
     ]

--- a/pontoon/base/placeables.py
+++ b/pontoon/base/placeables.py
@@ -20,7 +20,7 @@ class PythonFormattingVariable:
 
 
 class FluentTerm:
-    parser = re.compile(r"({ ?-[^}]* ?})")
+    parser = re.compile(r"({ *-[^}]*})")
 
 
 class FluentParametrizedTerm:
@@ -28,7 +28,7 @@ class FluentParametrizedTerm:
 
 
 class FluentFunction:
-    parser = re.compile(r"({ ?[A-W0-9\-_]+[^}]* ?})")
+    parser = re.compile(r"({ *[A-W0-9\-_]+[^}]*})")
 
 
 class JavaFormattingVariable:

--- a/pontoon/base/placeables.py
+++ b/pontoon/base/placeables.py
@@ -33,7 +33,17 @@ class FluentFunction:
 
 class JavaFormattingVariable:
     parser = re.compile(
-        r"(?x){[0-9]+(,\s*(number(,\s*(integer|currency|percent|[-0#.,E;%\u2030\u00a4']+)?)?|(date|time)(,\s*(short|medium|long|full|.+?))?|choice,([^{]+({.+})?)+)?)?}"
+        r"""
+        {
+          [0-9]+
+          (,\s*(
+            number(,\s*(integer | currency | percent | [-0#.,E;%\u2030\u00a4']+)?)?
+            | (date | time)(,\s*(short | medium | long | full | .+?))?
+            | choice,([^{]+({.+})?)+
+          )?)?
+        }
+        """,
+        re.X,
     )
 
 

--- a/pontoon/base/tests/test_placeables.py
+++ b/pontoon/base/tests/test_placeables.py
@@ -40,8 +40,6 @@ def test_FluentTerm():
 
     assert placeables == ["{ -name }"]
 
-
-def test_FluentParametrizedTerm():
     input = 'My { -name(foo-bar: "now that\'s a value!") } is Luka.'
     placeables = get_placeables(input)
 

--- a/pontoon/base/tests/test_placeables.py
+++ b/pontoon/base/tests/test_placeables.py
@@ -8,6 +8,28 @@ def test_no_placeables():
     assert placeables == []
 
 
+def test_MozillaPrintfString():
+    input = "My %S is Luka."
+    placeables = get_placeables(input)
+
+    assert placeables == ["%S"]
+
+    input = "My %1$S is Luka."
+    placeables = get_placeables(input)
+
+    assert placeables == ["%1$S"]
+
+    input = "My %@ is Luka."
+    placeables = get_placeables(input)
+
+    assert placeables == ["%@"]
+
+    input = "My %2$@ is Luka."
+    placeables = get_placeables(input)
+
+    assert placeables == ["%2$@"]
+
+
 def test_PythonPrintfString():
     input = "My %(name)s is Luka."
     placeables = get_placeables(input)

--- a/pontoon/base/tests/test_placeables.py
+++ b/pontoon/base/tests/test_placeables.py
@@ -8,16 +8,16 @@ def test_no_placeables():
     assert placeables == []
 
 
-def test_PythonFormatNamedString():
+def test_PythonPrintfString():
     input = "My %(name)s is Luka."
     placeables = get_placeables(input)
 
     assert placeables == ["%(name)s"]
 
-    input = "My %(number)D is Luka."
+    input = "My %(name)d is Luka."
     placeables = get_placeables(input)
 
-    assert placeables == ["%(number)D"]
+    assert placeables == ["%(name)d"]
 
 
 def test_PythonFormatString():
@@ -25,13 +25,6 @@ def test_PythonFormatString():
     placeables = get_placeables(input)
 
     assert placeables == ["{ name }"]
-
-
-def test_PythonFormattingVariable():
-    input = "My %(name)d is Luka."
-    placeables = get_placeables(input)
-
-    assert placeables == ["%(name)d"]
 
 
 def test_FluentTerm():

--- a/pontoon/base/tests/test_placeables.py
+++ b/pontoon/base/tests/test_placeables.py
@@ -55,23 +55,6 @@ def test_FluentFunction():
     assert placeables == ["{ NAME() }"]
 
 
-def test_JavaFormattingVariable():
-    input = "My {2} is Luka."
-    placeables = get_placeables(input)
-
-    assert placeables == ["{2}"]
-
-    input = "My {1,date} is Luka."
-    placeables = get_placeables(input)
-
-    assert placeables == ["{1,date}"]
-
-    input = "My {0,number,integer} is Luka."
-    placeables = get_placeables(input)
-
-    assert placeables == ["{0,number,integer}"]
-
-
 def test_JsonPlaceholder():
     input = "My $NAME$ is Luka."
     placeables = get_placeables(input)

--- a/pontoon/base/tests/test_placeables.py
+++ b/pontoon/base/tests/test_placeables.py
@@ -53,3 +53,11 @@ def test_FluentFunction():
     placeables = get_placeables(input)
 
     assert placeables == ["{ NAME() }"]
+
+
+def test_multiple_placeables():
+    input = "This { STRING() } contains multiple { -string } variables with some { -string } variables repeated."
+    placeables = get_placeables(input)
+
+    assert len(placeables) == 2
+    assert sorted(placeables) == sorted(["{ STRING() }", "{ -string }"])

--- a/pontoon/base/tests/test_placeables.py
+++ b/pontoon/base/tests/test_placeables.py
@@ -42,10 +42,10 @@ def test_FluentTerm():
 
 
 def test_FluentParametrizedTerm():
-    input = "My { -name(foo-bar: 'now that's a value!') } is Luka."
+    input = "My { -name(foo-bar: \"now that's a value!\") } is Luka."
     placeables = get_placeables(input)
 
-    assert placeables == ["{ -name(foo-bar: 'now that's a value!') }"]
+    assert placeables == ["{ -name(foo-bar: \"now that's a value!\") }"]
 
 
 def test_FluentFunction():

--- a/pontoon/base/tests/test_placeables.py
+++ b/pontoon/base/tests/test_placeables.py
@@ -8,6 +8,18 @@ def test_no_placeables():
     assert placeables == []
 
 
+def test_JsonPlaceholder():
+    input = "My $NAME$ is Luka."
+    placeables = get_placeables(input)
+
+    assert placeables == ["$NAME$"]
+
+    input = "My $FIRST_NAME$ is Luka."
+    placeables = get_placeables(input)
+
+    assert placeables == ["$FIRST_NAME$"]
+
+
 def test_MozillaPrintfString():
     input = "My %S is Luka."
     placeables = get_placeables(input)
@@ -49,7 +61,7 @@ def test_PythonFormatString():
     assert placeables == ["{ name }"]
 
 
-def test_FluentTerm():
+def test_FluentPlaceable():
     input = "My { -name } is Luka."
     placeables = get_placeables(input)
 
@@ -60,24 +72,10 @@ def test_FluentTerm():
 
     assert placeables == ['{ -name(foo-bar: "now that\'s a value!") }']
 
-
-def test_FluentFunction():
     input = "My { NAME() } is Luka."
     placeables = get_placeables(input)
 
     assert placeables == ["{ NAME() }"]
-
-
-def test_JsonPlaceholder():
-    input = "My $NAME$ is Luka."
-    placeables = get_placeables(input)
-
-    assert placeables == ["$NAME$"]
-
-    input = "My $FIRST_NAME$ is Luka."
-    placeables = get_placeables(input)
-
-    assert placeables == ["$FIRST_NAME$"]
 
 
 def test_multiple_placeables():

--- a/pontoon/base/tests/test_placeables.py
+++ b/pontoon/base/tests/test_placeables.py
@@ -1,0 +1,36 @@
+from pontoon.base.placeables import get_placeables
+
+
+def test_no_placeables():
+    input = "My name is Luka."
+    placeables = get_placeables(input)
+
+    assert placeables == []
+
+
+def test_PythonFormatNamedString():
+    input = "My %(name)s is Luka."
+    placeables = get_placeables(input)
+
+    assert placeables == ["%(name)s"]
+
+
+def test_PythonFormatString():
+    input = "My { name } is Luka."
+    placeables = get_placeables(input)
+
+    assert placeables == ["{ name }"]
+
+
+def test_FluentTerm():
+    input = "My { -name } is Luka."
+    placeables = get_placeables(input)
+
+    assert placeables == ["{ -name }"]
+
+
+def test_FluentFunction():
+    input = "My { NAME() } is Luka."
+    placeables = get_placeables(input)
+
+    assert placeables == ["{ NAME() }"]

--- a/pontoon/base/tests/test_placeables.py
+++ b/pontoon/base/tests/test_placeables.py
@@ -55,6 +55,35 @@ def test_FluentFunction():
     assert placeables == ["{ NAME() }"]
 
 
+def test_JavaFormattingVariable():
+    input = "My {2} is Luka."
+    placeables = get_placeables(input)
+
+    assert placeables == ["{2}"]
+
+    input = "My {1,date} is Luka."
+    placeables = get_placeables(input)
+
+    assert placeables == ["{1,date}"]
+
+    input = "My {0,number,integer} is Luka."
+    placeables = get_placeables(input)
+
+    assert placeables == ["{0,number,integer}"]
+
+
+def test_JsonPlaceholder():
+    input = "My $NAME$ is Luka."
+    placeables = get_placeables(input)
+
+    assert placeables == ["$NAME$"]
+
+    input = "My $FIRST_NAME$ is Luka."
+    placeables = get_placeables(input)
+
+    assert placeables == ["$FIRST_NAME$"]
+
+
 def test_multiple_placeables():
     input = "This { STRING() } contains multiple { -string } variables with some { -string } variables repeated."
     placeables = get_placeables(input)

--- a/pontoon/base/tests/test_placeables.py
+++ b/pontoon/base/tests/test_placeables.py
@@ -22,11 +22,25 @@ def test_PythonFormatString():
     assert placeables == ["{ name }"]
 
 
+def test_PythonFormattingVariable():
+    input = "My %(name)d is Luka."
+    placeables = get_placeables(input)
+
+    assert placeables == ["%(name)d"]
+
+
 def test_FluentTerm():
     input = "My { -name } is Luka."
     placeables = get_placeables(input)
 
     assert placeables == ["{ -name }"]
+
+
+def test_FluentParametrizedTerm():
+    input = "My { -name(foo-bar: 'now that's a value!') } is Luka."
+    placeables = get_placeables(input)
+
+    assert placeables == ["{ -name(foo-bar: 'now that's a value!') }"]
 
 
 def test_FluentFunction():

--- a/pontoon/base/tests/test_placeables.py
+++ b/pontoon/base/tests/test_placeables.py
@@ -42,10 +42,10 @@ def test_FluentTerm():
 
 
 def test_FluentParametrizedTerm():
-    input = "My { -name(foo-bar: \"now that's a value!\") } is Luka."
+    input = 'My { -name(foo-bar: "now that\'s a value!") } is Luka.'
     placeables = get_placeables(input)
 
-    assert placeables == ["{ -name(foo-bar: \"now that's a value!\") }"]
+    assert placeables == ['{ -name(foo-bar: "now that\'s a value!") }']
 
 
 def test_FluentFunction():

--- a/pontoon/base/tests/test_placeables.py
+++ b/pontoon/base/tests/test_placeables.py
@@ -14,6 +14,11 @@ def test_PythonFormatNamedString():
 
     assert placeables == ["%(name)s"]
 
+    input = "My %(number)D is Luka."
+    placeables = get_placeables(input)
+
+    assert placeables == ["%(number)D"]
+
 
 def test_PythonFormatString():
     input = "My { name } is Luka."

--- a/pontoon/machinery/utils.py
+++ b/pontoon/machinery/utils.py
@@ -164,7 +164,7 @@ def use_placeables_glossary(text, client, project_id, location, request_params):
 
     # Store any new terms to the glossary
     if existing_terms:
-        new_terms = set([term for term in placeables if term not in existing_terms])
+        new_terms = {term for term in placeables if term not in existing_terms}
 
         if new_terms:
             store_new_terms(url, headers, new_terms)

--- a/pontoon/machinery/utils.py
+++ b/pontoon/machinery/utils.py
@@ -174,6 +174,8 @@ def use_placeables_glossary(text, client, project_id, location, request_params):
 
 
 def get_existing_terms(url, headers):
+    # TODO: Placeables should be cached in a new DB table, that will be updated in
+    # store_new_terms() and synced daily from upstream to account for any drift.
     try:
         r = requests.get(url, headers=headers)
         r.raise_for_status()

--- a/pontoon/machinery/utils.py
+++ b/pontoon/machinery/utils.py
@@ -96,26 +96,30 @@ def get_google_automl_translation(text, locale, format="text"):
             "message": "Bad Request: Missing Project ID.",
         }
 
-    model_id = locale.google_automl_model
-
     # Google AutoML Translation requires location "us-central1"
     location = "us-central1"
 
     parent = f"projects/{project_id}/locations/{location}"
+    model_id = locale.google_automl_model
     model_path = f"{parent}/models/{model_id}"
 
-    response = client.translate_text(
-        request={
-            "contents": [text],
-            "target_language_code": locale.google_translate_code,
-            "model": model_path,
-            "source_language_code": "en",
-            "parent": parent,
-            "mime_type": "text/html" if format == "html" else "text/plain",
-        }
-    )
+    request_params = {
+        "contents": [text],
+        "target_language_code": locale.google_translate_code,
+        "model": model_path,
+        "source_language_code": "en",
+        "parent": parent,
+        "mime_type": "text/html" if format == "html" else "text/plain",
+    }
 
-    if len(response.translations) == 0:
+    # Get translations
+    response = client.translate_text(request=request_params)
+
+    translations = response.translations
+    if response.glossary_translations:
+        translations = response.glossary_translations
+
+    if len(translations) == 0:
         return {
             "status": False,
             "message": "No translations found.",
@@ -123,7 +127,7 @@ def get_google_automl_translation(text, locale, format="text"):
     else:
         return {
             "status": True,
-            "translation": response.translations[0].translated_text,
+            "translation": translations[0].translated_text,
         }
 
 

--- a/pontoon/machinery/utils.py
+++ b/pontoon/machinery/utils.py
@@ -25,9 +25,9 @@ log = logging.getLogger(__name__)
 MAX_RESULTS = 5
 
 
-def get_google_translate_data(text, locale, format="text", preserve_placeables=False):
+def get_google_translate_data(text, locale, format="text"):
     res = (
-        get_google_automl_translation(text, locale, format, preserve_placeables)
+        get_google_automl_translation(text, locale, format)
         if locale.google_automl_model
         else get_google_generic_translation(text, locale.google_translate_code, format)
     )
@@ -82,7 +82,7 @@ def get_google_generic_translation(text, locale_code, format="text"):
         }
 
 
-def get_google_automl_translation(text, locale, format="text", preserve_placeables=False):
+def get_google_automl_translation(text, locale, format="text"):
     try:
         client = translate.TranslationServiceClient()
     except DefaultCredentialsError as e:
@@ -117,8 +117,7 @@ def get_google_automl_translation(text, locale, format="text", preserve_placeabl
         "mime_type": "text/html" if format == "html" else "text/plain",
     }
 
-    if preserve_placeables:
-        use_placeables_glossary(text, client, project_id, location, request_params)
+    use_placeables_glossary(text, client, project_id, location, request_params)
 
     # Get translations
     response = client.translate_text(request=request_params)

--- a/pontoon/machinery/utils.py
+++ b/pontoon/machinery/utils.py
@@ -5,7 +5,6 @@ import Levenshtein
 import logging
 import operator
 import os
-import re
 import requests
 
 from collections import defaultdict
@@ -20,6 +19,7 @@ from django.contrib.postgres.aggregates import ArrayAgg
 from django.db.models import Q
 
 import pontoon.base as base
+from pontoon.base.placeables import get_placeables
 
 log = logging.getLogger(__name__)
 MAX_RESULTS = 5
@@ -139,7 +139,7 @@ def get_google_automl_translation(text, locale, format="text"):
 
 
 def use_placeables_glossary(text, client, project_id, location, request_params):
-    placeables = re.findall(r"(\{{?[\w\d!.,[\]%:$<>+-= ]*\}?})", text)
+    placeables = get_placeables(text)
 
     if not placeables:
         return

--- a/pontoon/machinery/utils.py
+++ b/pontoon/machinery/utils.py
@@ -25,9 +25,9 @@ log = logging.getLogger(__name__)
 MAX_RESULTS = 5
 
 
-def get_google_translate_data(text, locale, format="text"):
+def get_google_translate_data(text, locale, format="text", preserve_placeables=False):
     res = (
-        get_google_automl_translation(text, locale, format)
+        get_google_automl_translation(text, locale, format, preserve_placeables)
         if locale.google_automl_model
         else get_google_generic_translation(text, locale.google_translate_code, format)
     )
@@ -82,7 +82,7 @@ def get_google_generic_translation(text, locale_code, format="text"):
         }
 
 
-def get_google_automl_translation(text, locale, format="text"):
+def get_google_automl_translation(text, locale, format="text", preserve_placeables=False):
     try:
         client = translate.TranslationServiceClient()
     except DefaultCredentialsError as e:
@@ -117,7 +117,8 @@ def get_google_automl_translation(text, locale, format="text"):
         "mime_type": "text/html" if format == "html" else "text/plain",
     }
 
-    use_placeables_glossary(text, client, project_id, location, request_params)
+    if preserve_placeables:
+        use_placeables_glossary(text, client, project_id, location, request_params)
 
     # Get translations
     response = client.translate_text(request=request_params)

--- a/pontoon/machinery/utils.py
+++ b/pontoon/machinery/utils.py
@@ -25,9 +25,9 @@ log = logging.getLogger(__name__)
 MAX_RESULTS = 5
 
 
-def get_google_translate_data(text, locale, format="text"):
+def get_google_translate_data(text, locale, format="text", preserve_placeables=False):
     res = (
-        get_google_automl_translation(text, locale, format)
+        get_google_automl_translation(text, locale, format, preserve_placeables)
         if locale.google_automl_model
         else get_google_generic_translation(text, locale.google_translate_code, format)
     )
@@ -82,7 +82,9 @@ def get_google_generic_translation(text, locale_code, format="text"):
         }
 
 
-def get_google_automl_translation(text, locale, format="text"):
+def get_google_automl_translation(
+    text, locale, format="text", preserve_placeables=False
+):
     try:
         client = translate.TranslationServiceClient()
     except DefaultCredentialsError as e:
@@ -117,7 +119,8 @@ def get_google_automl_translation(text, locale, format="text"):
         "mime_type": "text/html" if format == "html" else "text/plain",
     }
 
-    use_placeables_glossary(text, client, project_id, location, request_params)
+    if preserve_placeables:
+        use_placeables_glossary(text, client, project_id, location, request_params)
 
     # Get translations
     response = client.translate_text(request=request_params)

--- a/pontoon/pretranslation/pretranslate.py
+++ b/pontoon/pretranslation/pretranslate.py
@@ -23,7 +23,7 @@ parser = FluentParser()
 serializer = FluentSerializer()
 
 
-def get_pretranslations(entity, locale, preserve_placeables=False):
+def get_pretranslations(entity, locale):
     """
     Get pretranslations for the entity-locale pair using internal translation memory and
     Google's machine translation.
@@ -34,7 +34,6 @@ def get_pretranslations(entity, locale, preserve_placeables=False):
 
     :arg Entity entity: the Entity object
     :arg Locale locale: the Locale object
-    :arg boolean preserve_placeables
 
     :returns: a list of tuples, consisting of:
         - a pretranslation of the entity
@@ -46,7 +45,7 @@ def get_pretranslations(entity, locale, preserve_placeables=False):
 
     if entity.resource.format == "ftl":
         entry = parser.parse_entry(source)
-        pretranslate = ApplyPretranslation(locale, entry, get_pretranslated_data, preserve_placeables)
+        pretranslate = ApplyPretranslation(locale, entry, get_pretranslated_data)
 
         try:
             pretranslate.visit(entry)
@@ -62,7 +61,7 @@ def get_pretranslations(entity, locale, preserve_placeables=False):
         return [(pretranslation, None, author)]
 
     else:
-        pretranslation, service = get_pretranslated_data(source, locale, preserve_placeables)
+        pretranslation, service = get_pretranslated_data(source, locale)
 
         if pretranslation is None:
             return []
@@ -77,7 +76,7 @@ def get_pretranslations(entity, locale, preserve_placeables=False):
             ]
 
 
-def get_pretranslated_data(source, locale, preserve_placeables):
+def get_pretranslated_data(source, locale):
     # Empty strings do not need translation
     if re.search("^\\s*$", source):
         return source, "tm"
@@ -90,7 +89,9 @@ def get_pretranslated_data(source, locale, preserve_placeables):
 
     # Fetch from Google Translate
     elif locale.google_translate_code:
-        gt_response = get_google_translate_data(text=source, locale=locale, preserve_placeables=preserve_placeables)
+        gt_response = get_google_translate_data(
+            text=source, locale=locale, format="text"
+        )
         if gt_response["status"]:
             return gt_response["translation"], "gt"
 

--- a/pontoon/pretranslation/pretranslate.py
+++ b/pontoon/pretranslation/pretranslate.py
@@ -23,7 +23,7 @@ parser = FluentParser()
 serializer = FluentSerializer()
 
 
-def get_pretranslations(entity, locale):
+def get_pretranslations(entity, locale, preserve_placeables=False):
     """
     Get pretranslations for the entity-locale pair using internal translation memory and
     Google's machine translation.
@@ -34,6 +34,7 @@ def get_pretranslations(entity, locale):
 
     :arg Entity entity: the Entity object
     :arg Locale locale: the Locale object
+    :arg boolean preserve_placeables
 
     :returns: a list of tuples, consisting of:
         - a pretranslation of the entity
@@ -45,7 +46,7 @@ def get_pretranslations(entity, locale):
 
     if entity.resource.format == "ftl":
         entry = parser.parse_entry(source)
-        pretranslate = ApplyPretranslation(locale, entry, get_pretranslated_data)
+        pretranslate = ApplyPretranslation(locale, entry, get_pretranslated_data, preserve_placeables)
 
         try:
             pretranslate.visit(entry)
@@ -61,7 +62,7 @@ def get_pretranslations(entity, locale):
         return [(pretranslation, None, author)]
 
     else:
-        pretranslation, service = get_pretranslated_data(source, locale)
+        pretranslation, service = get_pretranslated_data(source, locale, preserve_placeables)
 
         if pretranslation is None:
             return []
@@ -76,7 +77,7 @@ def get_pretranslations(entity, locale):
             ]
 
 
-def get_pretranslated_data(source, locale):
+def get_pretranslated_data(source, locale, preserve_placeables):
     # Empty strings do not need translation
     if re.search("^\\s*$", source):
         return source, "tm"
@@ -89,9 +90,7 @@ def get_pretranslated_data(source, locale):
 
     # Fetch from Google Translate
     elif locale.google_translate_code:
-        gt_response = get_google_translate_data(
-            text=source, locale=locale, format="text"
-        )
+        gt_response = get_google_translate_data(text=source, locale=locale, preserve_placeables=preserve_placeables)
         if gt_response["status"]:
             return gt_response["translation"], "gt"
 

--- a/pontoon/pretranslation/tasks.py
+++ b/pontoon/pretranslation/tasks.py
@@ -18,6 +18,7 @@ from pontoon.pretranslation.pretranslate import (
 )
 from pontoon.base.tasks import PontoonTask
 from pontoon.sync.core import serial_task
+from pontoon.checks.libraries import run_checks
 from pontoon.checks.utils import bulk_run_checks
 
 
@@ -124,6 +125,19 @@ def pretranslate(self, project_pk, locales=None, entities=None):
 
             if not pretranslations:
                 continue
+
+            failed_checks = run_checks(
+                entity,
+                locale.code,
+                entity.string,
+                pretranslations[0],
+                use_tt_checks=False,
+            )
+
+            if failed_checks:
+                pretranslations = get_pretranslations(
+                    entity, locale, preserve_placeables=True
+                )
 
             for string, plural_form, user in pretranslations:
                 t = Translation(

--- a/pontoon/pretranslation/tasks.py
+++ b/pontoon/pretranslation/tasks.py
@@ -18,7 +18,6 @@ from pontoon.pretranslation.pretranslate import (
 )
 from pontoon.base.tasks import PontoonTask
 from pontoon.sync.core import serial_task
-from pontoon.checks.libraries import run_checks
 from pontoon.checks.utils import bulk_run_checks
 
 
@@ -125,19 +124,6 @@ def pretranslate(self, project_pk, locales=None, entities=None):
 
             if not pretranslations:
                 continue
-
-            failed_checks = run_checks(
-                entity,
-                locale.code,
-                entity.string,
-                pretranslations[0],
-                use_tt_checks=False,
-            )
-
-            if failed_checks:
-                pretranslations = get_pretranslations(
-                    entity, locale, preserve_placeables=True
-                )
 
             for string, plural_form, user in pretranslations:
                 t = Translation(

--- a/pontoon/pretranslation/tasks.py
+++ b/pontoon/pretranslation/tasks.py
@@ -18,6 +18,7 @@ from pontoon.pretranslation.pretranslate import (
 )
 from pontoon.base.tasks import PontoonTask
 from pontoon.sync.core import serial_task
+from pontoon.checks.libraries import run_checks
 from pontoon.checks.utils import bulk_run_checks
 
 
@@ -124,6 +125,19 @@ def pretranslate(self, project_pk, locales=None, entities=None):
 
             if not pretranslations:
                 continue
+
+            failed_checks = run_checks(
+                entity,
+                locale.code,
+                entity.string,
+                pretranslations[0][0],
+                use_tt_checks=False,
+            )
+
+            if failed_checks:
+                pretranslations = get_pretranslations(
+                    entity, locale, preserve_placeables=True
+                )
 
             for string, plural_form, user in pretranslations:
                 t = Translation(

--- a/pontoon/pretranslation/tests/test_transformer.py
+++ b/pontoon/pretranslation/tests/test_transformer.py
@@ -7,7 +7,7 @@ from pontoon.test.factories import LocaleFactory
 
 
 def visit(src):
-    def callback(source, locale):
+    def callback(source, locale, preserve_placeables):
         return (source, locale.code)
 
     locale = LocaleFactory(code="en-XX")
@@ -127,7 +127,7 @@ def test_transformer_value_and_attributes():
 def test_transformer_callback(locale_a):
     called = []
 
-    def callback(source, locale):
+    def callback(source, locale, preserve_placeables):
         called.append(source)
         return ("res: " + source, locale.code)
 
@@ -149,7 +149,7 @@ def test_transformer_callback(locale_a):
 def test_plural_variants(locale_a):
     called = []
 
-    def callback(source, locale):
+    def callback(source, locale, preserve_placeables):
         called.append(source)
         return ("res: " + source, locale.code)
 

--- a/pontoon/pretranslation/transformer.py
+++ b/pontoon/pretranslation/transformer.py
@@ -175,9 +175,11 @@ class ApplyPretranslation(Transformer):
         locale: Locale,
         entry: FTL.EntryType,
         callback: Callable[[str, str], tuple[Optional[str], str]],
+        preserve_placeables: bool = None,
     ):
         prep = PreparePretranslation(locale)
         prep.visit(entry)
+        self.preserve_placeables = preserve_placeables
         self.callback = callback
         self.entry = entry
         self.locale = locale
@@ -234,7 +236,9 @@ class ApplyPretranslation(Transformer):
             # hence we replace newline characters with spaces.
             source = source.replace("\n", " ")
 
-            translation, service = self.callback(source, self.locale)
+            translation, service = self.callback(
+                source, self.locale, self.preserve_placeables
+            )
             if translation is None:
                 raise ValueError(
                     f"Pretranslation for `{source}` to {self.locale.code} not available."

--- a/pontoon/pretranslation/transformer.py
+++ b/pontoon/pretranslation/transformer.py
@@ -175,7 +175,6 @@ class ApplyPretranslation(Transformer):
         locale: Locale,
         entry: FTL.EntryType,
         callback: Callable[[str, str], tuple[Optional[str], str]],
-        preserve_placeables: bool,
     ):
         prep = PreparePretranslation(locale)
         prep.visit(entry)
@@ -235,7 +234,7 @@ class ApplyPretranslation(Transformer):
             # hence we replace newline characters with spaces.
             source = source.replace("\n", " ")
 
-            translation, service = self.callback(source, self.locale, self.preserve_placeables)
+            translation, service = self.callback(source, self.locale)
             if translation is None:
                 raise ValueError(
                     f"Pretranslation for `{source}` to {self.locale.code} not available."

--- a/pontoon/pretranslation/transformer.py
+++ b/pontoon/pretranslation/transformer.py
@@ -175,6 +175,7 @@ class ApplyPretranslation(Transformer):
         locale: Locale,
         entry: FTL.EntryType,
         callback: Callable[[str, str], tuple[Optional[str], str]],
+        preserve_placeables: bool,
     ):
         prep = PreparePretranslation(locale)
         prep.visit(entry)
@@ -234,7 +235,7 @@ class ApplyPretranslation(Transformer):
             # hence we replace newline characters with spaces.
             source = source.replace("\n", " ")
 
-            translation, service = self.callback(source, self.locale)
+            translation, service = self.callback(source, self.locale, self.preserve_placeables)
             if translation is None:
                 raise ValueError(
                     f"Pretranslation for `{source}` to {self.locale.code} not available."


### PR DESCRIPTION
Fixes #2181.

This patch prevents placeables modifications by machine translation. Any placeable found in the input string is stored in the glossary with equivalent translations for all locales supported by Google Translate.

~I [tried to](https://github.com/mozilla/pontoon/pull/2873/commits/8b03a884ca551102e3d92b2643900daca3c2c522) use the glossary only on strings containing errors and warnings, but I [reverted](https://github.com/mozilla/pontoon/pull/2873/commits/1ff9dce6ca4eba7ef4d5b98137c1eb127763b7bd) the commit, because the code looks ugly. A bigger refactor will be needed should we want to proceed with that.~

~Which means, at least for now, any string containing placeables is translated using the glossary. Placeables are detected using the most common parsers taken from `react-content-marker`. I still need to port a few more.~

_**EDIT**: We only use glossary to re-pretranslate strings for which the default (non-glossary) machine translation output resulted in a failed check (error or warning)._