### PR TITLE
Do not break comment layout when pasting multiline strings

### DIFF
--- a/translate/src/modules/comments/components/AddComment.css
+++ b/translate/src/modules/comments/components/AddComment.css
@@ -9,13 +9,12 @@
   border: none;
   border-radius: 4px;
   color: var(--white-1);
-  display: flex;
-  flex-grow: 2;
   font-size: 11px;
   max-height: 144px;
   margin: auto;
   overflow: auto;
   padding: 7px;
+  width: 100%;
   word-break: break-word;
 }
 


### PR DESCRIPTION
Fix #2974.