### PR TITLE
Speed up Django Admin Edit and New and views

### DIFF
--- a/pontoon/actionlog/admin.py
+++ b/pontoon/actionlog/admin.py
@@ -16,7 +16,8 @@ class ActionLogAdmin(admin.ModelAdmin):
         "entity_id",
         "locale_id",
     )
-    raw_id_fields = (
+    autocomplete_fields = (
+        "performed_by",
         "entity",
         "translation",
     )

--- a/pontoon/base/admin.py
+++ b/pontoon/base/admin.py
@@ -222,6 +222,7 @@ class ProjectAdmin(admin.ModelAdmin):
         "enabled",
     )
     ordering = ("disabled",)
+    autocomplete_fields = ["contact"]
 
     @admin.display(ordering="contact__first_name")
     def contact_person(self, obj):
@@ -268,6 +269,7 @@ class ProjectLocaleAdmin(admin.ModelAdmin):
     search_fields = ["project__name", "project__slug", "locale__name", "locale__code"]
     list_display = ("pk", "project", "locale", "readonly", "pretranslation_enabled")
     ordering = ("-pk",)
+    autocomplete_fields = ["translators_group", "latest_translation"]
 
 
 class ResourceAdmin(admin.ModelAdmin):
@@ -279,17 +281,24 @@ class TranslatedResourceAdmin(admin.ModelAdmin):
     search_fields = ["resource__path", "locale__name", "locale__code"]
     list_display = ("pk", "resource", "locale")
     readonly_fields = AGGREGATED_STATS_FIELDS + ("latest_translation",)
-    raw_id_fields = ("resource",)
+    autocomplete_fields = ("resource",)
 
 
 class EntityAdmin(admin.ModelAdmin):
     search_fields = ["string", "string_plural"]
-    raw_id_fields = ("resource",)
+    autocomplete_fields = ("resource",)
 
 
 class TranslationAdmin(admin.ModelAdmin):
     search_fields = ["string"]
-    raw_id_fields = ("entity",)
+    autocomplete_fields = [
+        "entity",
+        "user",
+        "approved_user",
+        "unapproved_user",
+        "rejected_user",
+        "unrejected_user",
+    ]
 
 
 class ProjectSlugHistoryAdmin(admin.ModelAdmin):
@@ -302,13 +311,13 @@ class LocaleCodeHistoryAdmin(admin.ModelAdmin):
 
 class CommentAdmin(admin.ModelAdmin):
     search_fields = ["content"]
-    raw_id_fields = ("translation", "entity")
+    autocomplete_fields = ("author", "translation", "entity")
 
 
 class TranslationMemoryEntryAdmin(admin.ModelAdmin):
     search_fields = ["source", "target", "locale__name", "locale__code"]
     list_display = ("pk", "source", "target", "locale")
-    raw_id_fields = (
+    autocomplete_fields = (
         "entity",
         "translation",
     )
@@ -318,7 +327,7 @@ class ChangedEntityLocaleAdmin(admin.ModelAdmin):
     search_fields = ["entity__string", "locale__name", "locale__code"]
     # Entity column should come last, for it can be looong
     list_display = ("pk", "when", "locale", "entity")
-    raw_id_fields = ("entity",)
+    autocomplete_fields = ("entity",)
 
 
 class UserRoleLogActionAdmin(admin.ModelAdmin):
@@ -336,6 +345,11 @@ class UserRoleLogActionAdmin(admin.ModelAdmin):
         "created_at",
     )
     ordering = ("-created_at",)
+    autocomplete_fields = (
+        "performed_by",
+        "performed_on",
+        "group",
+    )
 
     def get_user_edit_url(self, user_pk):
         return reverse(

--- a/pontoon/checks/admin.py
+++ b/pontoon/checks/admin.py
@@ -5,7 +5,7 @@ from pontoon.checks import models
 
 class FailedCheckModelAdmin(admin.ModelAdmin):
     search_fields = ["message", "library"]
-    raw_id_fields = ("translation",)
+    autocomplete_fields = ("translation",)
 
     list_display = (
         "translation",

--- a/pontoon/sync/admin.py
+++ b/pontoon/sync/admin.py
@@ -27,6 +27,7 @@ class ProjectSyncLogInline(admin.TabularInline):
 
 
 class SyncLogAdmin(admin.ModelAdmin):
+    search_fields = ("sync_log",)
     list_display = TIMES
     inlines = (ProjectSyncLogInline,)
 
@@ -38,15 +39,18 @@ class RepositorySyncLogInline(admin.TabularInline):
 
 
 class ProjectSyncLogAdmin(admin.ModelAdmin):
+    search_fields = ("project_sync_log",)
     list_display = (
         "project",
         "status",
     ) + TIMES
     inlines = (RepositorySyncLogInline,)
+    autocomplete_fields = ("sync_log",)
 
 
 class RepositorySyncLogAdmin(admin.ModelAdmin):
     list_display = ("repository_url",) + TIMES
+    autocomplete_fields = ("project_sync_log",)
 
     @admin.display
     def repository_url(self, obj):

--- a/pontoon/terminology/admin.py
+++ b/pontoon/terminology/admin.py
@@ -29,7 +29,7 @@ class TermAdmin(admin.ModelAdmin):
         "do_not_translate",
         "forbidden",
     )
-    raw_id_fields = ("entity",)
+    autocomplete_fields = ("entity", "created_by")
 
     def save_model(self, request, obj, form, change):
         obj.created_by = request.user


### PR DESCRIPTION
Speed up Django Admin New and Edit pages by introducing `autocomplete_fields` for fields with a lot of entries. 

All `raw_id_fields` are also replaced with `autocomplete_fields` for an improved usability.

Deployed to stage. You can compare for example the loading times of the following URLs:
https://mozilla-pontoon-staging.herokuapp.com/a/actionlog/actionlog/4742759/change/
https://pontoon.mozilla.org/a/actionlog/actionlog/4742759/change/