### PR TITLE
Introduce dev utils, add debug_sql()

### DIFF
--- a/pontoon/dev/utils.py
+++ b/pontoon/dev/utils.py
@@ -1,0 +1,34 @@
+"""
+Author: phlax
+
+Usage:
+with debug_sql():
+    code_with_some_db_action()
+"""
+
+import logging
+from contextlib import contextmanager
+from django.db import connection
+
+
+log = logging.getLogger(__name__)
+
+
+def log_new_queries(queries):
+    new_queries = list(connection.queries[queries:])
+
+    for query in new_queries:
+        log.debug(query["time"])
+        log.debug("\t%s", query["sql"])
+
+    log.debug("total db calls: %s", len(new_queries))
+
+
+@contextmanager
+def debug_sql():
+    queries = len(connection.queries)
+
+    try:
+        yield
+    finally:
+        log_new_queries(queries)


### PR DESCRIPTION
Fix #3114.

This is an old script for quick SQL performance debugging:
https://github.com/mozilla-l10n/pontoon-scripts/blob/main/dev/debug_sql_performance.py

It's easier to use when integrated into Pontoon directly.