### PR TITLE
Restore notification panel delay back to 2 seconds

### DIFF
--- a/translate/src/modules/notification/components/NotificationPanel.tsx
+++ b/translate/src/modules/notification/components/NotificationPanel.tsx
@@ -25,7 +25,7 @@ export function NotificationPanel(): React.ReactElement<'div'> {
   useEffect(() => {
     window.clearTimeout(timeout.current);
     if (message) {
-      timeout.current = window.setTimeout(hide, 20000);
+      timeout.current = window.setTimeout(hide, 2000);
     }
   }, [message]);
 


### PR DESCRIPTION
Fix #3011.

During the development of the light theme, I needed the notification popup to be shown for a longer period than just 2 seconds. And I committed that change by mistake. 🤦 

https://github.com/mozilla/pontoon/commit/b97cbb7fc2cec6731680476f880ec643ab4831ec#diff-c0aa89be6ec58edea23eb616736c9bdf130d5ce3063749733db72e24c020e8c0R28