### PR TITLE
A light refactor of pontoon/sync/ code

### DIFF
--- a/pontoon/sync/changeset.py
+++ b/pontoon/sync/changeset.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import logging
 
 from collections import defaultdict
@@ -11,11 +12,14 @@ from pontoon.actionlog.models import ActionLog
 from pontoon.base.models import (
     Entity,
     Locale,
+    Project,
+    Resource,
     Translation,
     TranslationMemoryEntry,
 )
 from pontoon.base.utils import match_attr
 from pontoon.checks.utils import bulk_run_checks
+from .vcs.models import VCSEntity, VCSProject, VCSTranslation
 
 log = logging.getLogger(__name__)
 
@@ -27,7 +31,13 @@ class ChangeSet:
     stored, execute all the changes at once efficiently.
     """
 
-    def __init__(self, db_project, vcs_project, now, locale=None):
+    def __init__(
+        self,
+        db_project: Project,
+        vcs_project: VCSProject,
+        now: datetime,
+        locale: Locale | None = None,
+    ):
         """
         :param now:
             Datetime to use for marking when approvals happened.
@@ -39,7 +49,9 @@ class ChangeSet:
 
         # Store locales and resources for FK relationships.
         self.locales = {loc.code: loc for loc in Locale.objects.all()}
-        self.resources = {r.path: r for r in self.db_project.resources.all()}
+        self.resources: dict[str, Resource] = {
+            r.path: r for r in self.db_project.resources.all()
+        }
 
         self.executed = False
         self.changes = {
@@ -56,8 +68,8 @@ class ChangeSet:
         self.actions_to_log = []
 
         self.commit_authors_per_locale = defaultdict(list)
-        self.locales_to_commit = set()
-        self.new_entities = []
+        self.locales_to_commit: set[Locale] = set()
+        self.new_entities: list[Entity] = []
 
         self.sync_user = User.objects.get(username="pontoon-sync")
 
@@ -66,7 +78,9 @@ class ChangeSet:
         """A list of Translation objects that have been created or updated."""
         return self.translations_to_create + list(self.translations_to_update.values())
 
-    def update_vcs_entity(self, locale, db_entity, vcs_entity):
+    def update_vcs_entity(
+        self, locale: Locale, db_entity: Entity, vcs_entity: VCSEntity
+    ):
         """
         Replace the translations in VCS with the translations from the
         database.
@@ -76,19 +90,21 @@ class ChangeSet:
             self.changes["update_vcs"].append((locale.code, db_entity, vcs_entity))
             self.locales_to_commit.add(locale)
 
-    def create_db_entity(self, vcs_entity):
+    def create_db_entity(self, vcs_entity: VCSEntity):
         """Create a new entity in the database."""
         self.changes["create_db"].append(vcs_entity)
 
-    def update_db_entity(self, locale, db_entity, vcs_entity):
+    def update_db_entity(
+        self, locale: Locale, db_entity: Entity, vcs_entity: VCSEntity
+    ):
         """Update the database with translations from VCS."""
         self.changes["update_db"].append((locale.code, db_entity, vcs_entity))
 
-    def update_db_source_entity(self, db_entity, vcs_entity):
+    def update_db_source_entity(self, db_entity: Entity, vcs_entity: VCSEntity):
         """Update the entities with the latest data from vcs."""
         self.changes["update_db"].append((None, db_entity, vcs_entity))
 
-    def obsolete_db_entity(self, db_entity):
+    def obsolete_db_entity(self, db_entity: Entity):
         """Mark the given entity as obsolete."""
         self.changes["obsolete_db"].append(db_entity.pk)
 
@@ -179,7 +195,9 @@ class ChangeSet:
         for resource in changed_resources:
             resource.save(self.locale)
 
-    def get_entity_updates(self, vcs_entity, db_entity=None):
+    def get_entity_updates(
+        self, vcs_entity: VCSEntity, db_entity: Entity | None = None
+    ):
         """
         Return a dict of the properties and values necessary to create
         or update a database entity from a VCS entity.
@@ -206,13 +224,9 @@ class ChangeSet:
         count = len(new_entities)
 
         if count > 0:
-            log.info(
-                "Sending new string notifications for project {}.".format(
-                    self.db_project
-                )
-            )
+            log.info(f"Sending new string notifications for project {self.db_project}.")
 
-            verb = "updated with {} new string{}".format(count, pluralize(count))
+            verb = f"updated with {count} new string{pluralize(count)}"
             contributors = User.objects.filter(
                 translation__entity__resource__project=self.db_project,
                 profile__new_string_notifications=True,
@@ -244,9 +258,9 @@ class ChangeSet:
                             string=string,
                             plural_form=plural_form,
                             approved=not vcs_translation.fuzzy,
-                            approved_date=self.now
-                            if not vcs_translation.fuzzy
-                            else None,
+                            approved_date=(
+                                self.now if not vcs_translation.fuzzy else None
+                            ),
                             fuzzy=vcs_translation.fuzzy,
                         )
                     )
