### PR TITLE
Fix broken team dashboard for non-authenticated users

### DIFF
--- a/pontoon/teams/views.py
+++ b/pontoon/teams/views.py
@@ -84,7 +84,8 @@ def ajax_projects(request, locale):
     )
 
     pretranslation_request_enabled = (
-        locale in request.user.translated_locales
+        request.user.is_authenticated
+        and locale in request.user.translated_locales
         and locale.code in settings.GOOGLE_AUTOML_SUPPORTED_LOCALES
         and pretranslated_projects.count() < enabled_projects.count()
     )


### PR DESCRIPTION
Views like https://pontoon.mozilla.org/sl/ are broken if the user is not logged in.