### PR TITLE
Use proper paging for entities

### DIFF
--- a/pontoon/base/forms.py
+++ b/pontoon/base/forms.py
@@ -294,6 +294,7 @@ class GetEntitiesForm(forms.Form):
     locale = forms.CharField()
     paths = forms.MultipleChoiceField(required=False)
     limit = forms.IntegerField(required=False, initial=50)
+    page = forms.IntegerField(required=False, initial=1)
     status = forms.CharField(required=False)
     extra = forms.CharField(required=False)
     tag = forms.CharField(required=False)
@@ -303,7 +304,6 @@ class GetEntitiesForm(forms.Form):
     reviewer = forms.CharField(required=False)
     exclude_self_reviewed = forms.BooleanField(required=False)
     search = forms.CharField(required=False)
-    exclude_entities = forms.CharField(required=False)
     entity_ids = forms.CharField(required=False)
     pk_only = forms.BooleanField(required=False)
     inplace_editor = forms.BooleanField(required=False)
@@ -322,13 +322,16 @@ class GetEntitiesForm(forms.Form):
         except (TypeError, ValueError):
             return 50
 
+    def clean_page(self):
+        try:
+            return int(self.cleaned_data["page"])
+        except (TypeError, ValueError):
+            return 1
+
     def clean_search(self):
         # Return the search input as is, without any cleaning. This is in order to allow
         # users to search for strings with leading or trailing whitespaces.
         return self.data.get("search")
-
-    def clean_exclude_entities(self):
-        return utils.split_ints(self.cleaned_data["exclude_entities"])
 
     def clean_entity_ids(self):
         return utils.split_ints(self.cleaned_data["entity_ids"])

--- a/pontoon/base/models.py
+++ b/pontoon/base/models.py
@@ -2920,7 +2920,6 @@ class Entity(DirtyFieldsMixin, models.Model):
         status=None,
         tag=None,
         search=None,
-        exclude_entities=None,
         extra=None,
         time=None,
         author=None,
@@ -3059,9 +3058,6 @@ class Entity(DirtyFieldsMixin, models.Model):
             entities = Entity.objects.filter(
                 pk__in=set(list(translation_matches) + list(entity_matches))
             )
-
-        if exclude_entities:
-            entities = entities.exclude(pk__in=exclude_entities)
 
         order_fields = ("resource__order", "order")
         if project.slug == "all-projects":

--- a/pontoon/base/tests/views/test_entity.py
+++ b/pontoon/base/tests/views/test_entity.py
@@ -1,8 +1,13 @@
+import json
 from unittest.mock import patch
 
 import pytest
 
-from pontoon.base.models import Entity
+from pontoon.base.models import Entity, TranslatedResource
+from pontoon.test.factories import (
+    EntityFactory,
+    ProjectLocaleFactory,
+)
 
 
 @pytest.mark.django_db
@@ -39,3 +44,47 @@ def test_view_entity_filters(member, resource_a, locale_a):
                 HTTP_X_REQUESTED_WITH="XMLHttpRequest",
             )
             assert m.called is True
