### PR TITLE
Update reactour to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6673,9 +6673,9 @@
       "dev": true
     },
     "node_modules/focus-lock": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.9.2.tgz",
-      "integrity": "sha512-YtHxjX7a0IC0ZACL5wsX8QdncXofWpGPNoVMuI/nZUrPGp6LmNI6+D5j0pPj+v8Kw5EpweA+T5yImK0rnWf7oQ==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.3.5.tgz",
+      "integrity": "sha512-QFaHbhv9WPUeLYBDe/PAuLKJ4Dd9OPvKs9xZBr3yLXnUrDNaVXKu2baDBXe3naPY30hgHYSsf2JW4jzas2mDEQ==",
       "dependencies": {
         "tslib": "^2.0.3"
       },
@@ -10183,11 +10183,6 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
-    "node_modules/lodash.pick": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha512-hXt6Ul/5yWjfklSGvLQl8vM//l3FtyHZeuelpzK6mm99pNvN9yTDruNZPEJZD1oWrqo+izBmB7oUfWgcCX7s4Q=="
-    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -11109,19 +11104,25 @@
       }
     },
     "node_modules/react-focus-lock": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.5.2.tgz",
-      "integrity": "sha512-WzpdOnEqjf+/A3EH9opMZWauag7gV0BxFl+EY4ElA4qFqYsUsBLnmo2sELbN5OC30S16GAWMy16B9DLPpdJKAQ==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.13.2.tgz",
+      "integrity": "sha512-T/7bsofxYqnod2xadvuwjGKHOoL5GH7/EIPI5UyEvaU/c2CcphvGI371opFtuY/SYdbMsNiuF4HsHQ50nA/TKQ==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
-        "focus-lock": "^0.9.1",
+        "focus-lock": "^1.3.5",
         "prop-types": "^15.6.2",
-        "react-clientside-effect": "^1.2.5",
-        "use-callback-ref": "^1.2.5",
-        "use-sidecar": "^1.0.5"
+        "react-clientside-effect": "^1.2.6",
+        "use-callback-ref": "^1.3.2",
+        "use-sidecar": "^1.1.2"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0"
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-infinite-scroll-hook": {
@@ -11262,17 +11263,16 @@
       }
     },
     "node_modules/reactour": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/reactour/-/reactour-1.19.0.tgz",
-      "integrity": "sha512-KHWX46yRXgQX1iD+cS/qI33VYH5jFgZeRxXIk4yJyIAGsTrDTwPeFFa6m7Pv+WX/CoEfggGfdSi2LPAkkuOkOg==",
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/reactour/-/reactour-1.19.4.tgz",
+      "integrity": "sha512-cMIaUQazGkdXt03m7AXAYXrCdyQl+uvH4nQBGP/oEjIaeSTZqj92C3W3y6doPakIIu21WeoGh1b0hBRKOxIViA==",
       "dependencies": {
         "@rooks/use-mutation-observer": "4.11.2",
         "classnames": "2.3.1",
         "focus-outline-manager": "^1.0.2",
         "lodash.debounce": "4.0.8",
-        "lodash.pick": "4.4.0",
         "prop-types": "15.7.2",
-        "react-focus-lock": "2.5.2",
+        "react-focus-lock": "^2.12.1",
         "scroll-smooth": "1.1.1",
         "scrollparent": "2.0.1"
       },
@@ -12612,9 +12612,9 @@
       }
     },
     "node_modules/use-callback-ref": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
-      "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.2.tgz",
+      "integrity": "sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==",
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -13055,7 +13055,7 @@
         "react-redux": "^7.2.6",
         "react-tabs": "^3.0.0",
         "react-time-ago": "^7.1.3",
-        "reactour": "^1.15.1",
+        "reactour": "^1.19.4",
         "redux": "^4.1.1",
         "redux-thunk": "^2.3.0",
         "slate": "^0.78.0",

--- a/translate/package.json
+++ b/translate/package.json
@@ -34,7 +34,7 @@
     "react-redux": "^7.2.6",
     "react-tabs": "^3.0.0",
     "react-time-ago": "^7.1.3",
-    "reactour": "^1.15.1",
+    "reactour": "^1.19.4",
     "redux": "^4.1.1",
     "redux-thunk": "^2.3.0",
     "slate": "^0.78.0",


### PR DESCRIPTION
The important bit here is the removal of (the outdated version of) `lodash.pick`.

Deployed to stage.