### PR TITLE
Include "name" column in concordance search result sorting order

### DIFF
--- a/pontoon/machinery/views.py
+++ b/pontoon/machinery/views.py
@@ -87,7 +87,7 @@ def concordance_search(request):
     # ArrayAgg (used in get_concordance_search_data()) does not support using
     # distinct=True in combination with ordering, so we need to do one of them
     # manually - after pagination, to reduce the number of rows processed.
-    projects = Project.objects.order_by("disabled", "-priority").values_list(
+    projects = Project.objects.order_by("disabled", "-priority", "name").values_list(
         "name", flat=True
     )
     for r in data.object_list:


### PR DESCRIPTION
[This test](https://github.com/mozilla/pontoon/blob/0c7943f7afe8f86d16a5d4313276958aff71e6ec/pontoon/machinery/tests/test_views.py#L379) consistently fails on my machine, as the returned project_names array is `['Project B', 'Project A']` rather than the expected `['Project A', 'Project B']`.

Adding the "name" column as the third sorting criterion makes the results consistent.