### PR TITLE
List Admins that are also Locale Managers or Translators as members of these groups in the Locale Contributors page

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -251,14 +251,14 @@ def user_role(self, managers=None, translators=None):
 
 
 def user_locale_role(self, locale):
-    if self.is_superuser:
-        return "Admin"
-    if self.pk is None or self.profile.system_user:
-        return "System User"
     if self in locale.managers_group.user_set.all():
         return "Manager"
     if self in locale.translators_group.user_set.all():
         return "Translator"
+    if self.is_superuser:
+        return "Admin"
+    if self.pk is None or self.profile.system_user:
+        return "System User"
     else:
         return "Contributor"
 

--- a/pontoon/base/tests/models/test_user.py
+++ b/pontoon/base/tests/models/test_user.py
@@ -56,3 +56,7 @@ def test_user_locale_role(user_a, user_b, user_c, locale_a):
     # Manager
     locale_a.managers_group.user_set.add(user_c)
     assert user_c.locale_role(locale_a) == "Manager"
+
+    # Admin and Manager
+    locale_a.managers_group.user_set.add(user_a)
+    assert user_a.locale_role(locale_a) == "Manager"


### PR DESCRIPTION
Fix #3035.

Fix locale_role logic to check if the user is a manager or translator before checking if it's an admin.