### PR TITLE
Add ability to send emails and notifications from the Messaging Center

### DIFF
--- a/pontoon/base/static/css/check-box.css
+++ b/pontoon/base/static/css/check-box.css
@@ -4,33 +4,33 @@
   margin: 0;
   display: inline-block;
   text-align: left;
-}
 
-#main .check-list .check-box {
-  padding: 8px 0;
-}
+  .check-box {
+    padding: 8px 0;
+  }
 
-#main .check-list .check-box:last-child {
-  padding-bottom: 0;
-}
+  .check-box:last-child {
+    padding-bottom: 0;
+  }
 
-#main .check-list .check-box-wrapper {
-  color: var(--light-grey-7);
-  display: table;
-  font-size: 16px;
-  font-weight: 300;
-  overflow: hidden;
-  text-align: right;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  width: 342px;
-}
+  .check-box-wrapper {
+    color: var(--light-grey-7);
+    display: table;
+    font-size: 16px;
+    font-weight: 300;
+    overflow: hidden;
+    text-align: right;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    width: 342px;
+  }
 
-#main .check-list .check-box-wrapper:hover {
-  color: var(--white-1);
-}
+  .check-box-wrapper:hover {
+    color: var(--white-1);
+  }
 
-#main .check-list .fa {
-  margin-left: 27px;
-  margin-right: 0;
+  .fa {
+    margin-left: 27px;
+    margin-right: 0;
+  }
 }

--- a/pontoon/base/static/css/check-box.css
+++ b/pontoon/base/static/css/check-box.css
@@ -1,0 +1,36 @@
+#main .check-list {
+  cursor: pointer;
+  list-style: none;
+  margin: 0;
+  display: inline-block;
+  text-align: left;
+}
+
+#main .check-list .check-box {
+  padding: 8px 0;
+}
+
+#main .check-list .check-box:last-child {
+  padding-bottom: 0;
+}
+
+#main .check-list .check-box-wrapper {
+  color: var(--light-grey-7);
+  display: table;
+  font-size: 16px;
+  font-weight: 300;
+  overflow: hidden;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 342px;
+}
+
+#main .check-list .check-box-wrapper:hover {
+  color: var(--white-1);
+}
+
+#main .check-list .fa {
+  margin-left: 27px;
+  margin-right: 0;
+}

--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -517,7 +517,7 @@ tfoot td a {
   text-align: left;
 }
 
