### PR TITLE
Only spellcheck string content, not placeholders or html tags

### DIFF
--- a/translate/src/modules/translationform/utils/editFieldExtensions.test.ts
+++ b/translate/src/modules/translationform/utils/editFieldExtensions.test.ts
@@ -1,0 +1,56 @@
+import { EditorView } from '@codemirror/view';
+import { EditorState } from '@codemirror/state';
+
+import { getExtensions } from './editFieldExtensions';
+
+const div = document.createElement('div');
+document.body.appendChild(div);
+
+let currentTempView: EditorView | null = null;
+
+// Create a hidden view with the given document and extensions that
+// lives until the next call to `tempView`.
+// From: https://github.com/codemirror/view/blob/main/test/tempview.ts
+function tempView(doc = '', format: string): EditorView {
+  if (currentTempView) {
+    currentTempView.destroy();
+    currentTempView = null;
+  }
+
+  const extensions = getExtensions(format, {} as any);
+  currentTempView = new EditorView({
+    state: EditorState.create({ doc, extensions }),
+  });
+  div.appendChild(currentTempView.dom);
+  return currentTempView;
+}
+
+function getAncestorWith(node: Node | null, attribute: string) {
+  let el = node instanceof HTMLElement ? node : node?.parentElement;
+  while (el && !el.hasAttribute(attribute)) {
+    el = el.parentElement;
+  }
+  return el;
+}
+
+describe('spellcheck', () => {
+  test('ftl mode', () => {
+    const view = tempView('foo { $bar }', 'ftl');
+
+    const text = getAncestorWith(view.domAtPos(1).node, 'spellcheck');
+    expect(text?.getAttribute('spellcheck')).toBe('true');
+
+    const ph = getAncestorWith(view.domAtPos(8).node, 'spellcheck');
+    expect(ph?.getAttribute('spellcheck')).toBe('false');
+  });
+
+  test('common mode', () => {
+    const view = tempView('%1$s foo', 'common');
+
+    const text = getAncestorWith(view.domAtPos(7).node, 'spellcheck');
+    expect(text?.getAttribute('spellcheck')).toBe('true');
+
+    const ph = getAncestorWith(view.domAtPos(1).node, 'spellcheck');
+    expect(ph?.getAttribute('spellcheck')).toBe('false');
+  });
+});


### PR DESCRIPTION
With the new editor and its syntax highlighting, we can limit the spellcheck to just the literal translatable content of a message, rather than needing to apply it to all of it.

This allows us to e.g. not have a fluent placeholder `{ $tabCount }` get marked as a spelling error by the browser.

This isn't a workaround for [Firefox bug 1837268](https://bugzilla.mozilla.org/show_bug.cgi?id=1837268), though tbf seeing if it were was a part of the reason why I implemented this.