### PR TITLE
Implement search filter for matching case

### DIFF
--- a/pontoon/base/forms.py
+++ b/pontoon/base/forms.py
@@ -300,6 +300,7 @@ class GetEntitiesForm(forms.Form):
     search_identifiers = forms.BooleanField(required=False)
     search_translations_only = forms.BooleanField(required=False)
     search_rejected_translations = forms.BooleanField(required=False)
+    search_match_case = forms.BooleanField(required=False)
     tag = forms.CharField(required=False)
     time = forms.CharField(required=False)
     author = forms.CharField(required=False)

--- a/pontoon/base/models/entity.py
+++ b/pontoon/base/models/entity.py
@@ -844,10 +844,8 @@ class Entity(DirtyFieldsMixin, models.Model):
                 entities = entities.distinct()
 
         # TODO: Uncomment the following lines to reactivate the
-        #       feature once all search options are implemented:
-        #       - 857 (rejected translations)
-        #       - 869-870 (context identifiers)
-        #       - 883-884 (translations only)
+        #       context identifiers filter once .ftl bug is fixed (issue #3284):
+        #       - 883-888
 
         # Filter by search parameters
         if search:
@@ -882,12 +880,12 @@ class Entity(DirtyFieldsMixin, models.Model):
             if not search_translations_only:
                 # Search in string (context) identifiers
                 q_key = Q()