-.notification {
+body > header > .notification {
   background: var(--tooltip-background);
   color: var(--status-translated);
   cursor: pointer;
@@ -530,14 +530,14 @@ tfoot td a {
   z-index: 100;
 }
 
-.notification li {
+body > header > .notification li {
   font-size: 14px;
   line-height: 60px;
   list-style: none;
   text-align: center;
 }
 
-.notification li.error {
+body > header > .notification li.error {
   color: var(--status-error);
 }
 

--- a/pontoon/base/static/js/main.js
+++ b/pontoon/base/static/js/main.js
@@ -85,7 +85,7 @@ var Pontoon = (function (my) {
      * Close notification
      */
     closeNotification: function () {
-      $('.notification').animate(
+      $('body > header > .notification').animate(
         {
           top: '-60px',
         },
@@ -107,7 +107,7 @@ var Pontoon = (function (my) {
      */
     endLoader: function (text, type, duration) {
       if (text) {
-        $('.notification')
+        $('body > header > .notification')
           .html('<li class="' + (type || '') + '">' + text + '</li>')
           .removeClass('hide')
           .animate(

--- a/pontoon/contributors/static/css/settings.css
+++ b/pontoon/contributors/static/css/settings.css
@@ -154,43 +154,6 @@
   font-style: italic;
 }
 
-#main .check-list {
-  cursor: pointer;
-  list-style: none;
-  margin: 0;
-  display: inline-block;
-  text-align: left;
-}
-
-#main .check-list .check-box {
-  padding: 8px 0;
-}
-
-#main .check-list .check-box:last-child {
-  padding-bottom: 0;
-}
-
-#main .check-list .check-box-wrapper {
-  color: var(--light-grey-7);
-  display: table;
-  font-size: 16px;
-  font-weight: 300;
-  overflow: hidden;
-  text-align: right;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  width: 342px;
-}
-
-#main .check-list .check-box-wrapper:hover {
-  color: var(--white-1);
-}
-
-#main .check-list .fa {
-  margin-left: 27px;
-  margin-right: 0;
-}
-
 .errorlist {
   color: var(--status-error);
   font-style: italic;

--- a/pontoon/messaging/forms.py
+++ b/pontoon/messaging/forms.py
@@ -1,0 +1,10 @@
+from django import forms
+
+from pontoon.base.forms import HtmlField
+
+
+class MessageForm(forms.Form):
+    notification = forms.BooleanField(required=False)
+    email = forms.BooleanField(required=False)
+    subject = forms.CharField()
+    body = HtmlField()

--- a/pontoon/messaging/static/css/messaging.css
+++ b/pontoon/messaging/static/css/messaging.css
@@ -1,0 +1,86 @@
+.messaging #compose {
+  padding: 20px;
+  box-sizing: border-box;
+}
+
+.messaging .menu #compose li:hover {
+  background: inherit;
+}
+
+.messaging #compose h3 {
+  color: var(--white-1);
+  font-size: 22px;
+  letter-spacing: 0;
+}
+
+.messaging #compose h3 .stress {
+  color: var(--status-translated);
+}
+
+.messaging #compose .controls {
+  margin: 0;
+}
+
+.messaging #compose .errors {
+  visibility: hidden;
+}
+
+.messaging #compose .errors p {
+  color: var(--status-error);
+  font-size: 13px;
+  padding-top: 5px;
+  text-transform: uppercase;
+}
+
+.messaging #compose .message-type,
+.messaging #compose .message-editor {
+  margin: 20px 0;
+}
+
+.messaging #compose .message-type .check-list .check-box-wrapper {
+  text-align: left;
+}
+
+.messaging #compose .message-type .check-list .fa {
+  margin: 2px 10px 0 0;
+  float: left;
+}
+
+.messaging #compose .message-type [type='checkbox'] {
+  display: none;
+}
+
+.messaging #compose .field {
+  color: var(--light-grey-7);
+  font-size: 16px;
+  margin-bottom: 20px;
+  text-align: left;
+}
+
+.messaging #compose label {
+  display: block;
+  margin-bottom: 5px;
+}
+
+.messaging #compose input,
+.messaging #compose textarea {
+  background: var(--black-3);
+  float: none;
+  font-size: 16px;
+  padding: 4px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.messaging #compose textarea {
+  border-radius: 3px;
+  height: 150px;
+}
+
+.messaging #compose .message-editor .subtitle {
+  color: var(--light-grey-7);
+  float: right;
+  font-size: 13px;
+  padding-top: 5px;
+  text-transform: uppercase;
+}

--- a/pontoon/messaging/static/css/messaging.css
+++ b/pontoon/messaging/static/css/messaging.css
@@ -1,86 +1,92 @@
-.messaging #compose {
-  padding: 20px;
-  box-sizing: border-box;
-}
+.messaging {
+  .menu #compose li:hover {
+    background: inherit;
+  }
 
-.messaging .menu #compose li:hover {
-  background: inherit;
-}
+  #compose {
+    padding: 20px;
+    box-sizing: border-box;
 
-.messaging #compose h3 {
-  color: var(--white-1);
-  font-size: 22px;
-  letter-spacing: 0;
-}
+    h3 {
+      color: var(--white-1);
+      font-size: 22px;
+      letter-spacing: 0;
 
-.messaging #compose h3 .stress {
-  color: var(--status-translated);
-}
+      .stress {
+        color: var(--status-translated);
+      }
+    }
 
-.messaging #compose .controls {
-  margin: 0;
-}
+    .controls {
+      margin: 0;
+    }
 
-.messaging #compose .errors {
-  visibility: hidden;
-}
+    .errors {
+      visibility: hidden;
 
-.messaging #compose .errors p {
-  color: var(--status-error);
-  font-size: 13px;
-  padding-top: 5px;
-  text-transform: uppercase;
-}
+      p {
+        color: var(--status-error);
+        font-size: 13px;
+        padding-top: 5px;
+        text-transform: uppercase;
+      }
+    }
 
-.messaging #compose .message-type,
-.messaging #compose .message-editor {
-  margin: 20px 0;
-}
+    .message-type,
+    .message-editor {
+      margin: 20px 0;
+    }
 
-.messaging #compose .message-type .check-list .check-box-wrapper {
-  text-align: left;
-}
+    .message-type {
+      .check-list {
+        .check-box-wrapper {
+          text-align: left;
+        }
 
-.messaging #compose .message-type .check-list .fa {
-  margin: 2px 10px 0 0;
-  float: left;
-}
+        .fa {
+          margin: 2px 10px 0 0;
+          float: left;
+        }
+      }
 
-.messaging #compose .message-type [type='checkbox'] {
-  display: none;
-}
+      [type='checkbox'] {
+        display: none;
+      }
+    }
 
