### PR TITLE
Upgrade tracker code for Google Analytics 4

### DIFF
--- a/pontoon/base/templates/tracker.html
+++ b/pontoon/base/templates/tracker.html
@@ -1,3 +1,4 @@
+{% if settings.GOOGLE_ANALYTICS_KEY %}
 <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ settings.GOOGLE_ANALYTICS_KEY }}"></script>
 <script>
@@ -7,3 +8,4 @@
 
   gtag('config', '{{ settings.GOOGLE_ANALYTICS_KEY }}');
 </script>
+{% endif %}

--- a/pontoon/base/templates/tracker.html
+++ b/pontoon/base/templates/tracker.html
@@ -1,14 +1,9 @@
-{% if settings.GOOGLE_ANALYTICS_KEY %}
-  <!-- Google Analytics -->
-  <script type="text/javascript">
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ settings.GOOGLE_ANALYTICS_KEY }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
 
-    ga('create', '{{ settings.GOOGLE_ANALYTICS_KEY }}', 'auto');
-    ga('send', 'pageview');
-  </script>
-  <!-- End Google Analytics -->
-{% endif %}
-
+  gtag('config', '{{ settings.GOOGLE_ANALYTICS_KEY }}');
+</script>

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -825,8 +825,8 @@ CSP_SCRIPT_SRC = (
     "'unsafe-eval'",
     "'sha256-fDsgbzHC0sNuBdM4W91nXVccgFLwIDkl197QEca/Cl4='",
     # Rules related to Google Analytics
-    "'sha256-G5/M3dBlZdlvno5Cibw42fbeLr2PTEGd1M909Z7vPZE='",
-    "https://www.google-analytics.com/analytics.js",
+    "'sha256-MAn2iEyXLmB7sfv/20ImVRdQs8NCZ0A5SShdZsZdv20='",
+    "https://www.googletagmanager.com/gtag/js",
 )
 CSP_STYLE_SRC = (
     "'self'",


### PR DESCRIPTION
Fix #3080.

Upgrade tracker code for Google Analytics 4. Also update corresponding [CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) settings.