### PR TITLE
Disable loading animation on Project Admin page load

### DIFF
--- a/pontoon/administration/static/js/admin_project.js
+++ b/pontoon/administration/static/js/admin_project.js
@@ -168,6 +168,8 @@ $(function () {
     });
   });
 
+  self.NProgressUnbind();
+
   // Set locales to existing projects to be copied to the current project
   $.ajax({
     url: '/admin/get-project-locales/',
@@ -181,6 +183,8 @@ $(function () {
       });
     },
   });
+
+  self.NProgressBind();
 
   // Copy locales from another project
   $('#copy-locales option').on('click', function () {


### PR DESCRIPTION
This is a followup from #3160.

There should be no loading animation on page load while data is being fetched in the background.