### PR TITLE
Restore Translate view full height

### DIFF
--- a/translate/src/App.css
+++ b/translate/src/App.css
@@ -14,6 +14,7 @@
 
 #app > .main-content {
   display: flex;
+  flex: 1;
   justify-content: space-between;
   overflow: auto;
 }


### PR DESCRIPTION
Fix #3052.

It turns out the CSS property removed in cc7d3503db342958d225029e5521c2e847986eed was not so unused afterall.