### PR TITLE
Drop the custom tr_tr collation

### DIFF
--- a/pontoon/base/migrations/0058_remove_tr_tr_collation.py
+++ b/pontoon/base/migrations/0058_remove_tr_tr_collation.py
@@ -1,0 +1,20 @@
+# Generated manually on 2024-04-04
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("base", "0057_remove_lang_format"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="UPDATE base_locale SET db_collation='tr-x-icu' WHERE db_collation='tr_tr';",
+        ),
+        migrations.RunSQL(
+            sql="DROP COLLATION IF EXISTS tr_tr;",
+            reverse_sql="CREATE COLLATION tr_tr (LOCALE = 'tr_TR.utf8');",
+        ),
+    ]


### PR DESCRIPTION
Fixes #3165 

This is a prerequisite to being able to simplify our dev env postgres container.

Because we currently include a
```sql
CREATE COLLATION tr_tr (LOCALE = 'tr_TR.utf8');
```
command in our database initialization, it means that the results of a `pg_dump` or `pg_upgrade` will include that as well, and that means that any environment where the data is restored is expected to include a `tr_TR.utf8` locale, which is itself non-standard. In other words, migrating dev environment data to a not-custom postgres instance is a pain.

So let's drop the collation, and wherever it's used, switch to `tr-x-icu` instead.

This also needs to be a SQL migration, because it's touching stuff that's not accessible via Django.