### PR TITLE
Fix bug when Match Case and Translations Only filter were active

### DIFF
--- a/pontoon/base/models/entity.py
+++ b/pontoon/base/models/entity.py
@@ -864,7 +864,7 @@ class Entity(DirtyFieldsMixin, models.Model):
 
             translation_filters = (
                 q_match_case & Q(translation__locale=locale) & q_rejected
-                for search in search_list
+                for s in search_list
             )
 
             translation_matches = entities.filter(*translation_filters).values_list(

--- a/pontoon/base/models/entity.py
+++ b/pontoon/base/models/entity.py
@@ -853,22 +853,10 @@ class Entity(DirtyFieldsMixin, models.Model):
             )
 
             # Modify query based on case sensitivity filter
-
-            translation_case_lookup = (
-                "contains" if search_match_case else "icontains_collate"
-            )
-
             translation_filters = (
-                Q(
-                    **{
-                        f"translation__string__{translation_case_lookup}": (
-                            s,
-                            locale.db_collation,
-                        )
-                        if not search_match_case
-                        else s
-                    }
-                )
+                Q(translation__string__contains=s)
+                if search_match_case
+                else Q(translation__string__icontains_collate=(s, locale.db_collation))
                 & Q(translation__locale=locale)
                 & q_rejected
                 for s in search_list

--- a/pontoon/base/models/entity.py
+++ b/pontoon/base/models/entity.py
@@ -854,16 +854,23 @@ class Entity(DirtyFieldsMixin, models.Model):
 
             # Modify query based on case sensitivity filter
 
-            q_match_case = (
-                Q(translation__string__contains=search)
-                if search_match_case
-                else Q(
-                    translation__string__icontains_collate=(search, locale.db_collation)
-                )
+            translation_case_lookup = (
+                "contains" if search_match_case else "icontains_collate"
             )
 
             translation_filters = (
-                q_match_case & Q(translation__locale=locale) & q_rejected
+                Q(
+                    **{
+                        f"translation__string__{translation_case_lookup}": (
+                            s,
+                            locale.db_collation,
+                        )
+                        if not search_match_case
+                        else s
+                    }
+                )
+                & Q(translation__locale=locale)
+                & q_rejected
                 for s in search_list
             )
 

--- a/pontoon/base/models/entity.py
+++ b/pontoon/base/models/entity.py
@@ -853,21 +853,17 @@ class Entity(DirtyFieldsMixin, models.Model):
             )
 
             # Modify query based on case sensitivity filter
-            translation_case_lookup = (
-                "contains" if search_match_case else "icontains_collate"
+
+            q_match_case = (
+                Q(translation__string__contains=search)
+                if search_match_case
+                else Q(
+                    translation__string__icontains_collate=(search, locale.db_collation)
+                )
             )
 
             translation_filters = (
-                Q(
-                    **{
-                        f"translation__string__{translation_case_lookup}": (
-                            search,
-                            locale.db_collation,
-                        )
-                    }
-                )
-                & Q(translation__locale=locale)
-                & q_rejected
+                q_match_case & Q(translation__locale=locale) & q_rejected
                 for search in search_list
             )
 

--- a/translate/src/modules/search/components/SearchPanel.css
+++ b/translate/src/modules/search/components/SearchPanel.css
@@ -26,6 +26,7 @@
     box-sizing: border-box;
     position: absolute;
     top: 44px;
+    right: 5px;
     width: 350px;
     z-index: 20;
     padding: 10px 12px;


### PR DESCRIPTION
Currently in production, if both `Match case` and `Translations only` are active Search Options, then no results will be displayed, no matter what the search term is

Before: https://pontoon.mozilla.org/fr/facebook-container/messages.json/?search=Facebook&search_translations_only=true&search_match_case=true

After: http://localhost:8000/fr/facebook-container/messages.json/?search=Facebook&search_translations_only=true&search_match_case=true

This PR fixes that bug, and also adjusts the placement of the Search Options panel to display under the magnifying glass icon.

The bug was fixed by removing the second parameter (`locale.db_collation`) from the query when `search_match_case` is set to true.