### PR TITLE
Escape straight apostrophes in strings.xml files

### DIFF
--- a/pontoon/checks/libraries/compare_locales.py
+++ b/pontoon/checks/libraries/compare_locales.py
@@ -10,7 +10,7 @@ from compare_locales.parser.properties import PropertiesEntityMixin
 
 from compare_locales.paths import File
 
-from pontoon.sync.utils import escape_quotes, escape_apostrophes
+from pontoon.sync.utils import escape_apostrophes
 
 
 CommentEntity = namedtuple("Comment", ("all",))
@@ -102,10 +102,6 @@ def cast_to_compare_locales(resource_ext, entity, string):
         )
 
     elif resource_ext == ".dtd":
-        if "mobile/android/base" in entity.resource.path:
-            entity.string = escape_quotes(entity.string)
-            string = escape_quotes(string)
-
         return (
             CompareDTDEntity(
                 entity.key,
@@ -186,9 +182,6 @@ def run_checks(entity, locale_code, string):
         Both keys are optional.
     """
     resource_ext = f".{entity.resource.format}"
-    extra_tests = (
-        {"android-dtd"} if "mobile/android/base" in entity.resource.path else None
-    )
 
     source_ent, translation_ent = cast_to_compare_locales(
         resource_ext,
@@ -198,7 +191,6 @@ def run_checks(entity, locale_code, string):
 
     checker = getChecker(
         File(entity.resource.path, entity.resource.path, locale=locale_code),
-        extra_tests,
     )
     if checker is None:
         # compare-locales has no checks for this format, it's OK.

--- a/pontoon/checks/libraries/compare_locales.py
+++ b/pontoon/checks/libraries/compare_locales.py
@@ -10,7 +10,7 @@ from compare_locales.parser.properties import PropertiesEntityMixin
 
 from compare_locales.paths import File
 
-from pontoon.sync.utils import escape_quotes
+from pontoon.sync.utils import escape_quotes, escape_apostrophes
 
 
 CommentEntity = namedtuple("Comment", ("all",))
@@ -102,6 +102,10 @@ def cast_to_compare_locales(resource_ext, entity, string):
         )
 
     elif resource_ext == ".dtd":
+        if "mobile/android/base" in entity.resource.path:
+            entity.string = escape_quotes(entity.string)
+            string = escape_quotes(string)
+
         return (
             CompareDTDEntity(
                 entity.key,
@@ -142,8 +146,8 @@ def cast_to_compare_locales(resource_ext, entity, string):
             </resources>
         """.format(
             key=entity.key,
-            original=entity.string,
-            translation=string,
+            original=escape_apostrophes(entity.string),
+            translation=escape_apostrophes(string),
         )
 
         parser.readUnicode(content)
@@ -182,12 +186,9 @@ def run_checks(entity, locale_code, string):
         Both keys are optional.
     """
     resource_ext = f".{entity.resource.format}"
-    extra_tests = None
-
-    if "mobile/android/base" in entity.resource.path:
-        extra_tests = {"android-dtd"}
-        entity.string = escape_quotes(entity.string)
-        string = escape_quotes(string)
+    extra_tests = (
+        {"android-dtd"} if "mobile/android/base" in entity.resource.path else None
+    )
 
     source_ent, translation_ent = cast_to_compare_locales(
         resource_ext,

--- a/pontoon/checks/tests/test_compare_locales.py
+++ b/pontoon/checks/tests/test_compare_locales.py
@@ -287,31 +287,6 @@ def test_invalid_dtd_translations(quality_check_args, failed_checks):
     assert run_checks(**quality_check_args) == failed_checks
 
 
-def test_dtd_quotes():
-    quality_check_args = mock_quality_check_args(
-        resource_path="strings.dtd",
-        key="test",
-        string='<a href="http://mozilla.org">Mozilla</a>',
-        comment="Some comment",
-        translation='<a href="http://mozilla.org">Mozilla "2018"</a>',
-    )
-    assert run_checks(**quality_check_args) == {}
-
-
-def test_dtd_quotes_in_android_files():
-    """
-    Even DTD string with quotes in mobile/android/base** shouldn't fail.
-    """
-    quality_check_args = mock_quality_check_args(
-        resource_path="mobile/android/base/android_strings.dtd",
-        key="test",
-        string='Mozilla "2017"',
-        comment="Some comment",
-        translation='Mozilla "2018"',
-    )
-    assert run_checks(**quality_check_args) == {}
-
-
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     "quality_check_args,failed_checks",

--- a/pontoon/checks/tests/test_compare_locales.py
+++ b/pontoon/checks/tests/test_compare_locales.py
@@ -287,9 +287,20 @@ def test_invalid_dtd_translations(quality_check_args, failed_checks):
     assert run_checks(**quality_check_args) == failed_checks
 
 
-def test_dtd_source_string_with_quotes():
+def test_dtd_quotes():
+    quality_check_args = mock_quality_check_args(
+        resource_path="strings.dtd",
+        key="test",
+        string='<a href="http://mozilla.org">Mozilla</a>',
+        comment="Some comment",
+        translation='<a href="http://mozilla.org">Mozilla "2018"</a>',
+    )
+    assert run_checks(**quality_check_args) == {}
+
+
+def test_dtd_quotes_in_android_files():
     """
-    A correct source string with quotes shouldn't raise a warning.
+    Even DTD string with quotes in mobile/android/base** shouldn't fail.
     """
     quality_check_args = mock_quality_check_args(
         resource_path="mobile/android/base/android_strings.dtd",
@@ -297,17 +308,6 @@ def test_dtd_source_string_with_quotes():
         string='Mozilla "2017"',
         comment="Some comment",
         translation='Mozilla "2018"',
-    )
-    assert run_checks(**quality_check_args) == {}
-
-
-def test_dtd_entity_with_quotes():
-    quality_check_args = mock_quality_check_args(
-        resource_path="strings.dtd",
-        key="test",
-        string='<a href="http://mozilla.org">Mozilla</a>',
-        comment="Some comment",
-        translation='<a href="http://mozilla.org">Mozilla "2018"</a>',
     )
     assert run_checks(**quality_check_args) == {}
 
@@ -391,3 +391,14 @@ def test_dtd_entity_with_quotes():
 )
 def test_invalid_ftl_translations(quality_check_args, failed_checks):
     assert run_checks(**quality_check_args) == failed_checks
+
+
+def test_android_apostrophes():
+    quality_check_args = mock_quality_check_args(
+        resource_path="strings.xml",
+        key="test",
+        string="Source string",
+        comment="Some comment",
+        translation="Translation with a straight '",
+    )
+    assert run_checks(**quality_check_args) == {}

--- a/pontoon/sync/formats/__init__.py
+++ b/pontoon/sync/formats/__init__.py
@@ -7,7 +7,6 @@ import os.path
 import fnmatch
 
 from pontoon.sync.formats import (
-    compare_locales,
     ftl,
     json_extensions,
     json_keyvalue,
@@ -15,6 +14,7 @@ from pontoon.sync.formats import (
     po,
     silme,
     xliff,
+    xml,
 )
 
 # To add support for a new resource format, add an entry to this dict
@@ -33,7 +33,7 @@ SUPPORTED_FORMAT_PARSERS = {
     "*.properties": silme.parse_properties,
     "*.xlf": xliff.parse,
     "*.xliff": xliff.parse,
-    "*.xml": compare_locales.parse,
+    "*.xml": xml.parse,
 }
 
 

--- a/pontoon/sync/formats/compare_locales.py
+++ b/pontoon/sync/formats/compare_locales.py
@@ -12,7 +12,11 @@ from compare_locales import (
 
 from pontoon.sync.exceptions import ParseError, SyncError
 from pontoon.sync.formats.base import ParsedResource
-from pontoon.sync.utils import create_parent_directory
+from pontoon.sync.utils import (
+    create_parent_directory,
+    escape_apostrophes,
+    unescape_apostrophes,
+)
 from pontoon.sync.vcs.models import VCSTranslation
 
 
@@ -81,7 +85,7 @@ class CompareLocalesResource(ParsedResource):
             if isinstance(entity, parser.Entity):
                 self.entities[entity.key] = CompareLocalesEntity(
                     entity.key,
-                    entity.unwrap(),
+                    unescape_apostrophes(entity.unwrap()),
                     entity.pre_comment,
                     order,
                 )
@@ -99,7 +103,7 @@ class CompareLocalesResource(ParsedResource):
 
         # A dictionary of new translations
         new_l10n = {
-            key: entity.strings[None] if entity.strings else None
+            key: escape_apostrophes(entity.strings[None]) if entity.strings else None
             for key, entity in self.entities.items()
         }
 

--- a/pontoon/sync/formats/xml.py
+++ b/pontoon/sync/formats/xml.py
@@ -1,6 +1,5 @@
 """
-Parser and serializer for file formats supported by compare-locales library:
-https://hg.mozilla.org/l10n/compare-locales/
+Parser for the strings.xml file format.
 """
 import logging
 
@@ -23,9 +22,9 @@ from pontoon.sync.vcs.models import VCSTranslation
 log = logging.getLogger(__name__)
 
 
-class CompareLocalesEntity(VCSTranslation):
+class XMLEntity(VCSTranslation):
     """
-    Represents an entity in a file handled by compare-locales.
+    Represents an entity in an XML file.
     """
 
     def __init__(self, key, string, comment, order):
@@ -42,7 +41,7 @@ class CompareLocalesEntity(VCSTranslation):
         self.source = []
 
 
-class CompareLocalesResource(ParsedResource):
+class XMLResource(ParsedResource):
     def __init__(self, path, source_resource=None):
         self.path = path
         self.entities = OrderedDict()  # Preserve entity order.
@@ -61,7 +60,7 @@ class CompareLocalesResource(ParsedResource):
         # source resource entity.
         if source_resource:
             for key, entity in source_resource.entities.items():
-                self.entities[key] = CompareLocalesEntity(
+                self.entities[key] = XMLEntity(
                     entity.key,
                     None,
                     None,
@@ -83,7 +82,7 @@ class CompareLocalesResource(ParsedResource):
 
         for entity in self.parsed_objects:
             if isinstance(entity, parser.Entity):
-                self.entities[entity.key] = CompareLocalesEntity(
+                self.entities[entity.key] = XMLEntity(
                     entity.key,
                     unescape_apostrophes(entity.unwrap()),
                     entity.pre_comment,
@@ -124,8 +123,8 @@ class CompareLocalesResource(ParsedResource):
 
 def parse(path, source_path=None, locale=None):
     if source_path is not None:
-        source_resource = CompareLocalesResource(source_path)
+        source_resource = XMLResource(source_path)
     else:
         source_resource = None
 
-    return CompareLocalesResource(path, source_resource)
+    return XMLResource(path, source_resource)

--- a/pontoon/sync/tests/formats/test_formats.py
+++ b/pontoon/sync/tests/formats/test_formats.py
@@ -2,7 +2,7 @@ from pontoon.base.tests import TestCase
 from pontoon.sync.formats import are_compatible_files
 
 
-class CompareLocalesResourceTests(TestCase):
+class FormatsTests(TestCase):
     def test_are_compatible_files(self):
         """
         Return True if both extensions use the same file parser.

--- a/pontoon/sync/tests/formats/test_xml.py
+++ b/pontoon/sync/tests/formats/test_xml.py
@@ -12,11 +12,11 @@ from pontoon.base.tests import (
     TestCase,
 )
 from pontoon.sync.exceptions import ParseError
-from pontoon.sync.formats import compare_locales
+from pontoon.sync.formats import xml
 from pontoon.sync.tests.formats import FormatTestsMixin
 
 
-class CompareLocalesResourceTests(TestCase):
+class XMLResourceTests(TestCase):
     def setUp(self):
         super().setUp()
         self.tempdir = tempfile.mkdtemp()
@@ -46,9 +46,9 @@ class CompareLocalesResourceTests(TestCase):
             suffix=".xml",
             directory=self.tempdir,
         )
-        source_resource = compare_locales.CompareLocalesResource(source_path)
+        source_resource = xml.XMLResource(source_path)
 
-        return compare_locales.CompareLocalesResource(
+        return xml.XMLResource(
             path,
             source_resource=source_resource,
         )
@@ -60,7 +60,7 @@ class CompareLocalesResourceTests(TestCase):
         """
         path = self.get_invalid_file_path()
         with pytest.raises(ParseError):
-            compare_locales.CompareLocalesResource(path, source_resource=None)
+            xml.XMLResource(path, source_resource=None)
 
     def test_init_missing_resource(self):
         """
@@ -69,7 +69,7 @@ class CompareLocalesResourceTests(TestCase):
         """
         path = self.get_nonexistant_file_path()
         with pytest.raises(ParseError):
-            compare_locales.CompareLocalesResource(path, source_resource=None)
+            xml.XMLResource(path, source_resource=None)
 
     def test_init_missing_resource_with_source(self):
         """
@@ -113,7 +113,7 @@ BASE_ANDROID_XML_FILE = """<?xml version="1.0" encoding="utf-8"?>
 
 
 class AndroidXMLTests(FormatTestsMixin, TestCase):
-    parse = staticmethod(compare_locales.parse)
+    parse = staticmethod(xml.parse)
     supports_keys = False
     supports_source = False
     supports_source_string = False

--- a/pontoon/sync/utils.py
+++ b/pontoon/sync/utils.py
@@ -134,8 +134,8 @@ def source_to_locale_path(path):
 
 def escape_apostrophes(value):
     """
-    Apostrophes (straight single quotes) have special usage in Android strings.xml files,
-    so they need to be escaped according to the standard XML/HTML escaping rules.
+    Apostrophes (straight single quotes) have special meaning in Android strings.xml files,
+    so they need to be escaped using a preceding backslash.
 
     Learn more:
     https://developer.android.com/guide/topics/resources/string-resource.html#escaping_quotes

--- a/pontoon/sync/utils.py
+++ b/pontoon/sync/utils.py
@@ -132,6 +132,21 @@ def source_to_locale_path(path):
     return path
 
 
+def escape_apostrophes(value):
+    """
+    Apostrophes (straight single quotes) have special usage in Android strings.xml files,
+    so they need to be escaped according to the standard XML/HTML escaping rules.
+
+    Learn more:
+    https://developer.android.com/guide/topics/resources/string-resource.html#escaping_quotes
+    """
+    return value.replace("'", "\\'")
+
+
+def unescape_apostrophes(value):
+    return value.replace("\\'", "'")
+
+
 def escape_quotes(value):
     """
     DTD files can use single or double quotes for identifying strings,


### PR DESCRIPTION
Fix #2212 using the approach identified in https://github.com/mozilla/pontoon/issues/2212#issuecomment-918455079: straight apostrophes in strings.xml files are escaped on export serialization and unescaped on import parsing.

In return, users can now submit strings with straight apostrophes without the need to manually escape them. They are stored in the DB and displayed in the UI without any escaping.

We should unescape straight apostrophes in existing translations and TM entries.

I've also added an example string to our test project:
https://github.com/mozilla-l10n/pontoon-test/blob/master/en-US/strings.xml#L9