### PR TITLE
Allow IP ranges in BLOCKED_IPS setting

### DIFF
--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -73,9 +73,11 @@ you create:
    Set to 'google' if you want to use 'Google' (corresponding GOOGLE_* settings must be set).
 
 ``BLOCKED_IPS``
-   A comma-separated list of IP addresses or IP ranges (expressed using the CIDR
-   notation, e.g. `192.168.1.0/24`) to be blocked from accessing the app, for
+   A comma-separated list of IP addresses or IP ranges (expressed using the
+   `CIDR notation`_, e.g. `192.168.1.0/24`) to be blocked from accessing the app, for
    example because they are DDoS'ing the server.
+
+   .. _CIDR notation: https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation
 
 ``CELERY_ALWAYS_EAGER``
    Controls whether asynchronous tasks (mainly used during sync) are sent to

--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -73,8 +73,9 @@ you create:
    Set to 'google' if you want to use 'Google' (corresponding GOOGLE_* settings must be set).
 
 ``BLOCKED_IPS``
-   A comma-separated list of IP addresses to be blocked from accessing the app,
-   for example because they are DDoS'ing the server.
+   A comma-separated list of IP addresses or IP ranges (expressed using the CIDR
+   notation, e.g. `192.168.1.0/24`) to be blocked from accessing the app, for
+   example because they are DDoS'ing the server.
 
 ``CELERY_ALWAYS_EAGER``
    Controls whether asynchronous tasks (mainly used during sync) are sent to

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -277,8 +277,10 @@ INSTALLED_APPS = (
     "django_ace",
 )
 
-# A list of IP addresses to be blocked from accessing the app, because they are DDoS'ing the server
+# A list of IP addresses or ranges to be blocked from accessing the app, because
+# they are DDoS'ing the server
 BLOCKED_IPS = os.environ.get("BLOCKED_IPS", "").split(",")
+BLOCKED_IP_RANGES = [s for s in BLOCKED_IPS if "/" in s]
 
 MIDDLEWARE = (
     "django.middleware.security.SecurityMiddleware",


### PR DESCRIPTION
IP Ranges can be defined with the CIDR notation (e.g. 192.168.1.0/24).

Fixes #3304 