### PR TITLE
Speed up /notifications page

### DIFF
--- a/pontoon/contributors/static/js/notifications.js
+++ b/pontoon/contributors/static/js/notifications.js
@@ -1,4 +1,6 @@
 $(function () {
+  const self = Pontoon;
+
   window.history.replaceState(
     {},
     document.title,
@@ -36,5 +38,25 @@ $(function () {
     setTimeout(function () {
       Pontoon.markAllNotificationsAsRead();
     }, 1000);
+  }
+
+  // Load remaining notifications
+  if ($('#server').data('hasMore')) {
+    self.NProgressUnbind();
+
+    $.ajax({
+      url: '/ajax/notifications/',
+      success: function (data) {
+        $('#main .notification-list').append(data);
+
+        // Re-apply notification filters
+        $('.left-column .selected:not(.all) a').trigger('click');
+      },
+      error: function () {
+        Pontoon.endLoader('Oops, something went wrong.', 'error');
+      },
+    });
+
+    self.NProgressBind();
   }
 });

--- a/pontoon/contributors/templates/contributors/includes/notifications_remaining.html
+++ b/pontoon/contributors/templates/contributors/includes/notifications_remaining.html
@@ -1,0 +1,3 @@
+{% import "contributors/widgets/notifications_menu.html" as Notifications with context %}
+
+{{ Notifications.list(notifications=notifications, no_title="No notifications.") }}

--- a/pontoon/contributors/templates/contributors/notifications.html
+++ b/pontoon/contributors/templates/contributors/notifications.html
@@ -4,6 +4,14 @@
 
 {% block title %}Notifications{% endblock %}
 
+{% block before %}
+<!-- Server data -->
+<div id="server"
+     class="hidden"
+     data-has-more="{{ has_more|to_json() }}">
+</div>
+{% endblock %}
+
 {% block heading %}
   {{ Heading.heading(title='Notifications', subtitle='Updates for localizations you contribute to') }}
 {% endblock %}

--- a/pontoon/contributors/urls.py
+++ b/pontoon/contributors/urls.py
@@ -50,6 +50,12 @@ urlpatterns = [
         views.notifications,
         name="pontoon.contributors.notifications",
     ),
+    # Current user's remaining notifications
+    path(
+        "ajax/notifications/",
+        views.ajax_notifications,
+        name="pontoon.contributors.ajax.notifications",
+    ),
     # Mark current user's notifications as read
     path(
         "notifications/mark-all-as-read/",


### PR DESCRIPTION
Fix #2278.

The patch comes in 2 parts:

Part 1 improves performance by significantly reducing the number of DB calls through prefetching related data.

Part 2 improves perceived performance by only loading the first 100 notifications initially. Any remaining notifications are loaded afterwards via AJAX. That makes the page usable much faster, and by the time the user scrolls to the bottom of the page, the remaining notifications are likely to be loaded already.