### PR TITLE
Do not clobber EditField value & cursor position if the text does not change

### DIFF
--- a/translate/src/modules/translationform/components/EditField.tsx
+++ b/translate/src/modules/translationform/components/EditField.tsx
@@ -80,10 +80,13 @@ export const EditField = memo(
 
       const setValue = useCallback(
         (text: string) => {
-          view?.dispatch({
-            changes: { from: 0, to: view.state.doc.length, insert: text },
-            selection: { anchor: text.length },
-          });
+          const prev = view?.state.doc.toString();
+          if (text !== prev) {
+            view?.dispatch({
+              changes: { from: 0, to: view.state.doc.length, insert: text },
+              selection: { anchor: text.length },
+            });
+          }
         },
         [view],
       );


### PR DESCRIPTION
Fixes #2941 

As @mathjazz discovered, the user data fetch ends up triggering an EditField re-render if the text has been changed, because we've not optimised the parent components to avoid such. The EditField is so optimised, and so this re-render was not accounted for; the pings are made only every 2 minutes.

Adding a rather straightforward check should prevent the cursor jump here and on any other unexpected re-render.