+
+
+@pytest.mark.django_db
+def test_view_get_entities_paging(
+    member,
+    resource_a,
+    locale_a,
+):
+    """
+    Only entities from the requested page should be returned by get_entities().
+    """
+    TranslatedResource.objects.create(resource=resource_a, locale=locale_a)
+    ProjectLocaleFactory.create(project=resource_a.project, locale=locale_a)
+    entities = EntityFactory.create_batch(size=3, resource=resource_a)
+
+    response = member.client.post(
+        "/get-entities/",
+        {
+            "project": resource_a.project.slug,
+            "locale": locale_a.code,
+            "paths[]": [resource_a.path],
+            "page": 1,
+            "limit": 1,
+        },
+        HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+    )
+    assert response.status_code == 200
+    assert json.loads(response.content)["has_next"] is True
+    assert json.loads(response.content)["entities"][0]["pk"] == entities[0].pk
+
+    response = member.client.post(
+        "/get-entities/",
+        {
+            "project": resource_a.project.slug,
+            "locale": locale_a.code,
+            "paths[]": [resource_a.path],
+            "page": len(entities),
+            "limit": 1,
+        },
+        HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+    )
+    assert response.status_code == 200
+    assert json.loads(response.content)["has_next"] is False
+    assert json.loads(response.content)["entities"][0]["pk"] == entities[-1].pk

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -179,14 +179,15 @@ def _get_paginated_entities(locale, preferred_source_locale, project, form, enti
     This is used by the regular mode of the Translate page.
     """
     paginator = Paginator(entities, form.cleaned_data["limit"])
+    page = form.cleaned_data["page"]
 
     try:
-        entities_page = paginator.page(1)
+        entities_page = paginator.page(page)
     except EmptyPage:
         return JsonResponse({"has_next": False, "stats": {}})
 
-    has_next = entities_page.has_next()
     entities_to_map = entities_page.object_list
+    requested_entity = form.cleaned_data["entity"] if page == 1 else None
 
     return JsonResponse(
         {
@@ -194,9 +195,9 @@ def _get_paginated_entities(locale, preferred_source_locale, project, form, enti
                 locale,
                 preferred_source_locale,
                 entities_to_map,
-                requested_entity=form.cleaned_data["entity"],
+                requested_entity=requested_entity,
             ),
-            "has_next": has_next,
+            "has_next": entities_page.has_next(),
             "stats": TranslatedResource.objects.stats(
                 project, form.cleaned_data["paths"], locale
             ),
@@ -244,7 +245,6 @@ def entities(request):
         "paths",
         "status",
         "search",
-        "exclude_entities",
         "extra",
         "time",
         "author",

--- a/translate/src/api/entity.ts
+++ b/translate/src/api/entity.ts
@@ -76,23 +76,21 @@ type EntitiesResponse =
  * Return a list of entities for a project and locale.
  *
  * Pass in a `resource` to restrict the list to a specific path.
- * If the `exclude` array has values, those entities will be excluded from
- * the query. Use this to query for the next set of entities.
  */
 export async function fetchEntities(
   location: Location & { list: number[] },
 ): Promise<{ entities: Entity[]; stats: APIStats }>;
 export async function fetchEntities(
   location: Location,
-  exclude: Entity[],
+  page: number,
 ): Promise<EntitiesResponse>;
 export async function fetchEntities(
   location: Location,
-  exclude?: Entity[],
+  page?: number,
 ): Promise<EntitiesResponse> {
   const payload = buildFetchPayload(location);
-  if (exclude?.length) {
-    payload.append('exclude_entities', exclude.map((ent) => ent.pk).join(','));
+  if (page) {
+    payload.append('page', String(page));
   }
   return await POST('/get-entities/', payload);
 }

--- a/translate/src/modules/entities/actions.ts
+++ b/translate/src/modules/entities/actions.ts
@@ -63,10 +63,10 @@ export const updateEntityTranslation = (
 
 /** Fetch entities and their translation.  */
 export const getEntities =
-  (location: Location, exclude: Entity[]) => async (dispatch: AppDispatch) => {
+  (location: Location, page: number) => async (dispatch: AppDispatch) => {
     dispatch({ type: REQUEST_ENTITIES });
 
-    const content = await fetchEntities(location, exclude);
+    const content = await fetchEntities(location, page);
 
     if (content.entities) {
       dispatch({

--- a/translate/src/modules/entities/reducer.ts
+++ b/translate/src/modules/entities/reducer.ts
@@ -19,6 +19,7 @@ type EntitiesState = {
   readonly fetching: boolean;
   readonly fetchCount: number;
   readonly hasMore: boolean;
+  readonly page: number;
 };
 
 function updateEntityTranslation(
@@ -82,6 +83,7 @@ const initial: EntitiesState = {
   fetching: false,
   fetchCount: 0,
   hasMore: true,
+  page: 1,
 };
 
 export function reducer(
@@ -96,6 +98,7 @@ export function reducer(
         fetching: false,
         fetchCount: state.fetchCount + 1,
         hasMore: action.hasMore,
+        page: state.page + 1,
       };
     case REQUEST_ENTITIES:
       return {
@@ -109,6 +112,7 @@ export function reducer(
         entities: [],
         fetching: false,
         hasMore: true,
+        page: 1,
       };
     case UPDATE_ENTITIES:
       return {

--- a/translate/src/modules/entitieslist/components/EntitiesList.test.js
+++ b/translate/src/modules/entitieslist/components/EntitiesList.test.js
@@ -88,6 +88,24 @@ describe('<EntitiesList>', () => {
     expect(wrapper.find('Entity')).toHaveLength(2);
   });
 
+  it('when requesting new entities, load page 2', () => {
+    jest.useFakeTimers();
+    mockAllIsIntersecting(false);
+
+    const store = createReduxStore();
+    store.dispatch({
+      type: EntitiesActions.RECEIVE_ENTITIES,
+      entities: ENTITIES,
+      hasMore: true,
+    });
+    mountComponentWithStore(EntitiesList, store);
+
+    mockAllIsIntersecting(true);
+    jest.advanceTimersByTime(100); // default value for react-infinite-scroll-hook delayInMs
+
+    expect(EntitiesActions.getEntities.args[0][1]).toEqual(2);
+  });
+
   it('redirects to the first entity when none is selected', () => {
     const history = createMemoryHistory({
       initialEntries: ['/kg/firefox/all-resources/'],

--- a/translate/src/modules/entitieslist/components/EntitiesList.test.js
+++ b/translate/src/modules/entitieslist/components/EntitiesList.test.js
@@ -88,24 +88,6 @@ describe('<EntitiesList>', () => {
     expect(wrapper.find('Entity')).toHaveLength(2);
   });
 
-  it('excludes current entities when requesting new entities', () => {
-    jest.useFakeTimers();
-    mockAllIsIntersecting(false);
-
-    const store = createReduxStore();
-    store.dispatch({
-      type: EntitiesActions.RECEIVE_ENTITIES,
-      entities: ENTITIES,
-      hasMore: true,
-    });
-    mountComponentWithStore(EntitiesList, store);
-
-    mockAllIsIntersecting(true);
-    jest.advanceTimersByTime(100); // default value for react-infinite-scroll-hook delayInMs
-
-    expect(EntitiesActions.getEntities.args[0][1]).toEqual(ENTITIES);
-  });
-
   it('redirects to the first entity when none is selected', () => {
     const history = createMemoryHistory({
       initialEntries: ['/kg/firefox/all-resources/'],

--- a/translate/src/modules/entitieslist/components/EntitiesList.tsx
+++ b/translate/src/modules/entitieslist/components/EntitiesList.tsx
@@ -89,7 +89,7 @@ export function EntitiesList(): React.ReactElement<'div'> {
 
   const showNotification = useContext(ShowNotification);
   const batchactions = useBatchactions();
-  const { entities, fetchCount, fetching, hasMore } = useEntities();
+  const { entities, fetchCount, fetching, hasMore, page } = useEntities();
   const location = useContext(Location);
   const isAuthUser = useAppSelector((state) => state[USER].isAuthenticated);
   const { checkUnsavedChanges } = useContext(UnsavedActions);
@@ -245,9 +245,9 @@ export function EntitiesList(): React.ReactElement<'div'> {
   const getMoreEntities = useCallback(() => {
     if (!fetching) {
       // Currently shown entities should be excluded from the next results.
-      dispatch(getEntities(location, entities));
+      dispatch(getEntities(location, page));
     }
-  }, [dispatch, entities, fetching, location]);
+  }, [dispatch, entities, fetching, location, page]);
 
   // Must be after other useEffect() calls, as they are run in order during mount
   useEffect(() => {


### PR DESCRIPTION
Fix #2522.

We currently use a weird way of paginating entities - in each request we include a list of already loaded entities, which we exclude from the matching entities in Django and then return the first page of the remaining entities.

This is a relic of the react-infinite-scroller library which we no longer use.

We should implement proper paging, i.e. drop exclude_entities and only return the relevant page.

That should also speed up loading of entities, because NOT IN DB queries tend to be slow and because less data will be transferred.