### PR TITLE
Add syntax highlighting for placeholders and tags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13040,6 +13040,7 @@
         "@fluent/langneg": "^0.7.0",
         "@fluent/react": "^0.15.1",
         "@fluent/syntax": "^0.19.0",
+        "@lezer/highlight": "^1.1.6",
         "@messageformat/fluent": "^0.4.1",
         "@reduxjs/toolkit": "^1.6.1",
         "classnames": "^2.3.1",

--- a/translate/package.json
+++ b/translate/package.json
@@ -11,6 +11,7 @@
     "@fluent/langneg": "^0.7.0",
     "@fluent/react": "^0.15.1",
     "@fluent/syntax": "^0.19.0",
+    "@lezer/highlight": "^1.1.6",
     "@messageformat/fluent": "^0.4.1",
     "@reduxjs/toolkit": "^1.6.1",
     "classnames": "^2.3.1",

--- a/translate/src/modules/translationform/components/EditField.tsx
+++ b/translate/src/modules/translationform/components/EditField.tsx
@@ -17,6 +17,7 @@ import { Locale } from '~/context/Locale';
 import { useReadonlyEditor } from '~/hooks/useReadonlyEditor';
 
 import { getExtensions, useKeyHandlers } from '../utils/editFieldExtensions';
+import { EntityView } from '~/context/EntityView';
 
 export type EditFieldProps = {
   index: number;
@@ -38,13 +39,14 @@ export const EditField = memo(
       const { l10n } = useLocalization();
       const locale = useContext(Locale);
       const readOnly = useReadonlyEditor();
+      const { entity } = useContext(EntityView);
       const { setResultFromInput } = useContext(EditorActions);
       const keyHandlers = useKeyHandlers();
       const [view, setView] = useState<EditorView | null>(null);
 
       const initView = useCallback((parent: HTMLDivElement | null) => {
         if (parent) {
-          const extensions = getExtensions(keyHandlers);
+          const extensions = getExtensions(entity.format, keyHandlers);
           if (readOnly) {
             extensions.push(
               EditorState.readOnly.of(true),

--- a/translate/src/modules/translationform/utils/editFieldExtensions.ts
+++ b/translate/src/modules/translationform/utils/editFieldExtensions.ts
@@ -58,10 +58,10 @@ export function useKeyHandlers() {
 }
 
 const style = HighlightStyle.define([
-  { tag: tags.keyword, color: '#708', fontFamily: 'monospace' }, // printf
-  { tag: tags.tagName, color: '#174', fontFamily: 'monospace' }, // <...>
-  { tag: tags.brace, color: '#708', fontWeight: 'bold' }, // {...}
-  { tag: tags.name, color: '#708' }, // {...}
+  { tag: tags.keyword, color: '#872bff', fontFamily: 'monospace' }, // printf
+  { tag: tags.tagName, color: '#3e9682', fontFamily: 'monospace' }, // <...>
+  { tag: tags.brace, color: '#872bff', fontWeight: 'bold' }, // {...}
+  { tag: tags.name, color: '#872bff' }, // {...}
 ]);
 
 export const getExtensions = (

--- a/translate/src/modules/translationform/utils/editFieldExtensions.ts
+++ b/translate/src/modules/translationform/utils/editFieldExtensions.ts
@@ -5,7 +5,12 @@ import {
   insertNewlineAndIndent,
   standardKeymap,
 } from '@codemirror/commands';
-import { bracketMatching } from '@codemirror/language';
+import {
+  HighlightStyle,
+  StreamLanguage,
+  bracketMatching,
+  syntaxHighlighting,
+} from '@codemirror/language';
 import { Extension } from '@codemirror/state';
 import { EditorView, keymap } from '@codemirror/view';
 import { useContext, useEffect, useRef } from 'react';
@@ -17,6 +22,8 @@ import {
   useHandleEnter,
   useHandleEscape,
 } from './editFieldShortcuts';
+import { fluentMode, commonMode } from './editFieldModes';
+import { tags } from '@lezer/highlight';
 
 /**
  * Key handlers depend on application state,
@@ -50,13 +57,23 @@ export function useKeyHandlers() {
   return ref;
 }
 
+const style = HighlightStyle.define([
+  { tag: tags.keyword, color: '#708', fontFamily: 'monospace' }, // printf
+  { tag: tags.tagName, color: '#174', fontFamily: 'monospace' }, // <...>
+  { tag: tags.brace, color: '#708', fontWeight: 'bold' }, // {...}
+  { tag: tags.name, color: '#708' }, // {...}
+]);
+
 export const getExtensions = (
+  format: string,
   ref: ReturnType<typeof useKeyHandlers>,
 ): Extension[] => [
   history(),
   bracketMatching(),
   closeBrackets(),
   EditorView.lineWrapping,
+  StreamLanguage.define<any>(format === 'ftl' ? fluentMode : commonMode),
+  syntaxHighlighting(style),
   keymap.of([
     {
       key: 'Enter',

--- a/translate/src/modules/translationform/utils/editFieldModes.ts
+++ b/translate/src/modules/translationform/utils/editFieldModes.ts
@@ -1,0 +1,64 @@
+import { StreamParser } from '@codemirror/language';
+
+export const fluentMode: StreamParser<{ expression: boolean; tag: boolean }> = {
+  name: 'fluent',
+  startState: () => ({ expression: false, tag: false }),
+  token(stream, state) {
+    const ch = stream.next();
+    if (state.expression) {
+      if (ch === '}') {
+        state.expression = false;
+        return 'brace';
+      }
+      stream.skipTo('}');
+      return 'name';
+    } else {
+      if (ch === '{') {
+        state.expression = true;
+        return 'brace';
+      }
+      if (ch === '<') {
+        state.tag = true;
+      }
+      if (state.tag) {
+        if (ch === '>') {
+          state.tag = false;
+        } else {
+          stream.eatWhile(/[^>{]+/);
+        }
+        return 'tagName';
+      }
+      stream.eatWhile(/[^<{]+/);
+      return 'string';
+    }
+  },
+};
+
+const printf =
+  /^%(\d\$|\(.*?\))?[-+ 0'#]*[\d*]*(\.[\d*])?(hh?|ll?|[jLtz])?[%@AacdEeFfGginopSsuXx]/;
+
+const pythonFormat = /^{[\w.[\]]*(![rsa])?(:.*?)?}/;
+
+export const commonMode: StreamParser<{ tag: boolean }> = {
+  name: 'common',
+  startState: () => ({ tag: false }),
+  token(stream, state) {
+    if (stream.match(printf) || stream.match(pythonFormat)) {
+      return 'keyword';
+    }
+    const ch = stream.next();
+    if (ch === '<') {
+      state.tag = true;
+    }
+    if (state.tag) {
+      if (ch === '>') {
+        state.tag = false;
+      } else {
+        stream.eatWhile(/[^>%{]+/);
+      }
+      return 'tagName';
+    }
+    stream.eatWhile(/[^%{<]+/);
+    return 'string';
+  },
+};


### PR DESCRIPTION
Fixes part of #2180

These use a a CodeMirror 5-style [stream parser](https://codemirror.net/docs/ref/#language.StreamParser) or tokenizer, as that seemed like the easiest solution for the level of complexity we need. As these have a slightly different shape than our other parsers, and as our current regexps are somewhat suboptimal as identified in mozilla/react-content-marker#23, I wrote new ones for use here. Fluent patterns are handled specially, while all others are parsed for printf and Python-style variables. HTML-ish tags are identified in both.

Happy to take instruction on the CSS styles used by the highlighter.

Some examples:

<img width="717" alt="Screenshot 2023-06-16 at 21 44 50" src="https://github.com/mozilla/pontoon/assets/617000/97b8172c-7b93-4cd8-8fa9-94b96259de71">

<img width="720" alt="Screenshot 2023-06-16 at 21 45 24" src="https://github.com/mozilla/pontoon/assets/617000/df4bf6f0-4a1d-4263-bf2a-e500dd5eea8b">

<img width="717" alt="Screenshot 2023-06-16 at 21 46 31" src="https://github.com/mozilla/pontoon/assets/617000/fe7afd83-b438-4892-8cfb-6e86a7ebf37e">

<img width="717" alt="Screenshot 2023-06-16 at 21 47 05" src="https://github.com/mozilla/pontoon/assets/617000/801f9456-d387-4e7b-9bfe-1c8e2d22f462">

<img width="718" alt="Screenshot 2023-06-16 at 21 48 17" src="https://github.com/mozilla/pontoon/assets/617000/9d5fddee-2536-4b81-95b5-0a705fc963e0">

<img width="719" alt="Screenshot 2023-06-16 at 21 49 44" src="https://github.com/mozilla/pontoon/assets/617000/760b1c07-31cc-4865-a79e-a2d89ff5a6bb">

<img width="719" alt="Screenshot 2023-06-16 at 21 50 53" src="https://github.com/mozilla/pontoon/assets/617000/b7e55e28-68c5-4ddd-a204-28ea12870a1b">
