### PR TITLE
Added backend logic to award badges

### DIFF
--- a/pontoon/base/forms.py
+++ b/pontoon/base/forms.py
@@ -100,6 +100,15 @@ class UserPermissionLogFormMixin:
         if users:
             group.user_set.add(*users)
 
+        badge_thresholds = [1, 2, 5]
+        for level, threshold in enumerate(badge_thresholds, start=1):
+            if (
+                self.user.profile.community_builder_level < level
+                and len(self.user.badges_promoted_users) >= threshold
+            ):
+                self.user.profile.community_builder_level = level
+                # TODO: Send a notification to the user
+
         log_group_members(self.user, group, (add_users, remove_users))
 
 

--- a/pontoon/translations/views.py
+++ b/pontoon/translations/views.py
@@ -169,6 +169,16 @@ def create_translation(request):
                 description=desc,
             )
 
+    # Update Translation Champion Badge stats
+    badge_thresholds = [5, 50, 250, 1000]
+    for level, threshold in enumerate(badge_thresholds, start=1):
+        if (
+            user.profile.translation_champion_level < level
+            and len(user.badges_translations_count) >= threshold
+        ):
+            user.profile.translation_champion_level = level
+            # TODO: Send a notification to the user
+
     return JsonResponse(
         {
             "status": True,
@@ -309,6 +319,16 @@ def approve_translation(request):
         plural_form=translation.plural_form,
     )
 
+    # Update Review Master Badge stats
+    badge_thresholds = [5, 50, 250, 1000]
+    for level, threshold in enumerate(badge_thresholds, start=1):
+        if (
+            user.profile.review_master_level < level
+            and len(user.badges_reviewed_translations) >= threshold
+        ):
+            user.profile.review_master_level = level
+            # TODO: Send a notification to the user
+
     return JsonResponse(
         {
             "translation": active_translation.serialize(),
@@ -438,6 +458,17 @@ def reject_translation(request):
         locale=locale,
         plural_form=translation.plural_form,
     )
+
+    # Update Review Master Badge stats
+    user = request.user
+    badge_thresholds = [5, 50, 250, 1000]
+    for level, threshold in enumerate(badge_thresholds, start=1):
+        if (
+            user.profile.review_master_level < level
+            and len(user.badges_reviewed_translations) >= threshold
+        ):
+            user.profile.review_master_level = level
+            # TODO: Send a notification to the user
 
     return JsonResponse(
         {


### PR DESCRIPTION
Fix #3396 

This PR adds the relevant stat tracking needed to award badges based on the criteria defined in the [specification](https://github.com/mozilla/pontoon/blob/3b840b967932e898b4ed398f7c7ea3d847106dd2/specs/0119-gamification-badges.md#feature-explanation). If these criteria are met, the relevant badge field in `pontoon/base/models/user_profile.py` is updated to reflect the user's new badge level.

Currently, I've only began tracking activity on or after today's date (October 16 2024), but in the future, this will be changed to the date of the official badges release in Pontoon. I've also held off on creating tests within the initial commit in case adjustments need to be made.

**To reproduce results**: Badges are awarded when users either submit translations, review translations, or promote users. Submitting and reviewing translations are all done in the `translate` view, so adding `print(user.profile.[BADGE TYPE])` statements before and after the updating logic in `pontoon/translations/views.py` should indicate if a badge was successfully awarded.

Similarly, for promoting users, head to the `{locale}/permissions` page for any team (with admin permissions) and observe how promoting users updates the fields using print statements in `pontoon/base/forms.py::assign_users_to_groups`.

Alternatively, the Django admin panel should also serve as an easy way to observe the changes in the `user_profile` fields.

