### PR TITLE
Add i18next format support to editFieldModes

### DIFF
--- a/translate/src/modules/translationform/utils/editFieldExtensions.test.ts
+++ b/translate/src/modules/translationform/utils/editFieldExtensions.test.ts
@@ -54,3 +54,25 @@ describe('spellcheck', () => {
     expect(ph?.getAttribute('spellcheck')).toBe('false');
   });
 });
+
+describe('keyword', () => {
+  describe('common mode', () => {
+    test('i18next format', () => {
+      const view1 = tempView('{{name}} foo', 'common');
+      const nameEl = getAncestorWith(view1.domAtPos(1).node, 'dir');
+      expect(nameEl?.textContent).toBe('{{name}}');
+
+      const view2 = tempView('{{balance, money}} foo', 'common');
+      const balanceEl = getAncestorWith(view2.domAtPos(1).node, 'dir');
+      expect(balanceEl?.textContent).toBe('{{balance, money}}');
+
+      const view3 = tempView('{{num, number(minimumFractionDigits: 2)}} foo', 'common');
+      const numEl = getAncestorWith(view3.domAtPos(1).node, 'dir');
+      expect(numEl?.textContent).toBe('{{num, number(minimumFractionDigits: 2)}}');
+      
+      const view4 = tempView('{{value, formatter1, formatter2}} foo', 'common');
+      const valueEl = getAncestorWith(view4.domAtPos(1).node, 'dir');
+      expect(valueEl?.textContent).toBe('{{value, formatter1, formatter2}}');
+    });
+  })
+})

--- a/translate/src/modules/translationform/utils/editFieldExtensions.test.ts
+++ b/translate/src/modules/translationform/utils/editFieldExtensions.test.ts
@@ -66,13 +66,18 @@ describe('keyword', () => {
       const balanceEl = getAncestorWith(view2.domAtPos(1).node, 'dir');
       expect(balanceEl?.textContent).toBe('{{balance, money}}');
 
-      const view3 = tempView('{{num, number(minimumFractionDigits: 2)}} foo', 'common');
+      const view3 = tempView(
+        '{{num, number(minimumFractionDigits: 2)}} foo',
+        'common',
+      );
       const numEl = getAncestorWith(view3.domAtPos(1).node, 'dir');
-      expect(numEl?.textContent).toBe('{{num, number(minimumFractionDigits: 2)}}');
-      
+      expect(numEl?.textContent).toBe(
+        '{{num, number(minimumFractionDigits: 2)}}',
+      );
+
       const view4 = tempView('{{value, formatter1, formatter2}} foo', 'common');
       const valueEl = getAncestorWith(view4.domAtPos(1).node, 'dir');
       expect(valueEl?.textContent).toBe('{{value, formatter1, formatter2}}');
     });
-  })
-})
+  });
+});

--- a/translate/src/modules/translationform/utils/editFieldModes.ts
+++ b/translate/src/modules/translationform/utils/editFieldModes.ts
@@ -88,12 +88,15 @@ const printf =
 
 const pythonFormat = /^{[\w.[\]]*(![rsa])?(:.*?)?}/;
 
+// https://www.i18next.com/translation-function/interpolation
+const i18nextFormat = /{{\s*[\w.[\]]*\s*(?:,\s*\w+(?:\([^)]*\))?)*\s*(?:![rsa])?(?::.*?)?\s*}}/;
+
 export const commonMode: StreamParser<Array<'literal' | 'tag'>> = {
   name: 'common',
   languageData: { closeBrackets: { brackets: ['(', '[', '{', '"', '<'] } },
   startState: () => [],
   token(stream, state) {
-    if (stream.match(printf) || stream.match(pythonFormat)) {
+    if (stream.match(printf) || stream.match(pythonFormat) || stream.match(i18nextFormat)) {
       return 'keyword';
     }
 

--- a/translate/src/modules/translationform/utils/editFieldModes.ts
+++ b/translate/src/modules/translationform/utils/editFieldModes.ts
@@ -89,14 +89,19 @@ const printf =
 const pythonFormat = /^{[\w.[\]]*(![rsa])?(:.*?)?}/;
 
 // https://www.i18next.com/translation-function/interpolation
-const i18nextFormat = /{{\s*[\w.[\]]*\s*(?:,\s*\w+(?:\([^)]*\))?)*\s*(?:![rsa])?(?::.*?)?\s*}}/;
+const i18nextFormat =
+  /{{\s*[\w.[\]]*\s*(?:,\s*\w+(?:\([^)]*\))?)*\s*(?:![rsa])?(?::.*?)?\s*}}/;
 
 export const commonMode: StreamParser<Array<'literal' | 'tag'>> = {
   name: 'common',
   languageData: { closeBrackets: { brackets: ['(', '[', '{', '"', '<'] } },
   startState: () => [],
   token(stream, state) {
-    if (stream.match(printf) || stream.match(pythonFormat) || stream.match(i18nextFormat)) {
+    if (
+      stream.match(printf) ||
+      stream.match(pythonFormat) ||
+      stream.match(i18nextFormat)
+    ) {
       return 'keyword';
     }
 

--- a/translate/src/modules/translationform/utils/editFieldModes.ts
+++ b/translate/src/modules/translationform/utils/editFieldModes.ts
@@ -89,8 +89,7 @@ const printf =
 const pythonFormat = /^{[\w.[\]]*(![rsa])?(:.*?)?}/;
 
 // https://www.i18next.com/translation-function/interpolation
-const i18nextFormat =
-  /{{\s*[\w.[\]]*\s*(?:,\s*\w+(?:\([^)]*\))?)*\s*(?:![rsa])?(?::.*?)?\s*}}/;
+const i18nextFormat = /{{.*?}}/;
 
 export const commonMode: StreamParser<Array<'literal' | 'tag'>> = {
   name: 'common',


### PR DESCRIPTION
I've added highlighting support for the i18next interpolation format to the `common` mode of editFieldModes.

~~It's a quite extensive regex as there is quite some stuff you can do inside a i18next interpolation:~~
<sub>Thank you @eemeli for simplifying it</sub>

```
/{{.*?}}/
```
https://regex101.com/r/gokJ09/1


<img width="762" alt="image" src="https://github.com/user-attachments/assets/b786ef9d-62a5-4625-9648-97fe0143dc62">
