### PR TITLE
Improve position of the tooltip of the charts on the /insights page

### DIFF
--- a/pontoon/insights/static/js/insights.js
+++ b/pontoon/insights/static/js/insights.js
@@ -75,6 +75,7 @@ var Pontoon = (function (my) {
             },
             legendCallback: Pontoon.insights.customLegend(chart),
             tooltips: {
+              position: 'nearest',
               mode: 'index',
               intersect: false,
               borderColor: style.getPropertyValue('--white-1'),


### PR DESCRIPTION
Touch #2981.

With this improvement, the tooltip changes position based on the mouse position, so it can be made visible for all data points. It's still not always visible, though.