### PR TITLE
Revert "Add Subresource Integrity (SRI) to an external script (#3298)"

### DIFF
--- a/pontoon/base/templates/tracker.html
+++ b/pontoon/base/templates/tracker.html
@@ -1,6 +1,6 @@
 {% if settings.GOOGLE_ANALYTICS_KEY %}
 <!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id={{ settings.GOOGLE_ANALYTICS_KEY }}" integrity="sha384-P+/gO70aRNgro7ildI69M1F0Za/q3tzYH8UR7/8Z5Z3B9qdRtL/5cDp3fVRr3hA4" crossorigin="anonymous"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ settings.GOOGLE_ANALYTICS_KEY }}"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}


### PR DESCRIPTION
This reverts commit 61d58fc1e44e243d9e2f988e8db3ebfafd1fe19d.

It turns out the https://www.googletagmanager.com/gtag/js contents change on each page load, so we can't use the static integrity value.