### PR TITLE
Only make one DB query when string param provided in URL

### DIFF
--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -3051,10 +3051,19 @@ class Entity(DirtyFieldsMixin, models.Model):
         preferred_source_locale,
         entities,
         is_sibling=False,
+        requested_entity=None,
     ):
         entities_array = []
 
         entities = entities.prefetch_entities_data(locale, preferred_source_locale)
+
+        # If requested entity not in the current page
+        if requested_entity and requested_entity not in [e.pk for e in entities]:
+            entities = list(entities) + list(
+                Entity.objects.filter(pk=requested_entity).prefetch_entities_data(
+                    locale, preferred_source_locale
+                )
+            )
 
         for entity in entities:
             translation_array = []

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -188,21 +188,13 @@ def _get_paginated_entities(locale, preferred_source_locale, project, form, enti
     has_next = entities_page.has_next()
     entities_to_map = entities_page.object_list
 
-    # If requested entity not on the first page
-    if form.cleaned_data["entity"]:
-        entity_pk = form.cleaned_data["entity"]
-        entities_to_map_pks = [e.pk for e in entities_to_map]
-
-        # TODO: entities_to_map.values_list() doesn't return entities from selected page
-        if entity_pk not in entities_to_map_pks:
-            if entity_pk in entities.values_list("pk", flat=True):
-                entities_to_map_pks.append(entity_pk)
-                entities_to_map = entities.filter(pk__in=entities_to_map_pks)
-
     return JsonResponse(
         {
             "entities": Entity.map_entities(
-                locale, preferred_source_locale, entities_to_map
+                locale,
+                preferred_source_locale,
+                entities_to_map,
+                requested_entity=form.cleaned_data["entity"],
             ),
             "has_next": has_next,
             "stats": TranslatedResource.objects.stats(


### PR DESCRIPTION
Currently, the main DB query to load entities in the entity list is executed twice if the `string` parameter is provided in the URL. That's particularly bad, because that query is often very slow (see #2965).

This patch drops that redundant DB query and reorganizes the code to prefetch data.