@@ -256,9 +270,9 @@ class ChangeSet:
 
     def update_entity_translations_from_vcs(
         self,
-        db_entity,
-        locale_code,
-        vcs_translation,
+        db_entity: Entity,
+        locale_code: str,
+        vcs_translation: VCSTranslation,
         user=None,
         db_translations=None,
         db_translations_approved_before_sync=None,

--- a/pontoon/sync/core.py
+++ b/pontoon/sync/core.py
@@ -1,9 +1,11 @@
+from collections import Counter
+from datetime import datetime
 from functools import wraps
 import logging
-import requests
+from typing import Any
 
 from celery import shared_task
-from collections import Counter
+import requests
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -14,17 +16,18 @@ from django.template.loader import render_to_string
 from pontoon.base.models import (
     Entity,
     Locale,
+    Project,
     Resource,
     TranslatedResource,
 )
-from pontoon.sync.changeset import ChangeSet
-from pontoon.sync.vcs.models import VCSProject
+from .changeset import ChangeSet
+from .vcs.models import VCSProject
 
 
 log = logging.getLogger(__name__)
 
 
-def update_originals(db_project, now, force=False):
+def update_originals(db_project: Project, now, force=False):
     vcs_project = VCSProject(db_project, locales=[], force=force)
 
     with transaction.atomic():
@@ -52,14 +55,11 @@ def serial_task(timeout, lock_key="", on_error=None, **celery_args):
         @shared_task(bind=True, **celery_args)
         @wraps(func)
         def wrapped_func(self, *args, **kwargs):
-            lock_name = "serial_task.{}[{}]".format(
-                self.name, lock_key.format(*args, **kwargs)
-            )
+            lock_name = f"serial_task.{self.name}[{lock_key.format(*args, **kwargs)}]"
             # Acquire the lock
             if not cache.add(lock_name, True, timeout=timeout):
                 error = RuntimeError(
-                    "Can't execute task '{}' because the previously called "
-                    "task is still running.".format(lock_name)
+                    f"Can't execute task '{lock_name}' because the previously called task is still running."
                 )
                 if callable(on_error):
                     on_error(error, *args, **kwargs)
@@ -75,7 +75,7 @@ def serial_task(timeout, lock_key="", on_error=None, **celery_args):
     return wrapper
 
 
-def collect_entities(db_project, vcs_project, changed_resources):
+def collect_entities(db_project: Project, vcs_project: VCSProject, changed_resources):
     """
     Find all the entities in the database and on the filesystem and
     match them together, yielding tuples of the form
@@ -91,7 +91,7 @@ def collect_entities(db_project, vcs_project, changed_resources):
         yield key, db_entities.get(key, None), vcs_entities.get(key, None)
 
 
-def update_entities(db_project, vcs_project, changeset):
+def update_entities(db_project: Project, vcs_project: VCSProject, changeset):
     changed_resources = vcs_project.changed_files
     for key, db_entity, vcs_entity in collect_entities(
         db_project, vcs_project, changed_resources
@@ -110,7 +110,7 @@ def update_entities(db_project, vcs_project, changeset):
             changeset.update_db_source_entity(db_entity, vcs_entity)
 
 
-def update_resources(db_project, vcs_project):
+def update_resources(db_project: Project, vcs_project: VCSProject):
     """Update the database on what resource files exist in VCS."""
     log.debug(f"Scanning {vcs_project.source_directory_path}")
     vcs_changed_files, vcs_removed_files = vcs_project.changed_source_files
@@ -123,7 +123,7 @@ def update_resources(db_project, vcs_project):
 
     added_paths = []
 
-    log.debug("Removed files: {}".format(", ".join(removed_paths) or "None"))
+    log.debug(f"Removed files: {', '.join(removed_paths) or 'None'}")
     removed_resources.delete()
 
     for relative_path, vcs_resource in vcs_project.resources.items():
@@ -136,27 +136,28 @@ def update_resources(db_project, vcs_project):
             db_project.reset_resource_order()
             added_paths.append(relative_path)
 
-    log.debug("Added files: {}".format(", ".join(added_paths) or "None"))
+    log.debug(f"Added files: {', '.join(added_paths) or 'None'}")
     return added_paths, removed_paths, changed_paths
 
 
-def get_changed_resources(db_project, vcs_project):
-    changed_resources = vcs_project.changed_files
-
+def get_changed_resources(
+    db_project: Project, vcs_project: VCSProject
+) -> list[Any] | None:
     if db_project.unsynced_locales:
-        changed_resources = None
+        return None
+    changed_files = vcs_project.changed_files
+    if changed_files is None:
+        return None
+    return (
+        list(changed_files.keys())
+        + list(vcs_project.added_paths)
+        + list(vcs_project.changed_paths)
+    )
 
-    if changed_resources is not None:
-        changed_resources = (
-            list(changed_resources.keys())
-            + list(vcs_project.added_paths)
-            + list(vcs_project.changed_paths)
-        )
 
-    return changed_resources
-
-
-def update_translations(db_project, vcs_project, locale, changeset):
+def update_translations(
+    db_project: Project, vcs_project: VCSProject, locale, changeset
+):
     changed_resources = get_changed_resources(db_project, vcs_project)
     all_entities = collect_entities(db_project, vcs_project, changed_resources)
     for key, db_entity, vcs_entity in all_entities:
@@ -180,7 +181,7 @@ def update_translations(db_project, vcs_project, locale, changeset):
             changeset.update_db_entity(locale, db_entity, vcs_entity)
 
 
-def update_translated_resources(db_project, vcs_project, locale):
+def update_translated_resources(db_project: Project, vcs_project: VCSProject, locale):
     """
     Update the TranslatedResource entries in the database.
     Returns true if a new TranslatedResource is added to the locale.
@@ -199,7 +200,9 @@ def update_translated_resources(db_project, vcs_project, locale):
         )
 
 
