### PR TITLE
Drop version from docker-compose.yml, because it is obsolete

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 # docker-compose for Pontoon development.
 #
-# Note: Requires docker-compose 1.10+.
+# Note: Requires docker-compose 1.27+.
 services:
   server:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 # docker-compose for Pontoon development.
 #
 # Note: Requires docker-compose 1.10+.
-version: '2.3'
 services:
   server:
     build:


### PR DESCRIPTION
This removes the following warning on `make run`:

> WARN[0000] ~/pontoon/docker-compose.yml: `version` is obsolete