-.messaging #compose .field {
-  color: var(--light-grey-7);
-  font-size: 16px;
-  margin-bottom: 20px;
-  text-align: left;
-}
+    .field {
+      color: var(--light-grey-7);
+      font-size: 16px;
+      margin-bottom: 20px;
+      text-align: left;
+    }
 
-.messaging #compose label {
-  display: block;
-  margin-bottom: 5px;
-}
+    label {
+      display: block;
+      margin-bottom: 5px;
+    }
 
-.messaging #compose input,
-.messaging #compose textarea {
-  background: var(--black-3);
-  float: none;
-  font-size: 16px;
-  padding: 4px;
-  width: 100%;
-  box-sizing: border-box;
-}
+    input,
+    textarea {
+      background: var(--black-3);
+      float: none;
+      font-size: 16px;
+      padding: 4px;
+      width: 100%;
+      box-sizing: border-box;
+    }
 
-.messaging #compose textarea {
-  border-radius: 3px;
-  height: 150px;
-}
+    textarea {
+      border-radius: 3px;
+      height: 150px;
+    }
 
-.messaging #compose .message-editor .subtitle {
-  color: var(--light-grey-7);
-  float: right;
-  font-size: 13px;
-  padding-top: 5px;
-  text-transform: uppercase;
+    .message-editor .subtitle {
+      color: var(--light-grey-7);
+      float: right;
+      font-size: 13px;
+      padding-top: 5px;
+      text-transform: uppercase;
+    }
+  }
 }

--- a/pontoon/messaging/static/js/messaging.js
+++ b/pontoon/messaging/static/js/messaging.js
@@ -1,0 +1,64 @@
+$(function () {
+  // Toggle check box
+  $('.check-box').click(function () {
+    const self = $(this);
+
+    const name = self.data('attribute');
+    $(`[type=checkbox][name=${name}]`).click();
+
+    self.toggleClass('enabled');
+  });
+
+  const container = $('#main .container');
+
+  function isValidForm($form, isNotification, isEmail, subject, body) {
+    $form.find('.errors').css('visibility', 'hidden');
+
+    if (!isNotification && !isEmail) {
+      $form.find('.message-type .errors').css('visibility', 'visible');
+    }
+
+    if (!subject) {
+      $form
+        .find('.message-editor .subject .errors')
+        .css('visibility', 'visible');
+    }
+
+    if (!body) {
+      $form.find('.message-editor .body .errors').css('visibility', 'visible');
+    }
+
+    return (isNotification || isEmail) && subject && body;
+  }
+
+  // Send message
+  container.on('click', '#send-message .send', function (e) {
+    e.preventDefault();
+    const $form = $('#send-message');
+
+    const isNotification = $('.message-type .check-box.notification').is(
+      '.enabled',
+    );
+    const isEmail = $('.message-type .check-box.email').is('.enabled');
+    const subject = $form.find('[name=subject]').val();
+    const body = $form.find('[name=body]').val();
+
+    // Validate form
+    if (!isValidForm($form, isNotification, isEmail, subject, body)) {
+      return;
+    }
+
+    // Submit form
+    $.ajax({
+      url: $form.prop('action'),
+      type: $form.prop('method'),
+      data: $form.serialize(),
+      success: function () {
+        Pontoon.endLoader('Message sent.');
+      },
+      error: function () {
+        Pontoon.endLoader('Oops, something went wrong.', 'error');
+      },
+    });
+  });
+});

