### PR TITLE
Properly serialize Fluent placeables generated by Pretranslation

### DIFF
--- a/pontoon/pretranslation/pretranslate.py
+++ b/pontoon/pretranslation/pretranslate.py
@@ -5,7 +5,7 @@ import re
 from django.db.models import CharField, Value as V
 from django.db.models.functions import Concat
 
-from fluent.syntax import ast, FluentParser, FluentSerializer
+from fluent.syntax import FluentParser, FluentSerializer
 from functools import reduce
 
 from pontoon.base.models import User, TranslatedResource
@@ -60,13 +60,6 @@ def get_pretranslations(entity, locale, preserve_placeables=False):
 
         # Parse and serialize pretranslation again in order to assure cannonical style
         parsed_pretranslation = parser.parse_entry(pretranslation)
-
-        if isinstance(parsed_pretranslation, ast.Junk):
-            log.info(
-                f"Fluent pretranslation error: Invalid translation: {pretranslation}"
-            )
-            return []
-
         pretranslation = serializer.serialize_entry(parsed_pretranslation)
 
         authors = [services[service] for service in pretranslate.services]

--- a/pontoon/pretranslation/pretranslate.py
+++ b/pontoon/pretranslation/pretranslate.py
@@ -93,7 +93,7 @@ def get_pretranslations(entity, locale, preserve_placeables=False):
 
 
 def get_pretranslated_data(source, locale, preserve_placeables):
-    # Empty strings do not need translation
+    # Empty strings and strings containing whitespace only do not need translation
     if re.search("^\\s*$", source):
         return source, "tm"
 

--- a/pontoon/pretranslation/pretranslate.py
+++ b/pontoon/pretranslation/pretranslate.py
@@ -57,6 +57,15 @@ def get_pretranslations(entity, locale, preserve_placeables=False):
             return []
 
         pretranslation = serializer.serialize_entry(entry)
+        print(pretranslation)
+        # error-not-subscribed = Esta dirección de correo electrónico no está suscrita a {-product-name}.
+
+        # Parse and serialize pretranslation again in order to assure cannonical style
+        parsed_pretranslation = parser.parse_entry(pretranslation)
+        pretranslation = serializer.serialize_entry(parsed_pretranslation)
+        # error-not-subscribed = Esta dirección de correo electrónico no está suscrita a { -product-name }.
+
+        print(pretranslation)
 
         authors = [services[service] for service in pretranslate.services]
         author = max(set(authors), key=authors.count) if authors else services["tm"]

--- a/pontoon/pretranslation/tests/test_pretranslate.py
+++ b/pontoon/pretranslation/tests/test_pretranslate.py
@@ -48,6 +48,22 @@ def test_get_pretranslations_empty_string(entity_a, locale_b, tm_user):
 
 
 @pytest.mark.django_db
+def test_get_pretranslations_whitespace(entity_a, locale_b, tm_user):
+    # Entity.string is an empty string
+    entity_a.string = " "
+    response = get_pretranslations(entity_a, locale_b)
+    assert response == [(" ", None, tm_user)]
+
+    entity_a.string = "\t"
+    response = get_pretranslations(entity_a, locale_b)
+    assert response == [("\t", None, tm_user)]
+
+    entity_a.string = "\n"
+    response = get_pretranslations(entity_a, locale_b)
+    assert response == [("\n", None, tm_user)]
+
+
+@pytest.mark.django_db
 def test_get_pretranslations_tm_match(entity_a, entity_b, locale_b, tm_user):
     # 100% TM match exists
     TranslationMemoryFactory.create(
@@ -143,32 +159,6 @@ def test_get_pretranslations_fluent_empty(
 
     response = get_pretranslations(fluent_entity, google_translate_locale)
     assert response == [(pretranslated_string, None, gt_user)]
-
-
-@pytest.mark.django_db
-def test_get_pretranslations_fluent_whitespace(
-    fluent_resource, google_translate_locale, tm_user
-):
-    # Various types of whitespace should be preserved
-    input_string = dedent(
-        """
-        whitespace =
-            { $count ->
-                [0] { "" }
-                [1] { " " }
-                *[other] { "\t" } { "\n" }
-            }
-    """
-    )
-    fluent_entity = EntityFactory(resource=fluent_resource, string=input_string)
-
-    output_string = input_string
-
-    # Re-serialize to match whitespace
-    pretranslated_string = serializer.serialize_entry(parser.parse_entry(output_string))
-
-    response = get_pretranslations(fluent_entity, google_translate_locale)
-    assert response == [(pretranslated_string, None, tm_user)]
 
 
 @patch("pontoon.pretranslation.pretranslate.get_google_translate_data")


### PR DESCRIPTION
After Fluent pretranslations are created, we need to parse and serialize them again in order to make sure they are stored in the canonical form (e.g. with spaces within curly braces).

Fix #3072.