### PR TITLE
Implement filter for matching whole words

### DIFF
--- a/pontoon/base/forms.py
+++ b/pontoon/base/forms.py
@@ -301,7 +301,7 @@ class GetEntitiesForm(forms.Form):
     search_translations_only = forms.BooleanField(required=False)
     search_rejected_translations = forms.BooleanField(required=False)
     search_match_case = forms.BooleanField(required=False)
-    search_match_word = forms.BooleanField(required=False)
+    search_match_whole_word = forms.BooleanField(required=False)
     tag = forms.CharField(required=False)
     time = forms.CharField(required=False)
     author = forms.CharField(required=False)

--- a/pontoon/base/forms.py
+++ b/pontoon/base/forms.py
@@ -301,6 +301,7 @@ class GetEntitiesForm(forms.Form):
     search_translations_only = forms.BooleanField(required=False)
     search_rejected_translations = forms.BooleanField(required=False)
     search_match_case = forms.BooleanField(required=False)
+    search_match_word = forms.BooleanField(required=False)
     tag = forms.CharField(required=False)
     time = forms.CharField(required=False)
     author = forms.CharField(required=False)

--- a/pontoon/base/models/entity.py
+++ b/pontoon/base/models/entity.py
@@ -853,10 +853,10 @@ class Entity(DirtyFieldsMixin, models.Model):
                 Q() if search_rejected_translations else Q(translation__rejected=False)
             )
 
+            # Modify query based on case sensitivity filter
             i = "" if search_match_case else "i"
             y = r"\y" if search_match_whole_word else ""
 