-def update_translated_resources_with_config(db_project, vcs_project, locale):
+def update_translated_resources_with_config(
+    db_project: Project, vcs_project: VCSProject, locale
+):
     """
     Create/update the TranslatedResource objects for each Resource instance
     that is enabled for the given locale through project configuration.
@@ -218,7 +221,9 @@ def update_translated_resources_with_config(db_project, vcs_project, locale):
     return tr_created
 
 
-def update_translated_resources_without_config(db_project, vcs_project, locale):
+def update_translated_resources_without_config(
+    db_project: Project, vcs_project: VCSProject, locale
+):
     """
     We only want to create/update the TranslatedResource object if the
     resource exists in the current locale, UNLESS the file is asymmetric.
@@ -242,7 +247,9 @@ def update_translated_resources_without_config(db_project, vcs_project, locale):
     return tr_created
 
 
-def update_translated_resources_no_files(db_project, locale, changed_resources):
+def update_translated_resources_no_files(
+    db_project: Project, locale, changed_resources
+):
     """
     Create/update TranslatedResource entries if files aren't available. This typically happens when
     originals change and translations don't, so we don't pull locale repositories.
@@ -261,11 +268,11 @@ def update_translated_resources_no_files(db_project, locale, changed_resources):
         translatedresource.calculate_stats()
 
 
-def get_vcs_entities(vcs_project):
+def get_vcs_entities(vcs_project: VCSProject):
     return {entity_key(entity): entity for entity in vcs_project.entities}
 
 
-def get_changed_entities(db_project, changed_resources):
+def get_changed_entities(db_project: Project, changed_resources):
     entities = (
         Entity.objects.select_related("resource")
         .prefetch_related("changed_locales")
@@ -277,14 +284,14 @@ def get_changed_entities(db_project, changed_resources):
     return entities
 
 
-def get_db_entities(db_project, changed_resources=None):
+def get_db_entities(db_project: Project, changed_resources=None) -> dict[str, Entity]:
     return {
         entity_key(entity): entity
         for entity in get_changed_entities(db_project, changed_resources)
     }
 
 
-def entity_key(entity):
+def entity_key(entity: Entity) -> str:
     """
     Generate a key for the given entity that is unique within the
     project.
