### PR TITLE
Implement UX Logging and Fix LLM Translation Shortcut Functionality

### DIFF
--- a/translate/src/context/TranslationContext.tsx
+++ b/translate/src/context/TranslationContext.tsx
@@ -4,7 +4,7 @@ import { type MachineryTranslation, fetchGPTTransform } from '~/api/machinery';
 export type SelState = {
   loading: boolean;
   selectedOption: string;
-  llmTranslations: Record<string, string>;
+  llmTranslation: string;
 };
 
 interface LLMTranslationContextType {
@@ -20,7 +20,7 @@ interface LLMTranslationContextType {
 const initSelState = () => ({
   loading: false,
   selectedOption: '',
-  llmTranslations: {},
+  llmTranslation: '',
 });
 
 const LLMTranslationContext = createContext<LLMTranslationContextType>({
@@ -59,10 +59,7 @@ export const LLMTranslationProvider: React.FC = ({ children }) => {
       stateRef.current.set(mt, {
         loading: false,
         selectedOption: characteristic,
-        llmTranslations: {
-          ...currentState.llmTranslations,
-          [characteristic]: machineryTranslations[0].translation,
-        },
+        llmTranslation: machineryTranslations[0].translation,
       });
     } else {
       stateRef.current.set(mt, {
@@ -78,7 +75,7 @@ export const LLMTranslationProvider: React.FC = ({ children }) => {
     stateRef.current.set(mt, {
       ...currentState,
       selectedOption: '',
-      llmTranslations: {},
+      llmTranslation: '',
     });
     setVersion((v) => v + 1);
   };

--- a/translate/src/context/TranslationContext.tsx
+++ b/translate/src/context/TranslationContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useState, useRef } from 'react';
 import { type MachineryTranslation, fetchGPTTransform } from '~/api/machinery';
 
-export type SelState = {
+type SelState = {
   loading: boolean;
   selectedOption: string;
   llmTranslation: string;

--- a/translate/src/context/TranslationContext.tsx
+++ b/translate/src/context/TranslationContext.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useState, useRef } from 'react';
 import { type MachineryTranslation, fetchGPTTransform } from '~/api/machinery';
 
-type SelState = {
+export type SelState = {
   loading: boolean;
   selectedOption: string;
   llmTranslations: Record<string, string>;

--- a/translate/src/context/TranslationContext.tsx
+++ b/translate/src/context/TranslationContext.tsx
@@ -4,7 +4,7 @@ import { type MachineryTranslation, fetchGPTTransform } from '~/api/machinery';
 type SelState = {
   loading: boolean;
   selectedOption: string;
-  llmTranslation: string;
+  llmTranslations: Record<string, string>;
 };
 
 interface LLMTranslationContextType {
@@ -20,7 +20,7 @@ interface LLMTranslationContextType {
 const initSelState = () => ({
   loading: false,
   selectedOption: '',
-  llmTranslation: '',
+  llmTranslations: {},
 });
 
 const LLMTranslationContext = createContext<LLMTranslationContextType>({
@@ -59,7 +59,10 @@ export const LLMTranslationProvider: React.FC = ({ children }) => {
       stateRef.current.set(mt, {
         loading: false,
         selectedOption: characteristic,
-        llmTranslation: machineryTranslations[0].translation,
+        llmTranslations: {
+          ...currentState.llmTranslations,
+          [characteristic]: machineryTranslations[0].translation,
+        },
       });
     } else {
       stateRef.current.set(mt, {
@@ -75,7 +78,7 @@ export const LLMTranslationProvider: React.FC = ({ children }) => {
     stateRef.current.set(mt, {
       ...currentState,
       selectedOption: '',
-      llmTranslation: '',
+      llmTranslations: {},
     });
     setVersion((v) => v + 1);
   };

--- a/translate/src/context/TranslationContext.tsx
+++ b/translate/src/context/TranslationContext.tsx
@@ -88,9 +88,14 @@ export const LLMTranslationProvider: React.FC = ({ children }) => {
   );
 };
 
-export const useLLMTranslation = (mt: MachineryTranslation) => {
+export const useLLMTranslation = () => {
   const { getSelState, transformLLMTranslation, restoreOriginal } = useContext(
     LLMTranslationContext,
   );
-  return { ...getSelState(mt), transformLLMTranslation, restoreOriginal };
+
+  return (mt: MachineryTranslation) => ({
+    ...getSelState(mt),
+    transformLLMTranslation,
+    restoreOriginal,
+  });
 };

--- a/translate/src/modules/machinery/components/MachineryTranslation.tsx
+++ b/translate/src/modules/machinery/components/MachineryTranslation.tsx
@@ -39,7 +39,9 @@ export function MachineryTranslationComponent({
   const { element, setElement } = useContext(HelperSelection);
   const isSelected = element === index;
 
-  const { llmTranslation } = useLLMTranslation(translation);
+  const getLLMTranslationState = useLLMTranslation();
+  const { llmTranslation } = getLLMTranslationState(translation);
+
   const locale = useContext(Locale);
 
   const copyTranslationIntoEditor = useCallback(() => {
@@ -109,8 +111,8 @@ function MachineryTranslationSuggestion({
 }) {
   const { code, direction, script } = useContext(Locale);
 
-  // Updated to use the new context structure
-  const { llmTranslation, loading } = useLLMTranslation(translation);
+  const getLLMTranslationState = useLLMTranslation();
+  const { llmTranslation, loading } = getLLMTranslationState(translation);
 
   return (
     <>

--- a/translate/src/modules/machinery/components/MachineryTranslation.tsx
+++ b/translate/src/modules/machinery/components/MachineryTranslation.tsx
@@ -39,15 +39,12 @@ export function MachineryTranslationComponent({
   const { element, setElement } = useContext(HelperSelection);
   const isSelected = element === index;
 
-  // Updated to use the new context structure
-  const { llmTranslations, selectedOption } = useLLMTranslation(translation);
+  const { llmTranslation } = useLLMTranslation(translation);
   const locale = useContext(Locale);
 
   const copyTranslationIntoEditor = useCallback(() => {
     if (window.getSelection()?.isCollapsed !== false) {
       setElement(index);
-      // Extract the appropriate LLM translation
-      const llmTranslation = llmTranslations[selectedOption];
       const content = llmTranslation || translation.translation;
       const sources: SourceType[] = llmTranslation
         ? ['gpt-transform']
@@ -60,13 +57,7 @@ export function MachineryTranslationComponent({
         });
       }
     }
-  }, [
-    index,
-    setEditorFromHelpers,
-    translation,
-    llmTranslations,
-    selectedOption,
-  ]);
+  }, [index, setEditorFromHelpers, translation, llmTranslation]);
 
   const className = classNames(
     'translation',
@@ -119,11 +110,8 @@ function MachineryTranslationSuggestion({
   const { code, direction, script } = useContext(Locale);
 
   // Updated to use the new context structure
-  const { llmTranslations, selectedOption, loading } =
-    useLLMTranslation(translation);
+  const { llmTranslation, loading } = useLLMTranslation(translation);
 
-  // Extract the appropriate LLM translation
-  const llmTranslation = llmTranslations[selectedOption];
   return (
     <>
       <header>

--- a/translate/src/modules/machinery/components/MachineryTranslation.tsx
+++ b/translate/src/modules/machinery/components/MachineryTranslation.tsx
@@ -39,12 +39,14 @@ export function MachineryTranslationComponent({
   const { element, setElement } = useContext(HelperSelection);
   const isSelected = element === index;
 
-  const { llmTranslation } = useLLMTranslation(translation);
-  const locale = useContext(Locale);
+  // Updated to use the new context structure
+  const { llmTranslations, selectedOption } = useLLMTranslation(translation);
 
   const copyTranslationIntoEditor = useCallback(() => {
     if (window.getSelection()?.isCollapsed !== false) {
       setElement(index);
+      // Extract the appropriate LLM translation
+      const llmTranslation = llmTranslations[selectedOption];
       const content = llmTranslation || translation.translation;
       const sources: SourceType[] = llmTranslation
         ? ['gpt-transform']
@@ -57,7 +59,13 @@ export function MachineryTranslationComponent({
         });
       }
     }
-  }, [index, setEditorFromHelpers, translation, llmTranslation]);
+  }, [
+    index,
+    setEditorFromHelpers,
+    translation,
+    llmTranslations,
+    selectedOption,
+  ]);
 
   const className = classNames(
     'translation',
@@ -108,7 +116,13 @@ function MachineryTranslationSuggestion({
   translation: MachineryTranslation;
 }) {
   const { code, direction, script } = useContext(Locale);
-  const { llmTranslation, loading } = useLLMTranslation(translation);
+
+  // Updated to use the new context structure
+  const { llmTranslations, selectedOption, loading } =
+    useLLMTranslation(translation);
+
+  // Extract the appropriate LLM translation
+  const llmTranslation = llmTranslations[selectedOption];
   return (
     <>
       <header>

--- a/translate/src/modules/machinery/components/MachineryTranslation.tsx
+++ b/translate/src/modules/machinery/components/MachineryTranslation.tsx
@@ -41,6 +41,7 @@ export function MachineryTranslationComponent({
 
   // Updated to use the new context structure
   const { llmTranslations, selectedOption } = useLLMTranslation(translation);
+  const locale = useContext(Locale);
 
   const copyTranslationIntoEditor = useCallback(() => {
     if (window.getSelection()?.isCollapsed !== false) {

--- a/translate/src/modules/machinery/components/source/GoogleTranslation.tsx
+++ b/translate/src/modules/machinery/components/source/GoogleTranslation.tsx
@@ -25,8 +25,10 @@ export function GoogleTranslation({
   const dropdownRef = useRef<HTMLLIElement>(null);
   const locale = useContext(Locale);
 
+  const getLLMTranslationState = useLLMTranslation();
+
   const { transformLLMTranslation, selectedOption, restoreOriginal } =
-    useLLMTranslation(translation);
+    getLLMTranslationState(translation);
 
   const toggleDropdown = (ev: React.MouseEvent) => {
     ev.stopPropagation();

--- a/translate/src/modules/translationform/utils/editFieldShortcuts.ts
+++ b/translate/src/modules/translationform/utils/editFieldShortcuts.ts
@@ -9,6 +9,8 @@ import { SearchData } from '~/context/SearchData';
 import { UnsavedActions, UnsavedChanges } from '~/context/UnsavedChanges';
 import { useAppSelector } from '~/hooks';
 import { getPlainMessage } from '~/utils/message';
+import { useLLMTranslation } from '~/context/TranslationContext';
+import type { SourceType } from '~/api/machinery';
 
 import { useExistingTranslationGetter } from '../../editor/hooks/useExistingTranslationGetter';
 import { useSendTranslation } from '../../editor/hooks/useSendTranslation';
@@ -109,11 +111,21 @@ export function useHandleCtrlShiftArrow(): (
 
     if (isMachinery) {
       const len = machineryTranslations.length;
-      const { translation, sources } =
+      const translationObj =
         nextIdx < len
           ? machineryTranslations[nextIdx]
           : concordanceSearchResults[nextIdx - len];
-      setEditorFromHelpers(translation, sources, true);
+
+      const { translation, sources } = translationObj;
+      const { llmTranslations, selectedOption } =
+        useLLMTranslation(translationObj);
+
+      // Check if there's an LLM translation available
+      const llmTranslation = llmTranslations[selectedOption];
+      const updatedSources: SourceType[] = llmTranslation
+        ? ['gpt-transform']
+        : sources;
+      setEditorFromHelpers(translation, updatedSources, true);
     } else {
       const { translation } = otherLocaleTranslations[nextIdx];
       setEditorFromHelpers(

--- a/translate/src/modules/translationform/utils/editFieldShortcuts.ts
+++ b/translate/src/modules/translationform/utils/editFieldShortcuts.ts
@@ -4,6 +4,7 @@ import { EditorActions } from '~/context/Editor';
 import { EntityView } from '~/context/EntityView';
 import { FailedChecksData } from '~/context/FailedChecksData';
 import { HelperSelection } from '~/context/HelperSelection';
+import type { SelState } from '~/context/TranslationContext';
 import { MachineryTranslations } from '~/context/MachineryTranslations';
 import { SearchData } from '~/context/SearchData';
 import { UnsavedActions, UnsavedChanges } from '~/context/UnsavedChanges';
@@ -100,7 +101,7 @@ export function useHandleCtrlShiftArrow(): (
     : otherLocaleTranslations.length;
 
   // Precompute LLM state at the top level
-  let llmState = null;
+  let llmState: SelState | null = null;
   if (isMachinery && element < machineryTranslations.length) {
     llmState = useLLMTranslation(machineryTranslations[element]);
   }
@@ -133,7 +134,11 @@ export function useHandleCtrlShiftArrow(): (
           ? ['gpt-transform']
           : sources;
 
-        setEditorFromHelpers(llmTranslation || translation, updatedSources, true);
+        setEditorFromHelpers(
+          llmTranslation || translation,
+          updatedSources,
+          true,
+        );
       }
     } else {
       const { translation } = otherLocaleTranslations[nextIdx];

--- a/translate/src/modules/translationform/utils/editFieldShortcuts.ts
+++ b/translate/src/modules/translationform/utils/editFieldShortcuts.ts
@@ -113,7 +113,6 @@ export function useHandleCtrlShiftArrow(): (
         : (element - 1 + numTranslations) % numTranslations;
     setElement(nextIdx);
 
-    // Use the selected translation, falling back to the original if needed
     if (isMachinery) {
       const len = machineryTranslations.length;
       const translationObj =


### PR DESCRIPTION
Fully fixes #3204 

This PR includes the following changes:

- **Refactored the LLM hook**: The LLM hook (`useLLMTranslation`) was refactored to return a function that is called outside of the callback. This change was made to address issues with the `useHandleCtrlShiftArrow` function, which previously caused the keyboard shortcut to stop functioning correctly after an LLM translation was generated. 

- **Added UX logging**: Implemented UX logging for when LLM translations are copied into the editor using the keyboard shortcut. This helps track the adoption and usage of the LLM translation feature.

### Issue Resolved

- The keyboard shortcut now works as expected for LLM translations and other translations, including when an LLM translation is selected from the dropdown.

### Note

As discussed with @eemeli, there is a need for further refactoring to fully address this issue. Specifically, issue #3305 - "When the main edit box is not in focus, the global arrow key combinations (ArrowDown or ArrowUp) do not function as expected" - should be addressed in the future. While the current changes enable the feature to function as expected, a more comprehensive solution is still needed to address the underlying issue in the existing code.