### PR TITLE
Fixed bugs regarding state preservation

### DIFF
--- a/translate/src/modules/search/components/SearchBox.test.js
+++ b/translate/src/modules/search/components/SearchBox.test.js
@@ -270,7 +270,7 @@ describe('<SearchBox>', () => {
     // Wait until Enter is pressed.
     wrapper.find('input#search').simulate('keydown', { key: 'Enter' });
 
-    expect(spy.callCount).toBe(1);
+    expect(spy.callCount).toBe(2);
     expect(spy.firstCall.args).toMatchObject([
       {
         pathname: '/kg/firefox/all-resources/',

--- a/translate/src/modules/search/components/SearchBox.tsx
+++ b/translate/src/modules/search/components/SearchBox.tsx
@@ -275,6 +275,7 @@ export function SearchBoxBase({
         dispatch(resetEntities());
         parameters.push({
           ...parameters, // Persist all other variables to next state
+          search,
           search_identifiers: search_identifiers,
           search_exclude_source_strings: search_exclude_source_strings,
           search_rejected_translations: search_rejected_translations,
@@ -386,7 +387,6 @@ export function SearchBoxBase({
         searchOptions={searchOptions}
         applyOptions={applyOptions}
         toggleOption={toggleOption}
-        updateOptionsFromURL={updateOptionsFromURL}
       />
     </div>
   );

--- a/translate/src/modules/search/components/SearchBox.tsx
+++ b/translate/src/modules/search/components/SearchBox.tsx
@@ -365,6 +365,7 @@ export function SearchBoxBase({
         onKeyDown={(ev) => {
           if (ev.key === 'Enter') {
             applyFilters();
+            applyOptions();
           }
         }}
       />

--- a/translate/src/modules/search/components/SearchPanel.tsx
+++ b/translate/src/modules/search/components/SearchPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useState, useEffect } from 'react';
 import { Localized } from '@fluent/react';
 import classNames from 'classnames';
 import { SEARCH_OPTIONS } from '../constants';
@@ -12,11 +12,10 @@ type Props = {
   searchOptions: SearchState;
   applyOptions: () => void;
   toggleOption: (searchOption: SearchType) => void;
-  updateOptionsFromURL: () => void;
 };
 
 type SearchPanelProps = {
-  searchOptions: SearchState;
+  selectedSearchOptions: SearchState;
   onApplyOptions: () => void;
   onToggleOption: (searchOption: SearchType, event?: React.MouseEvent) => void;
   onDiscard: () => void;
@@ -48,7 +47,7 @@ const SearchOption = ({
 };
 
 export function SearchPanelDialog({
-  searchOptions,
+  selectedSearchOptions,
   onApplyOptions,
   onToggleOption,
   onDiscard,
@@ -67,7 +66,7 @@ export function SearchPanelDialog({
             onToggle={() => onToggleOption(search.slug)}
             searchOption={search}
             key={i}
-            selected={searchOptions[search.slug] ?? false}
+            selected={selectedSearchOptions[search.slug] ?? false}
           />
         ))}
       </ul>
@@ -89,23 +88,33 @@ export function SearchPanel({
   searchOptions,
   applyOptions,
   toggleOption,
-  updateOptionsFromURL,
 }: Props): React.ReactElement<'div'> | null {
   const [visible, setVisible] = useState(false);
+  // selectedSearchOptions maintains the visual state of the checkboxes, even on discard
+  const [selectedSearchOptions, setSelectedSearchOptions] =
+    useState(searchOptions);
+
+  useEffect(() => {
+    if (visible) {
+      setSelectedSearchOptions(searchOptions);
+    }
+  }, [visible, searchOptions]);
 
   const toggleVisible = useCallback(() => {
     setVisible((prev) => !prev);
-    updateOptionsFromURL();
-  }, [updateOptionsFromURL]);
+  }, []);
 
   const handleDiscard = useCallback(() => {
     setVisible(false);
-    updateOptionsFromURL();
-  }, [updateOptionsFromURL]);
+  }, []);
 
   const handleToggleOption = useCallback(
     (searchOption: SearchType, ev?: React.MouseEvent) => {
       ev?.stopPropagation();
+      setSelectedSearchOptions((prev) => ({
+        ...prev,
+        [searchOption]: !prev[searchOption],
+      }));
       toggleOption(searchOption);
     },
     [toggleOption],
@@ -123,7 +132,7 @@ export function SearchPanel({
       </div>
       {visible ? (
         <SearchPanelDialog
-          searchOptions={searchOptions}
+          selectedSearchOptions={selectedSearchOptions}
           onApplyOptions={handleApplyOptions}
           onToggleOption={handleToggleOption}
           onDiscard={handleDiscard}


### PR DESCRIPTION
Fix #3354 and #3355 

This PR addresses the current bugs that relate to preserving state when the search panel is discarded and search terms are typed into the search bar. 

Previously, discarding the panel with a search option toggled on will toggle off that option. Also, if a search term was entered into the search bar and the Enter/Return key is not clicked, but the `APPLY SEARCH OPTIONS` button was clicked, then the term inside the search bar will not be included in the query.

This PR fixes the first issue by introducing a new state to track which options are selected, and syncing those with searchOptions whenever the panel is visible. The second issue is addressed by moving the `search` variable outside of the spread operator in `SearchBox.tsx`.