### PR TITLE
Use default Gunicorn worker timeout setting

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-web: newrelic-admin run-program gunicorn pontoon.wsgi:application -t 120 --log-file -
+web: newrelic-admin run-program gunicorn pontoon.wsgi:application --log-file -
 worker: newrelic-admin run-program celery --app=pontoon.base.celeryapp worker --loglevel=info --without-gossip --without-mingle --without-heartbeat
 automl-warmup: newrelic-admin run-program python pontoon/machinery/automl_warmup.py


### PR DESCRIPTION
The Heroku router drops a long-running request after 30 seconds, but the dyno behind it continues processing the request until completion.

Adding a timeout to the webserver ensures that the dyno itself drops the long-running request, creating capacity for other requests.

A while ago the webserver timeout was set to 120 seconds, in order to potentially help with long request like downloading TMX files via curl. It's not clear if this was actually helpful, but it increases a chance of Applcation Errors under heavy load.