### PR TITLE
Prevent FOUT when using System Theme

### DIFF
--- a/pontoon/base/static/js/theme-switcher.js
+++ b/pontoon/base/static/js/theme-switcher.js
@@ -13,6 +13,7 @@ $(function () {
   function applyTheme(newTheme) {
     if (newTheme === 'system') {
       newTheme = getSystemTheme();
+      storeSystemTheme(newTheme);
     }
     $('body')
       .removeClass('dark-theme light-theme system-theme')
@@ -20,9 +21,9 @@ $(function () {
   }
 
   /*
-    Storing system theme setting in a cookie makes the setting available to the server.
-    That allows us to set the theme class already in the Django template, which (unlike
-    setting it on the client) prevents FOUC.
+   * Storing system theme setting in a cookie makes the setting available to the server.
+   * That allows us to set the theme class already in the Django template, which (unlike
+   * setting it on the client) prevents FOUC.
    */
   function storeSystemTheme(systemTheme) {
     document.cookie = `system_theme=${systemTheme}; path=/; max-age=${
@@ -32,25 +33,17 @@ $(function () {
 
   window
     .matchMedia('(prefers-color-scheme: dark)')
-    .addEventListener('change', function (e) {
+    .addEventListener('change', function () {
       // Check the 'data-theme' attribute on the body element
       let userThemeSetting = $('body').data('theme');
 
       if (userThemeSetting === 'system') {
-        const systemTheme = e.matches ? 'dark' : 'light';
-        applyTheme(systemTheme);
-        storeSystemTheme(systemTheme);
+        applyTheme(userThemeSetting);
       }
     });
 
   if ($('body').data('theme') === 'system') {
-    let systemTheme = getSystemTheme();
-
-    if ($('body').hasClass('system-theme')) {
-      $('body').removeClass('system-theme').addClass(`${systemTheme}-theme`);
-    }
-
-    storeSystemTheme(systemTheme);
+    applyTheme('system');
   }
 
   $('.appearance .toggle-button button').click(function (e) {

--- a/pontoon/base/static/js/theme-switcher.js
+++ b/pontoon/base/static/js/theme-switcher.js
@@ -19,6 +19,17 @@ $(function () {
       .addClass(`${newTheme}-theme`);
   }
 
+  /*
+    Storing system theme setting in a cookie makes the setting available to the server.
+    That allows us to set the theme class already in the Django template, which (unlike
+    setting it on the client) prevents FOUC.
+   */
+  function storeSystemTheme(systemTheme) {
+    document.cookie = `system_theme=${systemTheme}; path=/; max-age=${
+      60 * 60 * 24 * 365
+    }; Secure`;
+  }
+
   window
     .matchMedia('(prefers-color-scheme: dark)')
     .addEventListener('change', function (e) {
@@ -26,13 +37,20 @@ $(function () {
       let userThemeSetting = $('body').data('theme');
 
       if (userThemeSetting === 'system') {
-        applyTheme(e.matches ? 'dark' : 'light');
+        const systemTheme = e.matches ? 'dark' : 'light';
+        applyTheme(systemTheme);
+        storeSystemTheme(systemTheme);
       }
     });
 
-  if ($('body').hasClass('system-theme')) {
+  if ($('body').data('theme') === 'system') {
     let systemTheme = getSystemTheme();
-    $('body').removeClass('system-theme').addClass(`${systemTheme}-theme`);
+
+    if ($('body').hasClass('system-theme')) {
+      $('body').removeClass('system-theme').addClass(`${systemTheme}-theme`);
+    }
+
+    storeSystemTheme(systemTheme);
   }
 
   $('.appearance .toggle-button button').click(function (e) {

--- a/pontoon/base/templates/base.html
+++ b/pontoon/base/templates/base.html
@@ -33,9 +33,9 @@
   </head>
 
   <body
-    class="{% block class %}{% endblock %} {{ theme(request.user) }}-theme"
+    class="{% block class %}{% endblock %} {{ theme_class(request) }}"
     {% if csrf_token %}data-csrf="{{ csrf_token }}"{% endif %}
-    data-theme="{{ theme(request.user) }}"
+    data-theme="{{ user_theme(request.user) }}"
   >
     {% block content %}
 

--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -37,11 +37,26 @@ def return_url(request):
 
 
 @library.global_function
-def theme(user):
+def user_theme(user):
     """Get user's theme or return 'dark' if user is not authenticated."""
     if user.is_authenticated:
         return user.profile.theme
     return "dark"
+
+
+@library.global_function
+def theme_class(request):
+    """Get theme class name based on user preferences and system settings."""
+    theme = "dark"
+    user = request.user
+
+    if user.is_authenticated:
+        theme = user.profile.theme
+
+        if theme == "system":
+            theme = request.COOKIES.get("system_theme", "system")
+
+    return f"{theme}-theme"
 
 
 @library.global_function

--- a/translate/public/translate.html
+++ b/translate/public/translate.html
@@ -24,7 +24,7 @@
 
     {% include "tracker.html" %}
   </head>
-  <body class="{% block class %}{% endblock %} {{ theme(request.user) }}-theme" data-theme="{{ theme(request.user) }}">
+  <body class="{% block class %}{% endblock %} {{ theme_class(request) }}" data-theme="{{ user_theme(request.user) }}">
     <noscript>
       You need to enable JavaScript to run this app.
     </noscript>

--- a/translate/src/context/Theme.tsx
+++ b/translate/src/context/Theme.tsx
@@ -5,28 +5,6 @@ export const ThemeContext = createContext({
   theme: 'dark',
 });
 
-function getSystemTheme() {
-  if (
-    window.matchMedia &&
-    window.matchMedia('(prefers-color-scheme: dark)').matches
-  ) {
-    return 'dark';
-  } else {
-    return 'light';
-  }
-}
-
-/*
- * Storing system theme setting in a cookie makes the setting available to the server.
- * That allows us to set the theme class already in the Django template, which (unlike
- * setting it on the client) prevents FOUC.
- */
-function storeSystemTheme(systemTheme: string) {
-  document.cookie = `system_theme=${systemTheme}; path=/; max-age=${
-    60 * 60 * 24 * 365
-  }; Secure`;
-}
-
 export function ThemeProvider({ children }: { children: React.ReactElement }) {
   const [theme] = useState(
     () => document.body.getAttribute('data-theme') || 'dark',
@@ -37,21 +15,18 @@ export function ThemeProvider({ children }: { children: React.ReactElement }) {
   useEffect(() => {
     const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
 
-    function handleThemeChange(e: MediaQueryListEvent) {
-      let userThemeSetting = document.body.getAttribute('data-theme') || 'dark';
+    function handleThemeChange() {
+      let userThemeSetting = document.body.getAttribute('data-theme');
 
       if (userThemeSetting === 'system') {
-        const systemTheme = e.matches ? 'dark' : 'light';
-        applyTheme(systemTheme);
-        storeSystemTheme(systemTheme);
+        applyTheme(userThemeSetting);
       }
     }
 
     mediaQuery.addEventListener('change', handleThemeChange);
 
-    if (theme == 'system') {
+    if (theme === 'system') {
       applyTheme(theme);
-      storeSystemTheme(getSystemTheme());
     }
 
     return () => {

--- a/translate/src/context/Theme.tsx
+++ b/translate/src/context/Theme.tsx
@@ -5,6 +5,28 @@ export const ThemeContext = createContext({
   theme: 'dark',
 });
 
+function getSystemTheme() {
+  if (
+    window.matchMedia &&
+    window.matchMedia('(prefers-color-scheme: dark)').matches
+  ) {
+    return 'dark';
+  } else {
+    return 'light';
+  }
+}
+
+/*
+ * Storing system theme setting in a cookie makes the setting available to the server.
+ * That allows us to set the theme class already in the Django template, which (unlike
+ * setting it on the client) prevents FOUC.
+ */
+function storeSystemTheme(systemTheme) {
+  document.cookie = `system_theme=${systemTheme}; path=/; max-age=${
+    60 * 60 * 24 * 365
+  }; Secure`;
+}
+
 export function ThemeProvider({ children }: { children: React.ReactElement }) {
   const [theme] = useState(
     () => document.body.getAttribute('data-theme') || 'dark',
@@ -19,13 +41,18 @@ export function ThemeProvider({ children }: { children: React.ReactElement }) {
       let userThemeSetting = document.body.getAttribute('data-theme') || 'dark';
 
       if (userThemeSetting === 'system') {
-        applyTheme(e.matches ? 'dark' : 'light');
+        const systemTheme = e.matches ? 'dark' : 'light';
+        applyTheme(systemTheme);
+        storeSystemTheme(systemTheme);
       }
     }
 
     mediaQuery.addEventListener('change', handleThemeChange);
 
-    applyTheme(theme);
+    if (theme == 'system') {
+      applyTheme(theme);
+      storeSystemTheme(getSystemTheme());
+    }
 
     return () => {
       mediaQuery.removeEventListener('change', handleThemeChange);

--- a/translate/src/context/Theme.tsx
+++ b/translate/src/context/Theme.tsx
@@ -21,7 +21,7 @@ function getSystemTheme() {
  * That allows us to set the theme class already in the Django template, which (unlike
  * setting it on the client) prevents FOUC.
  */
-function storeSystemTheme(systemTheme) {
+function storeSystemTheme(systemTheme: string) {
   document.cookie = `system_theme=${systemTheme}; path=/; max-age=${
     60 * 60 * 24 * 365
   }; Secure`;

--- a/translate/src/hooks/useTheme.ts
+++ b/translate/src/hooks/useTheme.ts
@@ -1,4 +1,15 @@
 export function useTheme() {
+  /*
+   * Storing system theme setting in a cookie makes the setting available to the server.
+   * That allows us to set the theme class already in the Django template, which (unlike
+   * setting it on the client) prevents FOUC.
+   */
+  function storeSystemTheme(systemTheme: string) {
+    document.cookie = `system_theme=${systemTheme}; path=/; max-age=${
+      60 * 60 * 24 * 365
+    }; Secure`;
+  }
+
   function getSystemTheme(): string {
     if (
       window.matchMedia &&
@@ -10,9 +21,10 @@ export function useTheme() {
     }
   }
 
-  return function (newTheme: string) {
+  return function useTheme(newTheme: string) {
     if (newTheme === 'system') {
       newTheme = getSystemTheme();
+      storeSystemTheme(newTheme);
     }
     document.body.classList.remove('dark-theme', 'light-theme', 'system-theme');
     document.body.classList.add(`${newTheme}-theme`);


### PR DESCRIPTION
When system theme is selected, we apply the right theme in the client, because system settings can only be accessed from the client. That results in FOUT (flash of unstyled text) when navigating between pages if the system theme is Light, because Pontoon defaults to the dark theme and then immediatelly changes it to light when the JS executed.

This patch prevents that by storing the system theme setting in a cookie. Cookie is read by the server, so we set the theme accordingly already in a template.

Deployed to https://mozilla-pontoon-staging.herokuapp.com/.