### PR TITLE
Add ability to filter message recipients by activity

### DIFF
--- a/pontoon/base/static/css/check-box.css
+++ b/pontoon/base/static/css/check-box.css
@@ -6,7 +6,7 @@
   text-align: left;
 
   .check-box {
-    padding: 8px 0;
+    padding: 4px 0;
   }
 
   .check-box:last-child {

--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -139,6 +139,7 @@ input[type='password'],
 input[type='url'],
 input[type='number'],
 input[type='email'],
+input[type='date'],
 textarea {
   background: var(--input-background-1);
   border: 1px solid var(--main-border-1);

--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -1153,13 +1153,15 @@ body > form,
 }
 
 .check-box .fa:before {
-  color: var(--status-error);
-  content: '';
+  color: var(--toggle-color-1);
+  content: '';
+  font-weight: normal;
 }
 
 .check-box.enabled .fa:before {
   color: var(--status-translated);
   content: '';
+  font-weight: bold;
 }
 
 #helpers > section ul {

--- a/pontoon/contributors/static/css/settings.css
+++ b/pontoon/contributors/static/css/settings.css
@@ -129,6 +129,10 @@
   font-style: italic;
 }
 
+#main .check-list .check-box {
+  padding: 8px 0;
+}
+
 #main .appearance .field .help {
   margin: 0 0 -12px;
 }

--- a/pontoon/messaging/forms.py
+++ b/pontoon/messaging/forms.py
@@ -22,3 +22,16 @@ class MessageForm(forms.Form):
     projects = forms.CharField(
         validators=[validators.validate_comma_separated_integer_list]
     )
+
+    translation_minimum = forms.IntegerField(required=False, min_value=0)
+    translation_maximum = forms.IntegerField(required=False, min_value=0)
+    translation_from = forms.DateField(required=False)
+    translation_to = forms.DateField(required=False)
+
+    review_minimum = forms.IntegerField(required=False, min_value=0)
+    review_maximum = forms.IntegerField(required=False, min_value=0)
+    review_from = forms.DateField(required=False)
+    review_to = forms.DateField(required=False)
+
+    login_from = forms.DateField(required=False)
+    login_to = forms.DateField(required=False)

--- a/pontoon/messaging/static/css/messaging.css
+++ b/pontoon/messaging/static/css/messaging.css
@@ -68,12 +68,23 @@
       text-align: left;
     }
 
+    .field.half {
+      float: left;
+      width: 285px;
+    }
+
+    .field.half:nth-child(2n) {
+      float: right;
+    }
+
     label {
       display: block;
       margin-bottom: 5px;
     }
 
     input[type='text'],
+    input[type='date'],
+    input[type='number'],
     textarea {
       background: var(--black-3);
       float: none;

--- a/pontoon/messaging/static/css/messaging.css
+++ b/pontoon/messaging/static/css/messaging.css
@@ -4,13 +4,10 @@
   }
 
   #compose {
