### PR TITLE
Check if users are managers and translators first, then admins (frontend code)

### DIFF
--- a/translate/src/hooks/useUserStatus.test.js
+++ b/translate/src/hooks/useUserStatus.test.js
@@ -31,7 +31,7 @@ describe('useUserStatus', () => {
       fakeSelector({
         isAuthenticated: true,
         isAdmin: true,
-        managerForLocales: ['mylocale'],
+        managerForLocales: [],
         translatorForLocales: [],
       }),
     );

--- a/translate/src/hooks/useUserStatus.ts
+++ b/translate/src/hooks/useUserStatus.ts
@@ -21,16 +21,16 @@ export function useUserStatus(): Array<string> {
     return ['', ''];
   }
 
-  if (isAdmin) {
-    return ['ADMIN', 'Admin'];
-  }
-
   if (managerForLocales.includes(code)) {
     return ['MNGR', 'Manager'];
   }
 
   if (translatorForLocales.includes(code)) {
     return ['TRNSL', 'Translator'];
+  }
+
+  if (isAdmin) {
+    return ['ADMIN', 'Admin'];
   }
 
   const dateJoinedObj = new Date(dateJoined);


### PR DESCRIPTION
This is a fix for an inconsistency I caused in #3414, which only changes the order in which user statuses are assigned in the backend code.