### PR TITLE
Use postgres:15 instead of custom postgres:13.4 build for dev env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,9 +24,7 @@ services:
 
   # Database
   postgresql:
-    build:
-      context: ./docker/postgres
-      dockerfile: ./Dockerfile
+    image: postgres:15
     environment:
       # Create the superuser account
       - POSTGRES_USER=pontoon

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,6 +1,0 @@
-FROM postgres:13.4
-
-RUN echo "tr_TR.UTF-8 UTF-8\nen_US.UTF-8 UTF-8" >> /etc/locale.gen \
-    && locale-gen
-
-ADD ./docker-entrypoint-initdb.d /docker-entrypoint-initdb.d

--- a/docker/postgres/docker-entrypoint-initdb.d/collations.sql
+++ b/docker/postgres/docker-entrypoint-initdb.d/collations.sql
@@ -1,2 +1,0 @@
-
-CREATE COLLATION tr_tr (LOCALE = 'tr_TR.utf8');


### PR DESCRIPTION
This drops the custom postgres dev container build originally introduced in #866 in favour of using the upstream `postgres` image directly. While at it, let's also update to v15.

This change should not be applied until #3169 has landed, and anyone who cares has had an opportunity to apply its migration, so that the `pg_upgrade` or `pg_dump`/`pg_restore` this PR necessitates applies cleanly.