### PR TITLE
Tweaked search panel design

### DIFF
--- a/pontoon/base/forms.py
+++ b/pontoon/base/forms.py
@@ -298,7 +298,7 @@ class GetEntitiesForm(forms.Form):
     status = forms.CharField(required=False)
     extra = forms.CharField(required=False)
     search_identifiers = forms.BooleanField(required=False)
-    search_translations_only = forms.BooleanField(required=False)
+    search_exclude_source_strings = forms.BooleanField(required=False)
     search_rejected_translations = forms.BooleanField(required=False)
     search_match_case = forms.BooleanField(required=False)
     search_match_whole_word = forms.BooleanField(required=False)

--- a/pontoon/base/models/entity.py
+++ b/pontoon/base/models/entity.py
@@ -732,7 +732,7 @@ class Entity(DirtyFieldsMixin, models.Model):
         search=None,
         extra=None,
         search_identifiers=None,
-        search_translations_only=None,
+        search_exclude_source_strings=None,
         search_rejected_translations=None,
         search_match_case=None,
         search_match_whole_word=None,
@@ -889,8 +889,8 @@ class Entity(DirtyFieldsMixin, models.Model):
             # Search in source strings
             entity_filters = (
                 (
-                    Q(pk=None)  # Ensures that no source strings are returned
-                    if search_translations_only
+                    Q(pk__in=[])  # Ensures that no source strings are returned
+                    if search_exclude_source_strings
                     else (
                         Q(
                             Q(resource__format="ftl")

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -246,7 +246,7 @@ def entities(request):
         "search",
         "extra",
         "search_identifiers",
-        "search_translations_only",
+        "search_exclude_source_strings",
         "search_rejected_translations",
         "search_match_case",
         "search_match_whole_word",

--- a/translate/src/api/entity.ts
+++ b/translate/src/api/entity.ts
@@ -125,7 +125,7 @@ function buildFetchPayload(
       'search',
       'status',
       'search_identifiers',
-      'search_translations_only',
+      'search_exclude_source_strings',
       'search_rejected_translations',
       'search_match_case',
       'search_match_whole_word',

--- a/translate/src/context/Location.tsx
+++ b/translate/src/context/Location.tsx
@@ -21,7 +21,7 @@ export type Location = {
   status: string | null;
   extra: string | null;
   search_identifiers: boolean;
-  search_translations_only: boolean;
+  search_exclude_source_strings: boolean;
   search_rejected_translations: boolean;
   search_match_case: boolean;
   search_match_whole_word: boolean;
@@ -39,7 +39,7 @@ const emptyParams = {
   status: null,
   extra: null,
   search_identifiers: false,
-  search_translations_only: false,
+  search_exclude_source_strings: false,
   search_rejected_translations: false,
   search_match_case: false,
   search_match_whole_word: false,
@@ -103,7 +103,9 @@ function parse(
         status: params.get('status'),
         extra: params.get('extra'),
         search_identifiers: params.has('search_identifiers'),
-        search_translations_only: params.has('search_translations_only'),
+        search_exclude_source_strings: params.has(
+          'search_exclude_source_strings',
+        ),
         search_rejected_translations: params.has(
           'search_rejected_translations',
         ),
@@ -140,7 +142,7 @@ function stringify(prev: Location, next: string | Partial<Location>) {
       'status',
       'extra',
       'search_identifiers',
-      'search_translations_only',
+      'search_exclude_source_strings',
       'search_rejected_translations',
       'search_match_case',
       'search_match_whole_word',

--- a/translate/src/modules/entitieslist/components/Entity.tsx
+++ b/translate/src/modules/entitieslist/components/Entity.tsx
@@ -135,7 +135,9 @@ export function Entity({
             content={entity.original}
             format={entity.format}
             search={
-              parameters.search_translations_only ? null : parameters.search
+              parameters.search_exclude_source_strings
+                ? null
+                : parameters.search
             }
           />
         </p>

--- a/translate/src/modules/search/components/SearchBox.tsx
+++ b/translate/src/modules/search/components/SearchBox.tsx
@@ -43,7 +43,7 @@ export type FilterType = 'authors' | 'extras' | 'statuses' | 'tags';
 
 export type SearchType =
   | 'search_identifiers'
-  | 'search_translations_only'
+  | 'search_exclude_source_strings'
   | 'search_rejected_translations'
   | 'search_match_case'
   | 'search_match_whole_word';
@@ -67,7 +67,7 @@ export type FilterAction = {
 
 export type SearchState = {
   search_identifiers: boolean;
-  search_translations_only: boolean;
+  search_exclude_source_strings: boolean;
   search_rejected_translations: boolean;
   search_match_case: boolean;
   search_match_whole_word: boolean;
@@ -131,7 +131,7 @@ export function SearchBoxBase({
     },
     {
       search_identifiers: false,
-      search_translations_only: false,
+      search_exclude_source_strings: false,
       search_rejected_translations: false,
       search_match_case: false,
       search_match_whole_word: false,
@@ -164,7 +164,7 @@ export function SearchBoxBase({
   const updateOptionsFromURL = useCallback(() => {
     const {
       search_identifiers,
-      search_translations_only,
+      search_exclude_source_strings,
       search_rejected_translations,
       search_match_case,
       search_match_whole_word,
@@ -173,8 +173,8 @@ export function SearchBoxBase({
     updateSearchOptions([
       { searchOption: 'search_identifiers', value: search_identifiers },
       {
-        searchOption: 'search_translations_only',
-        value: search_translations_only,
+        searchOption: 'search_exclude_source_strings',
+        value: search_exclude_source_strings,
       },
       {
         searchOption: 'search_rejected_translations',
@@ -267,7 +267,7 @@ export function SearchBoxBase({
       checkUnsavedChanges(() => {
         const {
           search_identifiers,
-          search_translations_only,
+          search_exclude_source_strings,
           search_rejected_translations,
           search_match_case,
           search_match_whole_word,
@@ -276,7 +276,7 @@ export function SearchBoxBase({
         parameters.push({
           ...parameters, // Persist all other variables to next state
           search_identifiers: search_identifiers,
-          search_translations_only: search_translations_only,
+          search_exclude_source_strings: search_exclude_source_strings,
           search_rejected_translations: search_rejected_translations,
           search_match_case: search_match_case,
           search_match_whole_word: search_match_whole_word,

--- a/translate/src/modules/search/components/SearchPanel.css
+++ b/translate/src/modules/search/components/SearchPanel.css
@@ -56,7 +56,7 @@
         color: var(--white-1);
       }
 
-      &.option-separator {
+      &.search_identifiers {
         margin-top: 10px;
       }
 

--- a/translate/src/modules/search/components/SearchPanel.css
+++ b/translate/src/modules/search/components/SearchPanel.css
@@ -33,9 +33,8 @@
     padding: 10px 12px;
 
     & ul {
-      margin: 10px 0;
       list-style: none;
-      padding: 4px 0;
+      margin: 0;
     }
 
     & .title {
@@ -44,6 +43,7 @@
       font-size: 13px;
       font-weight: 300;
       height: auto;
+      margin: 5px 0;
     }
 
     li {
@@ -92,10 +92,13 @@
     color: var(--light-grey-7);
     font-weight: 300;
     border-radius: 3px;
+    margin-bottom: 5px;
+    margin-top: 8px;
 
     &:hover,
     .applied-count {
       color: var(--status-translated);
+      margin-top: 35px;
     }
   }
 }

--- a/translate/src/modules/search/components/SearchPanel.css
+++ b/translate/src/modules/search/components/SearchPanel.css
@@ -56,6 +56,10 @@
         color: var(--white-1);
       }
 
+      &.option-seperator {
+        margin-top: 10px;
+      }
+
       &.check-box {
         i {
           font-size: 16px;

--- a/translate/src/modules/search/components/SearchPanel.css
+++ b/translate/src/modules/search/components/SearchPanel.css
@@ -56,7 +56,7 @@
         color: var(--white-1);
       }
 
-      &.option-seperator {
+      &.option-separator {
         margin-top: 10px;
       }
 

--- a/translate/src/modules/search/components/SearchPanel.tsx
+++ b/translate/src/modules/search/components/SearchPanel.tsx
@@ -32,7 +32,7 @@ const SearchOption = ({
   onToggle: () => void;
 }) => {
   // Find the first option that doesn't have "Match" in the name, and apply top margin for visual seperation
-  const seperator = SEARCH_OPTIONS.find(
+  const separator = SEARCH_OPTIONS.find(
     (option) => !option.name.includes('Match'),
   )?.name;
 
@@ -41,7 +41,7 @@ const SearchOption = ({
       className={classNames(
         'check-box',
         selected && 'enabled',
-        name === seperator && 'option-seperator',
+        name === separator && 'option-separator',
       )}
       onClick={(ev) => {
         ev.stopPropagation();

--- a/translate/src/modules/search/components/SearchPanel.tsx
+++ b/translate/src/modules/search/components/SearchPanel.tsx
@@ -31,18 +31,9 @@ const SearchOption = ({
   selected: boolean;
   onToggle: () => void;
 }) => {
-  // Find the first option that doesn't have "Match" in the name, and apply top margin for visual seperation
-  const separator = SEARCH_OPTIONS.find(
-    (option) => !option.name.includes('Match'),
-  )?.name;
-
   return (
     <li
-      className={classNames(
-        'check-box',
-        selected && 'enabled',
-        name === separator && 'option-separator',
-      )}
+      className={classNames(`check-box ${slug}`, selected && 'enabled')}
       onClick={(ev) => {
         ev.stopPropagation();
         onToggle();

--- a/translate/src/modules/search/components/SearchPanel.tsx
+++ b/translate/src/modules/search/components/SearchPanel.tsx
@@ -31,9 +31,18 @@ const SearchOption = ({
   selected: boolean;
   onToggle: () => void;
 }) => {
+  // Find the first option that doesn't have "Match" in the name, and apply top margin for visual seperation
+  const seperator = SEARCH_OPTIONS.find(
+    (option) => !option.name.includes('Match'),
+  )?.name;
+
   return (
     <li
-      className={classNames('check-box', selected && 'enabled')}
+      className={classNames(
+        'check-box',
+        selected && 'enabled',
+        name === seperator && 'option-seperator',
+      )}
       onClick={(ev) => {
         ev.stopPropagation();
         onToggle();

--- a/translate/src/modules/search/constants.ts
+++ b/translate/src/modules/search/constants.ts
@@ -69,15 +69,15 @@ export const SEARCH_OPTIONS = [
     slug: 'search_match_whole_word',
   },
   {
-    name: 'Search in string identifiers',
+    name: 'Include string identifiers',
     slug: 'search_identifiers',
   },
   {
-    name: 'Search in translations only',
-    slug: 'search_translations_only',
+    name: 'Include rejected translations',
+    slug: 'search_rejected_translations',
   },
   {
-    name: 'Search in rejected translations',
-    slug: 'search_rejected_translations',
+    name: 'Exclude source strings',
+    slug: 'search_exclude_source_strings',
   },
 ] as const;


### PR DESCRIPTION
Fix #3345 

As per the discussion in the related issue, this PR renames the following in `translate/src/modules/search/constants.ts`:

- `search_translations_only` --> `search_exclude_source_strings`
- `Search in translations only` --> `Exclude source strings`
- `Search in string identifiers` --> `Include string identifiers`
- `Search in rejected translations` --> `Include rejected translations`

Renaming the variables was done to improve clarity and more accurately reflect how the query changes in the backend. Additionally, I've added visual separation between the 'Match' and 'Include/Exclude' filters, reflecting the difference in their behaviours.

<img width="1400" alt="image" src="https://github.com/user-attachments/assets/5e734960-530a-4cfc-b20f-454c5f262496">