@@ -293,27 +300,24 @@ def entity_key(entity):
     return ":".join([entity.resource.path, key])
 
 
-def has_repo_changed(last_synced_revisions, pulled_revisions):
-    has_changed = False
-
+def has_repo_changed(last_synced_revisions, pulled_revisions) -> bool:
     # If any revision is None, we can't be sure if a change
     # happened or not, so we default to assuming it did.
     unsure_change = None in pulled_revisions.values()
-
     if unsure_change or pulled_revisions != last_synced_revisions:
-        has_changed = True
+        return True
+    return False
 
-    return has_changed
 
-
-def pull_source_repo_changes(db_project):
+def pull_source_repo_changes(db_project: Project) -> bool:
     source_repo = db_project.source_repository
     pulled_revisions = source_repo.pull()
-    has_changed = has_repo_changed(source_repo.last_synced_revisions, pulled_revisions)
-    return has_changed
+    return has_repo_changed(source_repo.last_synced_revisions, pulled_revisions)
 
 
-def pull_locale_repo_changes(db_project, locales):
+def pull_locale_repo_changes(
+    db_project: Project, locales
+) -> tuple[bool, dict[str, Any]]:
     """
     Update the local files with changes from the VCS. Returns True
     if any of the updated repos have changed since the last sync.
@@ -344,18 +348,19 @@ def pull_locale_repo_changes(db_project, locales):
     return has_changed, repo_locales
 
 
-def commit_changes(db_project, vcs_project, changeset, locale):
+def commit_changes(
+    db_project: Project, vcs_project: VCSProject, changeset: ChangeSet, locale: Locale
+) -> None:
     """Commit the changes we've made back to the VCS."""
     authors = changeset.commit_authors_per_locale.get(locale.code, [])
 
     # Use the top translator for this batch as commit author, or
     # the fake Pontoon user if there are no authors.
