### PR TITLE
Uniform Checks for Locale, Project, and ProjectLocale in AJAX Views

### DIFF
--- a/pontoon/localizations/tests/test_views.py
+++ b/pontoon/localizations/tests/test_views.py
@@ -10,6 +10,7 @@ from pontoon.base.tests import (
     ResourceFactory,
     TranslationFactory,
     TranslatedResourceFactory,
+    ProjectLocaleFactory,
 )
 
 
@@ -18,6 +19,7 @@ from pontoon.base.tests import (
 @patch.object(Locale, "parts_stats")
 def test_latest_activity(mock_parts_stats, mock_render, client, project_a, locale_a):
     """Ensure that the latest_activity field is added to parts."""
+    ProjectLocaleFactory.create(locale=locale_a, project=project_a)
     resource = ResourceFactory.create(project=project_a, path="has/stats.po")
     resource2 = ResourceFactory.create(project=project_a, path="has/stats2.po")
 

--- a/pontoon/localizations/views.py
+++ b/pontoon/localizations/views.py
@@ -182,7 +182,6 @@ def ajax_insights(request, code, slug):
 
     get_object_or_404(Locale, code=code)
     get_object_or_404(Project.objects.visible_for(request.user), slug=slug)
-
     pl = get_object_or_404(ProjectLocale, locale__code=code, project__slug=slug)
     insights = get_insights(locale=pl.locale, project=pl.project)
 

--- a/pontoon/localizations/views.py
+++ b/pontoon/localizations/views.py
@@ -71,6 +71,9 @@ def ajax_resources(request, code, slug):
         slug=slug,
     )
 
+    # Check if ProjectLocale exists
+    get_object_or_404(ProjectLocale, locale=locale, project=project)
+
     # Amend the parts dict with latest activity info.
     translatedresources_qs = TranslatedResource.objects.filter(
         resource__project=project, locale=locale
@@ -150,6 +153,9 @@ def ajax_tags(request, code, slug):
     locale = get_object_or_404(Locale, code=code)
     project = get_object_or_404(Project.objects.visible_for(request.user), slug=slug)
 
+    # Check if ProjectLocale exists
+    get_object_or_404(ProjectLocale, locale=locale, project=project)
+
     if not project.tags_enabled:
         raise Http404
 
@@ -174,6 +180,9 @@ def ajax_insights(request, code, slug):
     if not settings.ENABLE_INSIGHTS:
         raise ImproperlyConfigured("ENABLE_INSIGHTS variable not set in settings.")
 
+    get_object_or_404(Locale, code=code)
+    get_object_or_404(Project.objects.visible_for(request.user), slug=slug)
+
     pl = get_object_or_404(ProjectLocale, locale__code=code, project__slug=slug)
     insights = get_insights(locale=pl.locale, project=pl.project)
 
@@ -188,6 +197,10 @@ class LocalizationContributorsView(ContributorsMixin, DetailView):
     template_name = "localizations/includes/contributors.html"
 
     def get_object(self):
+        get_object_or_404(Locale, code=self.kwargs["code"])
+        get_object_or_404(
+            Project.objects.visible_for(self.request.user), slug=self.kwargs["slug"]
+        )
         return get_object_or_404(
             ProjectLocale,
             locale__code=self.kwargs["code"],


### PR DESCRIPTION
Fixes #2338 

This PR addresses an inconsistency in our AJAX views regarding the checks for the existence and visibility of `Locale` and `Project`, as well as the existence of `ProjectLocale`. Previously, `ajax_resources` and `ajax_tags` only checked for the `Locale` and `Project`, while `ajax_contributors` and `ajax_insights` checked for the `ProjectLocale`. This update ensures that all these views consistently perform both sets of checks.