### PR TITLE
Cache insights views

### DIFF
--- a/pontoon/insights/urls.py
+++ b/pontoon/insights/urls.py
@@ -1,8 +1,15 @@
 from django.urls import path
+from django.views.decorators.cache import cache_page
+
+from pontoon.settings import VIEW_CACHE_TIMEOUT
 
 from . import views
 
 urlpatterns = [
     # Insights page
-    path("insights/", views.insights, name="pontoon.insights"),
+    path(
+        "insights/",
+        cache_page(VIEW_CACHE_TIMEOUT)(views.insights),
+        name="pontoon.insights",
+    ),
 ]

--- a/pontoon/localizations/urls.py
+++ b/pontoon/localizations/urls.py
@@ -76,7 +76,7 @@ urlpatterns = [
                             # Project insights
                             path(
                                 "insights/",
-                                views.ajax_insights,
+                                cache_page(VIEW_CACHE_TIMEOUT)(views.ajax_insights),
                                 name="pontoon.localizations.ajax.insights",
                             ),
                         ]

--- a/pontoon/projects/urls.py
+++ b/pontoon/projects/urls.py
@@ -81,7 +81,7 @@ urlpatterns = [
                             # Project insights
                             path(
                                 "insights/",
-                                views.ajax_insights,
+                                cache_page(VIEW_CACHE_TIMEOUT)(views.ajax_insights),
                                 name="pontoon.projects.ajax.insights",
                             ),
                             # Project info

--- a/pontoon/teams/urls.py
+++ b/pontoon/teams/urls.py
@@ -81,7 +81,7 @@ urlpatterns = [
                             # Team insights
                             path(
                                 "insights/",
-                                views.ajax_insights,
+                                cache_page(VIEW_CACHE_TIMEOUT)(views.ajax_insights),
                                 name="pontoon.teams.ajax.insights",
                             ),
                             # Team info


### PR DESCRIPTION
Fix #3094.

This is very similar to https://github.com/mozilla/pontoon/pull/3091, but for Insights rather than Contributors views.