-    if len(authors) > 0:
-        commit_author = Counter(authors).most_common(1)[0][0]
-    else:
-        commit_author = User(
-            first_name=settings.VCS_SYNC_NAME, email=settings.VCS_SYNC_EMAIL
-        )
+    commit_author = (
+        Counter(authors).most_common(1)[0][0]
+        if authors
+        else User(first_name=settings.VCS_SYNC_NAME, email=settings.VCS_SYNC_EMAIL)
+    )
 
     commit_message = render_to_string(
         "sync/commit_message.jinja",
@@ -367,7 +372,7 @@ def commit_changes(db_project, vcs_project, changeset, locale):
     repo.commit(commit_message, commit_author, locale_path)
 
 
-def get_changed_locales(db_project, locales, now):
+def get_changed_locales(db_project: Project, locales, now: datetime):
     """
     Narrow down locales to the ones that have changed since the last sync by fetching latest
     repository commit hashes via API. For projects with many repositories, this is much faster
@@ -434,19 +439,16 @@ def get_changed_locales(db_project, locales, now):
     for loc in error_locale_pks:
         if loc not in changed_locale_pks + unchanged_locale_pks:
             log.error(
-                "Unable to fetch latest commit hash for locale {locale} in project {project}".format(
-                    locale=Locale.objects.get(pk=loc), project=db_project.slug
-                )
+                "Unable to fetch latest commit hash for "
+                f"locale {Locale.objects.get(pk=loc)} in project {db_project.slug}"
             )
             changed_locale_pks.append(locale.pk)
 
     changed_locales = db_project.locales.filter(pk__in=changed_locale_pks)
 
     log.info(
-        "Fetching latest commit hashes for project {project} complete. Changed locales: {locales}.".format(
-            project=db_project.slug,
-            locales=", ".join(changed_locales.values_list("code", flat=True)),
-        )
+        f"Fetching latest commit hashes for project {db_project.slug} complete. "
+        f"Changed locales: {', '.join(changed_locales.values_list('code', flat=True))}."
     )
 
     return changed_locales

--- a/pontoon/sync/tasks.py
+++ b/pontoon/sync/tasks.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 
 from django.conf import settings
 from django.db import transaction
@@ -50,7 +51,7 @@ def sync_project_error(error, *args, **kwargs):
     ).skip()
 
 
-def update_locale_project_locale_stats(locale, project):
+def update_locale_project_locale_stats(locale: Locale, project: Project):
     locale.aggregate_stats()
     locale.project_locale.get(project=project).aggregate_stats()
 
@@ -80,9 +81,7 @@ def sync_project(
         SyncLog,
         pk=sync_log_pk,
         message=(
-            "Could not sync project {}, log with pk={} not found.".format(
-                db_project.slug, sync_log_pk
-            )
+            f"Could not sync project {db_project.slug}, log with pk={sync_log_pk} not found."
         ),
     )
 
@@ -119,7 +118,7 @@ def sync_project(
     )
 
 
-def sync_sources(db_project, now, force, no_pull):
+def sync_sources(db_project: Project, now: datetime, force: bool, no_pull: bool):
     # Pull from source repository
     if no_pull:
         has_source_repo_changed = True
@@ -168,9 +167,9 @@ def sync_sources(db_project, now, force, no_pull):
 
 
 def sync_translations(
-    db_project,
-    project_sync_log,
-    now,
+    db_project: Project,
+    project_sync_log: ProjectSyncLog,
+    now: datetime,
     has_source_repo_changed,
     added_paths=None,
     removed_paths=None,

--- a/pontoon/sync/vcs/git.py
+++ b/pontoon/sync/vcs/git.py
@@ -1,0 +1,110 @@
+import logging
+from typing import Any
+
+from django.conf import settings
+
+from .utils import CommitToRepositoryException, PullFromRepositoryException, execute
+
+log = logging.getLogger(__name__)
+
+
+def update(source: str, target: str, branch: str | None) -> None:
+    log.debug("Git: Update repository.")
+
+    command = ["git", "fetch", "--all"]
+    execute(command, target)
+
+    # Undo local changes
+    remote = f"origin/{branch}" if branch else "origin"
+
+    command = ["git", "reset", "--hard", remote]
+    code, _output, error = execute(command, target)
+
+    if code != 0:
+        log.info(f"Git: {error}")
+        log.debug("Git: Clone instead.")
+        command = ["git", "clone", source, target]
+        code, _output, error = execute(command)
+
+        if code != 0:
+            raise PullFromRepositoryException(error)
+
+        log.debug(f"Git: Repository at {source} cloned.")
+    else:
+        log.debug(f"Git: Repository at {source} updated.")
+
+    if branch:
+        command = ["git", "checkout", branch]
+        code, _output, error = execute(command, target)
+
+        if code != 0:
+            raise PullFromRepositoryException(error)
+
+        log.debug(f"Git: Branch {branch} checked out.")
+
+
+def commit(path: str, message: str, user: Any, branch: str | None, url: str) -> None:
+    log.debug("Git: Commit to repository.")
+
+    # Embed git identity info into commands
+    git_cmd = [
+        "git",
+        "-c",
+        f"user.name={settings.VCS_SYNC_NAME}",
+        "-c",
+        f"user.email={settings.VCS_SYNC_EMAIL}",
+    ]
+
+    # Add new and remove missing paths
+    execute(git_cmd + ["add", "-A", "--", path], path)
+
+    # Commit
+    commit = git_cmd + [
+        "commit",
+        "-m",
+        message,
+        "--author",
+        user.display_name_and_email,
+    ]
+    code, _output, error = execute(commit, path)
+    if code != 0 and error:
+        raise CommitToRepositoryException(error)
+
+    # Push
+    push = ["git", "push", url, branch or "HEAD"]
+    code, _output, error = execute(push, path)
+
+    if code != 0:
+        if (
+            "Updates were rejected because the remote contains work that you do"
+            in error
+        ):
+            error = "Remote contains work that you do not have locally. " + error
+        raise CommitToRepositoryException(error)
+
+    if "Everything up-to-date" in error:
+        return log.warning("Nothing to commit")
+
+    log.info(message)
+
+
+def revision(path: str) -> str | None:
+    cmd = ["git", "rev-parse", "HEAD"]
+    code, output, _error = execute(cmd, path, log=log)
+    return output.decode().strip() if code == 0 else None
+
+
+def changed_files(path: str, from_revision: str) -> tuple[list[str], list[str]] | None:
+    cmd = ["git", "diff", "--name-status", f"{from_revision}..HEAD", "--", path]
+    code, output, _error = execute(cmd, path, log=log)
+    if code != 0:
+        return None
+    changed = []
+    removed = []
+    for line in output.decode().split("\n"):
+        if line:
+            if line.startswith(("A", "M")):
+                changed.append(line.split(None, 2)[1])
+            elif line.startswith("D"):
+                removed.append(line.split(None, 2)[1])
+    return changed, removed

--- a/pontoon/sync/vcs/hg.py
+++ b/pontoon/sync/vcs/hg.py
@@ -1,0 +1,71 @@
+import logging
+from typing import Any
+
+from .utils import CommitToRepositoryException, PullFromRepositoryException, execute
+
+log = logging.getLogger(__name__)
+
+
+def update(source: str, target: str, branch: str | None) -> None:
+    log.debug("Mercurial: Update repository.")
+
+    # Undo local changes: Mercurial doesn't offer anything more elegant
+    command = ["rm", "-rf", target]
+    code, _output, error = execute(command)
+
+    command = ["hg", "clone", source, target]
+    code, _output, error = execute(command)
+
+    if code == 0:
+        log.debug(f"Mercurial: Repository at {source} cloned.")
+
+    else:
+        raise PullFromRepositoryException(error)
+
+
+def commit(path: str, message: str, user: Any, branch: str | None, url: str) -> None:
+    log.debug("Mercurial: Commit to repository.")
+
+    # Add new and remove missing paths
+    execute(["hg", "addremove"], path)
+
+    # Commit
+    commit = ["hg", "commit", "-m", message, "-u", user.display_name_and_email]
+    code, output, error = execute(commit, path)
+    if code != 0 and error:
+        raise CommitToRepositoryException(error)
+
+    # Push
+    code, output, error = execute(["hg", "push"], path)
+
+    if code == 1 and b"no changes found" in output:
+        return log.warning("Nothing to commit")
+
+    if code != 0 and error:
+        raise CommitToRepositoryException(error)
+
+    log.info(message)
+
+
+def revision(path: str) -> str | None:
+    cmd = ["hg", "identify", "--id", "--rev=default"]
+    code, output, _error = execute(cmd, path, log=log)
+    return output.decode().strip() if code == 0 else None
+
+
+def changed_files(path: str, from_revision: str) -> tuple[list[str], list[str]] | None:
+    # Ignore trailing + in revision number. It marks local changes.
+    rev = from_revision.rstrip("+")
+    cmd = ["hg", "status", "-a", "-m", "-r", f"--rev={rev}", "--rev=default"]
+    code, output, _error = execute(cmd, path, log=log)
+    if code != 0:
+        return None
+    changed = []
+    removed = []
+    for line in output.decode().split("\n"):
+        if line:
+            if line.startswith(("A", "M")):
+                changed.append(line.split(None, 2)[1])
+            elif line.startswith("R"):
+                removed.append(line.split(None, 2)[1])
+    return changed, removed

--- a/pontoon/sync/vcs/svn.py
+++ b/pontoon/sync/vcs/svn.py
@@ -1,0 +1,93 @@
+import logging
+from os import environ, path
+from typing import Any
+
+from django.conf import settings
+
+from .utils import CommitToRepositoryException, PullFromRepositoryException, execute
+
+log = logging.getLogger(__name__)
+
+
+def update(source: str, target: str, branch: str | None) -> None:
+    log.debug("Subversion: Checkout or update repository.")
+
+    if path.exists(target):
+        status = "updated"
+        command = ["svn", "update", "--accept", "theirs-full", target]
+
+    else:
+        status = "checked out"
+        command = [
+            "svn",
+            "checkout",
+            "--trust-server-cert",
+            "--non-interactive",
+            source,
+            target,
+        ]
+
+    code, _output, error = execute(command, env=get_svn_env())
+
+    if code != 0:
+        raise PullFromRepositoryException(error)
+
+    log.debug(f"Subversion: Repository at {source} {status}.")
+
+
+def commit(path: str, message: str, user: Any, branch: str | None, url: str) -> None:
+    log.debug("Subversion: Commit to repository.")
+
+    # Commit
+    commit = [
+        "svn",
+        "commit",
+        "-m",
+        message,
+        "--with-revprop",
+        f"author={user.display_name_and_email}",
+        path,
+    ]
+    code, output, error = execute(commit, env=get_svn_env())
+    if code != 0:
+        raise CommitToRepositoryException(error)
+
+    if not output and not error:
+        return log.warning("Nothing to commit")
+
+    log.info(message)
+
+
+def revision(path: str) -> str | None:
+    cmd = ["svnversion", path]
+    code, output, _error = execute(cmd, env=get_svn_env(), log=log)
+    return output.decode().strip() if code == 0 else None
+
+
+def changed_files(path: str, from_revision: str) -> tuple[list[str], list[str]] | None:
+    # Remove all non digit characters from the revision number.
+    rev = "".join(filter(lambda c: c.isdigit(), from_revision))
+    cmd = ["svn", "diff", "-r", f"{rev}:HEAD", "--summarize"]
+    code, output, _error = execute(cmd, path, env=get_svn_env(), log=log)
+    if code != 0:
+        return None
+    changed = []
+    removed = []
+    for line in output.decode().split("\n"):
+        if line.startswith(("A", "M")):
+            changed.append(line.split(None, 2)[1])
+        elif line.startswith("D"):
+            removed.append(line.split(None, 2)[1])
+    return changed, removed
+
+
+def get_svn_env():
+    """Return an environment dict for running SVN in."""
+    if settings.SVN_LD_LIBRARY_PATH:
+        env = environ.copy()
+        env[
+            "LD_LIBRARY_PATH"
+        ] = f"{settings.SVN_LD_LIBRARY_PATH}:{env['LD_LIBRARY_PATH']}"
+        return env
+    else:
+        return None

--- a/pontoon/sync/vcs/utils.py
+++ b/pontoon/sync/vcs/utils.py
@@ -1,0 +1,29 @@
+from logging import Logger
+import subprocess
+
+
+class PullFromRepositoryException(Exception):
+    pass
+
+
+class CommitToRepositoryException(Exception):
+    pass
+
+
+def execute(
+    command: list[str], cwd: str | None = None, env=None, log: Logger | None = None
+) -> tuple[int, bytes, str | None]:
+    try:
+        sp = subprocess.PIPE
+        proc = subprocess.Popen(
+            command, stdout=sp, stderr=sp, stdin=sp, cwd=cwd, env=env
+        )
+        output, error = proc.communicate()
+        strerror = error.decode() if error else None
+        if log is not None and proc.returncode != 0:
+            log.error(
+                f"Error while executing command `{command}` in `{cwd}`: {strerror}"
+            )
+        return proc.returncode, output, strerror
+    except OSError as error:
+        return -1, b"", error.strerror

--- a/pontoon/sync/views.py
+++ b/pontoon/sync/views.py
@@ -1,10 +1,11 @@
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
+from django.http import HttpRequest
 from django.shortcuts import get_object_or_404, render
 
 from pontoon.sync.models import SyncLog
 
 
-def sync_log_list(request):
+def sync_log_list(request: HttpRequest):
     sync_logs = SyncLog.objects.order_by("-start_time")
     paginator = Paginator(sync_logs, 24)
 
@@ -19,7 +20,7 @@ def sync_log_list(request):
     return render(request, "sync/log_list.html", {"sync_logs": sync_logs})
 
 
-def sync_log_details(request, sync_log_pk):
+def sync_log_details(request: HttpRequest, sync_log_pk: int):
     # Prefetch for the end_time
     queryset = SyncLog.objects.prefetch_related(
         "project_sync_logs__repository_sync_logs__repository",


### PR DESCRIPTION
This is a first pass at making the sync code a bit more readable to an outsider.

A smattering of type hints is added, but these aren't (yet) checked or anywhere near complete; they're just to help out the reader and editors get a better understanding of the shapes of the data that's being dealt with. Once #3183 lands, it should get easier to see if [django-stubs](https://github.com/typeddjango/django-stubs) could prove useful for better typing of e.g. querysets.

A few functions are refactored to be more pythonic.

The git/hg/svn implementations under `pontoon/sync/vcs/repositories` are each split into their own modules, and their unnecessary wrapper classes are dropped. Previously, the classes were being found using `globals()` and by string-concatenating repo type identifiers.

The `pontoon/sync/tests/test_vcs.py` tests are updated to match, and expanded to cover the `revision()` functions.