### PR TITLE
Fix attribution issues for Fluent sources and LLM translations

### DIFF
--- a/translate/src/modules/editor/hooks/useSendTranslation.ts
+++ b/translate/src/modules/editor/hooks/useSendTranslation.ts
@@ -22,7 +22,7 @@ import {
 import { updateResource } from '~/modules/resource/actions';
 import { updateStats } from '~/modules/stats/actions';
 import { useAppDispatch, useAppSelector } from '~/hooks';
-import { serializeEntry } from '~/utils/message';
+import { serializeEntry, getPlainMessage } from '~/utils/message';
 
 /**
  * Return a function to send a translation to the server.
@@ -53,8 +53,9 @@ export function useSendTranslation(): (ignoreWarnings?: boolean) => void {
     setEditorBusy(true);
 
     const translation = serializeEntry(entity.format, entry);
+    const normalizedTranslation = getPlainMessage(translation, entity.format);
     const sources =
-      machinery && machinery.translation === translation
+      machinery && machinery.translation === normalizedTranslation
         ? machinery.sources
         : [];
     const content = await createTranslation(

--- a/translate/src/modules/machinery/components/MachineryTranslation.tsx
+++ b/translate/src/modules/machinery/components/MachineryTranslation.tsx
@@ -2,7 +2,7 @@ import { Localized } from '@fluent/react';
 import classNames from 'classnames';
 import React, { useCallback, useContext, useEffect, useRef } from 'react';
 
-import type { MachineryTranslation } from '~/api/machinery';
+import type { MachineryTranslation, SourceType } from '~/api/machinery';
 import { logUXAction } from '~/api/uxaction';
 import { EditorActions } from '~/context/Editor';
 import { HelperSelection } from '~/context/HelperSelection';
@@ -45,7 +45,10 @@ export function MachineryTranslationComponent({
     if (window.getSelection()?.isCollapsed !== false) {
       setElement(index);
       const content = llmTranslation || translation.translation;
-      setEditorFromHelpers(content, translation.sources, true);
+      const sources: SourceType[] = llmTranslation
+        ? ['gpt-transform']
+        : translation.sources;
+      setEditorFromHelpers(content, sources, true);
       if (llmTranslation) {
         logUXAction('LLM Translation Copied', 'LLM Feature Adoption', {
           action: 'Copy LLM Translation',


### PR DESCRIPTION
**Fixes #3228 and #3204**

**Issue #3228:**

This PR addresses the problem where machinery sources were not being attributed correctly for any Fluent (FTL) strings. Previously, no sources were identified, leading to incorrect attribution. With this fix, sources are now accurately identified and attributed for Fluent files, ensuring correct tracking and reporting of translation sources.

**Issue #3204:**

This PR also fixes the issue where LLM translations (`gpt-transform`) were incorrectly attributed to Google Translate. This has been corrected, ensuring that LLM translations are now properly attributed as a machinery source, allowing for accurate logging and monitoring of this feature's usage.