### PR TITLE
Add regex to solve .ftl search bug

### DIFF
--- a/pontoon/base/models/entity.py
+++ b/pontoon/base/models/entity.py
@@ -892,6 +892,10 @@ class Entity(DirtyFieldsMixin, models.Model):
                         ~Q(resource__format="ftl")
                         & Q(**{f"string__{i}regex": rf"{y}{s}{y}"})
                     )
+                    | Q(
+                        ~Q(resource__format="ftl")
+                        & Q(**{f"string_plural__{i}regex": rf"{r}{y}{s}{y}{o}"})
+                    )
                     | (
                         Q(**{f"key__{i}regex": rf"{y}{s}{y}"})
                         if search_identifiers

--- a/pontoon/base/models/entity.py
+++ b/pontoon/base/models/entity.py
@@ -863,7 +863,7 @@ class Entity(DirtyFieldsMixin, models.Model):
                         Q(resource__format="ftl")
                         & (
                             Q(**{f"translation__string__{i}regex": rf"=.*{y}{s}{y}.*"})
-                            if search_identifiers
+                            if not search_identifiers
                             else Q(**{f"translation__string__{i}regex": rf"{y}{s}{y}"})
                         )
                     )
@@ -896,7 +896,7 @@ class Entity(DirtyFieldsMixin, models.Model):
                         Q(resource__format="ftl")
                         & (
                             Q(**{f"string__{i}regex": rf"=.*{y}{s}{y}.*"})
-                            if search_identifiers
+                            if not search_identifiers
                             else Q(**{f"string_plural__{i}regex": rf"{y}{s}{y}"})
                         )
                     )
@@ -908,7 +908,7 @@ class Entity(DirtyFieldsMixin, models.Model):
                         Q(resource__format="ftl")
                         & (
                             Q(**{f"string_plural__{i}regex": rf"=.*{y}{s}{y}.*"})
-                            if search_identifiers
+                            if not search_identifiers
                             else Q(**{f"string_plural__{i}regex": rf"{y}{s}{y}"})
                         )
                     )

--- a/pontoon/base/models/entity.py
+++ b/pontoon/base/models/entity.py
@@ -856,16 +856,14 @@ class Entity(DirtyFieldsMixin, models.Model):
             # Modify query based on case sensitivity filter
             i = "" if search_match_case else "i"
             y = r"\y" if search_match_whole_word else ""
