### PR TITLE
Sync theme toggle CSS between /translate and /pontoon

### DIFF
--- a/translate/src/modules/user/components/UserMenu.css
+++ b/translate/src/modules/user/components/UserMenu.css
@@ -122,10 +122,10 @@
 }
 
 .toggle-button button {
-  background: var(--black-3);
-  border: 1px solid var(--light-grey-3);
+  background: transparent;
+  border: 1px solid var(--main-border-1);
   border-radius: 3px;
-  color: var(--grey-6);
+  color: var(--toggle-color-1);
   font-size: 14px;
   font-weight: 100;
   padding: 4px;
@@ -141,8 +141,8 @@
 }
 
 .toggle-button button.active {
-  background: var(--dark-grey-1);
-  border-color: var(--grey-3);
+  background: var(--button-background-1);
+  border-color: var(--main-border-1);
   color: var(--light-grey-7);
   font-weight: 400;
 }


### PR DESCRIPTION
Forgot to push this commit in #2997.

Hence the borders in the Theme Toggle in the Translate View are currently missing:
https://mozilla-pontoon-staging.herokuapp.com/sl/firefox/all-resources/