### PR TITLE
Only show local part of the email address in the Profile page title

### DIFF
--- a/pontoon/contributors/templates/contributors/profile.html
+++ b/pontoon/contributors/templates/contributors/profile.html
@@ -3,7 +3,7 @@
 
 {% extends "base.html" %}
 
-{% block title %}{{ contributor.name_or_email }}{% endblock %}
+{% block title %}{{ contributor.display_name }}{% endblock %}
 
 {% block before %}
 <!-- Server data -->


### PR DESCRIPTION
Fix #3429.

The motivation for this change is that we currently publicly show the email address of a user that doesn't have any contributions yet in the Profile page title, but our Terms of Use say "Your name and email address, or a derivative of it, may be attached to your **contributions** and so be visible worldwide".

Note that we show the custom display name in the Profile page title for users that set it.