### PR TITLE
Calculate 12-month averages rather than averages of averages

### DIFF
--- a/pontoon/contributors/tests/test_utils.py
+++ b/pontoon/contributors/tests/test_utils.py
@@ -170,8 +170,21 @@ def test_get_shares_of_totals():
     assert utils.get_shares_of_totals(list1, list2) == [50, 0, 0, 100, 75]
 
 
-def test_get_sublist_averages():
-    assert utils.get_sublist_averages([1, 2, 3, 4, 5], 3) == [2, 3, 4]
+def test_get_12_month_averages():
+    assert utils.get_12_month_averages([1, 2, 3], [1, 2, 3]) == [
+        50,
+        50,
+        50,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    ]
 
 
 @pytest.mark.django_db
@@ -189,11 +202,9 @@ def test_get_approvals_charts_data_with_actions(user_a, action_user_a, action_us
     data = utils.get_approvals_charts_data(user_a)
 
     assert data["approval_rates"] == [0] * 11 + [100]
-    assert data["approval_rates_12_month_avg"] == [0] * 11 + [8.333333333333334]
+    assert data["approval_rates_12_month_avg"] == [0] * 11 + [100]
     assert data["self_approval_rates"] == [0] * 10 + [100, 0]
-    assert (
-        data["self_approval_rates_12_month_avg"] == [0] * 10 + [8.333333333333334] * 2
-    )
+    assert data["self_approval_rates_12_month_avg"] == [0] * 10 + [100, 50]
 
 
 @pytest.mark.django_db

--- a/pontoon/contributors/utils.py
+++ b/pontoon/contributors/utils.py
@@ -3,7 +3,6 @@ import jwt
 
 from collections import defaultdict
 from dateutil.relativedelta import relativedelta
-from statistics import mean
 from urllib.parse import urlencode
 
 from django.conf import settings
@@ -236,11 +235,18 @@ def get_shares_of_totals(list1, list2):
     ]
 
 
-def get_sublist_averages(main_list, sublist_len):
+def get_12_month_sums(lst):
     """
-    Get a list of average values for each sublist with a given length
+    Get a list of 12-month sums.
     """
-    return [mean(main_list[x : x + sublist_len]) for x in range(sublist_len)]
+    return [sum(lst[x : x + 12]) for x in range(12)]
+
+
+def get_12_month_averages(list1, list2):
+    """
+    Get a list of 12-month averages.
+    """
+    return get_shares_of_totals(get_12_month_sums(list1), get_12_month_sums(list2))
 
 
 def get_approvals_charts_data(user):
@@ -279,9 +285,11 @@ def get_approvals_charts_data(user):
     )
 
     approval_rates = get_shares_of_totals(peer_approvals, peer_rejections)
-    approval_rates_12_month_avg = get_sublist_averages(approval_rates, 12)
+    approval_rates_12_month_avg = get_12_month_averages(peer_approvals, peer_rejections)
     self_approval_rates = get_shares_of_totals(self_approvals, peer_approvals)
-    self_approval_rates_12_month_avg = get_sublist_averages(self_approval_rates, 12)
+    self_approval_rates_12_month_avg = get_12_month_averages(
+        self_approvals, peer_approvals
+    )
 
     return {
         "dates": months[-12:],


### PR DESCRIPTION
In Approval rate and Self-approval rate charts, we plot the 12-month average values. We used to calculate them as averages of monthly rates for the past 12 months. From now on, we calculate them as averages of all actions in the period of the past 12 months.