### PR TITLE
Release Messaging center

### DIFF
--- a/pontoon/base/templates/header.html
+++ b/pontoon/base/templates/header.html
@@ -19,6 +19,9 @@
         <li><a href="{{ url('pontoon.teams') }}">Teams</a></li>
         <li><a href="{{ url('pontoon.projects') }}">Projects</a></li>
         <li><a href="{{ url('pontoon.contributors') }}">Contributors</a></li>
+        {% if user.is_authenticated and user.is_superuser %}
+        <li><a href="{{ url('pontoon.messaging.compose') }}">Messaging</a></li>
+        {% endif %}
         <li><a href="{{ url('pontoon.machinery') }}">Machinery</a></li>
       </ul>
 

--- a/pontoon/messaging/forms.py
+++ b/pontoon/messaging/forms.py
@@ -11,6 +11,12 @@ class MessageForm(forms.ModelForm):
     body = HtmlField()
     send_to_myself = forms.BooleanField(required=False)
 
+    recipient_ids = forms.CharField(
+        required=False,
+        widget=forms.Textarea(),
+        validators=[validators.validate_comma_separated_integer_list],
+    )
+
     locales = forms.CharField(
         widget=forms.Textarea(),
         validators=[validators.validate_comma_separated_integer_list],
@@ -19,6 +25,7 @@ class MessageForm(forms.ModelForm):
     class Meta:
         model = Message
         fields = [
+            "recipient_ids",
             "notification",
             "email",
             "transactional",

--- a/pontoon/messaging/static/css/messaging.css
+++ b/pontoon/messaging/static/css/messaging.css
@@ -181,8 +181,8 @@
     }
 
     .recipients {
-      > div:not(:last-child) {
-        margin-bottom: 20px;
+      > div {
+        margin-top: 20px;
       }
 
       h5 {

--- a/pontoon/messaging/static/css/messaging.css
+++ b/pontoon/messaging/static/css/messaging.css
@@ -29,6 +29,24 @@
       color: inherit;
     }
 
+    .button.fetching {
+      pointer-events: none;
+      .fa-spin {
+        font-size: 16px;
+      }
+    }
+
+    .button.error {
+      display: none;
+      background-color: var(--status-error);
+      color: var(--translation-main-button-color);
+    }
+
+    .button.active {
+      display: none;
+      width: auto;
+    }
+
     .right {
       float: right;
 

--- a/pontoon/messaging/static/css/messaging.css
+++ b/pontoon/messaging/static/css/messaging.css
@@ -144,6 +144,7 @@
     }
 
     input#id_send_to_myself,
+    textarea#id_recipient_ids,
     textarea#id_body {
       display: none;
     }

--- a/pontoon/messaging/static/css/messaging.css
+++ b/pontoon/messaging/static/css/messaging.css
@@ -210,14 +210,14 @@
       text-align: center;
 
       .icon {
-        color: var(--light-grey-1);
+        color: var(--background-hover-2);
         font-size: 100px;
       }
 
       .title {
-        color: var(--light-grey-6);
-        font-size: 20px;
-        font-weight: 100;
+        color: var(--light-grey-7);
+        font-size: 18px;
+        font-weight: bold;
       }
     }
 

--- a/pontoon/messaging/static/css/messaging.css
+++ b/pontoon/messaging/static/css/messaging.css
@@ -36,7 +36,7 @@
       }
     }
 
