### PR TITLE
Do not enforce camel case on sibling entity object keys

### DIFF
--- a/translate/src/api/entity.ts
+++ b/translate/src/api/entity.ts
@@ -148,8 +148,7 @@ export async function fetchSiblingEntities(
   locale: string,
 ): Promise<EntitySiblings> {
   const search = new URLSearchParams({ entity: String(entity), locale });
-  const results = await GET('/get-sibling-entities/', search);
-  return keysToCamelCase(results);
+  return GET('/get-sibling-entities/', search);
 }
 
 export async function fetchEntityHistory(

--- a/translate/src/context/MachineryTranslations.tsx
+++ b/translate/src/context/MachineryTranslations.tsx
@@ -4,7 +4,6 @@ import {
   abortMachineryRequests,
   fetchCaighdeanTranslation,
   fetchGoogleTranslation,
-  fetchMicrosoftTerminology,
   fetchMicrosoftTranslation,
   fetchSystranTranslation,
   fetchTranslationMemory,


### PR DESCRIPTION
Fixes #2823

This was apparently missed out in the original PR #1866. Machinery depends on the `machinery_original` value, which was correctly sent from the backend, but "fixed" to use a key `machineryOriginal` instead.