### PR TITLE
Revert "Update to Debian 12, PostgreSQL 15, Node.js 18 in Docker (#3115)"

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-bookworm AS server
+FROM python:3.10-bullseye AS server
 
 ARG USER_ID=1000
 ARG GROUP_ID=1000
@@ -15,9 +15,8 @@ ENV PYTHONPATH /app
 RUN apt-get update \
     # Enable downloading packages over https
     && apt-get install -y apt-transport-https \
-    # Add source for node.js
-    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list \
+    # Get source for node.js
+    && curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
     # Install software
     && apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -25,7 +24,7 @@ RUN apt-get update \
         libmemcached-dev \
         nodejs \
         postgresql-client \
-        postgresql-server-dev-15 \
+        postgresql-server-dev-13 \
     # Clean up what can be cleaned up.
     && apt-get autoremove -y
 


### PR DESCRIPTION
This reverts commit fb25c53ddc8b984d5ccc6d445b23dddd5e9e71d8.

@flodolo Could you please give this an r+, so that I can merge it and see if collectstatic doesn't break in the GH workflow of https://github.com/mozilla/pontoon/pull/3117?