### PR TITLE
Update index.rst to explicitly link to the mozilla-l10n sites

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,7 @@ Important additional Pontoon documentation can also be found at the following si
 
 `How to localize with Pontoon <https://mozilla-l10n.github.io/localizer-documentation/tools/pontoon/>`_ (Mozilla Localizer Documentation)
 
-`Working with Pontoon <https://mozilla-l10n.github.io/documentation/tools/pontoon>`_ (Mozilla Internal Tools Documentation)
+`How to manage localizations on Pontoon <https://mozilla-l10n.github.io/documentation/tools/pontoon>`_ (Mozilla Internal Tools Documentation)
 
 (For an issue to improve the documentation, see  `#2214 <https://github.com/mozilla/pontoon/issues/2214>`_.)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,7 +21,7 @@ Other Documentation
 
 Important additional Pontoon documentation can also be found at the following sites:
 
-`How To Use Pontoon <https://mozilla-l10n.github.io/localizer-documentation/tools/pontoon/>`_ (Mozilla Localizer Documentation)
+`How to localize with Pontoon <https://mozilla-l10n.github.io/localizer-documentation/tools/pontoon/>`_ (Mozilla Localizer Documentation)
 
 `Working with Pontoon <https://mozilla-l10n.github.io/documentation/tools/pontoon>`_ (Mozilla Internal Tools Documentation)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,17 @@ them back periodically. Typically these external sources are version control
 repositories that store the strings for an application. Supported external
 sources include **Git**, **Mercurial** and **Subversion**.
 
+Other Documentation
+-------------------
+
+Important additional Pontoon documentation can also be found at the following sites:
+
+`How To Use Pontoon <https://mozilla-l10n.github.io/localizer-documentation/tools/pontoon/>`_ (Mozilla Localizer Documentation)
+
+`Working with Pontoon <https://mozilla-l10n.github.io/documentation/tools/pontoon>`_ (Mozilla Internal Tools Documentation)
+
+(For an issue to improve the documentation, see  `#2214 <https://github.com/mozilla/pontoon/issues/2214>`_.)
+
 Contributing
 ------------
 


### PR DESCRIPTION
Per discussion in https://github.com/mozilla/pontoon/issues/2135#issuecomment-1910356465, make it clearer that there are actually two different external subsites containing pontoon documentation. This wasn't clear to me from the docs.

Relates to #2214