### PR TITLE
Prefetch latest_translation__approved_user

### DIFF
--- a/pontoon/administration/views.py
+++ b/pontoon/administration/views.py
@@ -45,7 +45,9 @@ def admin(request):
 
     projects = (
         Project.objects.all()
-        .prefetch_related("latest_translation__user")
+        .prefetch_related(
+            "latest_translation__user", "latest_translation__approved_user"
+        )
         .order_by("name")
     )
 

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -683,7 +683,7 @@ class LocaleQuerySet(models.QuerySet):
                 "project_locale",
                 queryset=(
                     ProjectLocale.objects.filter(project=project).prefetch_related(
-                        "latest_translation__user"
+                        "latest_translation__user", "latest_translation__approved_user"
                     )
                 ),
                 to_attr="fetched_project_locale",
@@ -1210,7 +1210,7 @@ class ProjectQuerySet(models.QuerySet):
                 "project_locale",
                 queryset=(
                     ProjectLocale.objects.filter(locale=locale).prefetch_related(
-                        "latest_translation__user"
+                        "latest_translation__user", "latest_translation__approved_user"
                     )
                 ),
                 to_attr="fetched_project_locale",

--- a/pontoon/projects/views.py
+++ b/pontoon/projects/views.py
@@ -27,7 +27,9 @@ def projects(request):
     projects = (
         Project.objects.visible()
         .visible_for(request.user)
-        .prefetch_related("latest_translation__user")
+        .prefetch_related(
+            "latest_translation__user", "latest_translation__approved_user"
+        )
         .order_by("name")
     )
 

--- a/pontoon/teams/views.py
+++ b/pontoon/teams/views.py
@@ -31,7 +31,9 @@ from pontoon.teams.forms import LocaleRequestForm
 
 def teams(request):
     """List all active localization teams."""
-    locales = Locale.objects.available().prefetch_related("latest_translation__user")
+    locales = Locale.objects.available().prefetch_related(
+        "latest_translation__user", "latest_translation__approved_user"
+    )
 
     form = LocaleRequestForm()
 


### PR DESCRIPTION
Fix #3102.

Prefetch `latest_translation__approved_user` to speed up dashboards by retrieving Latest Activity data with less DB requests.