-    padding: 20px;
     box-sizing: border-box;
 
     h3 {
-      color: var(--white-1);
-      font-size: 22px;
-      letter-spacing: 0;
+      margin-bottom: 20px;
 
       .stress {
         color: var(--status-translated);
@@ -19,6 +16,7 @@
 
     .controls {
       margin: 0;
+      text-align: right;
     }
 
     .errors {
@@ -33,7 +31,7 @@
     }
 
     #send-message > section {
-      margin: 20px 0;
+      padding: 20px;
     }
 
     .check-list {
@@ -64,7 +62,7 @@
     .field {
       color: var(--light-grey-7);
       font-size: 16px;
-      margin-bottom: 20px;
+      margin-bottom: 10px;
       text-align: left;
     }
 
@@ -99,7 +97,7 @@
       height: 150px;
     }
 
-    .message-editor .subtitle {
+    .message-content .subtitle {
       color: var(--light-grey-7);
       float: right;
       font-size: 13px;

--- a/pontoon/messaging/static/js/messaging.js
+++ b/pontoon/messaging/static/js/messaging.js
@@ -32,10 +32,18 @@ $(function () {
 
     const isValidProject = $form.find('[name=projects]').val();
 
-    const isValidTranslationMinimum = $form.find('#translation-minimum')[0].checkValidity();
-    const isValidTranslationMaximum = $form.find('#translation-maximum')[0].checkValidity();
-    const isValidReviewMinimum = $form.find('#review-minimum')[0].checkValidity();
-    const isValidReviewMaximum = $form.find('#review-maximum')[0].checkValidity();
+    const isValidTranslationMinimum = $form
+      .find('#translation-minimum')[0]
+      .checkValidity();
+    const isValidTranslationMaximum = $form
+      .find('#translation-maximum')[0]
+      .checkValidity();
+    const isValidReviewMinimum = $form
+      .find('#review-minimum')[0]
+      .checkValidity();
+    const isValidReviewMaximum = $form
+      .find('#review-maximum')[0]
+      .checkValidity();
 
     $form.find('.errors').css('visibility', 'hidden');
 
@@ -51,8 +59,14 @@ $(function () {
     showErrorIfNotValid(isValidRole, '.filter-user-role');
     showErrorIfNotValid(isValidLocale, '.filter-locale');
     showErrorIfNotValid(isValidProject, '.filter-project');
-    showErrorIfNotValid(isValidTranslationMinimum, '.filter-translation > .minimum');
-    showErrorIfNotValid(isValidTranslationMaximum, '.filter-translation > .maximum');
+    showErrorIfNotValid(
+      isValidTranslationMinimum,
+      '.filter-translation > .minimum',
+    );
+    showErrorIfNotValid(
+      isValidTranslationMaximum,
+      '.filter-translation > .maximum',
+    );
     showErrorIfNotValid(isValidReviewMinimum, '.filter-review > .minimum');
     showErrorIfNotValid(isValidReviewMaximum, '.filter-review > .maximum');
 

--- a/pontoon/messaging/static/js/messaging.js
+++ b/pontoon/messaging/static/js/messaging.js
@@ -32,6 +32,11 @@ $(function () {
 
     const isValidProject = $form.find('[name=projects]').val();
 
+    const isValidTranslationMinimum = $form.find('#translation-minimum')[0].checkValidity();
+    const isValidTranslationMaximum = $form.find('#translation-maximum')[0].checkValidity();
+    const isValidReviewMinimum = $form.find('#review-minimum')[0].checkValidity();
+    const isValidReviewMaximum = $form.find('#review-maximum')[0].checkValidity();
+
     $form.find('.errors').css('visibility', 'hidden');
 
     function showErrorIfNotValid(isValid, selector) {
@@ -46,6 +51,10 @@ $(function () {
     showErrorIfNotValid(isValidRole, '.filter-user-role');
     showErrorIfNotValid(isValidLocale, '.filter-locale');
     showErrorIfNotValid(isValidProject, '.filter-project');
+    showErrorIfNotValid(isValidTranslationMinimum, '.filter-translation > .minimum');
+    showErrorIfNotValid(isValidTranslationMaximum, '.filter-translation > .maximum');
+    showErrorIfNotValid(isValidReviewMinimum, '.filter-review > .minimum');
+    showErrorIfNotValid(isValidReviewMaximum, '.filter-review > .maximum');
 
     return (
       isValidType &&
@@ -53,7 +62,11 @@ $(function () {
       isValidBody &&
       isValidRole &&
       isValidLocale &&
-      isValidProject
+      isValidProject &&
+      isValidTranslationMinimum &&
+      isValidTranslationMaximum &&
+      isValidReviewMinimum &&
+      isValidReviewMaximum
     );
   }
 

--- a/pontoon/messaging/templates/messaging/messaging.html
+++ b/pontoon/messaging/templates/messaging/messaging.html
@@ -138,11 +138,11 @@
                             <div>
                                 <div class="field clearfix from half">
                                     <label for="translation-from">From</label>
-                                    <input type="date" name="translation_from" id="translation-from">
+                                    <input type="date" value="{{ year_ago }}" name="translation_from" id="translation-from">
                                 </div>
                                 <div class="field clearfix to half">
                                     <label for="translation-to">To</label>
-                                    <input type="date" name="translation_to" id="translation-to">
+                                    <input type="date" value="{{ today }}" name="translation_to" id="translation-to">
                                 </div>
                             </div>
                         </section>
@@ -168,11 +168,11 @@
                             <div>
                                 <div class="field clearfix from half">
                                     <label for="review-from">From</label>
-                                    <input type="date" name="review_from" id="review-from">
+                                    <input type="date" value="{{ year_ago }}" name="review_from" id="review-from">
                                 </div>
                                 <div class="field clearfix to half">
                                     <label for="review-to">To</label>
-                                    <input type="date" name="review_to" id="review-to">
+                                    <input type="date" value="{{ today }}" name="review_to" id="review-to">
                                 </div>
                             </div>
                         </section>
@@ -183,11 +183,11 @@
 
                                 <div class="field clearfix from half">
                                     <label for="login-from">From</label>
-                                    <input type="date" name="login_from" id="login-from">
+                                    <input type="date" value="{{ year_ago }}" name="login_from" id="login-from">
                                 </div>
                                 <div class="field clearfix to half">
                                     <label for="login-to">To</label>
-                                    <input type="date" name="login_to" id="login-to">
+                                    <input type="date" value="{{ today }}" name="login_to" id="login-to">
                                 </div>
                             </div>
                         </section>

--- a/pontoon/messaging/templates/messaging/messaging.html
+++ b/pontoon/messaging/templates/messaging/messaging.html
@@ -138,11 +138,11 @@
                             <div>
                                 <div class="field clearfix from half">
                                     <label for="translation-from">From</label>
-                                    <input type="date" value="{{ year_ago }}" name="translation_from" id="translation-from">
+                                    <input type="date" name="translation_from" id="translation-from">
                                 </div>
                                 <div class="field clearfix to half">
                                     <label for="translation-to">To</label>
-                                    <input type="date" value="{{ today }}" name="translation_to" id="translation-to">
+                                    <input type="date" name="translation_to" id="translation-to">
                                 </div>
                             </div>
                         </section>
@@ -168,11 +168,11 @@
                             <div>
                                 <div class="field clearfix from half">
                                     <label for="review-from">From</label>
-                                    <input type="date" value="{{ year_ago }}" name="review_from" id="review-from">
+                                    <input type="date" name="review_from" id="review-from">
                                 </div>
                                 <div class="field clearfix to half">
                                     <label for="review-to">To</label>
-                                    <input type="date" value="{{ today }}" name="review_to" id="review-to">
+                                    <input type="date" name="review_to" id="review-to">
                                 </div>
                             </div>
                         </section>
@@ -183,11 +183,11 @@
 
                                 <div class="field clearfix from half">
                                     <label for="login-from">From</label>
-                                    <input type="date" value="{{ year_ago }}" name="login_from" id="login-from">
+                                    <input type="date" name="login_from" id="login-from">
                                 </div>
                                 <div class="field clearfix to half">
                                     <label for="login-to">To</label>
-                                    <input type="date" value="{{ today }}" name="login_to" id="login-to">
+                                    <input type="date" name="login_to" id="login-to">
                                 </div>
                             </div>
                         </section>

--- a/pontoon/messaging/templates/messaging/messaging.html
+++ b/pontoon/messaging/templates/messaging/messaging.html
@@ -15,180 +15,195 @@
 
 {% block bottom %}
 <section id="main">
-  <div class="container">
-    <section class="clearfix">
-      <div class="menu permanent left-column">
-        <ul>
-          <li class="selected">
-            <a href="#compose" data-target="#compose">Compose</a>
-          </li>
-          <li class="horizontal-separator"></li>
-          <li>
-            <a href="#sent" data-target="#sent">
-              <span class="name">Sent</span>
-              <span class="count">{{ messages|length }}</span>
-            </a>
-          </li>
-        </ul>
-      </div>
+    <div class="container">
+        <section class="clearfix">
+            <div class="menu permanent left-column">
+                <ul>
+                    <li class="selected">
+                        <a href="#compose" data-target="#compose">Compose</a>
+                    </li>
+                    <li class="horizontal-separator"></li>
+                    <li>
+                        <a href="#sent" data-target="#sent">
+                            <span class="name">Sent</span>
+                            <span class="count">{{ messages|length }}</span>
+                        </a>
+                    </li>
+                </ul>
+            </div>
 
-      <div class="menu permanent right-column">
-        <section id="compose" class="selected">
-          <form id="send-message" method="POST" action="{{ url('pontoon.messaging.send_message') }}">
-            {% csrf_token %}
+            <div class="menu permanent right-column">
+                <section id="compose" class="selected">
+                    <form id="send-message" method="POST" action="{{ url('pontoon.messaging.send_message') }}">
+                        {% csrf_token %}
 
-            <h3><span class="stress">#1</span> Message type</h3>
-            <section class="message-type">
-              <ul class="check-list">
-                {{ Checkbox.checkbox('Notification', class='notification', attribute='notification') }}
-                <li><input type="checkbox" name="notification"></li>
-                {{ Checkbox.checkbox('Email', class='email', attribute='email') }}
-                <li><input type="checkbox" name="email"></li>
-                {{ Checkbox.checkbox('Transactional', class='transactional', attribute='transactional', help='Transactional emails are also sent to users who have not opted in to email communication. They are restricted in the type of content that can be included.') }}
-                <li class="transactional"><input type="checkbox" name="transactional"></li>
-              </ul>
+                        <section class="message-type">
+                            <h3><span class="stress"></span> Message type</h3>
+                            <ul class="check-list">
+                                {{ Checkbox.checkbox('Notification', class='notification', attribute='notification') }}
+                                <li><input type="checkbox" name="notification"></li>
+                                {{ Checkbox.checkbox('Email', class='email', attribute='email') }}
+                                <li><input type="checkbox" name="email"></li>
+                                {{ Checkbox.checkbox('Transactional', class='transactional', attribute='transactional',
+                                help='Transactional emails are also sent to users who have not opted in to email
+                                communication. They are restricted in the type of content that can be included.') }}
+                                <li class="transactional"><input type="checkbox" name="transactional"></li>
+                            </ul>
+                            <div class="errors">
+                                <p>You must select at least one message type</p>
+                            </div>
+                        </section>
 
-                <div class="errors">
-                  <p>You must select at least one message type</p>
-                </div>
-            </section>
+                        <section class="message-content">
+                            <h3><span class="stress"></span> Message content</h3>
+                            <div class="field clearfix subject">
+                                <label for="subject">Subject</label>
+                                <input type="text" name="subject" required="" id="subject">
+                                <div class="errors">
+                                    <p>Your message must include a subject</p>
+                                </div>
+                            </div>
+                            <div class="field clearfix body">
+                                <label for="body">Body</label>
+                                <textarea name="body" cols="40" rows="10" required="" id="body"></textarea>
+                                <div class="subtitle">
+                                    <p>Supports html</p>
+                                </div>
+                                <div class="errors">
+                                    <p>Your message must include a body</p>
+                                </div>
+                            </div>
+                        </section>
 
-            <h3><span class="stress">#2</span> Message editor</h3>
-            <section class="message-editor">
-              <div class="field clearfix subject">
-                <label for="subject">Subject</label>
-                <input type="text" name="subject" required="" id="subject">
-                <div class="errors">
-                  <p>Your message must include a subject</p>
-                </div>
-              </div>
+                        <section class="filter-user-role">
+                            <h3><span class="stress"></span> Filter by user role</h3>
+                            <ul class="check-list">
+                                {{ Checkbox.checkbox('Managers', class='managers', attribute='managers',
+                                is_enabled=True) }}
+                                <li><input type="checkbox" name="managers" checked="checked"></li>
+                                {{ Checkbox.checkbox('Translators', class='translators', attribute='translators',
+                                is_enabled=True) }}
+                                <li><input type="checkbox" name="translators" checked="checked"></li>
+                                {{ Checkbox.checkbox('Contributors', class='contributors', attribute='contributors',
+                                is_enabled=True) }}
+                                <li><input type="checkbox" name="contributors" checked="checked"></li>
+                            </ul>
+                            <div class="errors">
+                                <p>You must select at least one user role</p>
+                            </div>
+                        </section>
 
-              <div class="field clearfix body">
-                <label for="body">Body</label>
-                <textarea name="body" cols="40" rows="10" required="" id="body"></textarea>
-                <div class="subtitle">
-                  <p>Supports html</p>
-                </div>
-                <div class="errors">
-                  <p>Your message must include a body</p>
-                </div>
-              </div>
-            </section>
+                        <section class="filter-locale">
+                            <h3><span class="stress"></span> Filter by locale</h3>
+                            <div class="multi-selector locale-selector">
+                                <div class="clearfix">
+                                    {{ multiple_team_selector.render(available_locales, [], form_field='locales') }}
+                                </div>
+                            </div>
+                            <div class="errors">
+                                <p>You must select at least one locale</p>
+                            </div>
+                        </section>
 
-            <h3><span class="stress">#3</span> Filter by user role</h3>
-            <section class="filter-user-role">
-              <ul class="check-list">
-                {{ Checkbox.checkbox('Managers', class='managers', attribute='managers', is_enabled=True) }}
-                <li><input type="checkbox" name="managers" checked="checked"></li>
-                {{ Checkbox.checkbox('Translators', class='translators', attribute='translators', is_enabled=True) }}
-                <li><input type="checkbox" name="translators" checked="checked"></li>
-                {{ Checkbox.checkbox('Contributors', class='contributors', attribute='contributors', is_enabled=True) }}
-                <li><input type="checkbox" name="contributors" checked="checked"></li>
-              </ul>
+                        <section class="filter-project">
+                            <h3><span class="stress"></span> Filter by project</h3>
+                            <div class="multi-selector project-selector">
+                                <div class="clearfix">
+                                    {{ multiple_item_selector.render(available_projects, [], form_field='projects') }}
+                                </div>
+                            </div>
+                            <div class="errors">
+                                <p>You must select at least one project</p>
+                            </div>
+                        </section>
 
-                <div class="errors">
-                  <p>You must select at least one user role</p>
-                </div>
-            </section>
+                        <section class="filter-translation clearfix">
+                            <h3><span class="stress"></span> Filter by submitted translations</h3>
+                            <div>
+                                <div class="field clearfix minimum half">
+                                    <label for="translation-minimum">Minimum</label>
+                                    <input type="number" min="0" name="translation_minimum" id="translation-minimum">
+                                    <div class="errors">
+                                        <p>The value must be an integer</p>
+                                    </div>
+                                </div>
+                                <div class="field clearfix maximum half">
+                                    <label for="translation-maximum">Maximum</label>
+                                    <input type="number" min="0" name="translation_maximum" id="translation-maximum">
+                                    <div class="errors">
+                                        <p>The value must be an integer</p>
+                                    </div>
+                                </div>
+                            </div>
+                            <div>
+                                <div class="field clearfix from half">
+                                    <label for="translation-from">From</label>
+                                    <input type="date" name="translation_from" id="translation-from">
+                                </div>
+                                <div class="field clearfix to half">
+                                    <label for="translation-to">To</label>
+                                    <input type="date" name="translation_to" id="translation-to">
+                                </div>
+                            </div>
+                        </section>
 
-            <h3><span class="stress">#4</span> Filter by locale</h3>
-            <section class="filter-locale">
-                <div class="multi-selector locale-selector">
-                    <div class="clearfix">
-                      {{ multiple_team_selector.render(available_locales, [], form_field='locales') }}
-                    </div>
-                </div>
-                <div class="errors">
-                    <p>You must select at least one locale</p>
-                </div>
-            </section>
+                        <section class="filter-review clearfix">
+                            <h3><span class="stress"></span> Filter by performed reviews</h3>
+                            <div>
+                                <div class="field clearfix minimum half">
+                                    <label for="review-minimum">Minimum</label>
+                                    <input type="number" min="0" name="review_minimum" id="review-minimum">
+                                    <div class="errors">
+                                        <p>The value must be an integer</p>
+                                    </div>
+                                </div>
+                                <div class="field clearfix maximum half">
+                                    <label for="review-maximum">Maximum</label>
+                                    <input type="number" min="0" name="review_maximum" id="review-maximum">
+                                    <div class="errors">
+                                        <p>The value must be an integer</p>
+                                    </div>
+                                </div>
+                            </div>
+                            <div>
+                                <div class="field clearfix from half">
+                                    <label for="review-from">From</label>
+                                    <input type="date" name="review_from" id="review-from">
+                                </div>
+                                <div class="field clearfix to half">
+                                    <label for="review-to">To</label>
+                                    <input type="date" name="review_to" id="review-to">
+                                </div>
+                            </div>
+                        </section>
 
-            <h3><span class="stress">#5</span> Filter by project</h3>
-            <section class="filter-project">
-                <div class="multi-selector project-selector">
-                    <div class="clearfix">
-                      {{ multiple_item_selector.render(available_projects, [], form_field='projects') }}
-                    </div>
-                </div>
-                <div class="errors">
-                    <p>You must select at least one project</p>
-                </div>
-            </section>
+                        <section class="filter-last-login clearfix">
+                            <h3><span class="stress"></span> Filter by last login</h3>
+                            <div>
 
-            <h3><span class="stress">#6</span> Filter by submitted translations</h3>
-            <section class="filter-translation clearfix">
-                <div class="field clearfix minimum half">
-                    <label for="translation-minimum">Minimum</label>
-                    <input type="number" min="0" name="translation_minimum" id="translation-minimum">
-                    <div class="errors">
-                        <p>The value must be an integer</p>
-                    </div>
-                </div>
-                <div class="field clearfix maximum half">
-                    <label for="translation-maximum">Maximum</label>
-                    <input type="number" min="0" name="translation_maximum" id="translation-maximum">
-                    <div class="errors">
-                        <p>The value must be an integer</p>
-                    </div>
-                </div>
-                <div class="field clearfix from half">
-                    <label for="translation-from">From</label>
-                    <input type="date" name="translation_from" id="translation-from">
-                </div>
-                <div class="field clearfix to half">
-                    <label for="translation-to">To</label>
-                    <input type="date" name="translation_to" id="translation-to">
-                </div>
-            </section>
+                                <div class="field clearfix from half">
+                                    <label for="login-from">From</label>
+                                    <input type="date" name="login_from" id="login-from">
+                                </div>
+                                <div class="field clearfix to half">
+                                    <label for="login-to">To</label>
+                                    <input type="date" name="login_to" id="login-to">
+                                </div>
+                            </div>
+                        </section>
 
-            <h3><span class="stress">#7</span> Filter by performed reviews</h3>
-            <section class="filter-review clearfix">
-                <div class="field clearfix minimum half">
-                    <label for="review-minimum">Minimum</label>
-                    <input type="number" min="0" name="review_minimum" id="review-minimum">
-                    <div class="errors">
-                        <p>The value must be an integer</p>
-                    </div>
-                </div>
-                <div class="field clearfix maximum half">
-                    <label for="review-maximum">Maximum</label>
-                    <input type="number" min="0" name="review_maximum" id="review-maximum">
-                    <div class="errors">
-                        <p>The value must be an integer</p>
-                    </div>
-                </div>
-                <div class="field clearfix from half">
-                    <label for="review-from">From</label>
-                    <input type="date" name="review_from" id="review-from">
-                </div>
-                <div class="field clearfix to half">
-                    <label for="review-to">To</label>
-                    <input type="date" name="review_to" id="review-to">
-                </div>
-            </section>
-
-            <h3><span class="stress">#8</span> Filter by last login</h3>
-            <section class="filter-last-login clearfix">
-                <div class="field clearfix from half">
-                    <label for="login-from">From</label>
-                    <input type="date" name="login_from" id="login-from">
-                </div>
-                <div class="field clearfix to half">
-                    <label for="login-to">To</label>
-                    <input type="date" name="login_to" id="login-to">
-                </div>
-            </section>
-
-            <menu class="controls">
-              <button class="button active send">Send</button>
-            </menu>
-          </form>
+                        <section class="filter-last-login clearfix">
+                            <menu class="controls">
+                                <button class="button active send">Send</button>
+                            </menu>
+                        </section>
+                    </form>
+                </section>
+                <section id="sent">
+                </section>
+            </div>
         </section>
-        <section id="sent">
-        </section>
-      </div>
-    </section>
-  </div>
+    </div>
 </section>
 {% endblock %}
 

--- a/pontoon/messaging/templates/messaging/messaging.html
+++ b/pontoon/messaging/templates/messaging/messaging.html
@@ -115,6 +115,70 @@
                 </div>
             </section>
 
+            <h3><span class="stress">#6</span> Filter by submitted translations</h3>
+            <section class="filter-translation clearfix">
+                <div class="field clearfix minimum half">
+                    <label for="translation-minimum">Minimum</label>
+                    <input type="number" min="0" name="translation_minimum" id="translation-minimum">
+                    <div class="errors">
+                        <p>The value must be an integer</p>
+                    </div>
+                </div>
+                <div class="field clearfix maximum half">
+                    <label for="translation-maximum">Maximum</label>
+                    <input type="number" min="0" name="translation_maximum" id="translation-maximum">
+                    <div class="errors">
+                        <p>The value must be an integer</p>
+                    </div>
+                </div>
+                <div class="field clearfix from half">
+                    <label for="translation-from">From</label>
+                    <input type="date" name="translation_from" id="translation-from">
+                </div>
+                <div class="field clearfix to half">
+                    <label for="translation-to">To</label>
+                    <input type="date" name="translation_to" id="translation-to">
+                </div>
+            </section>
+
+            <h3><span class="stress">#7</span> Filter by performed reviews</h3>
+            <section class="filter-review clearfix">
+                <div class="field clearfix minimum half">
+                    <label for="review-minimum">Minimum</label>
+                    <input type="number" min="0" name="review_minimum" id="review-minimum">
+                    <div class="errors">
+                        <p>The value must be an integer</p>
+                    </div>
+                </div>
+                <div class="field clearfix maximum half">
+                    <label for="review-maximum">Maximum</label>
+                    <input type="number" min="0" name="review_maximum" id="review-maximum">
+                    <div class="errors">
+                        <p>The value must be an integer</p>
+                    </div>
+                </div>
+                <div class="field clearfix from half">
+                    <label for="review-from">From</label>
+                    <input type="date" name="review_from" id="review-from">
+                </div>
+                <div class="field clearfix to half">
+                    <label for="review-to">To</label>
+                    <input type="date" name="review_to" id="review-to">
+                </div>
+            </section>
+
+            <h3><span class="stress">#8</span> Filter by last login</h3>
+            <section class="filter-last-login clearfix">
+                <div class="field clearfix from half">
+                    <label for="login-from">From</label>
+                    <input type="date" name="login_from" id="login-from">
+                </div>
+                <div class="field clearfix to half">
+                    <label for="login-to">To</label>
+                    <input type="date" name="login_to" id="login-to">
+                </div>
+            </section>
+
             <menu class="controls">
               <button class="button active send">Send</button>
             </menu>

--- a/pontoon/messaging/views.py
+++ b/pontoon/messaging/views.py
@@ -35,8 +35,6 @@ def messaging(request):
         {
             "available_locales": Locale.objects.available(),
             "available_projects": Project.objects.available().order_by("name"),
-            "today": timezone.now().date(),
-            "year_ago": timezone.now().date() - timezone.timedelta(days=365),
         },
     )
 

--- a/pontoon/messaging/views.py
+++ b/pontoon/messaging/views.py
@@ -43,16 +43,15 @@ def messaging(request):
 @require_POST
 @transaction.atomic
 def send_message(request):
-    # Send notifications
     form = forms.MessageForm(request.POST)
 
     if not form.is_valid():
         return JsonResponse(dict(form.errors.items()))
 
+    recipients = User.objects.none()
+
     locale_ids = sorted(split_ints(form.cleaned_data.get("locales")))
     project_ids = sorted(split_ints(form.cleaned_data.get("projects")))
-
-    recipients = User.objects.none()
 
     if form.cleaned_data.get("contributors"):
         contributors = (

--- a/pontoon/messaging/views.py
+++ b/pontoon/messaging/views.py
@@ -34,6 +34,8 @@ def messaging(request):
         {
             "available_locales": Locale.objects.available(),
             "available_projects": Project.objects.available().order_by("name"),
+            "today": timezone.now().date(),
+            "year_ago": timezone.now().date() - timezone.timedelta(days=365),
         },
     )
 


### PR DESCRIPTION
Fix #3244.

This is a continuation of what was started in #3314. It implements the remaining bits of the Compose screen in the Messaging Center, namely Activity filters. As mentioned in #l10n-team last Friday, Activity filters are always visible, which is not what the spec says, but it’s simpler from the UX and codebase point of view.

The diff looks bigger than the changes actually are because of a dedent in [Remove redundand condition](https://github.com/mozilla/pontoon/commit/0c6c645750a936719e6aeea3c2b2d0918137f369) and formatting of the HTML file in [Update check-box and messaging styling](https://github.com/mozilla/pontoon/commit/1203f69feaaf03bf2033434f4109e502d9a78ade). Hence, I suggest reviewing commit by commit.

Deployed to stage:
https://mozilla-pontoon-staging.herokuapp.com/messaging/