--- a/pontoon/messaging/templates/messaging/messaging.html
+++ b/pontoon/messaging/templates/messaging/messaging.html
@@ -1,0 +1,93 @@
+{% extends 'base.html' %}
+{% import "widgets/checkbox.html" as Checkbox %}
+{% import 'heading.html' as Heading %}
+{% import "contributors/widgets/notifications_menu.html" as Notifications with context %}
+
+{% block title %}Messaging Center{% endblock %}
+
+{% block class %}messaging{% endblock %}
+
+{% block heading %}
+{{ Heading.heading(title='Messaging Center', subtitle='Send emails and notifications to localizers') }}
+{% endblock %}
+
+{% block bottom %}
+<section id="main">
+  <div class="container">
+    <section class="clearfix">
+      <div class="menu permanent left-column">
+        <ul>
+          <li class="selected">
+            <a href="#compose" data-target="#compose">Compose</a>
+          </li>
+          <li class="horizontal-separator"></li>
+          <li>
+            <a href="#sent" data-target="#sent">
+              <span class="name">Sent</span>
+              <span class="count">{{ messages|length }}</span>
+            </a>
+          </li>
+        </ul>
+      </div>
+
+      <div class="menu permanent right-column">
+        <section id="compose" class="selected">
+          <form id="send-message" method="POST" action="{{ url('pontoon.messaging.send_message') }}">
+            {% csrf_token %}
+
+            <h3><span class="stress">#1</span> Message type</h3>
+            <div class="message-type">
+              <ul class="check-list">
+                {{ Checkbox.checkbox('Notification', class='notification', attribute='notification') }}
+                <input type="checkbox" name="notification">
+                {{ Checkbox.checkbox('Email', class='email', attribute='email') }}
+                <input type="checkbox" name="email">
+              </ul>
+
+                <div class="errors">
+                  <p>You must select at least one message type</p>
+                </div>
+            </div>
+
+            <h3><span class="stress">#2</span> Message editor</h3>
+            <div class="message-editor">
+              <div class="field clearfix subject">
+                <label for="subject">Subject</label>
+                <input type="text" name="subject" required="" id="subject">
+                <div class="errors">
+                  <p>Your message must include a subject</p>
+                </div>
+              </div>
+
+              <div class="field clearfix body">
+                <label for="body">Body</label>
+                <textarea name="body" cols="40" rows="10" required="" id="body"></textarea>
+                <div class="subtitle">
+                  <p>Supports html</p>
+                </div>
+                <div class="errors">
+                  <p>Your message must include a body</p>
+                </div>
+              </div>
+            </div>
+
+            <menu class="controls">
+              <button class="button active send">Send</button>
+            </menu>
+          </form>
+        </section>
+        <section id="sent">
+        </section>
+      </div>
+    </section>
+  </div>
+</section>
+{% endblock %}
+
+{% block extend_css %}
+{% stylesheet 'messaging' %}
+{% endblock %}
+
+{% block extend_js %}
+{% javascript 'messaging' %}
+{% endblock %}

