### PR TITLE
Drop can_be_requested flag from the pretranslation project request

### DIFF
--- a/pontoon/teams/views.py
+++ b/pontoon/teams/views.py
@@ -314,9 +314,7 @@ def request_pretranslation(request, locale):
 
     # Validate projects
     project_list = (
-        Project.objects.visible()
-        .visible_for(user)
-        .filter(slug__in=slug_list, can_be_requested=True)
+        Project.objects.visible().visible_for(user).filter(slug__in=slug_list)
     )
     if not project_list:
         return HttpResponseBadRequest("Bad Request: Non-existent projects specified")


### PR DESCRIPTION
This patch removes the requirement that only projects that can be requested to be enabled can be requested to be pretranslated. The requirement was included because the code was copied from the project request form.