### PR TITLE
Upgrade Postgres to version 15 in the app.json file

### DIFF
--- a/app.json
+++ b/app.json
@@ -34,7 +34,7 @@
     {
       "plan": "heroku-postgresql",
       "options": {
-        "version": "11"
+        "version": "15"
       }
     }
   ],


### PR DESCRIPTION
Fix #2662.

This patch unifies the PostgreSQL version used in deployment with the [Deploy with Heroku button](https://github.com/mozilla/pontoon#installing-pontoon) with the one used in production and stage environment.