### PR TITLE
Update logging configuration for better debug and error tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ venv
 /media/
 .cache/
 coverage/
+*.log
 
 # Docker
 .server-build

--- a/docker/config/server.env.template
+++ b/docker/config/server.env.template
@@ -10,6 +10,9 @@ FXA_SECRET_KEY=e43fd751ca5687d28288098e3e9b1294792ed9954008388e39b1cdaac0a1ebd6
 FXA_OAUTH_ENDPOINT=https://oauth.stage.mozaws.net/v1
 FXA_PROFILE_ENDPOINT=https://profile.stage.mozaws.net/v1
 
+LOG_TO_FILE=False
+LOGGING_FORMAT=simple
+
 EMAIL_CONSENT_ENABLED = False
 EMAIL_CONSENT_TITLE = Let’s keep in touch
 EMAIL_CONSENT_MAIN_TEXT = Want to stay up to date and informed about all localization matters at Mozilla? Just hit the button below to get the latest updates, announcements about new Pontoon features, invitations to contributor events and more. We won’t spam you — promise!

--- a/docker/config/server.env.template
+++ b/docker/config/server.env.template
@@ -11,7 +11,6 @@ FXA_OAUTH_ENDPOINT=https://oauth.stage.mozaws.net/v1
 FXA_PROFILE_ENDPOINT=https://profile.stage.mozaws.net/v1
 
 LOG_TO_FILE=False
-LOGGING_FORMAT=simple
 
 EMAIL_CONSENT_ENABLED = False
 EMAIL_CONSENT_TITLE = Let’s keep in touch

--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -171,6 +171,10 @@ you create:
    Optional. Set your `Google Cloud AutoML Translation`_ model ID to use custom machine
    translation engine by Google.
 
+``LOG_TO_FILE``
+   Optional. Set to true to enable logging to a file.
+   This is useful for retaining log data for later analysis or troubleshooting.
+
 ``MAINTENANCE_PAGE_URL``
    Optional. URL to the page displayed to your users when the application is placed
    in the maintenance state. See `Heroku Reference`_ for more information.

--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -172,7 +172,7 @@ you create:
    translation engine by Google.
 
 ``LOG_TO_FILE``
