### PR TITLE
During sync, fall back to reporting all files as changed if the hg/git/svn cli command fails

### DIFF
--- a/pontoon/sync/tests/test_vcs.py
+++ b/pontoon/sync/tests/test_vcs.py
@@ -69,7 +69,7 @@ class VCSChangedFilesTests:
         with patch.object(
             self.vcsrepository, "execute", side_effect=self.execute_failure
         ) as mock_execute:
-            assert self.vcsrepository.get_changed_files("path", "1") == []
+            assert self.vcsrepository.get_changed_files("path", "1") is None
             assert mock_execute.called
 
     def test_removed_files(self):
@@ -87,7 +87,7 @@ class VCSChangedFilesTests:
         with patch.object(
             self.vcsrepository, "execute", side_effect=self.execute_failure
         ) as mock_execute:
-            assert self.vcsrepository.get_removed_files("path", "1") == []
+            assert self.vcsrepository.get_removed_files("path", "1") is None
             assert mock_execute.called
 
 


### PR DESCRIPTION
Fixes #3178 

Tested manually by setting the data to be invalid in a local install:

```sql
update base_repository set last_synced_revisions = '{"single_locale": "foobar"}' where id = ...;
```