### PR TITLE
Add ability to search for keys within translations only

### DIFF
--- a/pontoon/base/models/entity.py
+++ b/pontoon/base/models/entity.py
@@ -889,7 +889,7 @@ class Entity(DirtyFieldsMixin, models.Model):
             # Search in source strings
             entity_filters = (
                 (
-                    Q(pk=None) # Ensures that no source strings are returned 
+                    Q(pk=None)  # Ensures that no source strings are returned
                     if search_translations_only
                     else (
                         Q(

--- a/pontoon/base/models/entity.py
+++ b/pontoon/base/models/entity.py
@@ -879,11 +879,6 @@ class Entity(DirtyFieldsMixin, models.Model):
                     if search_rejected_translations
                     else Q(translation__rejected=False)
                 )
-                | (
-                    Q(**{f"key__{i}regex": rf"{y}{escape(s)}{y}"})
-                    if search_identifiers
-                    else Q()
-                )
                 for s in search_list
             )
 
@@ -892,36 +887,43 @@ class Entity(DirtyFieldsMixin, models.Model):
             )
 
             # Search in source strings
-            if not search_translations_only:
-                entity_filters = (
-                    Q(
-                        Q(resource__format="ftl")
-                        & (Q(**{f"string__{i}regex": rf"{r}{y}{escape(s)}{y}{o}"}))
-                    )
-                    | Q(
-                        ~Q(resource__format="ftl")
-                        & (
-                            Q(**{f"string__{i}regex": rf"{y}{escape(s)}{y}"})
-                            | Q(**{f"string_plural__{i}regex": rf"{y}{escape(s)}{y}"})
+            entity_filters = (
+                (
+                    Q(pk=None)
+                    if search_translations_only
+                    else (
+                        Q(
+                            Q(resource__format="ftl")
+                            & (Q(**{f"string__{i}regex": rf"{r}{y}{escape(s)}{y}{o}"}))
+                        )
+                        | Q(
+                            ~Q(resource__format="ftl")
+                            & (
+                                Q(**{f"string__{i}regex": rf"{y}{escape(s)}{y}"})
+                                | Q(
+                                    **{
+                                        f"string_plural__{i}regex": rf"{y}{escape(s)}{y}"
+                                    }
+                                )
+                            )
                         )
                     )
-                    | (
-                        Q(**{f"key__{i}regex": rf"{y}{escape(s)}{y}"})
-                        if search_identifiers
-                        else Q()
-                    )
-                    for s in search_list
                 )
+                | (
+                    Q(**{f"key__{i}regex": rf"{y}{escape(s)}{y}"})
+                    if search_identifiers
+                    else Q()
+                )
+                for s in search_list
+            )
 
-                entity_matches = entities.filter(*entity_filters).values_list(
-                    "id", flat=True
-                )
+            entity_matches = entities.filter(*entity_filters).values_list(
+                "id", flat=True
+            )
 
-                entities = Entity.objects.filter(
-                    pk__in=set(list(translation_matches) + list(entity_matches))
-                )
-            else:
-                entities = Entity.objects.filter(pk__in=set(list(translation_matches)))
+            entities = Entity.objects.filter(
+                pk__in=set(list(translation_matches) + list(entity_matches))
+            )
 
         order_fields = ("resource__order", "order")
         if project.slug == "all-projects":

--- a/pontoon/base/models/entity.py
+++ b/pontoon/base/models/entity.py
@@ -889,7 +889,7 @@ class Entity(DirtyFieldsMixin, models.Model):
             # Search in source strings
             entity_filters = (
                 (
-                    Q(pk=None)
+                    Q(pk=None) # Ensures that no source strings are returned 
                     if search_translations_only
                     else (
                         Q(


### PR DESCRIPTION
Fix #3344 

This PR adds the `search_identifers` query to `translation_filters`, effectively allowing users to search for keys regardless of if they include source strings in their search.

Before, toggling the `Search in translations only` filter would only search within the `Translation.string` field, meaning that a user could not exclude source strings and still search within both the `key` and `Translation.string` fields.

From the filed issue, these two queries now produce the same results, as intended:

http://localhost:8000//it/firefox-for-android/all-resources/?search=mozac_browser_errorpages_redirect_loop_message&search_identifiers=true&string=196837

http://localhost:8000/it/firefox-for-android/all-resources/?search=mozac_browser_errorpages_redirect_loop_message&search_identifiers=true&search_translations_only=true&string=196837


