### PR TITLE
Reposition panels in a single-column translate view

### DIFF
--- a/translate/src/App.css
+++ b/translate/src/App.css
@@ -120,4 +120,9 @@
   #app .entity-navigation button.previous {
     margin-right: 15px;
   }
+
+  /* Helpers */
+  #app > .main-content .third-column {
+    border-left: none;
+  }
 }

--- a/translate/src/App.css
+++ b/translate/src/App.css
@@ -121,6 +121,11 @@
     margin-right: 15px;
   }
 
+  /* History */
+  #app .entity-details .history {
+    background: var(--editor-menu-background);
+  }
+
   /* Helpers */
   #app > .main-content .third-column {
     border-left: none;

--- a/translate/src/hooks/useViewport.ts
+++ b/translate/src/hooks/useViewport.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Return current window width. Useful in Responsive Web Design.
+ */
+export function useViewport(): { width: number } {
+  const [width, setWidth] = useState(window.innerWidth);
+
+  useEffect(() => {
+    const handleWindowResize = () => setWidth(window.innerWidth);
+    window.addEventListener('resize', handleWindowResize);
+    return () => window.removeEventListener('resize', handleWindowResize);
+  }, []);
+
+  return { width };
+}

--- a/translate/src/modules/entitydetails/components/Helpers.tsx
+++ b/translate/src/modules/entitydetails/components/Helpers.tsx
@@ -5,6 +5,7 @@ import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
 import type { Entity } from '~/api/entity';
 import { HelperSelection } from '~/context/HelperSelection';
 import type { Location } from '~/context/Location';
+import { useViewport } from '~/hooks/useViewport';
 import type { TermState } from '~/modules/terms';
 import type { UserState } from '~/modules/user';
 import { Machinery, MachineryCount } from '~/modules/machinery';
@@ -55,6 +56,83 @@ export function Helpers({
   const { setTab } = useContext(HelperSelection);
 
   const isTerminologyProject = parameters.project === 'terminology';
+
+  const { width } = useViewport();
+  const breakpoint = 600;
+
+  if (width < breakpoint) {
+    return (
+      <>
+        <div className='bottom'>
+          <Tabs
+            selectedIndex={commentTabIndex}
+            onSelect={(index, lastIndex) => {
+              if (index === lastIndex) {
+                return false;
+              } else {
+                setTab(index);
+              }
+              setCommentTabIndex(index);
+            }}
+          >
+            <TabList>
+              <Tab>
+                <Localized id='entitydetails-Helpers--machinery'>
+                  {'MACHINERY'}
+                </Localized>
+                <MachineryCount />
+              </Tab>
+              <Tab>
+                <Localized id='entitydetails-Helpers--locales'>
+                  {'LOCALES'}
+                </Localized>
+                <OtherLocalesCount otherlocales={otherlocales} />
+              </Tab>
+              {isTerminologyProject ? null : (
+                <Tab>
+                  <Localized id='entitydetails-Helpers--terms'>
+                    {'TERMS'}
+                  </Localized>
+                  <TermCount terms={terms} />
+                </Tab>
+              )}
+              <Tab ref={commentTabRef}>
+                <Localized id='entitydetails-Helpers--comments'>
+                  {'COMMENTS'}
+                </Localized>
+                <CommentCount teamComments={teamComments} />
+              </Tab>
+            </TabList>
+            <TabPanel>
+              <Machinery />
+            </TabPanel>
+            <TabPanel>
+              <OtherLocales
+                entity={entity}
+                otherlocales={otherlocales}
+                parameters={parameters}
+              />
+            </TabPanel>
+            {isTerminologyProject ? null : (
+              <TabPanel>
+                <Terms terms={terms} navigateToPath={navigateToPath} />
+              </TabPanel>
+            )}
+            <TabPanel>
+              <TeamComments
+                contactPerson={contactPerson}
+                initFocus={!isTerminologyProject}
+                teamComments={teamComments}
+                user={user}
+                togglePinnedStatus={togglePinnedStatus}
+                resetContactPerson={resetContactPerson}
+              />
+            </TabPanel>
+          </Tabs>
+        </div>
+      </>
+    );
+  }
 
   return (
     <>


### PR DESCRIPTION
Fix #3027.

This is a WIP to check if the approach to reposition Helpers using hooks makes sense. If it does, I'll factor out tabs and panels into components and reuse them in both views, desktop and mobile.

I've also included a CSS change to make a visual distinction between the History panel and the Helpers. Would love to hear your opinion on this.