### PR TITLE
Use more dependable file names in pontoon.localizations test

### DIFF
--- a/pontoon/localizations/tests/test_views.py
+++ b/pontoon/localizations/tests/test_views.py
@@ -20,10 +20,10 @@ def test_ajax_resources(mock_render, client, project_a, locale_a):
     """Ensure that the latest_activity field is added to parts."""
     ProjectLocaleFactory.create(locale=locale_a, project=project_a)
 
-    resource = ResourceFactory.create(project=project_a, path="has/stats.po")
+    resource1 = ResourceFactory.create(project=project_a, path="has/stats1.po")
     resource2 = ResourceFactory.create(project=project_a, path="has/stats2.po")
 
-    entity = EntityFactory.create(resource=resource)
+    entity = EntityFactory.create(resource=resource1)
     EntityFactory.create(resource=resource2)
     translation = TranslationFactory.create(entity=entity, locale=locale_a)
 
@@ -45,11 +45,12 @@ def test_ajax_resources(mock_render, client, project_a, locale_a):
 
     assert len(ctx["resources"]) == 2
 
-    assert ctx["resources"][0].title == "has/stats2.po"
-    assert ctx["resources"][0].deadline is None
-    assert ctx["resources"][0].priority is None
-    assert ctx["resources"][0].latest_activity == translation.latest_activity
-    assert ctx["resources"][0].chart == {
+    res = ctx["resources"][1]
+    assert res.title == "has/stats2.po"
+    assert res.deadline is None
+    assert res.priority is None
+    assert res.latest_activity == translation.latest_activity
+    assert res.chart == {
         "pretranslated_strings": 0,
         "total_strings": 1,
         "approved_strings": 0,


### PR DESCRIPTION
As I'm running Pontoon locally on my M1 Macbook without Docker, it appears that the paths `has/stats.po` and `has/stats2.po` are sorted differently than they are in the test environments, and so end up in a different order in the GET results.

Let's use `has/stats1.po` and `has/stats2.po`, as they're more predictably ordered.