-    .button.error {
+    .button.fetch-again {
       display: none;
       background-color: var(--status-error);
       color: var(--translation-main-button-color);

--- a/pontoon/messaging/static/css/messaging.css
+++ b/pontoon/messaging/static/css/messaging.css
@@ -23,6 +23,9 @@
       .fa-chevron-right {
         margin-left: 5px;
       }
+      .fa-spin {
+        font-size: 16px;
+      }
     }
 
     .button:hover {
@@ -31,9 +34,6 @@
 
     .button.fetching {
       pointer-events: none;
-      .fa-spin {
-        font-size: 16px;
-      }
     }
 
     .button.fetch-again {
@@ -45,6 +45,17 @@
     .button.active {
       display: none;
       width: auto;
+
+      .fa-spin {
+        display: none;
+      }
+    }
+
+    .button.active.sending {
+      pointer-events: none;
+      .fa-spin {
+        display: inline;
+      }
     }
 
     .right {

--- a/pontoon/messaging/static/css/messaging.css
+++ b/pontoon/messaging/static/css/messaging.css
@@ -51,6 +51,10 @@
       }
     }
 
+    .button.disabled {
+      pointer-events: none;
+    }
+
     .button.active.sending {
       pointer-events: none;
       .fa-spin {

--- a/pontoon/messaging/static/js/messaging.js
+++ b/pontoon/messaging/static/js/messaging.js
@@ -74,6 +74,30 @@ $(function () {
     );
   }
 
+  function fetchRecipients() {
+    $('#review .controls .fetching').show();
+    $('#review .controls .fetch-again').hide();
+    $('#review .controls .send.active').hide().find('.value').html('');
+
+    $.ajax({
+      url: '/messaging/ajax/fetch-recipients/',
+      type: 'POST',
+      data: $('#send-message').serialize(),
+      success: function (data) {
+        const count = nf.format(data.recipients.length);
+        $('#review .controls .send.active').show().find('.value').html(count);
+        $('#compose [name=recipient_ids]').val(data.recipients);
+      },
+      error: function () {
+        Pontoon.endLoader('Fetching recipients failed.', 'error');
+        $('#review .controls .fetch-again').show();
+      },
+      complete: function () {
+        $('#review .controls .fetching').hide();
+      },
+    });
+  }
+
   function updateReviewPanel() {
     function updateMultipleItemSelector(source, target, item) {
       const allProjects = !$(`${source}.available li:not(.no-match)`).length;
@@ -116,27 +140,7 @@ $(function () {
     const html = converter.makeHtml(bodyValue);
     $('#compose [name=body]').val(html);
 
-    // Fetch recipients
-    $('#review .controls .fetching').show();
-    $('#review .controls .error').hide();
-    $('#review .controls .send.active').hide().find('.value').html('');
-
-    $.ajax({
-      url: '/messaging/ajax/fetch-recipients/',
-      type: 'POST',
-      data: $('#send-message').serialize(),
-      success: function (data) {
-        const count = nf.format(data.recipients.length);
-        $('#review .controls .send.active').show().find('.value').html(count);
-        $('#compose [name=recipient_ids]').val(data.recipients);
-      },
-      error: function () {
-        $('#review .controls .error').show();
-      },
-      complete: function () {
-        $('#review .controls .fetching').hide();
-      },
-    });
+    fetchRecipients();
 
     // Subject
     $('#review .subject .value').html($('#id_subject').val());
@@ -312,6 +316,12 @@ $(function () {
 
     // Scroll to the top
     window.scrollTo(0, 0);
+  });
+
+  // Fetch recipients again
+  container.on('click', '.controls .fetch-again', function (e) {
+    e.preventDefault();
+    fetchRecipients();
   });
 
   // Send message

--- a/pontoon/messaging/static/js/messaging.js
+++ b/pontoon/messaging/static/js/messaging.js
@@ -349,7 +349,11 @@ $(function () {
       success: function () {
         Pontoon.endLoader('Message sent.');
         if (!sendToMyself) {
-          container.find('.left-column .sent a').click();
+          const count = container.find('.left-column .sent .count');
+          // Update count in the menu
+          count.html(parseInt(count.html(), 10) + 1);
+          // Load Sent panel
+          count.parents('a').click();
         }
       },
       error: function () {

--- a/pontoon/messaging/static/js/messaging.js
+++ b/pontoon/messaging/static/js/messaging.js
@@ -131,7 +131,12 @@ $(function () {
             let value = $(this).find('input').val().trim();
             if (value) {
               if (className === 'date') {
-                value = new Date(value).toLocaleDateString();
+                // Convert date to the format used in the input field
+                // and set timezone to UTC to prevent shifts by a day
+                // when using the local timezone.
+                value = new Date(value).toLocaleDateString(undefined, {
+                  timeZone: 'UTC',
+                });
               }
               values.push(`${label}: ${value}`);
               show = true;

--- a/pontoon/messaging/static/js/messaging.js
+++ b/pontoon/messaging/static/js/messaging.js
@@ -123,6 +123,7 @@ $(function () {
       success: function (data) {
         const count = nf.format(data.recipients.length);
         $('#review .controls .send.active').show().find('.value').html(count);
+        $('#compose [name=recipient_ids]').val(data.recipients);
       },
       error: function () {
         $('#review .controls .error').show();

--- a/pontoon/messaging/static/js/messaging.js
+++ b/pontoon/messaging/static/js/messaging.js
@@ -77,7 +77,11 @@ $(function () {
   function fetchRecipients() {
     $('#review .controls .fetching').show();
     $('#review .controls .fetch-again').hide();
-    $('#review .controls .send.active').hide().find('.value').html('');
+    $('#review .controls .send.active')
+      .hide()
+      .removeClass('disabled')
+      .find('.value')
+      .html('');
 
     $.ajax({
       url: '/messaging/ajax/fetch-recipients/',
@@ -85,7 +89,11 @@ $(function () {
       data: $('#send-message').serialize(),
       success: function (data) {
         const count = nf.format(data.recipients.length);
-        $('#review .controls .send.active').show().find('.value').html(count);
+        $('#review .controls .send.active')
+          .show()
+          .addClass('disabled', count === 0)
+          .find('.value')
+          .html(count);
         $('#compose [name=recipient_ids]').val(data.recipients);
       },
       error: function () {

--- a/pontoon/messaging/static/js/messaging.js
+++ b/pontoon/messaging/static/js/messaging.js
@@ -111,6 +111,11 @@ $(function () {
       $(`#review .${filter}`).toggle(show);
     }
 
+    // Update hidden textarea with the HTML content to be sent to backend
+    const bodyValue = $('#body').val();
+    const html = converter.makeHtml(bodyValue);
+    $('#compose [name=body]').val(html);
+
     // Fetch recipients
     $('#review .controls .fetching').show();
     $('#review .controls .error').hide();
@@ -137,12 +142,7 @@ $(function () {
     $('#review .subject .value').html($('#id_subject').val());
 
     // Body
-    const bodyValue = $('#body').val();
-    const html = converter.makeHtml(bodyValue);
     $('#review .body .value').html(html);
-
-    // Update hidden textarea with the HTML content to be sent to backend
-    $('#compose [name=body]').val(html);
 
     // User roles
     const userRoles = $('#compose .user-roles .enabled')

--- a/pontoon/messaging/static/js/messaging.js
+++ b/pontoon/messaging/static/js/messaging.js
@@ -91,7 +91,7 @@ $(function () {
         const count = nf.format(data.recipients.length);
         $('#review .controls .send.active')
           .show()
-          .addClass('disabled', count === 0)
+          .toggleClass('disabled', !data.recipients.length)
           .find('.value')
           .html(count);
         $('#compose [name=recipient_ids]').val(data.recipients);

--- a/pontoon/messaging/static/js/messaging.js
+++ b/pontoon/messaging/static/js/messaging.js
@@ -3,6 +3,7 @@ $(function () {
   const converter = new showdown.Converter({
     simpleLineBreaks: true,
   });
+  const nf = new Intl.NumberFormat('en');
   let inProgress = false;
 
   function validateForm() {
@@ -109,6 +110,27 @@ $(function () {
       });
       $(`#review .${filter}`).toggle(show);
     }
+
+    // Fetch recipients
+    $('#review .controls .fetching').show();
+    $('#review .controls .error').hide();
+    $('#review .controls .send.active').hide().find('.value').html('');
+
+    $.ajax({
+      url: '/messaging/ajax/fetch-recipients/',
+      type: 'POST',
+      data: $('#send-message').serialize(),
+      success: function (data) {
+        const count = nf.format(data.recipients.length);
+        $('#review .controls .send.active').show().find('.value').html(count);
+      },
+      error: function () {
+        $('#review .controls .error').show();
+      },
+      complete: function () {
+        $('#review .controls .fetching').hide();
+      },
+    });
 
     // Subject
     $('#review .subject .value').html($('#id_subject').val());

--- a/pontoon/messaging/static/js/messaging.js
+++ b/pontoon/messaging/static/js/messaging.js
@@ -330,6 +330,13 @@ $(function () {
 
     const $form = $('#send-message');
     const sendToMyself = $(this).is('.to-myself');
+    const button = $(this);
+
+    if (button.is('.sending')) {
+      return;
+    }
+
+    button.addClass('sending');
 
     // Distinguish between Send and Send to myself
     $('#id_send_to_myself').prop('checked', sendToMyself);
@@ -347,6 +354,9 @@ $(function () {
       },
       error: function () {
         Pontoon.endLoader('Oops, something went wrong.', 'error');
+      },
+      complete: function () {
+        button.removeClass('sending');
       },
     });
   });

--- a/pontoon/messaging/templates/messaging/includes/compose.html
+++ b/pontoon/messaging/templates/messaging/includes/compose.html
@@ -220,7 +220,7 @@
         <div class="right">
             <button class="button send to-myself">Send to myself</button>
             <button class="button fetching">Fetching recipients… <i class="fa fa-circle-notch fa-spin"></i></button>
-            <button class="button error">Fetching recipients failed</button>
+            <button class="button fetch-again">Fetch recipients again?</button>
             <button class="button active send">Send to <span class="value"></span> recipients</button>
         </div>
     </menu>

--- a/pontoon/messaging/templates/messaging/includes/compose.html
+++ b/pontoon/messaging/templates/messaging/includes/compose.html
@@ -221,7 +221,7 @@
             <button class="button send to-myself">Send to myself</button>
             <button class="button fetching">Fetching recipients… <i class="fa fa-circle-notch fa-spin"></i></button>
             <button class="button fetch-again">Fetch recipients again?</button>
-            <button class="button active send">Send to <span class="value"></span> recipients</button>
+            <button class="button active send">Send to <span class="value"></span> recipients <i class="fa fa-circle-notch fa-spin"></i></button>
         </div>
     </menu>
 </div>

--- a/pontoon/messaging/templates/messaging/includes/compose.html
+++ b/pontoon/messaging/templates/messaging/includes/compose.html
@@ -217,8 +217,10 @@
         <button class="button toggle edit" data-target="#compose"><span class="fa fa-chevron-left"></span>Back to
             editing</button>
         <div class="right">
-            <button class="button send to-myself">Send test to myself</button>
-            <button class="button active send">Send</button>
+            <button class="button send to-myself">Send to myself</button>
+            <button class="button fetching">Fetching recipients… <i class="fa fa-circle-notch fa-spin"></i></button>
+            <button class="button error">Fetching recipients failed</button>
+            <button class="button active send">Send to <span class="value"></span> recipients</button>
         </div>
     </menu>
 </div>

--- a/pontoon/messaging/templates/messaging/includes/compose.html
+++ b/pontoon/messaging/templates/messaging/includes/compose.html
@@ -6,6 +6,7 @@
     <form id="send-message" method="POST" action="{{ url('pontoon.messaging.ajax.send_message') }}">
         {% csrf_token %}
         {{ form.send_to_myself }}
+        {{ form.recipient_ids }}
 
         <section class="message-type">
             <h3>Message type</h3>

--- a/pontoon/messaging/urls.py
+++ b/pontoon/messaging/urls.py
@@ -50,6 +50,12 @@ urlpatterns = [
                                 views.ajax_sent,
                                 name="pontoon.messaging.ajax.sent",
                             ),
+                            # Fetch recipients
+                            path(
+                                "fetch-recipients/",
+                                views.fetch_recipients,
+                                name="pontoon.messaging.ajax.fetch_recipients",
+                            ),
                             # Send message
                             path(
                                 "send/",

--- a/pontoon/messaging/views.py
+++ b/pontoon/messaging/views.py
@@ -162,19 +162,19 @@ def get_recipients(form):
 
     submitted = translations
 
-    if translation_from is not None:
+    if translation_from:
         submitted = submitted.filter(date__gte=translation_from)
 
-    if translation_to is not None:
+    if translation_to:
         submitted = submitted.filter(date__lte=translation_to)
 
-    if translation_minimum is not None or translation_maximum is not None:
+    if translation_minimum or translation_maximum:
         submitted = submitted.values("user").annotate(count=Count("user"))
 
-    if translation_minimum is not None:
+    if translation_minimum:
         submitted = submitted.filter(count__gte=translation_minimum)
 
-    if translation_maximum is not None:
+    if translation_maximum:
         submitted = submitted.filter(count__lte=translation_maximum)
 
     """
@@ -196,15 +196,15 @@ def get_recipients(form):
         user=F("rejected_user")
     )
 
-    if review_from is not None:
+    if review_from:
         approved = approved.filter(approved_date__gte=review_from)
         rejected = rejected.filter(rejected_date__gte=review_from)
 
-    if review_to is not None:
+    if review_to:
         approved = approved.filter(approved_date__lte=review_to)
         rejected = rejected.filter(rejected_date__lte=review_to)
 
-    if review_minimum is not None or review_maximum is not None:
+    if review_minimum or review_maximum:
         approved = approved.values("approved_user").annotate(
             count=Count("approved_user")
         )
@@ -212,29 +212,19 @@ def get_recipients(form):
             count=Count("rejected_user")
         )
 
-    if review_minimum is not None:
+    if review_minimum:
         approved = approved.filter(count__gte=review_minimum)
         rejected = rejected.filter(count__gte=review_minimum)
 
-    if review_maximum is not None:
+    if review_maximum:
         approved = approved.filter(count__lte=review_maximum)
         rejected = rejected.filter(count__lte=review_maximum)
 
-    if (
-        translation_from is not None
-        or translation_to is not None
-        or translation_minimum is not None
-        or translation_maximum is not None
-    ):
+    if translation_from or translation_to or translation_minimum or translation_maximum:
         submission_filters = list(submitted.values_list("user", flat=True).distinct())
         recipients = recipients.filter(pk__in=submission_filters)
 
-    if (
-        review_from is not None
-        or review_to is not None
-        or review_minimum is not None
-        or review_maximum is not None
-    ):
+    if review_from or review_to or review_minimum or review_maximum:
         review_filters = list(
             approved.values_list("approved_user", flat=True).distinct()
         ) + list(rejected.values_list("rejected_user", flat=True).distinct())

--- a/pontoon/messaging/views.py
+++ b/pontoon/messaging/views.py
@@ -112,9 +112,6 @@ def get_recipients(form):
         entity__resource__project_id__in=project_ids,
     )
 
-    log.info("-- translation authors --")
-    # log.info(len(translations.values("user").distinct()))
-
     locales = Locale.objects.filter(pk__in=locale_ids)
     manager_ids = (
         locales.exclude(managers_group__user__isnull=True)
@@ -131,18 +128,11 @@ def get_recipients(form):
         contributors = translations.values("user").distinct()
         recipients = recipients | User.objects.filter(pk__in=contributors)
 
-        log.info("-- contributors only --")
-        # log.info(len(recipients.values("pk").distinct()))
-
     if form.cleaned_data.get("managers"):
         recipients = recipients | User.objects.filter(pk__in=manager_ids)
-        log.info("-- add managers --")
-        # log.info(len(recipients.values("pk").distinct()))
 
     if form.cleaned_data.get("translators"):
         recipients = recipients | User.objects.filter(pk__in=translator_ids)
-        log.info("-- add translators --")
-        # log.info(len(recipients.values("pk").distinct()))
 
     """
     Filter recipients by login date:
@@ -154,13 +144,9 @@ def get_recipients(form):
 
     if login_from:
         recipients = recipients.filter(last_login__gte=login_from)
-        log.info("-- login_from --")
-        # log.info(len(recipients.values("pk").distinct()))
 
     if login_to:
         recipients = recipients.filter(last_login__lte=login_to)
-        log.info("-- login_to --")
-        # log.info(len(recipients.values("pk").distinct()))
 
     """
     Filter recipients by translation submissions:
@@ -169,7 +155,6 @@ def get_recipients(form):
     - Submitted translations after provided From date
     - Submitted translations before provided To date
     """
-    log.info("-- submissions --")
     translation_minimum = form.cleaned_data.get("translation_minimum")
     translation_maximum = form.cleaned_data.get("translation_maximum")
     translation_from = form.cleaned_data.get("translation_from")
@@ -199,7 +184,6 @@ def get_recipients(form):
     - Reviewed translations after provided From date
     - Reviewed translations before provided To date
     """
-    log.info("-- reviews --")
     review_minimum = form.cleaned_data.get("review_minimum")
     review_maximum = form.cleaned_data.get("review_maximum")
     review_from = form.cleaned_data.get("review_from")
@@ -235,8 +219,6 @@ def get_recipients(form):
     if review_maximum:
         approved = approved.filter(count__lte=review_maximum)
         rejected = rejected.filter(count__lte=review_maximum)
-
-    log.info("-- almost therer --")
 
     action_filters = []
 

--- a/pontoon/messaging/views.py
+++ b/pontoon/messaging/views.py
@@ -162,19 +162,19 @@ def get_recipients(form):
 
     submitted = translations
 
-    if translation_from:
+    if translation_from is not None:
         submitted = submitted.filter(date__gte=translation_from)
 
-    if translation_to:
+    if translation_to is not None:
         submitted = submitted.filter(date__lte=translation_to)
 
-    if translation_minimum or translation_maximum:
+    if translation_minimum is not None or translation_maximum is not None:
         submitted = submitted.values("user").annotate(count=Count("user"))
 
-    if translation_minimum:
+    if translation_minimum is not None:
         submitted = submitted.filter(count__gte=translation_minimum)
 
-    if translation_maximum:
+    if translation_maximum is not None:
         submitted = submitted.filter(count__lte=translation_maximum)
 
     """
@@ -196,15 +196,15 @@ def get_recipients(form):
         user=F("rejected_user")
     )
 
-    if review_from:
+    if review_from is not None:
         approved = approved.filter(approved_date__gte=review_from)
         rejected = rejected.filter(rejected_date__gte=review_from)
 
-    if review_to:
+    if review_to is not None:
         approved = approved.filter(approved_date__lte=review_to)
         rejected = rejected.filter(rejected_date__lte=review_to)
 
-    if review_minimum or review_maximum:
+    if review_minimum is not None or review_maximum is not None:
         approved = approved.values("approved_user").annotate(
             count=Count("approved_user")
         )
@@ -212,19 +212,29 @@ def get_recipients(form):
             count=Count("rejected_user")
         )
 
-    if review_minimum:
+    if review_minimum is not None:
         approved = approved.filter(count__gte=review_minimum)
         rejected = rejected.filter(count__gte=review_minimum)
 
-    if review_maximum:
+    if review_maximum is not None:
         approved = approved.filter(count__lte=review_maximum)
         rejected = rejected.filter(count__lte=review_maximum)
 
-    if translation_from or translation_to or translation_minimum or translation_maximum:
+    if (
+        translation_from is not None
+        or translation_to is not None
+        or translation_minimum is not None
+        or translation_maximum is not None
+    ):
         submission_filters = list(submitted.values_list("user", flat=True).distinct())
         recipients = recipients.filter(pk__in=submission_filters)
 
-    if review_from or review_to or review_minimum or review_maximum:
+    if (
+        review_from is not None
+        or review_to is not None
+        or review_minimum is not None
+        or review_maximum is not None
+    ):
         review_filters = list(
             approved.values_list("approved_user", flat=True).distinct()
         ) + list(rejected.values_list("rejected_user", flat=True).distinct())

--- a/pontoon/messaging/views.py
+++ b/pontoon/messaging/views.py
@@ -241,6 +241,25 @@ def get_recipients(form):
 @require_AJAX
 @require_POST
 @transaction.atomic
+def fetch_recipients(request):
+    form = forms.MessageForm(request.POST)
+
+    if not form.is_valid():
+        return JsonResponse(dict(form.errors.items()), status=400)
+
+    recipients = get_recipients(form).distinct().values_list("pk", flat=True)
+
+    return JsonResponse(
+        {
+            "recipients": list(recipients),
+        }
+    )
+
+
+@permission_required_or_403("base.can_manage_project")
+@require_AJAX
+@require_POST
+@transaction.atomic
 def send_message(request):
     form = forms.MessageForm(request.POST)
 

--- a/pontoon/messaging/views.py
+++ b/pontoon/messaging/views.py
@@ -270,11 +270,12 @@ def send_message(request):
     is_email = form.cleaned_data.get("email")
     is_transactional = form.cleaned_data.get("transactional")
     send_to_myself = form.cleaned_data.get("send_to_myself")
+    recipient_ids = split_ints(form.cleaned_data.get("recipient_ids"))
 
     if send_to_myself:
         recipients = User.objects.filter(pk=request.user.pk)
     else:
-        recipients = get_recipients(form).distinct()
+        recipients = User.objects.filter(pk__in=recipient_ids)
 
     if is_email:
         recipients = recipients.prefetch_related("profile")

--- a/pontoon/messaging/views.py
+++ b/pontoon/messaging/views.py
@@ -168,13 +168,15 @@ def get_recipients(form):
     if translation_to:
         submitted = submitted.filter(date__lte=translation_to)
 
-    if translation_minimum or translation_maximum:
+    # For the Minimum count, no value is the same as 0
+    # For the Maximum count, distinguish between no value and 0
+    if translation_minimum or translation_maximum is not None:
         submitted = submitted.values("user").annotate(count=Count("user"))
 
     if translation_minimum:
         submitted = submitted.filter(count__gte=translation_minimum)
 
-    if translation_maximum:
+    if translation_maximum is not None:
         submitted = submitted.filter(count__lte=translation_maximum)
 
     """
@@ -204,7 +206,9 @@ def get_recipients(form):
         approved = approved.filter(approved_date__lte=review_to)
         rejected = rejected.filter(rejected_date__lte=review_to)
 
-    if review_minimum or review_maximum:
+    # For the Minimum count, no value is the same as 0
+    # For the Maximum count, distinguish between no value and 0
+    if review_minimum or review_maximum is not None:
         approved = approved.values("approved_user").annotate(
             count=Count("approved_user")
         )
@@ -216,15 +220,20 @@ def get_recipients(form):
         approved = approved.filter(count__gte=review_minimum)
         rejected = rejected.filter(count__gte=review_minimum)
 
-    if review_maximum:
+    if review_maximum is not None:
         approved = approved.filter(count__lte=review_maximum)
         rejected = rejected.filter(count__lte=review_maximum)
 
-    if translation_from or translation_to or translation_minimum or translation_maximum:
+    if (
+        translation_from
+        or translation_to
+        or translation_minimum
+        or translation_maximum is not None
+    ):
         submission_filters = list(submitted.values_list("user", flat=True).distinct())
         recipients = recipients.filter(pk__in=submission_filters)
 
-    if review_from or review_to or review_minimum or review_maximum:
+    if review_from or review_to or review_minimum or review_maximum is not None:
         review_filters = list(
             approved.values_list("approved_user", flat=True).distinct()
         ) + list(rejected.values_list("rejected_user", flat=True).distinct())

--- a/pontoon/messaging/views.py
+++ b/pontoon/messaging/views.py
@@ -247,6 +247,9 @@ def send_message(request):
     if not form.is_valid():
         return JsonResponse(dict(form.errors.items()), status=400)
 
+    is_notification = form.cleaned_data.get("notification")
+    is_email = form.cleaned_data.get("email")
+    is_transactional = form.cleaned_data.get("transactional")
     send_to_myself = form.cleaned_data.get("send_to_myself")
 
     if send_to_myself:
@@ -254,11 +257,11 @@ def send_message(request):
     else:
         recipients = get_recipients(form).distinct()
 
+    if is_email:
+        recipients = recipients.prefetch_related("profile")
+
     log.info(f"Total recipients count: {len(recipients)}.")
 
-    is_notification = form.cleaned_data.get("notification")
-    is_email = form.cleaned_data.get("email")
-    is_transactional = form.cleaned_data.get("transactional")
     subject = form.cleaned_data.get("subject")
     body = form.cleaned_data.get("body")
 

--- a/pontoon/messaging/views.py
+++ b/pontoon/messaging/views.py
@@ -230,13 +230,13 @@ def get_recipients(form):
         or translation_minimum
         or translation_maximum is not None
     ):
-        submission_filters = list(submitted.values_list("user", flat=True).distinct())
+        submission_filters = submitted.values_list("user", flat=True).distinct()
         recipients = recipients.filter(pk__in=submission_filters)
 
     if review_from or review_to or review_minimum or review_maximum is not None:
-        review_filters = list(
-            approved.values_list("approved_user", flat=True).distinct()
-        ) + list(rejected.values_list("rejected_user", flat=True).distinct())
+        approved_filters = approved.values_list("approved_user", flat=True).distinct()
+        rejected_filters = rejected.values_list("rejected_user", flat=True).distinct()
+        review_filters = approved_filters.union(rejected_filters)
         recipients = recipients.filter(pk__in=review_filters)
 
     return recipients

--- a/pontoon/messaging/views.py
+++ b/pontoon/messaging/views.py
@@ -292,7 +292,6 @@ def send_message(request):
 
     if is_notification:
         identifier = uuid.uuid4().hex
-        notification_recipients_count = 0
 
         for recipient in recipients:
             notify.send(
@@ -303,9 +302,8 @@ def send_message(request):
                 description=f"{subject}<br/><br/>{body}",
                 identifier=identifier,
             )
-            notification_recipients_count += 1
 
-        log.info(f"Notifications sent to {notification_recipients_count} users.")
+        log.info(f"Notifications sent to {len(recipients)} users.")
 
     if is_email:
         footer = (
@@ -317,7 +315,6 @@ You’re receiving this email as a contributor to Mozilla localization on Pontoo
         )
         html_template = body + footer
         text_template = utils.html_to_plain_text_with_links(html_template)
-        email_recipients_count = 0
 
         for recipient in recipients:
             if not recipient.profile.email_communications_enabled:
@@ -335,9 +332,8 @@ You’re receiving this email as a contributor to Mozilla localization on Pontoo
             )
             msg.attach_alternative(html, "text/html")
             msg.send()
-            email_recipients_count += 1
 
-        log.info(f"Emails sent to {email_recipients_count} users.")
+        log.info(f"Emails sent to {len(recipients)} users.")
 
     if not send_to_myself:
         message = form.save(commit=False)

--- a/pontoon/messaging/views.py
+++ b/pontoon/messaging/views.py
@@ -220,20 +220,15 @@ def get_recipients(form):
         approved = approved.filter(count__lte=review_maximum)
         rejected = rejected.filter(count__lte=review_maximum)
 
-    action_filters = []
-
     if translation_from or translation_to or translation_minimum or translation_maximum:
-        action_filters = list(submitted.values_list("user", flat=True).distinct())
+        submission_filters = list(submitted.values_list("user", flat=True).distinct())
+        recipients = recipients.filter(pk__in=submission_filters)
 
     if review_from or review_to or review_minimum or review_maximum:
-        action_filters = (
-            action_filters
-            + list(approved.values_list("approved_user", flat=True).distinct())
-            + list(rejected.values_list("rejected_user", flat=True).distinct())
-        )
-
-    if action_filters != []:
-        recipients = recipients.filter(pk__in=action_filters)
+        review_filters = list(
+            approved.values_list("approved_user", flat=True).distinct()
+        ) + list(rejected.values_list("rejected_user", flat=True).distinct())
+        recipients = recipients.filter(pk__in=review_filters)
 
     return recipients
 

--- a/pontoon/messaging/views.py
+++ b/pontoon/messaging/views.py
@@ -256,12 +256,6 @@ def send_message(request):
 
     log.info(f"Total recipients count: {len(recipients)}.")
 
-    return JsonResponse(
-        {
-            "status": True,
-        }
-    )
-
     is_notification = form.cleaned_data.get("notification")
     is_email = form.cleaned_data.get("email")
     is_transactional = form.cleaned_data.get("transactional")

--- a/pontoon/messaging/views.py
+++ b/pontoon/messaging/views.py
@@ -226,10 +226,11 @@ def get_recipients(form):
         action_filters = list(submitted.values_list("user", flat=True).distinct())
 
     if review_from or review_to or review_minimum or review_maximum:
-        action_filters = action_filters + list(
-            approved.values_list("approved_user", flat=True).distinct()
+        action_filters = (
+            action_filters
+            + list(approved.values_list("approved_user", flat=True).distinct())
+            + list(rejected.values_list("rejected_user", flat=True).distinct())
         )
-        +list(rejected.values_list("rejected_user", flat=True).distinct())
 
     if action_filters != []:
         recipients = recipients.filter(pk__in=action_filters)


### PR DESCRIPTION
Fix #3162.

This is the final step of functional changes to the Messaging center before we can start using it in production:
* Messaging link is added to the main menu, visible only to users that can actually access the page
* As soon as you hit the Review page, contributors start getting fetched, as indicated in the button in the bottom right part of the screen. 
* Once fetching is complete, the button to send the messages is made available with the recipient count written over it. 
* While messages are being sent or if the recipient count is 0, the Send button is disabled. 
* If fetching contributors fails, the button turns red and offers you the ability to retry fetching.

Note that you can only send notifications on stage, sending emails will fail. Also note that neither fetching nor sending is a background task, because testing on stage has shown that splitting fetching and sending in separate steps no longer results in request timeouts.