### PR TITLE
Fixed variable scoping in Match case query

### DIFF
--- a/pontoon/base/models/entity.py
+++ b/pontoon/base/models/entity.py
@@ -854,9 +854,13 @@ class Entity(DirtyFieldsMixin, models.Model):
 
             # Modify query based on case sensitivity filter
             translation_filters = (
-                Q(translation__string__contains=s)
-                if search_match_case
-                else Q(translation__string__icontains_collate=(s, locale.db_collation))
+                (
+                    Q(translation__string__contains=s)
+                    if search_match_case
+                    else Q(
+                        translation__string__icontains_collate=(s, locale.db_collation)
+                    )
+                )
                 & Q(translation__locale=locale)
                 & q_rejected
                 for s in search_list


### PR DESCRIPTION
Fix #3321

Simplifying the query creation seemed to cause an issue with the casing Search Option. 

To fix the issue, I simply added a bracket around the conditional query in `translation_filters`, which corrects the variable scope and produces the correct QuerySet.

Before:
![image](https://github.com/user-attachments/assets/f5885e98-58cb-4427-9406-0121659605bc)


After (Note: the three unhighlighted results are from #3284):
![image](https://github.com/user-attachments/assets/4ab2c480-21fc-4a15-92c8-8330c46dc866)
