### PR TITLE
Check for missing Django migrations in backend test

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -46,7 +46,8 @@ jobs:
         with:
           enable-cache: true
           version: "0.4.13"
-      - run: >
+      - name: Install requirements
+        run: >
           uv pip install
           -r requirements/default.txt
           -r requirements/dev.txt
@@ -67,7 +68,12 @@ jobs:
       - run: mkdir -p tag-admin/dist translate/dist translate/public
       - run: python manage.py collectstatic
 
-      - run: pytest --cov-report=xml:pontoon/coverage.xml --cov=.
+      # Check if there are missing migrations
+      - name: Verify missing migrations
+        run: python manage.py makemigrations --check
+
+      - name: Run tests
+        run: pytest --cov-report=xml:pontoon/coverage.xml --cov=.
       - uses: codecov/codecov-action@v4
         with:
           flags: backend


### PR DESCRIPTION
This should fix #2240 

`makemigrations --check` [doesn't create new migration files since 4.2](https://docs.djangoproject.com/en/5.1/releases/4.2/#miscellaneous), and returns 1 when there's a migration pending.