### PR TITLE
Fixed spacing bug after mentions in comments

### DIFF
--- a/translate/src/modules/comments/components/AddComment.tsx
+++ b/translate/src/modules/comments/components/AddComment.tsx
@@ -108,7 +108,7 @@ export function AddComment({
         children: [{ text: name }],
       };
       Transforms.insertNodes(editor, mention);
-      Transforms.move(editor);
+      Transforms.select(editor, Editor.end(editor, []));
       Transforms.insertText(editor, ' ');
     },
     [],

--- a/translate/src/modules/comments/components/AddComment.tsx
+++ b/translate/src/modules/comments/components/AddComment.tsx
@@ -111,7 +111,7 @@ export function AddComment({
       Transforms.select(editor, Editor.end(editor, []));
       Transforms.insertText(editor, ' ');
     },
-    [],
+    [editor],
   );
 
   useEffect(initMentions, []);


### PR DESCRIPTION
Fix #2840 

Fixed styling bug for comments, in which there was no automatic space appended after mentioning a user using `@[name]`. The bug was resolved by explicitly setting the cursor to the end of the editor's content, thereby ensuring that the space was added in the correct location within the editor.

To reproduce results: After starting up the server, navigate to any translated string within any team/project. Then, click the "COMMENT" button on that string, and type "@[any letter]" to bring up a list of users to mention in your comment. Choose any user using either your cursor or the arrow keys + tab, then type the rest of your comment. There should be a space automatically added after the mention, before the content of your comment.

![image](https://github.com/mozilla/pontoon/assets/90732381/b47322ef-dc13-41e6-b0a0-a09da34ee6ce)

