### PR TITLE
Fix failing test case in contributors/tests/test_utils.py

### DIFF
--- a/pontoon/contributors/tests/test_utils.py
+++ b/pontoon/contributors/tests/test_utils.py
@@ -83,12 +83,18 @@ def action_user_b(translation_a, user_b):
 
 @pytest.fixture
 def yesterdays_action_user_a(translation_a, user_a):
+    current_date = timezone.now()
     action = ActionLog.objects.create(
         action_type=ActionLog.ActionType.TRANSLATION_APPROVED,
         performed_by=user_a,
         translation=translation_a,
     )
-    action.created_at = timezone.now() - relativedelta(days=1)
+    if current_date.date == 1:
+        # First day of the month, so we instead set created_at to be earlier today
+        action.created_at = timezone.now() - relativedelta(minutes=1)
+    else:
+        action.created_at = timezone.now() - relativedelta(days=1)
+
     action.save()
     return action
 
@@ -274,6 +280,7 @@ def test_get_contribution_timeline_data_with_actions(
 ):
     end = timezone.now()
     start = end - relativedelta(day=1)
+    start = start.replace(hour=0, minute=0, second=0, microsecond=0)
 
     date = end.strftime("%B %Y")
 

--- a/pontoon/contributors/utils.py
+++ b/pontoon/contributors/utils.py
@@ -446,8 +446,11 @@ def get_contribution_timeline_data(
         # Get data from the 1st day of the current month, one year ago, to now
         start = end - relativedelta(years=1, day=1)
     else:
-        # Get data from the 1st day of the current month to now
+        # Get data from the 1st day of the current month to now.
         start = end - relativedelta(day=1)
+
+    # Set start to be 00:00 (midnight)
+    start = start.replace(hour=0, minute=0, second=0, microsecond=0)
 
     if day is not None:
         start = datetime.datetime.fromtimestamp(day, tz=timezone.get_current_timezone())

--- a/pontoon/contributors/utils.py
+++ b/pontoon/contributors/utils.py
@@ -446,7 +446,7 @@ def get_contribution_timeline_data(
         # Get data from the 1st day of the current month, one year ago, to now
         start = end - relativedelta(years=1, day=1)
     else:
-        # Get data from the 1st day of the current month to now.
+        # Get data from the 1st day of the current month to now
         start = end - relativedelta(day=1)
 
     # Set start to be 00:00 (midnight)


### PR DESCRIPTION
This PR fixes the existing bug with `test_get_contribution_timeline_data_with_actions` that occurs on the first day of the month (e.g. August 1st, September 1st, etc).


The `test_get_contribution_timeline_data_with_actions` test case inside of `contributors/tests/test_utils.py` was failing on the first of the first day of each month since actions are grouped by the month they are created in. The `yesterdays_action_user_a` variable was setting the `action.created_at` to be the last day of the previous month, so the contribution timeline data was returning an empty object.

I've also manually set the start date of the query to be midnight, to ensure that all actions within a month are captured, regardless of the time they were created.
