### PR TITLE
Update `master` branch references to `main`

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -3,7 +3,7 @@ name: Backend
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - requirements/**
       - docker**
@@ -11,7 +11,7 @@ on:
       - .github/workflows/backend.yml
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - requirements/**
       - docker**

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -3,13 +3,13 @@ name: Frontend
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - translate/**
       - .github/workflows/frontend.yml
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - translate/**
       - .github/workflows/frontend.yml

--- a/.github/workflows/heroku.yml
+++ b/.github/workflows/heroku.yml
@@ -3,13 +3,13 @@ name: Heroku
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - app.json
       - .github/workflows/heroku.yml
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - app.json
       - .github/workflows/heroku.yml

--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -3,7 +3,7 @@ name: JavaScript linting
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - '**.js'
       - '**.ts'
@@ -15,7 +15,7 @@ on:
       - .github/workflows/js-lint.yml
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - '**.js'
       - '**.ts'

--- a/.github/workflows/py-lint.yml
+++ b/.github/workflows/py-lint.yml
@@ -3,14 +3,14 @@ name: Python linting
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - pontoon/**.py
       - .github/workflows/py-lint.yml
       - requirements/lint.txt
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - pontoon/**.py
       - .github/workflows/py-lint.yml

--- a/.github/workflows/tag-admin.yml
+++ b/.github/workflows/tag-admin.yml
@@ -3,14 +3,14 @@ name: Non-frontend JavaScript
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - tag-admin/**
       - package.json
       - .github/workflows/tag-admin.yml
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - tag-admin/**
       - package.json

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -387,8 +387,8 @@ steps, as they don't affect your setup if nothing has changed:
 
 .. code-block:: shell
 
-   # Pull the latest code (assuming you've already checked out master).
-   git pull origin master
+   # Pull the latest code (assuming you've already checked out main).
+   git pull origin main
 
    # Install new dependencies or update existing ones.
    pip install -U --force --require-hashes -r requirements/default.txt

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you want to go further, you can:
 
 This software is licensed under the
 [New BSD License](https://creativecommons.org/licenses/BSD/). For more
-information, read [LICENSE](https://github.com/mozilla/pontoon/blob/master/LICENSE).
+information, read [LICENSE](https://github.com/mozilla/pontoon/blob/HEAD/LICENSE).
 
 ## Screenshots
 

--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -10,7 +10,7 @@ For quick and easy deployment without leaving your web browser, click this butto
 
 .. raw:: html
 
-   <a class="reference external image-reference" href="https://heroku.com/deploy?template=https://github.com/mozilla/pontoon/tree/master">
+   <a class="reference external image-reference" href="https://heroku.com/deploy?template=https://github.com/mozilla/pontoon/tree/main">
       <img src="https://www.herokucdn.com/deploy/button.svg">
    </a>
 
@@ -254,7 +254,7 @@ you create:
 ``VCS_SYNC_EMAIL``
   Optional. Default committer's email used when committing translations to version control system.
 
-.. _the spec: https://github.com/mozilla/pontoon/blob/master/specs/0108-community-health-dashboard.md
+.. _the spec: https://github.com/mozilla/pontoon/blob/HEAD/specs/0108-community-health-dashboard.md
 .. _Heroku Reference: https://devcenter.heroku.com/articles/error-pages#customize-pages
 .. _Firefox Accounts: https://developer.mozilla.org/docs/Mozilla/Tech/Firefox_Accounts/Introduction
 .. _Microsoft Translator API: http://msdn.microsoft.com/en-us/library/hh454950

--- a/docs/dev/first-contribution.rst
+++ b/docs/dev/first-contribution.rst
@@ -135,7 +135,7 @@ documentation resources:
 
 -  If you want to work on the front-end, it is important that you read
    the `Front-End
-   Documentation <https://github.com/mozilla/pontoon/tree/master/translate>`_.
+   Documentation <https://github.com/mozilla/pontoon/tree/HEAD/translate>`_.
 -  Most of the documentation around installing and developing can be
    found in `Pontoon's
    Documentation <https://mozilla-pontoon.readthedocs.io/en/latest/>`_.


### PR DESCRIPTION
Closes #2943

When this is merged, the GitHub default branch should also be updated via [settings](https://github.com/mozilla/pontoon/settings); that'll take care of the rest, and prompt later visitors to the repo with update instructions for their clients.