-            # Modify query based on case sensitivity filter
             translation_filters = (
                 Q(**{f"translation__string__{i}regex": rf"{y}{s}{y}"})
                 & Q(translation__locale=locale)

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -249,6 +249,7 @@ def entities(request):
         "search_translations_only",
         "search_rejected_translations",
         "search_match_case",
+        "search_match_word",
         "time",
         "author",
         "review_time",

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -249,7 +249,7 @@ def entities(request):
         "search_translations_only",
         "search_rejected_translations",
         "search_match_case",
-        "search_match_word",
+        "search_match_whole_word",
         "time",
         "author",
         "review_time",

--- a/translate/src/api/entity.ts
+++ b/translate/src/api/entity.ts
@@ -128,7 +128,7 @@ function buildFetchPayload(
       'search_translations_only',
       'search_rejected_translations',
       'search_match_case',
-      'search_match_word',
+      'search_match_whole_word',
       'extra',
       'tag',
       'author',

--- a/translate/src/api/entity.ts
+++ b/translate/src/api/entity.ts
@@ -128,6 +128,7 @@ function buildFetchPayload(
       'search_translations_only',
       'search_rejected_translations',
       'search_match_case',
+      'search_match_word',
       'extra',
       'tag',
       'author',

--- a/translate/src/context/Location.tsx
+++ b/translate/src/context/Location.tsx
@@ -24,6 +24,7 @@ export type Location = {
   search_translations_only: boolean;
   search_rejected_translations: boolean;
   search_match_case: boolean;
+  search_match_word: boolean;
   tag: string | null;
   author: string | null;
   time: string | null;
@@ -41,6 +42,7 @@ const emptyParams = {
   search_translations_only: false,
   search_rejected_translations: false,
   search_match_case: false,
+  search_match_word: false,
   tag: null,
   author: null,
   time: null,
@@ -106,6 +108,7 @@ function parse(
           'search_rejected_translations',
         ),
         search_match_case: params.has('search_match_case'),
+        search_match_word: params.has('search_match_word'),
         tag: params.get('tag'),
         author: params.get('author'),
         time: params.get('time'),
@@ -140,6 +143,7 @@ function stringify(prev: Location, next: string | Partial<Location>) {
       'search_translations_only',
       'search_rejected_translations',
       'search_match_case',
+      'search_match_word',
       'tag',
       'author',
       'time',

--- a/translate/src/context/Location.tsx
+++ b/translate/src/context/Location.tsx
@@ -24,7 +24,7 @@ export type Location = {
   search_translations_only: boolean;
   search_rejected_translations: boolean;
   search_match_case: boolean;
-  search_match_word: boolean;
+  search_match_whole_word: boolean;
   tag: string | null;
   author: string | null;
   time: string | null;
@@ -42,7 +42,7 @@ const emptyParams = {
   search_translations_only: false,
   search_rejected_translations: false,
   search_match_case: false,
-  search_match_word: false,
+  search_match_whole_word: false,
   tag: null,
   author: null,
   time: null,
@@ -108,7 +108,7 @@ function parse(
           'search_rejected_translations',
         ),
         search_match_case: params.has('search_match_case'),
-        search_match_word: params.has('search_match_word'),
+        search_match_whole_word: params.has('search_match_whole_word'),
         tag: params.get('tag'),
         author: params.get('author'),
         time: params.get('time'),
@@ -143,7 +143,7 @@ function stringify(prev: Location, next: string | Partial<Location>) {
       'search_translations_only',
       'search_rejected_translations',
       'search_match_case',
-      'search_match_word',
+      'search_match_whole_word',
       'tag',
       'author',
       'time',

--- a/translate/src/modules/placeable/components/Highlight.tsx
+++ b/translate/src/modules/placeable/components/Highlight.tsx
@@ -184,15 +184,32 @@ export function Highlight({
         if (i === -1) {
           i = marks.length;
         }
-        marks.splice(i, 0, {
-          index: next,
-          length: term.length,
-          mark: (
-            <mark className='search' key={++keyCounter}>
-              {source.substring(next, next + term.length)}
-            </mark>
-          ),
-        });
+
+        // Lookahead by one character to see if the current mark is an exact match to the search term
+        let lookahead = source.substring(next, next + term.length + 1).trim();
+
+        // Handle when Match case and Match word are both active
+        lookahead = location.search_match_case
+          ? lookahead
+          : lookahead.toLowerCase();
+
+        // Handle any punctuation at the end of the lookahead
+        const punctuationMarks = ['.', ',', '!', '?', ';', ':'];
+        if (punctuationMarks.includes(lookahead.slice(-1))) {
+          lookahead = lookahead.slice(0, -1);
+        }
+
+        if (!location.search_match_word || lookahead == highlightTerm) {
+          marks.splice(i, 0, {
+            index: next,
+            length: term.length,
+            mark: (
+              <mark className='search' key={++keyCounter}>
+                {source.substring(next, next + term.length)}
+              </mark>
+            ),
+          });
+        }
         pos = next + term.length;
       }
     }

--- a/translate/src/modules/placeable/components/Highlight.tsx
+++ b/translate/src/modules/placeable/components/Highlight.tsx
@@ -176,7 +176,7 @@ export function Highlight({
       const highlightSource = location.search_match_case ? source : lcSource;
       let next: number;
       const regexFlags = location.search_match_case ? 'g' : 'gi';
-      const re = location.search_match_word
+      const re = location.search_match_whole_word
         ? new RegExp(`\\b${escapeRegExp(term)}\\b`, regexFlags)
         : new RegExp(`${escapeRegExp(term)}`, regexFlags);
       let match;

--- a/translate/src/modules/placeable/components/Highlight.tsx
+++ b/translate/src/modules/placeable/components/Highlight.tsx
@@ -173,44 +173,29 @@ export function Highlight({
       if (term.startsWith('"') && term.length >= 3 && term.endsWith('"')) {
         term = term.slice(1, -1);
       }
-      const highlightTerm = location.search_match_case
-        ? term
-        : term.toLowerCase();
       const highlightSource = location.search_match_case ? source : lcSource;
-      let pos = 0;
       let next: number;
-      while ((next = highlightSource.indexOf(highlightTerm, pos)) !== -1) {
+      const regexFlags = location.search_match_case ? 'g' : 'gi';
+      const re = location.search_match_word
+        ? new RegExp(`\\b${escapeRegExp(term)}\\b`, regexFlags)
+        : new RegExp(`${escapeRegExp(term)}`, regexFlags);
+      let match;
+
+      while ((match = re.exec(highlightSource)) !== null) {
+        next = match.index;
         let i = marks.findIndex((m) => m.index + m.length > next);
         if (i === -1) {
           i = marks.length;
         }
-
-        // Lookahead by one character to see if the current mark is an exact match to the search term
-        let lookahead = source.substring(next, next + term.length + 1).trim();
-
-        // Handle when Match case and Match word are both active
-        lookahead = location.search_match_case
-          ? lookahead
-          : lookahead.toLowerCase();
-
-        // Handle any punctuation at the end of the lookahead
-        const punctuationMarks = ['.', ',', '!', '?', ';', ':'];
-        if (punctuationMarks.includes(lookahead.slice(-1))) {
-          lookahead = lookahead.slice(0, -1);
-        }
-
-        if (!location.search_match_word || lookahead == highlightTerm) {
-          marks.splice(i, 0, {
-            index: next,
-            length: term.length,
-            mark: (
-              <mark className='search' key={++keyCounter}>
-                {source.substring(next, next + term.length)}
-              </mark>
-            ),
-          });
-        }
-        pos = next + term.length;
+        marks.splice(i, 0, {
+          index: next,
+          length: term.length,
+          mark: (
+            <mark className='search' key={++keyCounter}>
+              {source.substring(next, next + term.length)}
+            </mark>
+          ),
+        });
       }
     }
   }

--- a/translate/src/modules/search/components/SearchBox.tsx
+++ b/translate/src/modules/search/components/SearchBox.tsx
@@ -46,7 +46,7 @@ export type SearchType =
   | 'search_translations_only'
   | 'search_rejected_translations'
   | 'search_match_case'
-  | 'search_match_word';
+  | 'search_match_whole_word';
 
 function getTimeRangeFromURL(timeParameter: string): TimeRangeType {
   const [from, to] = timeParameter.split('-');
@@ -70,7 +70,7 @@ export type SearchState = {
   search_translations_only: boolean;
   search_rejected_translations: boolean;
   search_match_case: boolean;
-  search_match_word: boolean;
+  search_match_whole_word: boolean;
 };
 
 export type SearchAction = {
@@ -134,7 +134,7 @@ export function SearchBoxBase({
       search_translations_only: false,
       search_rejected_translations: false,
       search_match_case: false,
-      search_match_word: false,
+      search_match_whole_word: false,
     },
   );
 
@@ -167,7 +167,7 @@ export function SearchBoxBase({
       search_translations_only,
       search_rejected_translations,
       search_match_case,
-      search_match_word,
+      search_match_whole_word,
       time,
     } = parameters;
     updateSearchOptions([
@@ -185,8 +185,8 @@ export function SearchBoxBase({
         value: search_match_case,
       },
       {
-        searchOption: 'search_match_word',
-        value: search_match_word,
+        searchOption: 'search_match_whole_word',
+        value: search_match_whole_word,
       },
     ]);
     setTimeRange(time);
@@ -270,7 +270,7 @@ export function SearchBoxBase({
           search_translations_only,
           search_rejected_translations,
           search_match_case,
-          search_match_word,
+          search_match_whole_word,
         } = searchOptions;
         dispatch(resetEntities());
         parameters.push({
@@ -279,7 +279,7 @@ export function SearchBoxBase({
           search_translations_only: search_translations_only,
           search_rejected_translations: search_rejected_translations,
           search_match_case: search_match_case,
-          search_match_word: search_match_word,
+          search_match_whole_word: search_match_whole_word,
           entity: 0, // With the new results, the current entity might not be available anymore.
         });
       }),

--- a/translate/src/modules/search/components/SearchBox.tsx
+++ b/translate/src/modules/search/components/SearchBox.tsx
@@ -45,7 +45,8 @@ export type SearchType =
   | 'search_identifiers'
   | 'search_translations_only'
   | 'search_rejected_translations'
-  | 'search_match_case';
+  | 'search_match_case'
+  | 'search_match_word';
 
 function getTimeRangeFromURL(timeParameter: string): TimeRangeType {
   const [from, to] = timeParameter.split('-');
@@ -69,6 +70,7 @@ export type SearchState = {
   search_translations_only: boolean;
   search_rejected_translations: boolean;
   search_match_case: boolean;
+  search_match_word: boolean;
 };
 
 export type SearchAction = {
@@ -132,6 +134,7 @@ export function SearchBoxBase({
       search_translations_only: false,
       search_rejected_translations: false,
       search_match_case: false,
+      search_match_word: false,
     },
   );
 
@@ -164,6 +167,7 @@ export function SearchBoxBase({
       search_translations_only,
       search_rejected_translations,
       search_match_case,
+      search_match_word,
       time,
     } = parameters;
     updateSearchOptions([
@@ -179,6 +183,10 @@ export function SearchBoxBase({
       {
         searchOption: 'search_match_case',
         value: search_match_case,
+      },
+      {
+        searchOption: 'search_match_word',
+        value: search_match_word,
       },
     ]);
     setTimeRange(time);
@@ -262,6 +270,7 @@ export function SearchBoxBase({
           search_translations_only,
           search_rejected_translations,
           search_match_case,
+          search_match_word,
         } = searchOptions;
         dispatch(resetEntities());
         parameters.push({
@@ -270,6 +279,7 @@ export function SearchBoxBase({
           search_translations_only: search_translations_only,
           search_rejected_translations: search_rejected_translations,
           search_match_case: search_match_case,
+          search_match_word: search_match_word,
           entity: 0, // With the new results, the current entity might not be available anymore.
         });
       }),

--- a/translate/src/modules/search/constants.ts
+++ b/translate/src/modules/search/constants.ts
@@ -77,7 +77,7 @@ export const SEARCH_OPTIONS = [
     slug: 'search_match_case',
   },
   {
-    name: 'Match whole words',
-    slug: 'search_match_word',
+    name: 'Match whole word',
+    slug: 'search_match_whole_word',
   },
 ] as const;

--- a/translate/src/modules/search/constants.ts
+++ b/translate/src/modules/search/constants.ts
@@ -72,12 +72,12 @@ export const SEARCH_OPTIONS = [
     name: 'Search in rejected translations',
     slug: 'search_rejected_translations',
   },
-  // {
-  //   name: 'Match whole words',
-  //   slug: 'matchWords',
-  // },
   {
     name: 'Match case',
     slug: 'search_match_case',
+  },
+  {
+    name: 'Match whole words',
+    slug: 'search_match_word',
   },
 ] as const;


### PR DESCRIPTION
Fix #3225 

Added a filter to only return search results that are an exact match to the search term (case insensitive). Currently, searing for "cookie" would also return results that contain "cookies". Now, if the filter is activated, only results that exactly match "cookie".

**To reproduce results:**

Head to any string within the translate view upon running the server. Ensure the string has both a singular and plural version present in the resource (e.g. cookie and cookies). Search for the singular version using the search box on the left side, and observe how both the singular and plural versions appear in the string list (left side column).

Then, click on the magnifying glass icon on the right side of the search box. Click on the `Match whole words` option to toggle the filter, then click the `APPLY SEARCH OPTIONS` button. Observe how the results in the string list now only include the singular version.  

<img width="1431" alt="image" src="https://github.com/user-attachments/assets/0267f0fe-20cf-4407-b33f-7b6a274ee37a">

<img width="1431" alt="image" src="https://github.com/user-attachments/assets/d1b268d7-1cb8-4aa4-9808-3a53ae7faae8">
