### PR TITLE
Ensure Preservation of HTML Tags in LLM-Generated Translations

### DIFF
--- a/pontoon/machinery/openai_service.py
+++ b/pontoon/machinery/openai_service.py
@@ -27,6 +27,7 @@ class OpenAIService:
             Your objective is to revise the {target_language} translation to ensure it utilizes simpler language. Adhere to the following guidelines to achieve this:
             - Clarity is Key: Ensure the translation conveys the original message in the clearest possible manner, without ambiguity or unnecessary complexity.
             - Consistent Simplicity: Maintain a consistent level of simplicity throughout the translation.
+            - Preserve All HTML Tags: Ensure that all HTML tags present in the original text are retained in the translation.
             The goal is to produce a translation that accurately reflects the original English text, but in a way that is more approachable and easier to understand for all {target_language} speakers."""
         )
 
@@ -36,6 +37,7 @@ class OpenAIService:
             - Adjust the Tone: Ensure the tone is respectful, polished, and devoid of colloquialisms or informal expressions commonly used in casual conversation.
             - Formal Addressing: Where applicable, use formal modes of address.
             - Consistency: Maintain a consistent level of formality throughout the translation, avoiding shifts in tone or style.
+            - Preserve All HTML Tags: Ensure that all HTML tags present in the original text are retained in the translation.
             Your goal is to produce a translation that not only accurately conveys the meaning of the English text but also meets the expectations for formality in {target_language}-speaking professional or formal settings."""
         )
 
@@ -44,6 +46,7 @@ class OpenAIService:
             Your objective is to provide an alternative translation. Adhere to the following guidelines to achieve this:
             - Cultural Nuances: Pay attention to cultural nuances and idiomatic expressions, ensuring they are appropriately translated for the {target_language}-speaking audience.
             - Clarification and Accuracy: Where the source text is ambiguous or idiomatic, offer clarifications or alternative expressions in {target_language}.
+            - Preserve All HTML Tags: Ensure that all HTML tags present in the original text are retained in the translation.
             Just provide the text for the alternative translation."""
         )
 


### PR DESCRIPTION
Fixes #3232 

This pull request enhances the translation process by explicitly instructing the LLM to preserve all HTML tags in the translated text. The following changes were made:

- Added a guideline to preserve all HTML tags in the system message prompts for "informal," "formal," and "rephrased" translation styles.

These changes will help maintain the integrity of the original HTML structure in the translated output, addressing issues where tags like `<small>` and `<p>` were sometimes lost.

#### Testing:
- Verified that HTML tags are now consistently retained in translations across different characteristics ("informal," "formal," "rephrased").
- Try these strings as an example for testing: [String 1](https://pontoon.mozilla.org/it/thunderbirdnet/LC_MESSAGES/messages.po/?string=281728) and [String 2](https://pontoon.mozilla.org/it/thunderbirdnet/LC_MESSAGES/messages.po/?string=285891)

