### PR TITLE
Make search panel visible on all screen widths

### DIFF
--- a/translate/src/modules/search/components/SearchPanel.css
+++ b/translate/src/modules/search/components/SearchPanel.css
@@ -26,8 +26,9 @@
     box-sizing: border-box;
     position: absolute;
     top: 44px;
+    left: 5px;
     right: 5px;
-    width: 350px;
+    min-width: 300px;
     z-index: 20;
     padding: 10px 12px;
 


### PR DESCRIPTION
The search panel could get cut-off on the left side on screen narrower than ~1400 px.