### PR TITLE
Enhance user action logging

### DIFF
--- a/translate/src/modules/machinery/components/MachineryTranslation.tsx
+++ b/translate/src/modules/machinery/components/MachineryTranslation.tsx
@@ -40,6 +40,7 @@ export function MachineryTranslationComponent({
   const isSelected = element === index;
 
   const { llmTranslation } = useLLMTranslation(translation);
+  const locale = useContext(Locale);
 
   const copyTranslationIntoEditor = useCallback(() => {
     if (window.getSelection()?.isCollapsed !== false) {
@@ -52,6 +53,8 @@ export function MachineryTranslationComponent({
       if (llmTranslation) {
         logUXAction('LLM Translation Copied', 'LLM Feature Adoption', {
           action: 'Copy LLM Translation',
+          localeCode: locale.code,
+          targetLanguage: locale.name,
         });
       }
     }

--- a/translate/src/modules/machinery/components/MachineryTranslation.tsx
+++ b/translate/src/modules/machinery/components/MachineryTranslation.tsx
@@ -54,7 +54,6 @@ export function MachineryTranslationComponent({
         logUXAction('LLM Translation Copied', 'LLM Feature Adoption', {
           action: 'Copy LLM Translation',
           localeCode: locale.code,
-          targetLanguage: locale.name,
         });
       }
     }

--- a/translate/src/modules/machinery/components/source/GoogleTranslation.tsx
+++ b/translate/src/modules/machinery/components/source/GoogleTranslation.tsx
@@ -44,7 +44,7 @@ export function GoogleTranslation({
       await transformLLMTranslation(translation, characteristic, locale.name);
       logUXAction('LLM Dropdown Select', 'LLM Feature Adoption', {
         optionSelected: characteristic,
-        targetLanguage: locale.name,
+        localeCode: locale.code,
       });
     }
     setDropdownOpen(false);


### PR DESCRIPTION
Fix #3269 

Updated user action logging by adding locale name and locale code when an LLM translation is copied. Additionally, updated the logging for dropdown selections to record the locale code instead of the locale name for the selected option.