### PR TITLE
Update Python coverage config file, fix warning

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,7 @@
-[coverage:run]
+[run]
 omit =
     setup.py
     *migrations*
-include =
+source =
     *pontoon*
     *tests*


### PR DESCRIPTION
Using specific coverage file instead of setup.cfg, fixed warning in `make pytest` (`CoverageWarning: --include is ignored because --source is set (include-ignored)`).