### PR TITLE
Added Tags search field to both Project and Localization dashboards

### DIFF
--- a/pontoon/localizations/templates/localizations/includes/tags.html
+++ b/pontoon/localizations/templates/localizations/includes/tags.html
@@ -1,6 +1,14 @@
 {% import 'tags/widgets/tag_list.html' as TagList %}
 
 <div class="tags">
+  <menu class="controls">
+    <div class="search-wrapper small clearfix">
+      <div class="icon fa fa-search"></div>
+      <input class="table-filter" type="search" autocomplete="off" autofocus placeholder="Filter tags">
+    </div>
+  </menu>
+
+  
   {{ TagList.header() }}
 
   {% for tag in tags %}

--- a/pontoon/projects/templates/projects/includes/tags.html
+++ b/pontoon/projects/templates/projects/includes/tags.html
@@ -1,6 +1,12 @@
 {% import 'tags/widgets/tag_list.html' as TagList %}
 
 <div class="tags">
+  <menu class="controls">
+    <div class="search-wrapper small clearfix">
+      <div class="icon fa fa-search"></div>
+      <input class="table-filter" type="search" autocomplete="off" autofocus placeholder="Filter tags">
+    </div>
+  </menu>
 
   {{ TagList.header() }}
   {% for tag in tags %}


### PR DESCRIPTION
Fix #3105

Added a search field for Tags in both the Localization and Project dashboards. Reused same component structure and styling as the search field in the Resources/Teams tab located in the Localization/Project dashboards respectively.

**To reproduce results:** First, you will need to download a database dump that includes the "Firefox" and "Mozilla.org" projects. Load the database dump as described [here](https://mozilla-pontoon.readthedocs.io/en/latest/dev/contributing.html#database). Next, create a new superuser account using `make setup`. Run the webapp and locate either the "Firefox" or "Mozilla.org" projects in either the Teams>Language>Projects tab or directly through the Projects tab at the top of the Pontoon website header. Finally, click on the Tags tab to view the new search bar.

See images below for reference, and directly type in the URLs shown in the images if you have trouble finding page:

<img width="1120" alt="image" src="https://github.com/mozilla/pontoon/assets/90732381/6eda8987-c9e1-4a06-bf99-b85b4bf8ef11">

<img width="1120" alt="image" src="https://github.com/mozilla/pontoon/assets/90732381/4d07e6c9-e8cc-4a70-bdd0-5cf2b0a84060">

