### PR TITLE
Added capability to mention users by username

### DIFF
--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -676,6 +676,8 @@ def get_users(request):
         .exclude(profile__system_user=True)
         # Exclude deleted users
         .exclude(email__regex=r"^deleted-user-(\w+)@example.com$")
+        # Prefetch profile for retrieving username
+        .prefetch_related("profile")
     )
     payload = []
 

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -685,6 +685,7 @@ def get_users(request):
                 "gravatar": u.gravatar_url(44),
                 "name": u.name_or_email,
                 "url": u.profile_url,
+                "username": u.profile.username,
             }
         )
 

--- a/translate/src/api/user.ts
+++ b/translate/src/api/user.ts
@@ -52,6 +52,7 @@ export type MentionUser = {
   gravatar: string;
   name: string;
   url: string;
+  username: string | null;
 };
 
 /** Dismiss Add-On Promotion. */

--- a/translate/src/modules/comments/components/AddComment.tsx
+++ b/translate/src/modules/comments/components/AddComment.tsx
@@ -135,8 +135,10 @@ export function AddComment({
   }, [initFocus]);
 
   const suggestedUsers = mentionUsers
-    .filter((user) =>
-      user.name.toLowerCase().includes(mentionSearch.toLowerCase()),
+    .filter(
+      (user) =>
+        user.username?.toLowerCase().includes(mentionSearch.toLowerCase()) ||
+        user.name.toLowerCase().includes(mentionSearch.toLowerCase()),
     )
     .slice(0, 5);
 


### PR DESCRIPTION
Fix #2625 

Added functionality for mentioning users by typing their username instead of only by display name. This feature was achieved by modifying the `/get-users/` API to return the usernames of all UserProfile objects in addition to the preexisting fields. The suggestedUsers filter function was modified to first check for a matching username (if it exists), then checking for a matching display name.

**To reproduce results**: After starting up the server, navigate to any team/project. Select any string that has an existing translation. Click the "COMMENT" button, and then inside the text editor field, type `@[any string of letters]` to display a list of users whose display name or username contains that string of letters. If you know a specific user's username, try typing their full username or a subset of it, and their profile will appear just as if you typed their display name instead. 

![image](https://github.com/mozilla/pontoon/assets/90732381/4d8e13fc-bf62-46d3-9f94-3ae94c709ee4)

![image](https://github.com/mozilla/pontoon/assets/90732381/6e7e76f9-d740-4228-9a66-71b72fcd17c8)
