### PR TITLE
Improve `make shell`, add instructions for SSH in Docker

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -75,6 +75,8 @@ you can start an interactive shell inside a Pontoon container:
 
     $ make shell
 
+`make shell-root` is also available to log in as `root`, instead of the
+default `pontoon` user.
 
 Browser Support
 ===============

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -29,6 +29,38 @@ If you're not familiar with `Docker <https://docs.docker.com/>`_ and
 `docker-compose <https://docs.docker.com/compose/overview/>`_, it's worth
 reading up on.
 
+Writing to external repositories
+--------------------------------
+
+:doc:`Environment variables <../admin/deployment>` like ``SSH_KEY`` and ``SSH_CONFIG``
+have no effect in a Docker setup.
+
+The `~/.ssh` folder of the host system is mapped automatically to the home
+folder within the container. In order to connect to a remote repository via SSH,
+you need to create a passwordless SSH key, and configure `~/.ssh/config`
+accordingly.
+
+Here's an example for GitHub, assuming the private key file is called
+`id_ed25519` (see also `GitHub's instructions
+<https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account>`_
+to generate a new key):
+
+.. code-block::
+
+   Host github.com
+      User YOUR_USERNAME
+      IdentityFile ~/.ssh/id_ed25519
+      StrictHostKeyChecking no
+
+The project's repository will use the format
+``git@github.com:{ORGANIZATION}/{REPOSITORY}.git`` for the ``URL`` field.
+
+An alternative approach for GitHub is to use a `Personal Access Token (PAT)
+<https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens>`_,
+and set up the project's ``URL`` as `https://` instead of `git@`. In this case,
+the ``URL`` will need to include both the PAT and username, e.g.
+``https://{USER}:{TOKEN}@github.com/{REPOSITORY}``.
+
 
 JavaScript setup
 ================

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ shell:
   		echo "Error: No container found based on local/pontoon" >&2; \
   		exit 1; \
 	else \
-  		${DOCKER} exec -it $$container /bin/bash; \
+  		DOCKER_CLI_HINTS="false" ${DOCKER} exec -it $$container /bin/bash; \
 	fi
 
 shell-root:
@@ -92,7 +92,7 @@ shell-root:
   		echo "Error: No container found based on local/pontoon" >&2; \
   		exit 1; \
 	else \
-  		${DOCKER} exec -u 0 -it $$container /bin/bash; \
+  		DOCKER_CLI_HINTS="false" ${DOCKER} exec -u 0 -it $$container /bin/bash; \
 	fi
 
 ci: test lint

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ help:
 	@echo "  setup            Configures a local instance after a fresh build"
 	@echo "  run              Runs the whole stack, served on http://localhost:8000/"
 	@echo "  clean            Forces a rebuild of docker containers"
-	@echo "  shell            Opens a Bash shell in a server docker container"
+	@echo "  shell            Opens a Bash shell in the server docker container"
+	@echo "  shell-root       Opens a Bash shell as root in the server docker container"
 	@echo "  ci               Test and lint all code"
 	@echo "  test             Runs all test suites"
 	@echo "  test-translate   Runs the translate frontend test suite (Jest)"
@@ -77,7 +78,22 @@ clean:
 	rm -rf translate/dist .server-build
 
 shell:
-	"${DC}" run --rm server //bin/bash
+	@container=$$(${DOCKER} ps -q --filter ancestor=local/pontoon | head -n 1); \
+	if [ -z "$$container" ]; then \
+  		echo "Error: No container found based on local/pontoon" >&2; \
+  		exit 1; \
+	else \
+  		${DOCKER} exec -it $$container /bin/bash; \
+	fi
+
+shell-root:
+	@container=$$(${DOCKER} ps -q --filter ancestor=local/pontoon | head -n 1); \
+	if [ -z "$$container" ]; then \
+  		echo "Error: No container found based on local/pontoon" >&2; \
+  		exit 1; \
+	else \
+  		${DOCKER} exec -u 0 -it $$container /bin/bash; \
+	fi
 
 ci: test lint
 

