### PR TITLE
Add reviewed time information to reviewed strings tooltip

### DIFF
--- a/translate/public/locale/en-US/translate.ftl
+++ b/translate/public/locale/en-US/translate.ftl
@@ -369,13 +369,13 @@ history-Translation--span-copied =
     .title = Copied ({ $machinerySources })
 
 history-translation--approved =
-    .title = Approved by { $user } on { $reviewedDate }
+    .title = Approved by { $user } on { DATETIME($reviewedDate, dateStyle:"long", timeStyle:"medium") }
 history-translation--approved-anonymous =
-    .title = Approved on { $reviewedDate }
+    .title = Approved on { DATETIME($reviewedDate, dateStyle:"long", timeStyle:"medium") }
 history-translation--rejected =
-    .title = Rejected by { $user } on { $reviewedDate }
+    .title = Rejected by { $user } on { DATETIME($reviewedDate, dateStyle:"long", timeStyle:"medium") }
 history-translation--rejected-anonymous =
-    .title = Rejected on { $reviewedDate }
+    .title = Rejected on { DATETIME($reviewedDate, dateStyle:"long", timeStyle:"medium") }
 history-translation--unreviewed =
     .title = Not reviewed yet
 

--- a/translate/public/locale/en-US/translate.ftl
+++ b/translate/public/locale/en-US/translate.ftl
@@ -369,13 +369,13 @@ history-Translation--span-copied =
     .title = Copied ({ $machinerySources })
 
 history-translation--approved =
-    .title = Approved by { $user }
+    .title = Approved by { $user } on { $reviewedDate }
 history-translation--approved-anonymous =
-    .title = Approved
+    .title = Approved on { $reviewedDate }
 history-translation--rejected =
-    .title = Rejected by { $user }
+    .title = Rejected by { $user } on { $reviewedDate }
 history-translation--rejected-anonymous =
-    .title = Rejected
+    .title = Rejected on { $reviewedDate }
 history-translation--unreviewed =
     .title = Not reviewed yet
 

--- a/translate/src/modules/history/components/HistoryTranslation.tsx
+++ b/translate/src/modules/history/components/HistoryTranslation.tsx
@@ -2,7 +2,6 @@ import { Localized } from '@fluent/react';
 import classNames from 'classnames';
 import React, { useCallback, useContext, useState } from 'react';
 import ReactTimeAgo from 'react-time-ago';
-import { format, isValid } from 'date-fns';
 
 import type { Entity } from '~/api/entity';
 import type { ChangeOperation, HistoryTranslation } from '~/api/translation';
@@ -195,17 +194,9 @@ export function HistoryTranslationBase({
     setEditorFromHistory(translation.string);
   }, [isReadOnlyEditor, setEditorFromHistory, translation.string]);
 
-  const customDateString = (dateIso: string) => {
-    const date = new Date(dateIso);
-    if (!isValid(date)) {
-      return ' ';
-    }
-    return format(date, "EEEE, MMMM d yyyy 'at' h:mm a");
-  };
-
   const review = {
     id: 'history-translation--unreviewed',
-    vars: { user: '', reviewedDate: customDateString(translation.dateIso) },
+    vars: { user: '', reviewedDate: new Date(translation.dateIso) },
     attrs: { title: true },
   };
   if (translation.approved) {

--- a/translate/src/modules/history/components/HistoryTranslation.tsx
+++ b/translate/src/modules/history/components/HistoryTranslation.tsx
@@ -2,7 +2,7 @@ import { Localized } from '@fluent/react';
 import classNames from 'classnames';
 import React, { useCallback, useContext, useState } from 'react';
 import ReactTimeAgo from 'react-time-ago';
-import { format } from 'date-fns';
+import { format, isValid } from 'date-fns';
 
 import type { Entity } from '~/api/entity';
 import type { ChangeOperation, HistoryTranslation } from '~/api/translation';
@@ -196,7 +196,11 @@ export function HistoryTranslationBase({
   }, [isReadOnlyEditor, setEditorFromHistory, translation.string]);
 
   const customDateString = (dateIso: string) => {
-    return format(new Date(dateIso), "EEEE, MMMM d yyyy 'at' h:mm a");
+    const date = new Date(dateIso);
+    if (!isValid(date)) {
+      return ' ';
+    }
+    return format(date, "EEEE, MMMM d yyyy 'at' h:mm a");
   };
 
   const review = {

--- a/translate/src/modules/history/components/HistoryTranslation.tsx
+++ b/translate/src/modules/history/components/HistoryTranslation.tsx
@@ -196,7 +196,7 @@ export function HistoryTranslationBase({
 
   const review = {
     id: 'history-translation--unreviewed',
-    vars: { user: '' },
+    vars: { user: '', reviewedDate: translation.date },
     attrs: { title: true },
   };
   if (translation.approved) {

--- a/translate/src/modules/history/components/HistoryTranslation.tsx
+++ b/translate/src/modules/history/components/HistoryTranslation.tsx
@@ -2,7 +2,7 @@ import { Localized } from '@fluent/react';
 import classNames from 'classnames';
 import React, { useCallback, useContext, useState } from 'react';
 import ReactTimeAgo from 'react-time-ago';
-import {format} from 'date-fns';
+import { format } from 'date-fns';
 
 import type { Entity } from '~/api/entity';
 import type { ChangeOperation, HistoryTranslation } from '~/api/translation';

--- a/translate/src/modules/history/components/HistoryTranslation.tsx
+++ b/translate/src/modules/history/components/HistoryTranslation.tsx
@@ -2,6 +2,7 @@ import { Localized } from '@fluent/react';
 import classNames from 'classnames';
 import React, { useCallback, useContext, useState } from 'react';
 import ReactTimeAgo from 'react-time-ago';
+import {format} from 'date-fns';
 
 import type { Entity } from '~/api/entity';
 import type { ChangeOperation, HistoryTranslation } from '~/api/translation';
@@ -194,9 +195,13 @@ export function HistoryTranslationBase({
     setEditorFromHistory(translation.string);
   }, [isReadOnlyEditor, setEditorFromHistory, translation.string]);
 
+  const customDateString = (dateIso: string) => {
+    return format(new Date(dateIso), "EEEE, MMMM d yyyy 'at' h:mm a");
+  };
+
   const review = {
     id: 'history-translation--unreviewed',
-    vars: { user: '', reviewedDate: translation.date },
+    vars: { user: '', reviewedDate: customDateString(translation.dateIso) },
     attrs: { title: true },
   };
   if (translation.approved) {


### PR DESCRIPTION
Fix #2763 

Added a `reviewedDate` field to the tooltip when hovering over rejected or approved strings.

**To reproduce results**: After starting the server, navigate to any team/project (e.g. `http://localhost:8000/sq/facebook-container/messages.json/?string=196694` ). Hover over the User Avatar or Username to show the tooltip. The tooltip should now display `[Approved/Rejected] by { $user } on { $reviewedDate }` or `[Approved/Rejected] on { $reviewedDate }`


![Screenshot 2024-06-27 at 12 15 53 PM](https://github.com/mozilla/pontoon/assets/90732381/ef464901-d196-47f1-b302-9e95f3de92cd)

![Screenshot 2024-06-27 at 12 16 42 PM](https://github.com/mozilla/pontoon/assets/90732381/e6032942-22bf-40b8-aa9c-1d41eee4ca39)
