### PR TITLE
Fix Missing Link in Comment Notifications

### DIFF
--- a/pontoon/contributors/templates/contributors/widgets/notifications_menu.html
+++ b/pontoon/contributors/templates/contributors/widgets/notifications_menu.html
@@ -74,9 +74,15 @@
             <a href="{{ actor_url }}">{{ actor_anchor }}</a>
           </span>
 
-          <span class="verb">
-            {{ notification.verb }}
-          </span>
+          {% if "has added a comment in" in notification.verb %}
+            <span class="verb">
+              has added a comment 
+            </span>
+          {% else %}
+            <span class="verb">
+              {{ notification.verb }} 
+            </span>
+          {% endif %}
 
           {% if target %}
             <span class="target">

--- a/translate/src/modules/user/components/UserNotification.tsx
+++ b/translate/src/modules/user/components/UserNotification.tsx
@@ -39,10 +39,14 @@ const Comment = ({
     <span className='actor'>{actor.anchor}</span>
 
     <span className='verb'>
-      <a href={target.url}>{verb}</a>
+      {target ? (
+        <a href={target.url}>{verb}</a>
+      ) : (
+        verb.replace('has added a comment in', 'has added a comment')
+      )}
     </span>
 
-    <span className='target'>{target.anchor}</span>
+    {target ? <span className='target'>{target.anchor}</span> : null}
 
     <ReactTimeAgo
       className='timeago'


### PR DESCRIPTION
Fixes #2538 

This pull request introduces enhancements to the notification system, specifically addressing the issue reported in [mozilla/pontoon#2538](https://github.com/mozilla/pontoon/issues/2538). It corrects the way notification verbs are displayed in scenarios where the associated strings have been deleted.

**Changes:**
- Implemented a check to accurately determine when a notification's target is missing (accounting for null or undefined values).
- Adjusted the notification verb phrasing to provide clearer context when the target string is absent, changing from "has added a comment in" to "has added a comment".