--- a/docs/dev/setup.rst
+++ b/docs/dev/setup.rst
@@ -77,6 +77,37 @@ The app should now be available at http://localhost:8000 or the custom SITE_URL.
 
 And with that, you're ready to start :doc:`contributing`!
 
+Writing to external repositories
+++++++++++++++++++++++++++++++++
+
+:doc:`Environment variables <../admin/deployment>` like ``SSH_KEY`` and ``SSH_CONFIG``
+have no effect in a Docker setup.
+
+The `~/.ssh` folder of the host system is mapped automatically to the home
+folder within the container. In order to connect to a remote repository via SSH,
+you need to create a passwordless SSH key, and configure `~/.ssh/config`
+accordingly.
+
+Here's an example for GitHub, assuming the private key file is called
+`id_ed25519` (see also `GitHub's instructions
+<https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account>`_
+to generate a new key):
+
+.. code-block::
+
+   Host github.com
+      User YOUR_USERNAME
+      IdentityFile ~/.ssh/id_ed25519
+      StrictHostKeyChecking no
+
+The project's repository will use the format
+``git@github.com:{ORGANIZATION}/{REPOSITORY}.git`` for the ``URL`` field.
+
+An alternative approach for GitHub is to use a `Personal Access Token (PAT)
+<https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens>`_,
+and set up the project's ``URL`` as `https://` instead of `git@`. In this case,
+the ``URL`` will need to include both the PAT and username, e.g.
+``https://{USER}:{TOKEN}@github.com/{REPOSITORY}``.
 
 Installing Docker on Windows Pro/Enterprise/Education
 -----------------------------------------------------

--- a/docs/dev/setup.rst
+++ b/docs/dev/setup.rst
@@ -77,38 +77,6 @@ The app should now be available at http://localhost:8000 or the custom SITE_URL.
 
 And with that, you're ready to start :doc:`contributing`!
 
-Writing to external repositories
-++++++++++++++++++++++++++++++++
-
-:doc:`Environment variables <../admin/deployment>` like ``SSH_KEY`` and ``SSH_CONFIG``
-have no effect in a Docker setup.
-
-The `~/.ssh` folder of the host system is mapped automatically to the home
-folder within the container. In order to connect to a remote repository via SSH,
-you need to create a passwordless SSH key, and configure `~/.ssh/config`
-accordingly.
-
-Here's an example for GitHub, assuming the private key file is called
-`id_ed25519` (see also `GitHub's instructions
-<https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account>`_
-to generate a new key):
-
-.. code-block::
-
-   Host github.com
-      User YOUR_USERNAME
-      IdentityFile ~/.ssh/id_ed25519
-      StrictHostKeyChecking no
-
-The project's repository will use the format
-``git@github.com:{ORGANIZATION}/{REPOSITORY}.git`` for the ``URL`` field.
-
-An alternative approach for GitHub is to use a `Personal Access Token (PAT)
-<https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens>`_,
-and set up the project's ``URL`` as `https://` instead of `git@`. In this case,
-the ``URL`` will need to include both the PAT and username, e.g.
-``https://{USER}:{TOKEN}@github.com/{REPOSITORY}``.
-
 Installing Docker on Windows Pro/Enterprise/Education
 -----------------------------------------------------
 

--- a/docs/dev/setup.rst
+++ b/docs/dev/setup.rst
@@ -77,6 +77,7 @@ The app should now be available at http://localhost:8000 or the custom SITE_URL.
 
 And with that, you're ready to start :doc:`contributing`!
 
+
 Installing Docker on Windows Pro/Enterprise/Education
 -----------------------------------------------------
 


### PR DESCRIPTION
Currently, `make shell` spins up a brand-new container, which is not particularly useful. Also added a `make shell-root` option to connect as root.