### PR TITLE
Fixed commenting bug for right-to-left languages

### DIFF
--- a/translate/src/modules/comments/components/Comment.css
+++ b/translate/src/modules/comments/components/Comment.css
@@ -15,6 +15,15 @@
   background-color: var(--dark-grey-2);
   padding: 0 2px;
   border-radius: 2px;
+  unicode-bidi: isolate;
+}
+
+.comments-list .comment .container .content p {
+  unicode-bidi: plaintext;
+}
+
+.comments-list .comment .container .content .Linkify {
+  display: block;
 }
 
 .comments-list .comment-author {


### PR DESCRIPTION
Fix #2400

Added the CSS changes proposed by @safaalfulaij (thank you!) to comments in Pontoon. In particular, directionality for comments is set to "plaintext" to treat it as simple text. Directionality for mentions is separated from the rest of the comment content, ensuring that Arabic and Hebrew nicknames maintain their directionality. To improve comment readability, the proposed change to move all comment content to a newline after the author's name was added.

**To reproduce results**: Populate your database as in [step 3 here](https://mozilla-pontoon.readthedocs.io/en/latest/dev/first-contribution.html). Create a superuser account, and set the nickname to be in either Arabic or Hebrew. Create a mock translation for one of the strings in a locale. Create another superuser account, and navigate back to the mock translation. Mention the first superuser using @[Arabic/Hebrew nickname], and post the comment. 

See attached photo below for reference.

![image](https://github.com/mozilla/pontoon/assets/90732381/703e7cf3-3aec-41c9-855b-d23d1d4da55d)



