### PR TITLE
Add ability to upload personal translation memory

### DIFF
--- a/pontoon/teams/static/css/translation_memory.css
+++ b/pontoon/teams/static/css/translation_memory.css
@@ -113,7 +113,6 @@
 
           .button {
             background: var(--button-background-1);
-            margin-left: 5px;
 
             .fa {
               margin-right: 2px;
@@ -130,6 +129,10 @@
 
           .button.save:hover {
             background: var(--status-translated);
+          }
+
+          .button.delete {
+            margin-left: 5px;
           }
 
           .button.delete:hover {

--- a/pontoon/teams/static/js/translation_memory.js
+++ b/pontoon/teams/static/js/translation_memory.js
@@ -168,4 +168,40 @@ $(function () {
       });
     },
   );
+
+  // Upload TM entries
+  $('body').on('click', '.translation-memory .upload-button', function () {
+    const fileInput = $('<input type="file" accept=".tmx">');
+    fileInput.on('change', function () {
+      const file = this.files[0];
+      if (!file) {
+        return;
+      }
+
+      const formData = new FormData();
+      formData.append('tmx_file', file);
+      formData.append('csrfmiddlewaretoken', $('body').data('csrf'));
+
+      $.ajax({
+        url: `/${locale}/ajax/translation-memory/upload/`,
+        method: 'POST',
+        data: formData,
+        processData: false,
+        contentType: false,
+        success: function (response) {
+          Pontoon.endLoader(response.message);
+        },
+        error: function (xhr) {
+          Pontoon.endLoader(
+            xhr.responseJSON
+              ? xhr.responseJSON.message
+              : 'Error uploading TMX file.',
+            'error',
+          );
+        },
+      });
+    });
+
+    fileInput.click();
+  });
 });

