### PR TITLE
Double curly-brackets placeholders

### DIFF
--- a/translate/src/modules/placeable/components/Highlight.test.js
+++ b/translate/src/modules/placeable/components/Highlight.test.js
@@ -285,6 +285,10 @@ describe('specific marker', () => {
     ["hello, <user name='John'>", "<user name='John'>"],
     ["hello, <user data-name='John'>", "<user data-name='John'>"],
     ['Happy <User.Birthday>!', '<User.Birthday>'],
+    // i18next interpolations
+    ['Hello, {{firstName}}', '{{firstName}}'],
+    ['You currently have {{balance, money}} on your account!', '{{balance, money}}'],
+    ['Hi {{0}}. You will now be connected to {{1}}', '{{0}}', '{{1}}'],
   ];
   for (const [source, ...exp] of tests) {
     test(source, () => {

--- a/translate/src/modules/placeable/components/Highlight.test.js
+++ b/translate/src/modules/placeable/components/Highlight.test.js
@@ -287,7 +287,10 @@ describe('specific marker', () => {
     ['Happy <User.Birthday>!', '<User.Birthday>'],
     // i18next interpolations
     ['Hello, {{firstName}}', '{{firstName}}'],
-    ['You currently have {{balance, money}} on your account!', '{{balance, money}}'],
+    [
+      'You currently have {{balance, money}} on your account!',
+      '{{balance, money}}',
+    ],
     ['Hi {{0}}. You will now be connected to {{1}}', '{{0}}', '{{1}}'],
   ];
   for (const [source, ...exp] of tests) {

--- a/translate/src/modules/placeable/components/Highlight.tsx
+++ b/translate/src/modules/placeable/components/Highlight.tsx
@@ -13,7 +13,7 @@ const placeholder = (() => {
   // HTML/XML <tags>
   const html = '<(?:(?:"[^"]*")|(?:\'[^\']*\')|[^>])*>';
   // Fluent & other similar {placeholders}
-  const curly = '{(?:(?:"[^"]*")|[^}])*}';
+  const curly = '{(?:(?:"[^"]*")|[^}])*}}?';
   // All printf-ish formats, including Python's.
   // Excludes Python's ` ` conversion flag, due to false positives -- https://github.com/mozilla/pontoon/issues/2988
   const printf =


### PR DESCRIPTION
fixes #3327 

[i18next](https://www.i18next.com/) uses `{{var}}` for it's [interpolations](https://www.i18next.com/translation-function/interpolation). The placeholder matching wasn't recognizing the 2nd closing bracket.

This has been fixed by adjusting the curly regex to `{(?:(?:"[^"]*")|[^}])*}}?` (as discussed in the chat)
<sub>https://regex101.com/r/ttFTUE/2</sub>


Additionally I've added test cases to cover this for the future


### Before
![image](https://github.com/user-attachments/assets/d2badb7e-c850-40ea-a463-93712bf63303)


## After
<img width="317" alt="image" src="https://github.com/user-attachments/assets/c3f63932-6d34-4a6d-b122-9140cd444078">