### PR TITLE
Fix #3097 - term entity not updating after text change

### DIFF
--- a/pontoon/terminology/models.py
+++ b/pontoon/terminology/models.py
@@ -160,10 +160,12 @@ class Term(models.Model):
 
         # Using update() to avoid circular Term.save() call
         Term.objects.filter(pk=self.pk).update(entity_id=entity.id)
+        entity.term = self
 
         if not created:
             entity.obsolete = False
-            entity.save(update_fields=["obsolete"])
+
+        entity.save()
 
         # Make sure Term entities are ordered alphabetically
         entities = list(

--- a/pontoon/terminology/tests/test_models.py
+++ b/pontoon/terminology/tests/test_models.py
@@ -267,3 +267,28 @@ def test_handle_term_update_definition(
     assert create_entity_mock.call_count == 0
     assert obsolete_entity_mock.call_count == 0
     assert update_terminology_project_stats_mock.call_count == 0
+
+
+@pytest.mark.django_db
+def test_create_entity_for_new_term(localizable_term):
+    """
+    Given a new localizable term when create_entity() is called,
+    then a new corresponding entity should be created and related to the term.
+    """
+    localizable_term.create_entity()
+    assert localizable_term.entity is not None
+    assert localizable_term.text in localizable_term.entity.string
+    assert localizable_term.entity.term == localizable_term
+
+
+@pytest.mark.django_db
+def test_create_entity_on_term_text_change(localizable_term):
+    """
+    Given an existing localizable term with an associated entity,
+    when the term's text is changed and create_entity() is called again,
+    then a new entity should be created and associated with the term.
+    """
+    original_entity = localizable_term.entity
+    localizable_term.text = "Changed text"
+    localizable_term.create_entity()
+    assert localizable_term.entity != original_entity


### PR DESCRIPTION
Fixes #3097

**Problem:**
When updating the `Term.text`, the associated entity was not correctly updating to point to the newly created entity. This led to `Term.entity` property still pointing to the previous, now obsolete entity.

**Solution:**
In the `create_entity()` method of the `Term` model, explicitly set the term property of the associated entity to the current term instance before saving it. This ensures that the entity is correctly associated with the updated term instance.

Additionally, removed the `update_fields` argument from the `entity.save()` call to ensure that all fields are properly saved, including the `obsolete` flag if the entity is not newly created.

Changes:
- Added `entity.term = self` before updating the `entity_id` in the `create_entity()` method.
- Removed the `update_fields` argument from `entity.save()` call to ensure all fields are saved.