+            r = "" if search_identifiers else "=.*"
+            o = "" if search_identifiers else ".*"
 
             translation_filters = (
                 (
                     Q(
                         Q(resource__format="ftl")
-                        & (
-                            Q(**{f"translation__string__{i}regex": rf"=.*{y}{s}{y}.*"})
-                            if not search_identifiers
-                            else Q(**{f"translation__string__{i}regex": rf"{y}{s}{y}"})
-                        )
+                        & (Q(**{f"translation__string__{i}regex": rf"{r}{y}{s}{y}{o}"}))
                     )
                     | Q(
                         ~Q(resource__format="ftl")
@@ -894,27 +892,11 @@ class Entity(DirtyFieldsMixin, models.Model):
                 entity_filters = (
                     Q(
                         Q(resource__format="ftl")
-                        & (
-                            Q(**{f"string__{i}regex": rf"=.*{y}{s}{y}.*"})
-                            if not search_identifiers
-                            else Q(**{f"string_plural__{i}regex": rf"{y}{s}{y}"})
-                        )
+                        & (Q(**{f"string__{i}regex": rf"{r}{y}{s}{y}{o}"}))
                     )
                     | Q(
                         ~Q(resource__format="ftl")
                         & Q(**{f"string__{i}regex": rf"{y}{s}{y}"})
-                    )
-                    | Q(
-                        Q(resource__format="ftl")
-                        & (
-                            Q(**{f"string_plural__{i}regex": rf"=.*{y}{s}{y}.*"})
-                            if not search_identifiers
-                            else Q(**{f"string_plural__{i}regex": rf"{y}{s}{y}"})
-                        )
-                    )
-                    | Q(
-                        ~Q(resource__format="ftl")
-                        & Q(**{f"string_plural__{i}regex": rf"{y}{s}{y}"})
                     )
                     | q_key
                     for s in search_list

--- a/pontoon/base/models/entity.py
+++ b/pontoon/base/models/entity.py
@@ -858,7 +858,7 @@ class Entity(DirtyFieldsMixin, models.Model):
             y = r"\y" if search_match_whole_word else ""
 
             translation_filters = (
-                Q(**{f"translation__string__{i}regex": rf"{y}{s}{y}"})
+                Q(**{f"translation__string__{i}regex": rf"=.*{y}{s}{y}.*"})
                 & Q(translation__locale=locale)
                 & q_rejected
                 for s in search_list
@@ -871,19 +871,16 @@ class Entity(DirtyFieldsMixin, models.Model):
             # Search in source strings
             if not search_translations_only:
                 # Search in string (context) identifiers
-
-                q_key = Q()
-                # TODO: Uncomment the 5 lines below to reactivate the
-                #       context identifiers filter once .ftl bug is fixed (issue #3284):
-                # q_key = (
-                #     Q(**{f"key__{case_lookup}": (search)})
-                #     if search_identifiers
-                #     else Q()
-                # )
+                case_lookup = "contains" if search_match_case else "icontains"
+                q_key = (
+                    Q(**{f"key__{case_lookup}": (search)})
+                    if search_identifiers
+                    else Q()
+                )
 
                 entity_filters = (
-                    Q(**{f"string__{i}regex": rf"{y}{s}{y}"})
-                    | Q(**{f"string_plural__{i}regex": rf"{y}{s}{y}"})
+                    Q(**{f"string__{i}regex": rf"=.*{y}{s}{y}.*"})
+                    | Q(**{f"string_plural__{i}regex": rf"=.*{y}{s}{y}.*"})
                     | q_key
                     for s in search_list
                 )

--- a/pontoon/base/models/entity.py
+++ b/pontoon/base/models/entity.py
@@ -890,11 +890,10 @@ class Entity(DirtyFieldsMixin, models.Model):
                     )
                     | Q(
                         ~Q(resource__format="ftl")
-                        & Q(**{f"string__{i}regex": rf"{y}{s}{y}"})
-                    )
-                    | Q(
-                        ~Q(resource__format="ftl")
-                        & Q(**{f"string_plural__{i}regex": rf"{r}{y}{s}{y}{o}"})
+                        & (
+                            Q(**{f"string__{i}regex": rf"{y}{s}{y}"})
+                            | Q(**{f"string_plural__{i}regex": rf"{y}{s}{y}"})
+                        )
                     )
                     | (
                         Q(**{f"key__{i}regex": rf"{y}{s}{y}"})

--- a/translate/src/modules/search/components/SearchPanel.css
+++ b/translate/src/modules/search/components/SearchPanel.css
@@ -70,6 +70,11 @@
           color: var(--status-translated);
           content: '';
         }
+
+        &:hover {
+          color: var(--white-1);
+          background-color: var(--dark-grey-2);
+        }
       }
     }
   }

--- a/translate/src/modules/search/constants.ts
+++ b/translate/src/modules/search/constants.ts
@@ -61,6 +61,14 @@ export const FILTERS_EXTRA = [
 
 export const SEARCH_OPTIONS = [
   {
+    name: 'Match case',
+    slug: 'search_match_case',
+  },
+  {
+    name: 'Match whole word',
+    slug: 'search_match_whole_word',
+  },
+  {
     name: 'Search in string identifiers',
     slug: 'search_identifiers',
   },
@@ -71,13 +79,5 @@ export const SEARCH_OPTIONS = [
   {
     name: 'Search in rejected translations',
     slug: 'search_rejected_translations',
-  },
-  {
-    name: 'Match case',
-    slug: 'search_match_case',
-  },
-  {
-    name: 'Match whole word',
-    slug: 'search_match_whole_word',
   },
 ] as const;

--- a/translate/src/modules/search/constants.ts
+++ b/translate/src/modules/search/constants.ts
@@ -60,10 +60,10 @@ export const FILTERS_EXTRA = [
 ] as const;
 
 export const SEARCH_OPTIONS = [
-  // {
-  //   name: 'Search in string identifiers',
-  //   slug: 'search_identifiers',
-  // },
+  {
+    name: 'Search in string identifiers',
+    slug: 'search_identifiers',
+  },
   {
     name: 'Search in translations only',
     slug: 'search_translations_only',


### PR DESCRIPTION
Fix #3284 

This PR adds additional regex to the `entity_filters` and `translation_filters` objects to solve the `.ftl` bug stemming from how Fluent translations are stored in the backend. As such, the `exclude_identifiers` filter has been re-enabled (See #3221).

**To reproduce results**: observe how for any fluent file, the Entity.string has the format of `{key} = {value}`. 

Now, [this query](http://localhost:8000/it/firefox/browser/branding/official/brand.ftl/?search=brand) will produce no results, since "brand" is only contained within the key of each Entity. Once the `exclude_identifiers` [filter is set](http://localhost:8000/it/firefox/browser/branding/official/brand.ftl/?search=brand&search_identifiers=true&string=192265), then all the keys containing "brand" will be displayed.

<img width="1502" alt="image" src="https://github.com/user-attachments/assets/8939386e-192d-4e4b-9ea4-06a2142896e3">

<img width="1435" alt="image" src="https://github.com/user-attachments/assets/5281b919-84db-42fb-8afb-66dc1cab8d9c">
