### PR TITLE
In parseFlatFluent(), also flatten terms

### DIFF
--- a/translate/src/utils/message/parseFlatFluent.test.js
+++ b/translate/src/utils/message/parseFlatFluent.test.js
@@ -83,4 +83,18 @@ describe('parseFlatFluent', () => {
       'Lost { 2 } parents, has { 1 } "$alfred"',
     );
   });
+
+  it('flattens a term', () => {
+    const res = parseFlatFluent(ftl`
+      -term = My { $awesome } term
+        .attr = { "" }
+      `);
+
+    expect(res.value.elements).toMatchObject([
+      { value: 'My { $awesome } term' },
+    ]);
+    expect(res.attributes).toMatchObject([
+      { id: { name: 'attr' }, value: { elements: [{ value: '' }] } },
+    ]);
+  });
 });

--- a/translate/src/utils/message/parseFlatFluent.ts
+++ b/translate/src/utils/message/parseFlatFluent.ts
@@ -5,6 +5,7 @@ import {
   Message,
   Pattern,
   serializeExpression,
+  Term,
   TextElement,
   Transformer,
 } from '@fluent/syntax';
@@ -15,11 +16,14 @@ class FlatParseTransformer extends Transformer {
     return this.genericVisit(node);
   }
 
-  visitMessage(node: Message) {
+  visitMessage(node: Message | Term) {
     if (node.value) {
       flattenPatternElements(node.value);
     }
     return this.genericVisit(node);
+  }
+  visitTerm(node: Term) {
+    return this.visitMessage(node);
   }
 
   visitTextElement(node: TextElement) {


### PR DESCRIPTION
Fixes #2954

The `parseFlatFuent()` Fluent visitor was not handling terms right, as they're not matched by `visitMessage()`, and need a separate `visitTerm()` method.