-   Optional. Set to true to enable logging to a file.
+   Optional. Enables logging to a file (default: ``False``).
    This is useful for retaining log data for later analysis or troubleshooting.
 
 ``MAINTENANCE_PAGE_URL``

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -780,14 +780,14 @@ LOGGING = {
         },
         "django_file": {
             "class": "logging.handlers.RotatingFileHandler",
-            "filename": os.path.join(path('django_debug.log')),
+            "filename": os.path.join(path("django_debug.log")),
             "maxBytes": 1024 * 1024 * 2,  # 2 MB
             "backupCount": 3,
             "formatter": "verbose" if DEBUG else "simple",
         },
         "pontoon_file": {
             "class": "logging.handlers.RotatingFileHandler",
-            "filename": os.path.join(path('pontoon_debug.log')),
+            "filename": os.path.join(path("pontoon_debug.log")),
             "maxBytes": 1024 * 1024 * 2,  # 2 MB
             "backupCount": 3,
             "formatter": "verbose" if DEBUG else "simple",

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -777,12 +777,7 @@ if LOG_TO_FILE:
     log_dir = path("logs")
     os.makedirs(log_dir, exist_ok=True)
 
-# Define handlers
-console_handler = {
-    "class": "logging.StreamHandler",
-    "formatter": "verbose",
-}
-
+# Define file handlers
 django_file_handler = {
     "class": "logging.handlers.RotatingFileHandler",
     "filename": path("logs", "django_debug.log"),
@@ -803,24 +798,15 @@ pontoon_file_handler = {
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
-    "handlers": {
-        "console": console_handler,
-    },
+    "handlers": {"console": {"class": "logging.StreamHandler"}},
     "formatters": {
-        "verbose": {
-            "format": "[%(levelname)s:%(name)s] %(asctime)s %(message)s",
+        "verbose": {"format": "[%(levelname)s:%(name)s] %(asctime)s %(message)s"},
         },
-    },
     "loggers": {
-        "django": {
-            "handlers": ["console"],
-            "level": os.environ.get("DJANGO_LOG_LEVEL", "DEBUG" if DEBUG else "INFO"),
-            "propagate": True,
-        },
+        "django": {"handlers": ["console"]},
         "pontoon": {
             "handlers": ["console"],
             "level": os.environ.get("DJANGO_LOG_LEVEL", "DEBUG" if DEBUG else "INFO"),
-            "propagate": True,
         },
     },
 }

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -801,7 +801,7 @@ LOGGING = {
     "handlers": {"console": {"class": "logging.StreamHandler"}},
     "formatters": {
         "verbose": {"format": "[%(levelname)s:%(name)s] %(asctime)s %(message)s"},
-        },
+    },
     "loggers": {
         "django": {"handlers": ["console"]},
         "pontoon": {

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -769,18 +769,48 @@ PASSWORD_HASHERS = (
 )
 
 # Logging
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
-    "handlers": {"console": {"class": "logging.StreamHandler"}},
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "verbose" if DEBUG else "simple",
+        },
+        "django_file": {
+            "class": "logging.handlers.RotatingFileHandler",
+            "filename": os.path.join(path('django_debug.log')),
+            "maxBytes": 1024 * 1024 * 2,  # 2 MB
+            "backupCount": 3,
+            "formatter": "verbose" if DEBUG else "simple",
+        },
+        "pontoon_file": {
+            "class": "logging.handlers.RotatingFileHandler",
+            "filename": os.path.join(path('pontoon_debug.log')),
+            "maxBytes": 1024 * 1024 * 2,  # 2 MB
+            "backupCount": 3,
+            "formatter": "verbose" if DEBUG else "simple",
+        },
+    },
     "formatters": {
-        "verbose": {"format": "[%(levelname)s:%(name)s] %(asctime)s %(message)s"},
+        "verbose": {
+            "format": "[%(levelname)s:%(name)s] %(asctime)s %(message)s",
+        },
+        "simple": {
+            "format": "%(levelname)s %(message)s",
+        },
     },
     "loggers": {
-        "django": {"handlers": ["console"]},
-        "pontoon": {
-            "handlers": ["console"],
+        "django": {
+            "handlers": ["console", "django_file"],
             "level": os.environ.get("DJANGO_LOG_LEVEL", "DEBUG" if DEBUG else "INFO"),
+            "propagate": True,
+        },
+        "pontoon": {
+            "handlers": ["console", "pontoon_file"],
+            "level": os.environ.get("DJANGO_LOG_LEVEL", "DEBUG" if DEBUG else "INFO"),
+            "propagate": True,
         },
     },
 }

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -771,7 +771,6 @@ PASSWORD_HASHERS = (
 # Logging
 # Get environment variables
 LOG_TO_FILE = os.getenv("LOG_TO_FILE", "False") == "True"
-LOGGING_FORMAT = os.getenv("LOGGING_FORMAT", "simple")
 
 # Ensure the logs directory exists
 if LOG_TO_FILE:
@@ -781,7 +780,7 @@ if LOG_TO_FILE:
 # Define handlers
 console_handler = {
     "class": "logging.StreamHandler",
-    "formatter": "verbose" if LOGGING_FORMAT == "verbose" else "simple",
+    "formatter": "verbose",
 }
 
 django_file_handler = {
@@ -789,7 +788,7 @@ django_file_handler = {
     "filename": path("logs", "django_debug.log"),
     "maxBytes": 1024 * 1024 * 2,  # 2 MB
     "backupCount": 3,
-    "formatter": "verbose" if LOGGING_FORMAT == "verbose" else "simple",
+    "formatter": "verbose",
 }
 
 pontoon_file_handler = {
@@ -797,7 +796,7 @@ pontoon_file_handler = {
     "filename": path("logs", "pontoon_debug.log"),
     "maxBytes": 1024 * 1024 * 2,  # 2 MB
     "backupCount": 3,
-    "formatter": "verbose" if LOGGING_FORMAT == "verbose" else "simple",
+    "formatter": "verbose",
 }
 
 # Define logging configuration
@@ -810,9 +809,6 @@ LOGGING = {
     "formatters": {
         "verbose": {
             "format": "[%(levelname)s:%(name)s] %(asctime)s %(message)s",
-        },
-        "simple": {
-            "format": "%(levelname)s %(message)s",
         },
     },
     "loggers": {


### PR DESCRIPTION
Fix #3192 
- Added rotating file handlers for Django and Pontoon loggers
- Console logging now uses verbose format in DEBUG mode
- Improved log formatting for clarity and consistency

- added *.log  in .gitignore to prevent log files from being pushed