### PR TITLE
Replace cache_page with low-level cache API calls

### DIFF
--- a/pontoon/localizations/urls.py
+++ b/pontoon/localizations/urls.py
@@ -1,8 +1,6 @@
 from django.urls import include, path, re_path
-from django.views.decorators.cache import cache_page
 
 from pontoon.projects import views as projects_views
-from pontoon.settings import VIEW_CACHE_TIMEOUT
 from pontoon.teams import views as teams_views
 
 from . import views
@@ -74,7 +72,7 @@ urlpatterns = [
                             # Project insights
                             path(
                                 "insights/",
-                                cache_page(VIEW_CACHE_TIMEOUT)(views.ajax_insights),
+                                views.ajax_insights,
                                 name="pontoon.localizations.ajax.insights",
                             ),
                         ]

--- a/pontoon/projects/urls.py
+++ b/pontoon/projects/urls.py
@@ -1,8 +1,5 @@
 from django.urls import include, path
-from django.views.decorators.cache import cache_page
 from django.views.generic import RedirectView
-
-from pontoon.settings import VIEW_CACHE_TIMEOUT
 
 from . import views
 
@@ -79,7 +76,7 @@ urlpatterns = [
                             # Project insights
                             path(
                                 "insights/",
-                                cache_page(VIEW_CACHE_TIMEOUT)(views.ajax_insights),
+                                views.ajax_insights,
                                 name="pontoon.projects.ajax.insights",
                             ),
                             # Project info

--- a/pontoon/teams/urls.py
+++ b/pontoon/teams/urls.py
@@ -1,8 +1,5 @@
 from django.urls import include, path
-from django.views.decorators.cache import cache_page
 from django.views.generic import RedirectView
-
-from pontoon.settings import VIEW_CACHE_TIMEOUT
 
 from . import views
 
@@ -79,7 +76,7 @@ urlpatterns = [
                             # Team insights
                             path(
                                 "insights/",
-                                cache_page(VIEW_CACHE_TIMEOUT)(views.ajax_insights),
+                                views.ajax_insights,
                                 name="pontoon.teams.ajax.insights",
                             ),
                             # Team info


### PR DESCRIPTION
By using low-level cache API we makes it explicit what exactly is cached and what cache key is used.