### PR TITLE
Optimize and fix the /insights page

### DIFF
--- a/pontoon/base/templates/robots.txt
+++ b/pontoon/base/templates/robots.txt
@@ -2,3 +2,4 @@ User-agent: *
 Disallow: /a/
 Disallow: /admin/
 Disallow: /contributors/
+Disallow: /*insights/

--- a/pontoon/insights/admin.py
+++ b/pontoon/insights/admin.py
@@ -52,6 +52,7 @@ class ProjectLocaleInsightsSnapshotAdmin(admin.ModelAdmin):
         "completion",
         "unreviewed_strings",
     )
+    readonly_fields = ("project_locale",)
 
 
 admin.site.register(LocaleInsightsSnapshot, LocaleInsightsSnapshotAdmin)

--- a/pontoon/insights/views.py
+++ b/pontoon/insights/views.py
@@ -26,7 +26,7 @@ def insights(request):
                 "locale", "code"
             ),
             "project_pretranslation_quality": get_global_pretranslation_quality(
-                "project", "slug"
+                "entity__resource__project", "slug"
             ),
         },
     )


### PR DESCRIPTION
Several Insights pages improvements are included in this PR:

* Fix #2980: Prevent bots from checking the /insights page
* Optimize ProjectLocaleInsightsSnapshot Admin view/editing page 
* Refactor data gathering for the /insights page:
  1. Fix https://github.com/mozilla/pontoon/issues/2979: Optimize /insights page. To render the charts on the Insights pages, we use periodically gathered ProjectLocaleInsightsSnapshot data. That works fine on Project, Locale and ProjectLocale pages, but not on the /insights page which shows data across the entire app. The amount of data requested from the DB quickly becomes big and the request starts timing out. In this patch, we gather data directly from the ActionLog as hinted at in https://github.com/mozilla/pontoon/issues/2938.
  2. Fix https://github.com/mozilla/pontoon/issues/2999: Show insights for all months.
  3. Calculate monthly averages rather than averages of averages. Lines for the "All" data point on both "Team pretranslation quality" and "Project pretranslation quality" are the same now.

Deployed to stage:
https://mozilla-pontoon-staging.herokuapp.com/insights/

Note that performance is hard to test reliably due to caching.