### PR TITLE
Do not make requests to non-configured Machinery services

### DIFF
--- a/pontoon/translate/views.py
+++ b/pontoon/translate/views.py
@@ -70,6 +70,11 @@ def translate(request, locale, project, resource):
             raise Http404
 
     context = {
+        "is_google_translate_supported": bool(settings.GOOGLE_TRANSLATE_API_KEY),
+        "is_microsoft_translator_supported": bool(
+            settings.MICROSOFT_TRANSLATOR_API_KEY
+        ),
+        "is_systran_translate_supported": bool(settings.SYSTRAN_TRANSLATE_API_KEY),
         "locale": get_preferred_locale(request),
         "notifications": [],
     }

--- a/translate/public/translate.html
+++ b/translate/public/translate.html
@@ -31,6 +31,9 @@
     <div
         id="root"
         data-csrf-token="{{ csrf_token }}"
+        data-is-google-translate-supported="{{ is_google_translate_supported | to_json() }}"
+        data-is-microsoft-translator-supported="{{ is_microsoft_translator_supported | to_json() }}"
+        data-is-systran-translate-supported="{{ is_systran_translate_supported | to_json() }}"
         data-notifications="{{ notifications | to_json }}"
         translate="no"
     ></div>

--- a/translate/src/context/MachineryTranslations.tsx
+++ b/translate/src/context/MachineryTranslations.tsx
@@ -99,15 +99,24 @@ export function MachineryProvider({
 
       // Only make requests to paid services if user is authenticated
       if (isAuthenticated) {
-        if (locale.googleTranslateCode) {
+        const root = document.getElementById('root');
+
+        const isGoogleTranslateSupported =
+          root?.dataset.isGoogleTranslateSupported === 'true';
+        const isMicrosoftTranslatorSupported =
+          root?.dataset.isMicrosoftTranslatorSupported === 'true';
+        const isSystranTranslateSupported =
+          root?.dataset.isSystranTranslateSupported === 'true';
+
+        if (isGoogleTranslateSupported && locale.googleTranslateCode) {
           fetchGoogleTranslation(plain, locale).then(addResults);
         }
 
-        if (locale.msTranslatorCode) {
+        if (isMicrosoftTranslatorSupported && locale.msTranslatorCode) {
           fetchMicrosoftTranslation(plain, locale).then(addResults);
         }
 
-        if (locale.systranTranslateCode) {
+        if (isSystranTranslateSupported && locale.systranTranslateCode) {
           fetchSystranTranslation(plain, locale).then(addResults);
         }
       }


### PR DESCRIPTION
Translate view makes requests to Google Translate and Microsoft Translator backend code even if API keys are not set. While the requests to external services are not made in this case, we should still prevent the redundant call to Pontoon backend.