### PR TITLE
Fix #3088 - <Highlight /> search miscapitalization 

### DIFF
--- a/translate/src/modules/placeable/components/Highlight.test.js
+++ b/translate/src/modules/placeable/components/Highlight.test.js
@@ -135,6 +135,13 @@ describe('<Highlight search>', () => {
     expect(marks).toHaveLength(2);
     expect(marks.at(1).text()).toEqual('""');
   });
+
+  it("does not alter source text's capitalization", () => {
+    const wrapper = mountMarker('hello world', [], 'HELLO');
+    const marks = wrapper.find('mark');
+    expect(marks).toHaveLength(1);
+    expect(marks.at(0).text()).toEqual('hello');
+  });
 });
 
 describe('specific marker', () => {

--- a/translate/src/modules/placeable/components/Highlight.tsx
+++ b/translate/src/modules/placeable/components/Highlight.tsx
@@ -184,7 +184,7 @@ export function Highlight({
           length: term.length,
           mark: (
             <mark className='search' key={++keyCounter}>
-              {term}
+              {source.substring(next, next + term.length)}
             </mark>
           ),
         });


### PR DESCRIPTION
Fixes #3088

**Problem:**
In the search results list, highlighted parts of strings are currently inherited from the search box, including its capitalisation, making the source/translated string appear different from its actual state in the search results list.

**Solution:**
Updated `<Highlight />` component to preserve the capitalization of the source text in the search results list. The highlighted marks now reflect the original capitalization of the source string.

| **Before** | **After** |
|---|---|
| <img height="600px" src="https://github.com/mozilla/pontoon/assets/16343560/59205663-12a9-4ed4-94cd-fcb7261bb4e7" alt="before" /> | <img height="600px" src="https://github.com/mozilla/pontoon/assets/16343560/0656ad34-fdbd-492e-8286-53e148efcd3a" alt="after" /> |