### PR TITLE
Fix Pontoon search for terms with special characters

### DIFF
--- a/pontoon/base/models/entity.py
+++ b/pontoon/base/models/entity.py
@@ -1,6 +1,6 @@
 from functools import reduce
 from operator import ior
-from re import findall, match
+from re import escape, findall, match
 
 from dirtyfields import DirtyFieldsMixin
 from jsonfield import JSONField
@@ -865,11 +865,17 @@ class Entity(DirtyFieldsMixin, models.Model):
                 (
                     Q(
                         Q(resource__format="ftl")
-                        & (Q(**{f"translation__string__{i}regex": rf"{r}{y}{s}{y}{o}"}))
+                        & (
+                            Q(
+                                **{
+                                    f"translation__string__{i}regex": rf"{r}{y}{escape(s)}{y}{o}"
+                                }
+                            )
+                        )
                     )
                     | Q(
                         ~Q(resource__format="ftl")
-                        & Q(**{f"translation__string__{i}regex": rf"{y}{s}{y}"})
+                        & Q(**{f"translation__string__{i}regex": rf"{y}{escape(s)}{y}"})
                     )
                 )
                 & Q(translation__locale=locale)
@@ -886,17 +892,17 @@ class Entity(DirtyFieldsMixin, models.Model):
                 entity_filters = (
                     Q(
                         Q(resource__format="ftl")
-                        & (Q(**{f"string__{i}regex": rf"{r}{y}{s}{y}{o}"}))
+                        & (Q(**{f"string__{i}regex": rf"{r}{y}{escape(s)}{y}{o}"}))
                     )
                     | Q(
                         ~Q(resource__format="ftl")
                         & (
-                            Q(**{f"string__{i}regex": rf"{y}{s}{y}"})
-                            | Q(**{f"string_plural__{i}regex": rf"{y}{s}{y}"})
+                            Q(**{f"string__{i}regex": rf"{y}{escape(s)}{y}"})
+                            | Q(**{f"string_plural__{i}regex": rf"{y}{escape(s)}{y}"})
                         )
                     )
                     | (
-                        Q(**{f"key__{i}regex": rf"{y}{s}{y}"})
+                        Q(**{f"key__{i}regex": rf"{y}{escape(s)}{y}"})
                         if search_identifiers
                         else Q()
                     )


### PR DESCRIPTION
Fix #3333 

Currently, Pontoon search fails if any search term contains a special character that's used in a regex pattern.

This PR surrounds all search terms with `re.escape`, which makes sure that any combination of special characters are included in the search term rather than affecting the preexisting regex pattern.

For example, this query will now work as intended: http://localhost:8000/it/sumo/all-resources/?search=%24moco_link&search_rejected_translations=true&string=222592

Additionally, the server error previously caused by this query is now fixed: http://localhost:8000/it/sumo/all-resources/?search=%28moco_link&string=222592