--- a/pontoon/teams/static/js/translation_memory.js
+++ b/pontoon/teams/static/js/translation_memory.js
@@ -193,9 +193,7 @@ $(function () {
         },
         error: function (xhr) {
           Pontoon.endLoader(
-            xhr.responseJSON
-              ? xhr.responseJSON.message
-              : 'Error uploading TMX file.',
+            xhr.responseJSON?.message ?? 'Error uploading TMX file.',
             'error',
           );
         },

--- a/pontoon/teams/static/js/translation_memory.js
+++ b/pontoon/teams/static/js/translation_memory.js
@@ -54,7 +54,7 @@ $(function () {
         updateURL(); // Update the URL with the new pages count and search query
       },
       error: function () {
-        Pontoon.endLoader('Error loading more TM entries.');
+        Pontoon.endLoader('Error loading more TM entries.', 'error');
         loader.each(function () {
           $(this).removeClass('loading');
         });
@@ -125,7 +125,7 @@ $(function () {
         node.html(new_target);
       },
       error: function () {
-        Pontoon.endLoader('Error editing TM entries.');
+        Pontoon.endLoader('Error editing TM entries.', 'error');
       },
       complete: function () {
         row.removeClass('editing');
@@ -160,7 +160,7 @@ $(function () {
           }, 500);
         },
         error: function () {
-          Pontoon.endLoader('Error deleting TM entries.');
+          Pontoon.endLoader('Error deleting TM entries.', 'error');
         },
         complete: function () {
           row.removeClass('deleting');

--- a/pontoon/teams/templates/teams/includes/translation_memory.html
+++ b/pontoon/teams/templates/teams/includes/translation_memory.html
@@ -5,6 +5,11 @@
             <input class="table-filter" type="search" autocomplete="off" value="{{ search_query }}" autofocus
                 placeholder="Search translation memory">
         </div>
+
+        <button class="upload-button button">
+            <span class="fa fa-upload"></span>
+            Upload .TMX
+        </button>
     </menu>
 
     <table class="translation-memory-list">

--- a/pontoon/teams/templates/teams/widgets/translation_memory_entries.html
+++ b/pontoon/teams/templates/teams/widgets/translation_memory_entries.html
@@ -18,6 +18,9 @@
         <textarea>{{ entry.target }}</textarea>
     </td>
     <td class="actions controls">
+        <button class="cancel button">
+            <span class="fa fa-times"></span>
+        </button>
         <button class="edit button">
             <span class="fa fa-pencil-alt"></span>
             Edit
@@ -33,9 +36,6 @@
         <button class="are-you-sure button">
             <span class="fa fa-trash"></span>
             Delete {{ entry.ids|length }} TM entr{{ entry.ids|length|pluralize("y,ies") }}?
-        </button>
-        <button class="cancel button">
-            <span class="fa fa-times"></span>
         </button>
     </td>
 </tr>

--- a/pontoon/teams/urls.py
+++ b/pontoon/teams/urls.py
@@ -121,6 +121,12 @@ urlpatterns = [
                                 views.ajax_translation_memory_delete,
                                 name="pontoon.teams.ajax.translation-memory.delete",
                             ),
+                            # Upload .TMX file
+                            path(
+                                "translation-memory/upload/",
+                                views.ajax_translation_memory_upload,
+                                name="pontoon.teams.ajax.translation-memory.upload",
+                            ),
                         ]
                     ),
                 ),

--- a/pontoon/teams/views.py
+++ b/pontoon/teams/views.py
@@ -399,6 +399,15 @@ def ajax_translation_memory_upload(request, locale):
             status=400,
         )
 
+    if file.size > 20 * 1024 * 1024:
+        return JsonResponse(
+            {
+                "status": False,
+                "message": "File size limit exceeded. The maximum allowed size is 20 MB.",
+            },
+            status=400,
+        )
+
     if not file.name.endswith(".tmx"):
         return JsonResponse(
             {

--- a/pontoon/teams/views.py
+++ b/pontoon/teams/views.py
@@ -431,7 +431,7 @@ def ajax_translation_memory_upload(request, locale):
 
     # Extract TM entries
     file_entries = []
-    srclang_pattern = re.compile(r"^en(?:[-_].+)?$", re.IGNORECASE)
+    srclang_pattern = re.compile(r"^en(?:[-_](us))?$", re.IGNORECASE)
     ns = {"xml": "http://www.w3.org/XML/1998/namespace"}
 
     header = root.find("header")

--- a/pontoon/teams/views.py
+++ b/pontoon/teams/views.py
@@ -422,7 +422,7 @@ def ajax_translation_memory_upload(request, locale):
 
     # Extract TM entries
     file_entries = []
-    srclang_pattern = re.compile(r"^en([-_].+)?$", re.IGNORECASE)
+    srclang_pattern = re.compile(r"^en(?:[-_].+)?$", re.IGNORECASE)
     ns = {"xml": "http://www.w3.org/XML/1998/namespace"}
 
     header = root.find("header")

--- a/pontoon/teams/views.py
+++ b/pontoon/teams/views.py
@@ -451,9 +451,10 @@ def ajax_translation_memory_upload(request, locale):
     for tu in tu_elements:
         try:
             srclang = tu.attrib.get("srclang", header_srclang)
+            tu_str = ET.tostring(tu, encoding="unicode")
 
             if not srclang_pattern.match(srclang):
-                log.info(f"Skipping <tu> with unsupported srclang: {srclang}")
+                log.info(f"Skipping <tu> with unsupported srclang: {tu_str}")
                 continue
 
             source = get_seg_text(tu, srclang, ns)
@@ -462,9 +463,7 @@ def ajax_translation_memory_upload(request, locale):
             if source and target:
                 file_entries.append({"source": source, "target": target})
             else:
-                log.info(
-                    f"Skipping <tu> with missing or empty segment: {ET.tostring(tu, encoding='unicode')}"
-                )
+                log.info(f"Skipping <tu> with missing or empty segment: {tu_str}")
 
         except Exception as e:
             log.info(f"Error processing <tu>: {e}")

--- a/pontoon/teams/views.py
+++ b/pontoon/teams/views.py
@@ -429,7 +429,13 @@ def ajax_translation_memory_upload(request, locale):
     header_srclang = header.attrib.get("srclang", "") if header else ""
 
     def get_seg_text(tu, lang, ns):
+        # Try to find <tuv> with the xml:lang attribute
         seg = tu.find(f"./tuv[@xml:lang='{lang}']/seg", namespaces=ns)
+
+        # If not found, try the lang attribute
+        if seg is None:
+            seg = tu.find(f"./tuv[@lang='{lang}']/seg")
+
         return seg.text.strip() if seg is not None and seg.text else None
 
     for tu in root.findall(".//tu"):


### PR DESCRIPTION
Fix https://github.com/mozilla/pontoon/issues/2031.

This is the final step towards Translation Memory Management ([spec](https://github.com/mozilla/pontoon/blob/main/specs/0121-translation-memory-management.md)), which adds the ability for team managers and translators to upload .TMX files to their locale's TM. The PR is deployed to [stage](https://mozilla-pontoon-staging.herokuapp.com/sl/translation-memory/) for testing.

Also included is the [minor change](https://github.com/mozilla/pontoon/pull/3452/commits/91cbd86cb81b1d8df47cead08ba0fe5d62129fe8) in how error messages are presented (as errors, rather than regular messages).

TODO:
- [x] "A maximum file upload size will be imposed, with the exact size to be determined based on the performance of the upload function."