### PR TITLE
Implement filter for searching in rejected translations

### DIFF
--- a/pontoon/base/forms.py
+++ b/pontoon/base/forms.py
@@ -299,6 +299,7 @@ class GetEntitiesForm(forms.Form):
     extra = forms.CharField(required=False)
     search_identifiers = forms.BooleanField(required=False)
     search_translations_only = forms.BooleanField(required=False)
+    search_rejected_translations = forms.BooleanField(required=False)
     tag = forms.CharField(required=False)
     time = forms.CharField(required=False)
     author = forms.CharField(required=False)

--- a/pontoon/base/models/entity.py
+++ b/pontoon/base/models/entity.py
@@ -733,6 +733,7 @@ class Entity(DirtyFieldsMixin, models.Model):
         extra=None,
         search_identifiers=None,
         search_translations_only=None,
+        search_rejected_translations=None,
         time=None,
         author=None,
         review_time=None,
@@ -845,9 +846,13 @@ class Entity(DirtyFieldsMixin, models.Model):
         if search:
             search_list = utils.get_search_phrases(search)
 
+            q_rejected = (
+                Q()
+            )  # if search_rejected_translations else Q(translation__approved=True)
             translation_filters = (
                 Q(translation__string__icontains_collate=(search, locale.db_collation))
                 & Q(translation__locale=locale)
+                & q_rejected
                 for search in search_list
             )
 

--- a/pontoon/base/models/entity.py
+++ b/pontoon/base/models/entity.py
@@ -842,13 +842,19 @@ class Entity(DirtyFieldsMixin, models.Model):
                 # only tag needs `distinct` as it traverses m2m fields
                 entities = entities.distinct()
 
+        # TODO: Uncomment the following lines to reactivate the
+        #       feature once all search options are implemented:
+        #       - 857 (rejected translations)
+        #       - 869-870 (context identifiers)
+        #       - 883-884 (translations only)
+
         # Filter by search parameters
         if search:
             search_list = utils.get_search_phrases(search)
 
             q_rejected = (
                 Q()
-            )  # if search_rejected_translations else Q(translation__approved=True)
+            )  # if search_rejected_translations else Q(translation__rejected=False)
             translation_filters = (
                 Q(translation__string__icontains_collate=(search, locale.db_collation))
                 & Q(translation__locale=locale)
@@ -861,9 +867,6 @@ class Entity(DirtyFieldsMixin, models.Model):
             )
 
             # if not search_translations_only:
