### PR TITLE
Sorted date labels for insights chart

### DIFF
--- a/pontoon/insights/static/js/insights.js
+++ b/pontoon/insights/static/js/insights.js
@@ -63,10 +63,18 @@ var Pontoon = (function (my) {
           };
         });
 
+        // Sort each timestamp chronologically and reorder the dataset
+        const sortedIndices = chart
+          .data('dates')
+          .map((timestamp, index) => ({ timestamp, index }))
+          .sort((a, b) => a.timestamp - b.timestamp)
+          .map((dateObj) => dateObj.index);
+        const sortedDates = sortedIndices.map((i) => chart.data('dates')[i]);
+
         new Chart(chart, {
           type: 'bar',
           data: {
-            labels: chart.data('dates'),
+            labels: sortedDates,
             datasets: datasets,
           },
           options: {

--- a/pontoon/insights/static/js/insights.js
+++ b/pontoon/insights/static/js/insights.js
@@ -63,18 +63,10 @@ var Pontoon = (function (my) {
           };
         });
 
-        // Sort each timestamp chronologically and reorder the dataset
-        const sortedIndices = chart
-          .data('dates')
-          .map((timestamp, index) => ({ timestamp, index }))
-          .sort((a, b) => a.timestamp - b.timestamp)
-          .map((dateObj) => dateObj.index);
-        const sortedDates = sortedIndices.map((i) => chart.data('dates')[i]);
-
         new Chart(chart, {
           type: 'bar',
           data: {
-            labels: sortedDates,
+            labels: chart.data('dates'),
             datasets: datasets,
           },
           options: {

--- a/pontoon/insights/utils.py
+++ b/pontoon/insights/utils.py
@@ -460,6 +460,6 @@ def get_global_pretranslation_quality(category, id):
     ]
 
     return {
-        "dates": list({convert_to_unix_time(x["month"]) for x in actions}),
+        "dates": sorted(list({convert_to_unix_time(x["month"]) for x in actions})),
         "dataset": json.dumps([v for _, v in data.items()]),
     }


### PR DESCRIPTION
Fixes #3276 

Fixed the bug on the [Insights page](https://pontoon.mozilla.org/insights/) where the graph shown was not a [function](https://en.wikipedia.org/wiki/Vertical_line_test) (i.e. line graph would jump back and forth horizontally). 

The issue seemed to be that the dates being passed through `chart.data('dates')` were not chronologically ordered by default.

Before:
![image](https://github.com/user-attachments/assets/f6cc526d-3dca-43ae-a1bb-2cba2db97c8b)
<img width="108" alt="image" src="https://github.com/user-attachments/assets/5f82b07c-0894-4e16-846b-6e84d891540d">

After:
![image](https://github.com/user-attachments/assets/69d9b5aa-110d-4abd-aa92-5c6772e38baa)
<img width="108" alt="image" src="https://github.com/user-attachments/assets/9ed84b62-a04b-40f7-8440-0e8fe994c12d">

