### PR TITLE
Fix broken links in docs, remove Windows Home section for docker

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -353,7 +353,7 @@ Put your tests in the ``tests/`` directory of the appropriate app in
 Mock usage
 ----------
 
-`Mock <http://www.voidspace.org.uk/python/mock/>`_ is a python library for mocks
+`Mock <https://docs.python.org/dev/library/unittest.mock.html>`_ is a python library for mocks
 objects. This allows us to write isolated tests by simulating services besides
 using the real ones. Best examples are existing tests which admittedly do mocking
 different depending on the context.

--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -202,7 +202,7 @@ you create:
    New Relic.
 
 ``OPENAI_API_KEY``
-   Optional. Set your `OpenAI API`_ key to add the ability to refine machine
+   Optional. Set your `OpenAI API` key to add the ability to refine machine
    translations using ChatGPT.
 
 ``PROJECT_MANAGERS``
@@ -281,7 +281,7 @@ you create:
    The default value is 3600 seconds (1 hour).
 
 ``SYSTRAN_TRANSLATE_API_KEY``
-   Optional. Set your `SYSTRAN Translate API key`_ to use machine translation
+   Optional. Set your `SYSTRAN Translate API key` to use machine translation
    by SYSTRAN.
 
 ``TZ``
@@ -444,6 +444,7 @@ these pages often hit the cold cache. We use this job to refresh data in the
 cache every day, because it changes often. The command is designed to run daily.
 
 .. code-block:: bash
+
    ./manage.py warmup_cache
 
 Clearing the session store

--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -4,7 +4,7 @@ Deployment
 Pontoon is designed to be deployed on Heroku. To deploy an instance of Pontoon
 on Heroku, you must first create an app on your Heroku dashboard. The steps
 below assume you've already created an app and have installed the
-`Heroku Toolbelt`_.
+`Heroku CLI`_.
 
 For quick and easy deployment without leaving your web browser, click this button:
 
@@ -14,7 +14,7 @@ For quick and easy deployment without leaving your web browser, click this butto
       <img src="https://www.herokucdn.com/deploy/button.svg">
    </a>
 
-.. _Heroku Toolbelt: https://toolbelt.heroku.com/
+.. _Heroku CLI: https://devcenter.heroku.com/articles/heroku-cli
 
 Buildpack
 ---------
@@ -369,7 +369,7 @@ RabbitMQ add-on:
    Again, you must attach the resource for RabbitMQ as ``RABBITMQ``. See the
    note in the Cache Add-ons section for details.
 
-.. _BROKER_URL: http://celery.readthedocs.io/en/latest/configuration.html#broker-url
+.. _BROKER_URL: https://docs.celeryq.dev/en/stable/userguide/configuration.html#broker-url
 
 Scheduled Jobs
 --------------

--- a/docs/dev/setup.rst
+++ b/docs/dev/setup.rst
@@ -81,7 +81,7 @@ And with that, you're ready to start :doc:`contributing`!
 Installing Docker on Windows Pro/Enterprise/Education
 -----------------------------------------------------
 
-Install `Docker Desktop for Windows <https://docs.docker.com/docker-for-windows/install/>`_.
+Install `Docker Desktop for Windows <https://docs.docker.com/desktop/install/windows-install/>`_.
 
 Install tools (git, make, cygwin)
 +++++++++++++++++++++++++++++++++
@@ -111,54 +111,3 @@ At this point, you can open the *Cygwin64 Terminal* and proceed with the
 installation (the content of ``C:`` will be available in ``/cygdrive/c``). Once
 the Docker image is running, Pontoon's instance will be available at
 `http://localhost:8000`.
-
-
-Installing Docker on Windows Home x64 (deprecated)
---------------------------------------------------
-
-These instructions rely on the installation of a deprecated tool called `Docker
-Toolbox <https://docs.docker.com/toolbox/toolbox_install_windows/>`_, since the
-official installer (Docker Desktop for Windows) is only compatible with Windows
-Pro, Enterprise, or Education.
-
-Once installed, it will create a *Docker Quickstart Terminal* icon on the
-Desktop that can be used to start a terminal.
-
-While ``git`` is installed as part of Docker Toolbox, you need to disable the
-config ``core.autocrlf`` before cloning the Pontoon repository, otherwise all
-files will use Windows line-endings (CRLF), and docker images will fail to
-build. To do so, open a Powershell as Admin (right click on the Start Menu,
-select *Windows Powershell (Admin)*), and run::
-
-   git config --system --unset core.autocrlf
-   git config --global core.autocrlf false
-
-Install make
-++++++++++++
-
-The easiest way is to use a package manager like `Chocolatey
-<https://chocolatey.org/install>`_. Follow the installation instructions for
-Windows Powershell (Admin), then run ``choco install make`` to install
-``make``.
-
-Follow the prompt requests allowing script execution. At the end, verify that
-make is available with ``make --version``, it should return a version (e.g. GNU
-Make 4.2.1)
-
-Repository Path and SITE_URL
-++++++++++++++++++++++++++++
-
-Make sure to clone the repository in a path where the user has write
-permissions. The procedure has been tested with the clone inside the user's
-home (``c:\Users\username``). Otherwise, the image might fail to load the
-correct volumes.
-
-Since Pontoon will be running inside a VirtualBox machine, in order to access
-Pontoon the Docker image needs to be build with a ``SITE_URL`` using the IP of
-the machine.
-
-The IP of the virtual machine is displayed when starting *Docker Quickstart
-Terminal*, or can be retrieved using the command `docker-machine ip default`.
-For example, if the IP is ``192.168.99.100``, the Docker image should be built
-with ``make build SITE_URL="http://192.168.99.100:8000"``. Pontoon's instance
-will be then available at ``http://192.168.99.100:8000`` from Windows.


### PR DESCRIPTION
Docker Toolbox is deprecated (and so are Windows 7–8): https://github.com/docker-archive/toolbox