-                if search_identifiers:
-                    q_key = (
-                        Q(key__contains=search)
-                        if search_match_case
-                        else Q(key__icontains=search)
-                    )
+                # if search_identifiers:
+                #     q_key = (
+                #         Q(key__contains=search)
+                #         if search_match_case
+                #         else Q(key__icontains=search)
+                #     )
 
                 entity_filters = (
                     (

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -248,6 +248,7 @@ def entities(request):
         "search_identifiers",
         "search_translations_only",
         "search_rejected_translations",
+        "search_match_case",
         "time",
         "author",
         "review_time",

--- a/translate/src/api/entity.ts
+++ b/translate/src/api/entity.ts
@@ -127,6 +127,7 @@ function buildFetchPayload(
       'search_identifiers',
       'search_translations_only',
       'search_rejected_translations',
+      'search_match_case',
       'extra',
       'tag',
       'author',

--- a/translate/src/context/Location.tsx
+++ b/translate/src/context/Location.tsx
@@ -23,6 +23,7 @@ export type Location = {
   search_identifiers: boolean;
   search_translations_only: boolean;
   search_rejected_translations: boolean;
+  search_match_case: boolean;
   tag: string | null;
   author: string | null;
   time: string | null;
@@ -39,6 +40,7 @@ const emptyParams = {
   search_identifiers: false,
   search_translations_only: false,
   search_rejected_translations: false,
+  search_match_case: false,
   tag: null,
   author: null,
   time: null,
@@ -103,6 +105,7 @@ function parse(
         search_rejected_translations: params.has(
           'search_rejected_translations',
         ),
+        search_match_case: params.has('search_match_case'),
         tag: params.get('tag'),
         author: params.get('author'),
         time: params.get('time'),
@@ -136,6 +139,7 @@ function stringify(prev: Location, next: string | Partial<Location>) {
       'search_identifiers',
       'search_translations_only',
       'search_rejected_translations',
+      'search_match_case',
       'tag',
       'author',
       'time',

--- a/translate/src/modules/placeable/components/Highlight.tsx
+++ b/translate/src/modules/placeable/components/Highlight.tsx
@@ -1,7 +1,8 @@
 import { Localized } from '@fluent/react';
 import escapeRegExp from 'lodash.escaperegexp';
-import React from 'react';
+import React, { useContext } from 'react';
 import { TermState } from '~/modules/terms';
+import { Location } from '~/context/Location';
 
 import './Highlight.css';
 import { ReactElement } from 'react';
@@ -63,6 +64,7 @@ export function Highlight({
     length: number;
     mark: ReactElement;
   }> = [];
+  const location = useContext(Location);
 
   for (const match of source.matchAll(placeholder)) {
     let l10nId: string;
@@ -171,10 +173,13 @@ export function Highlight({
       if (term.startsWith('"') && term.length >= 3 && term.endsWith('"')) {
         term = term.slice(1, -1);
       }
-      let lcTerm = term.toLowerCase();
+      const highlightTerm = location.search_match_case
+        ? term
+        : term.toLowerCase();
+      const highlightSource = location.search_match_case ? source : lcSource;
       let pos = 0;
       let next: number;
-      while ((next = lcSource.indexOf(lcTerm, pos)) !== -1) {
+      while ((next = highlightSource.indexOf(highlightTerm, pos)) !== -1) {
         let i = marks.findIndex((m) => m.index + m.length > next);
         if (i === -1) {
           i = marks.length;

--- a/translate/src/modules/search/components/SearchBox.tsx
+++ b/translate/src/modules/search/components/SearchBox.tsx
@@ -44,7 +44,8 @@ export type FilterType = 'authors' | 'extras' | 'statuses' | 'tags';
 export type SearchType =
   | 'search_identifiers'
   | 'search_translations_only'
-  | 'search_rejected_translations';
+  | 'search_rejected_translations'
+  | 'search_match_case';
 
 function getTimeRangeFromURL(timeParameter: string): TimeRangeType {
   const [from, to] = timeParameter.split('-');
@@ -67,6 +68,7 @@ export type SearchState = {
   search_identifiers: boolean;
   search_translations_only: boolean;
   search_rejected_translations: boolean;
+  search_match_case: boolean;
 };
 
 export type SearchAction = {
@@ -129,6 +131,7 @@ export function SearchBoxBase({
       search_identifiers: false,
       search_translations_only: false,
       search_rejected_translations: false,
+      search_match_case: false,
     },
   );
 
@@ -160,6 +163,7 @@ export function SearchBoxBase({
       search_identifiers,
       search_translations_only,
       search_rejected_translations,
+      search_match_case,
       time,
     } = parameters;
     updateSearchOptions([
@@ -171,6 +175,10 @@ export function SearchBoxBase({
       {
         searchOption: 'search_rejected_translations',
         value: search_rejected_translations,
+      },
+      {
+        searchOption: 'search_match_case',
+        value: search_match_case,
       },
     ]);
     setTimeRange(time);
@@ -253,6 +261,7 @@ export function SearchBoxBase({
           search_identifiers,
           search_translations_only,
           search_rejected_translations,
+          search_match_case,
         } = searchOptions;
         dispatch(resetEntities());
         parameters.push({
@@ -260,6 +269,7 @@ export function SearchBoxBase({
           search_identifiers: search_identifiers,
           search_translations_only: search_translations_only,
           search_rejected_translations: search_rejected_translations,
+          search_match_case: search_match_case,
           entity: 0, // With the new results, the current entity might not be available anymore.
         });
       }),

--- a/translate/src/modules/search/components/SearchPanel.tsx
+++ b/translate/src/modules/search/components/SearchPanel.tsx
@@ -11,7 +11,7 @@ import './SearchPanel.css';
 // TODO: Remove the variable below to reactivate the feature once
 //       all search options are implemented
 // Disable SearchPanel component until fully complete
-const disable: Boolean = true;
+const disable: Boolean = false;
 
 type Props = {
   searchOptions: SearchState;

--- a/translate/src/modules/search/components/SearchPanel.tsx
+++ b/translate/src/modules/search/components/SearchPanel.tsx
@@ -11,7 +11,6 @@ import './SearchPanel.css';
 // TODO: Remove the variable below to reactivate the feature once
 //       all search options are implemented
 // Disable SearchPanel component until fully complete
-const disable: Boolean = false;
 
 type Props = {
   searchOptions: SearchState;
@@ -123,16 +122,10 @@ export function SearchPanel({
 
   return (
     <div className='search-panel'>
-      {/* {TODO: Remove the style attribute for the div below} */}
-      <div
-        className='visibility-switch'
-        style={{ cursor: disable ? 'default' : 'pointer' }}
-        onClick={toggleVisible}
-      >
+      <div className='visibility-switch' onClick={toggleVisible}>
         <span className='fa fa-search'></span>
       </div>
-      {/* {TODO: Remove the second condition below} */}
-      {visible && !disable ? (
+      {visible ? (
         <SearchPanelDialog
           searchOptions={searchOptions}
           onApplyOptions={handleApplyOptions}

--- a/translate/src/modules/search/components/SearchPanel.tsx
+++ b/translate/src/modules/search/components/SearchPanel.tsx
@@ -8,10 +8,6 @@ import { useOnDiscard } from '~/utils';
 
 import './SearchPanel.css';
 
-// TODO: Remove the variable below to reactivate the feature once
-//       all search options are implemented
-// Disable SearchPanel component until fully complete
-
 type Props = {
   searchOptions: SearchState;
   applyOptions: () => void;

--- a/translate/src/modules/search/constants.ts
+++ b/translate/src/modules/search/constants.ts
@@ -60,10 +60,10 @@ export const FILTERS_EXTRA = [
 ] as const;
 
 export const SEARCH_OPTIONS = [
-  {
-    name: 'Search in string identifiers',
-    slug: 'search_identifiers',
-  },
+  // {
+  //   name: 'Search in string identifiers',
+  //   slug: 'search_identifiers',
+  // },
   {
     name: 'Search in translations only',
     slug: 'search_translations_only',

--- a/translate/src/modules/search/constants.ts
+++ b/translate/src/modules/search/constants.ts
@@ -76,8 +76,8 @@ export const SEARCH_OPTIONS = [
   //   name: 'Match whole words',
   //   slug: 'matchWords',
   // },
-  // {
-  //   name: 'Match case',
-  //   slug: 'matchCase',
-  // },
+  {
+    name: 'Match case',
+    slug: 'search_match_case',
+  },
 ] as const;


### PR DESCRIPTION
Fix #3224 

Added a search filter for matching exact casing. Currently, by default, searches are case insensitive (e.g. `Foo` and `foo` would both appear when searching for `Foo`). This feature retains the default behaviour, but adds the option to strictly match casing between the search term and matches.

**To reproduce results**:

Head to any string within the translate view upon running the server. Ensure that the string appears at least twice in the string list (left-side column), once with an uppercase letter and once with all lowercase letters.

Then, click on the magnifying glass icon on the right side of the search box. Click on the `Match case` option to toggle the filter, then click the APPLY SEARCH OPTIONS button. The results shown on the left column will now only include instances of the search term that match the casing you inputted. Try changing the casing of your search term, and observe how the results on the string list change.

<img width="1149" alt="Screenshot 2024-09-06 at 4 51 06 PM" src="https://github.com/user-attachments/assets/dffbf0fb-88bc-444a-a5c8-4dff27e8ddec">
<img width="1128" alt="Screenshot 2024-09-06 at 4 51 29 PM" src="https://github.com/user-attachments/assets/7633f04e-654a-48b8-86d2-0eefa698a98d">
<img width="1138" alt="Screenshot 2024-09-06 at 4 51 43 PM" src="https://github.com/user-attachments/assets/8bf3b904-daf2-4dd5-8eb8-136332ebd0a7">