-
-            # TODO: remove the comments above and below to reactivate the feature once
-            #       all search options are implemented
             q_key = Q(key__icontains=search)  # if search_identifiers else Q()
             entity_filters = (
                 Q(string__icontains=search) | Q(string_plural__icontains=search) | q_key

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -247,6 +247,7 @@ def entities(request):
         "extra",
         "search_identifiers",
         "search_translations_only",
+        "search_rejected_translations",
         "time",
         "author",
         "review_time",

--- a/translate/src/api/entity.ts
+++ b/translate/src/api/entity.ts
@@ -126,6 +126,7 @@ function buildFetchPayload(
       'status',
       'search_identifiers',
       'search_translations_only',
+      'search_rejected_translations',
       'extra',
       'tag',
       'author',

--- a/translate/src/context/Location.tsx
+++ b/translate/src/context/Location.tsx
@@ -22,6 +22,7 @@ export type Location = {
   extra: string | null;
   search_identifiers: boolean;
   search_translations_only: boolean;
+  search_rejected_translations: boolean;
   tag: string | null;
   author: string | null;
   time: string | null;
@@ -37,6 +38,7 @@ const emptyParams = {
   extra: null,
   search_identifiers: false,
   search_translations_only: false,
+  search_rejected_translations: false,
   tag: null,
   author: null,
   time: null,
@@ -98,6 +100,9 @@ function parse(
         extra: params.get('extra'),
         search_identifiers: params.has('search_identifiers'),
         search_translations_only: params.has('search_translations_only'),
+        search_rejected_translations: params.has(
+          'search_rejected_translations',
+        ),
         tag: params.get('tag'),
         author: params.get('author'),
         time: params.get('time'),
@@ -130,6 +135,7 @@ function stringify(prev: Location, next: string | Partial<Location>) {
       'extra',
       'search_identifiers',
       'search_translations_only',
+      'search_rejected_translations',
       'tag',
       'author',
       'time',

--- a/translate/src/modules/search/components/SearchBox.tsx
+++ b/translate/src/modules/search/components/SearchBox.tsx
@@ -41,7 +41,10 @@ type InternalProps = Props & {
 
 export type FilterType = 'authors' | 'extras' | 'statuses' | 'tags';
 
-export type SearchType = 'search_identifiers' | 'search_translations_only';
+export type SearchType =
+  | 'search_identifiers'
+  | 'search_translations_only'
+  | 'search_rejected_translations';
 
 function getTimeRangeFromURL(timeParameter: string): TimeRangeType {
   const [from, to] = timeParameter.split('-');
@@ -63,6 +66,7 @@ export type FilterAction = {
 export type SearchState = {
   search_identifiers: boolean;
   search_translations_only: boolean;
+  search_rejected_translations: boolean;
 };
 
 export type SearchAction = {
@@ -124,6 +128,7 @@ export function SearchBoxBase({
     {
       search_identifiers: false,
       search_translations_only: false,
+      search_rejected_translations: false,
     },
   );
 
@@ -151,12 +156,21 @@ export function SearchBoxBase({
   }, [parameters]);
 
   const updateOptionsFromURL = useCallback(() => {
-    const { search_identifiers, search_translations_only, time } = parameters;
+    const {
+      search_identifiers,
+      search_translations_only,
+      search_rejected_translations,
+      time,
+    } = parameters;
     updateSearchOptions([
       { searchOption: 'search_identifiers', value: search_identifiers },
       {
         searchOption: 'search_translations_only',
         value: search_translations_only,
+      },
+      {
+        searchOption: 'search_rejected_translations',
+        value: search_rejected_translations,
       },
     ]);
     setTimeRange(time);
@@ -235,12 +249,17 @@ export function SearchBoxBase({
   const applyOptions = useCallback(
     () =>
       checkUnsavedChanges(() => {
-        const { search_identifiers, search_translations_only } = searchOptions;
+        const {
+          search_identifiers,
+          search_translations_only,
+          search_rejected_translations,
+        } = searchOptions;
         dispatch(resetEntities());
         parameters.push({
           ...parameters, // Persist all other variables to next state
           search_identifiers: search_identifiers,
           search_translations_only: search_translations_only,
+          search_rejected_translations: search_rejected_translations,
           entity: 0, // With the new results, the current entity might not be available anymore.
         });
       }),

--- a/translate/src/modules/search/constants.ts
+++ b/translate/src/modules/search/constants.ts
@@ -68,10 +68,10 @@ export const SEARCH_OPTIONS = [
     name: 'Search in translations only',
     slug: 'search_translations_only',
   },
-  // {
-  //   name: 'Search in rejected translations',
-  //   slug: 'rejected',
-  // },
+  {
+    name: 'Search in rejected translations',
+    slug: 'search_rejected_translations',
+  },
   // {
   //   name: 'Match whole words',
   //   slug: 'matchWords',


### PR DESCRIPTION
Fix #3226 

Added a filter to expand a user's search to include rejected translations. Currently, by default, rejected translations are included in the QuerySet returned after a search. This feature will remove that default behaviour to only search in approved translations, and if the filter is set, then rejected translations are included in the QuerySet as well.

**To reproduce results**: 

Head to any string within the translate view upon running the server. Ensure that the string has an approved translation, as well as a rejected translation. Find the difference between the two strings, then enter that within the Search Box input. The left side column will show no results, as long as the searched string does not appear in any other **approved** translation.

Then, click on the magnifying glass icon on the right side of the search box. Click on the `Search in rejected translations` option to toggle the filter, then click the `APPLY SEARCH OPTIONS` button. The results shown on the left column will now include the rejected translation.

![Screenshot 2024-09-06 at 8 45 33 AM](https://github.com/user-attachments/assets/0564e233-d57e-449c-b0b9-b170302029fc)
![Screenshot 2024-09-06 at 8 45 49 AM](https://github.com/user-attachments/assets/ab31451d-c386-4d63-826e-d24f0a497716)
