### PR TITLE
Fix validation of strings with leading and trailing newlines

### DIFF
--- a/pontoon/translations/forms.py
+++ b/pontoon/translations/forms.py
@@ -51,5 +51,8 @@ class CreateTranslationForm(forms.Form):
             return None
         return self.cleaned_data["plural_form"]
 
+    def clean_original(self):
+        return self.data.get("original", "")
+
     def clean_translation(self):
         return self.data.get("translation", "")


### PR DESCRIPTION
Fix #2991.

We use CharFields for validating original strings and translations when translations are being saved.

By default, CharField [strips the value of the leading and trailing whitespace](https://docs.djangoproject.com/en/4.2/ref/forms/fields/#django.forms.CharField).

Until now, we've been only bypassing this default for translations. 

From now on, we also do that for original strings.

Deployed to stage for testing:
https://mozilla-pontoon-staging.herokuapp.com/fi/all-projects/all-resources/?string=192448