--- a/pontoon/messaging/urls.py
+++ b/pontoon/messaging/urls.py
@@ -4,6 +4,17 @@ from . import views
 
 
 urlpatterns = [
+    # Messaging center
+    path(
+        "messaging/",
+        views.messaging,
+        name="pontoon.messaging",
+    ),
+    path(
+        "send-message/",
+        views.send_message,
+        name="pontoon.messaging.send_message",
+    ),
     # Email consent
     path(
         "email-consent/",

--- a/pontoon/messaging/utils.py
+++ b/pontoon/messaging/utils.py
@@ -1,0 +1,10 @@
+import html2text
+
+
+def html_to_plain_text_with_links(html):
+    h = html2text.HTML2Text()
+
+    h.wrap_links = False
+    h.body_width = 0
+
+    return h.handle(html)

--- a/pontoon/messaging/views.py
+++ b/pontoon/messaging/views.py
@@ -1,6 +1,12 @@
 import json
+import uuid
+
+from guardian.decorators import permission_required_or_403
+from notifications.signals import notify
 
 from django.contrib.auth.decorators import login_required
+from django.core.exceptions import PermissionDenied
+from django.core.mail import EmailMultiAlternatives
 from django.db import transaction
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, render
@@ -8,6 +14,80 @@ from django.utils import timezone
 from django.views.decorators.http import require_POST
 
 from pontoon.base.models import UserProfile
+from pontoon.base.utils import require_AJAX
+from pontoon.messaging import forms, utils
+
+
+def messaging(request):
+    if not request.user.has_perm("base.can_manage_project"):
+        raise PermissionDenied
+
+    return render(
+        request,
+        "messaging/messaging.html",
+    )
+
+
+@permission_required_or_403("base.can_manage_project")
+@require_AJAX
+@require_POST
+@transaction.atomic
+def send_message(request):
+    # Send notifications
+    if request.method == "POST":
+        form = forms.MessageForm(request.POST)
+
+        if not form.is_valid():
+            return JsonResponse(dict(form.errors.items()))
+
+        # TODO: implement recipient filters
+        from django.contrib.auth.models import User
+
+        recipients = User.objects.filter(pk=request.user.pk)
+
+        is_notification = form.cleaned_data.get("notification")
+        is_email = form.cleaned_data.get("email")
+        subject = form.cleaned_data.get("subject")
+        body = form.cleaned_data.get("body")
+
+        if is_notification:
+            identifier = uuid.uuid4().hex
+            for recipient in recipients.distinct():
+                notify.send(
+                    request.user,
+                    recipient=recipient,
+                    verb="has sent you a message",
+                    target=None,
+                    description=f"{subject}<br/><br/>{body}",
+                    identifier=identifier,
+                )
+
+        if is_email:
+            footer = """<br><br>
+You’re receiving this email as a contributor to Mozilla localization on Pontoon. <br>To no longer receive emails like these, unsubscribe here: <a href="https://pontoon.mozilla.org/unsubscribe/{ uuid }">Unsubscribe</a>.
+            """
+            html_template = body + footer
+            text_template = utils.html_to_plain_text_with_links(html_template)
+
+            for recipient in recipients.distinct():
+                unique_id = str(recipient.profile.unique_id)
+                text = text_template.replace("{ uuid }", unique_id)
+                html = html_template.replace("{ uuid }", unique_id)
+
+                msg = EmailMultiAlternatives(
+                    subject=subject,
+                    body=text,
+                    from_email="Mozilla L10n Team <team@pontoon.mozilla.com>",
+                    to=[recipient.contact_email],
+                )
+                msg.attach_alternative(html, "text/html")
+                msg.send()
+
+    return JsonResponse(
+        {
+            "status": True,
+        }
+    )
 
 
 @login_required(redirect_field_name="", login_url="/403")

--- a/pontoon/messaging/views.py
+++ b/pontoon/messaging/views.py
@@ -4,7 +4,9 @@ import uuid
 from guardian.decorators import permission_required_or_403
 from notifications.signals import notify
 
+from django.conf import settings
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
 from django.core.mail import EmailMultiAlternatives
 from django.db import transaction
@@ -41,8 +43,6 @@ def send_message(request):
             return JsonResponse(dict(form.errors.items()))
 
         # TODO: implement recipient filters
-        from django.contrib.auth.models import User
-
         recipients = User.objects.filter(pk=request.user.pk)
 
         is_notification = form.cleaned_data.get("notification")
@@ -77,7 +77,7 @@ You’re receiving this email as a contributor to Mozilla localization on Pontoo
                 msg = EmailMultiAlternatives(
                     subject=subject,
                     body=text,
-                    from_email="Mozilla L10n Team <team@pontoon.mozilla.com>",
+                    from_email=settings.DEFAULT_FROM_EMAIL,
                     to=[recipient.contact_email],
                 )
                 msg.attach_alternative(html, "text/html")

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -486,6 +486,7 @@ PIPELINE_CSS = {
             "css/multiple_team_selector.css",
             "css/contributor.css",
             "css/team_selector.css",
+            "css/check-box.css",
             "css/settings.css",
         ),
         "output_filename": "css/settings.min.css",
@@ -526,6 +527,14 @@ PIPELINE_CSS = {
     "unsubscribe": {
         "source_filenames": ("css/unsubscribe.css",),
         "output_filename": "css/unsubscribe.min.css",
+    },
+    "messaging": {
+        "source_filenames": (
+            "css/sidebar_menu.css",
+            "css/check-box.css",
+            "css/messaging.css",
+        ),
+        "output_filename": "css/messaging.min.css",
     },
 }
 
@@ -669,6 +678,13 @@ PIPELINE_JS = {
     "email_consent": {
         "source_filenames": ("js/email_consent.js",),
         "output_filename": "js/email_consent.min.js",
+    },
+    "messaging": {
+        "source_filenames": (
+            "js/sidebar_menu.js",
+            "js/messaging.js",
+        ),
+        "output_filename": "js/messaging.min.js",
     },
 }
 

--- a/requirements/default.in
+++ b/requirements/default.in
@@ -33,6 +33,7 @@ django-pipeline==3.0.0
 google-cloud-translate==3.8.4
 graphene-django==3.2.1
 gunicorn==19.9.0
+html2text==2024.2.26
 jsonfield==3.1.0
 jsonschema==2.6.0
 lxml==4.9.1

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -459,6 +459,9 @@ h11==0.14.0 \
     --hash=sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d \
     --hash=sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761
     # via httpcore
+html2text==2024.2.26 \
+    --hash=sha256:05f8e367d15aaabc96415376776cdd11afd5127a77fce6e36afc60c563ca2c32
+    # via -r requirements/default.in
 httpcore==1.0.5 \
     --hash=sha256:34a38e2f9291467ee3b44e89dd52615370e152954ba21721378a87b2960f7a61 \
     --hash=sha256:421f18bac248b25d310f3cacd198d55b8e6125c107797b609ff9b7a6ba7991b5


### PR DESCRIPTION
Fix #3243.
Fix #2072.

This is the first part of the implementation of the Messaging Center. It allows for sending emails and in-app notifications from `/messaging/`. Locally emails are sent to stdout.

Note that until we implement recipient filters (#3244), the recipient of the messages is the sender.

While the development is in progress, the page is not linked from the UI.

Also included:
- Factor out check-box CSS
- Make .notification selectors in style.css and main.js more specific