### PR TITLE
Disable Microsoft Terminology service in Machinery

### DIFF
--- a/pontoon/machinery/static/js/machinery.js
+++ b/pontoon/machinery/static/js/machinery.js
@@ -133,10 +133,9 @@ $(function () {
       var listitems = ul.children('li'),
         sourceMap = {
           'Translation memory': 1,
-          Microsoft: 2,
-          'Google Translate': 3,
-          'Systran Translate': 4,
-          'Microsoft Translator': 5,
+          'Google Translate': 2,
+          'Systran Translate': 3,
+          'Microsoft Translator': 4,
         };
 
       function getTranslationSource(el) {

--- a/pontoon/machinery/static/js/machinery.js
+++ b/pontoon/machinery/static/js/machinery.js
@@ -371,44 +371,6 @@ $(function () {
       });
     }
 
-    // Microsoft Terminology
-    if (self.locale.ms_terminology_code.length) {
-      requests++;
-
-      if (self.XHRmicrosoftTerminology) {
-        self.XHRmicrosoftTerminology.abort();
-      }
-
-      self.XHRmicrosoftTerminology = $.ajax({
-        url: '/microsoft-terminology/',
-        data: {
-          text: original,
-          locale: self.locale.ms_terminology_code,
-        },
-        success: function (data) {
-          if (data.translations) {
-            $.each(data.translations, function () {
-              append({
-                url:
-                  'https://www.microsoft.com/Language/en-US/Search.aspx?sString=' +
-                  this.source +
-                  '&langID=' +
-                  self.locale.ms_terminology_code,
-                title:
-                  'Visit Microsoft Terminology Service API.\n' +
-                  '© 2018 Microsoft Corporation. All rights reserved.',
-                source: 'Microsoft',
-                original: this.source,
-                translation: this.target,
-              });
-            });
-          }
-        },
-        error: error,
-        complete: complete,
-      });
-    }
-
     self.NProgressBind();
   }
 

--- a/translate/src/context/MachineryTranslations.tsx
+++ b/translate/src/context/MachineryTranslations.tsx
@@ -113,10 +113,6 @@ export function MachineryProvider({
         }
       }
 
-      if (locale.msTerminologyCode) {
-        fetchMicrosoftTerminology(plain, locale).then(addResults);
-      }
-
       if (locale.code === 'ga-IE' && pk) {
         fetchCaighdeanTranslation(pk).then(addResults);
       }


### PR DESCRIPTION
Fixes #2899.

As of yesterday, Microsoft Terminology API seems to be shut down:
https://slator.com/microsoft-kills-off-beloved-language-portal/

Filed #2901 to investigate if we can build a replacement service.

Deployed to stage for testing:
https://mozilla-pontoon-staging.herokuapp.com/machinery/