### PR TITLE
Add an API endpoint to retrieve User action data

### DIFF
--- a/pontoon/api/urls.py
+++ b/pontoon/api/urls.py
@@ -1,7 +1,8 @@
 from graphene_django.views import GraphQLView
 
-from django.urls import re_path
+from django.urls import include, path, re_path
 
+from pontoon.api import views
 from pontoon.api.schema import schema
 from pontoon.settings import DEV
 
@@ -12,5 +13,33 @@ urlpatterns = [
     re_path(
         r"^graphql/?$",
         GraphQLView.as_view(schema=schema, graphiql=DEV),
+    ),
+    # API v1
+    path(
+        "api/v1/",
+        include(
+            [
+                path(
+                    # User actions
+                    "get-user-actions/",
+                    include(
+                        [
+                            # General
+                            path(
+                                "<str:date>/",
+                                views.get_user_actions,
+                                name="pontoon.api.get_user_actions",
+                            ),
+                            # Project-specific
+                            path(
+                                "<str:date>/project/<slug:slug>/",
+                                views.get_user_actions,
+                                name="pontoon.api.get_user_actions.project",
+                            ),
+                        ]
+                    ),
+                ),
+            ]
+        ),
     ),
 ]

--- a/pontoon/api/urls.py
+++ b/pontoon/api/urls.py
@@ -21,7 +21,7 @@ urlpatterns = [
             [
                 path(
                     # User actions
-                    "get-user-actions/",
+                    "user-actions/",
                     include(
                         [
                             # General

--- a/pontoon/api/urls.py
+++ b/pontoon/api/urls.py
@@ -24,13 +24,7 @@ urlpatterns = [
                     "user-actions/",
                     include(
                         [
-                            # General
-                            path(
-                                "<str:date>/",
-                                views.get_user_actions,
-                                name="pontoon.api.get_user_actions",
-                            ),
-                            # Project-specific
+                            # In a given project
                             path(
                                 "<str:date>/project/<slug:slug>/",
                                 views.get_user_actions,

--- a/pontoon/api/views.py
+++ b/pontoon/api/views.py
@@ -1,0 +1,102 @@
+from datetime import datetime, timedelta
+
+from django.contrib.auth.decorators import login_required
+from django.http import JsonResponse
+from django.utils.timezone import make_aware
+from django.views.decorators.http import require_GET
+
+from pontoon.actionlog.models import ActionLog
+from pontoon.base.models import Project
+
+
+@require_GET
+@login_required(redirect_field_name="", login_url="/403")
+def get_user_actions(request, date, slug=None):
+    try:
+        start_date = make_aware(datetime.strptime(date, "%Y-%m-%d"))
+    except ValueError:
+        return JsonResponse(
+            {
+                "error": "Invalid date format. Please use YYYY-MM-DD.",
+            },
+            status=400,
+        )
+
+    end_date = start_date + timedelta(days=1)
+
+    actions = ActionLog.objects.filter(
+        created_at__gte=start_date,
+        created_at__lt=end_date,
+        action_type__startswith="translation:",
+    )
+
+    if slug:
+        try:
+            project = Project.objects.get(slug=slug)
+        except Project.DoesNotExist:
+            return JsonResponse(
+                {
+                    "error": "Project not found. Please use a valid project slug.",
+                },
+                status=404,
+            )
+        actions = actions.filter(translation__entity__resource__project=project)
+
+    actions = actions.prefetch_related(
+        "performed_by__profile",
+        "translation__entity__resource__project",
+        "translation__errors",
+        "translation__warnings",
+        "translation__locale",
+        "entity__resource__project",
+        "locale",
+    )
+
+    output = []
+
+    for action in actions:
+        user = action.performed_by
+        locale = action.locale or action.translation.locale
+        entity = action.entity or action.translation.entity
+        resource = entity.resource
+        project = resource.project
+
+        data = {
+            "type": action.action_type,
+            "date": action.created_at,
+            "user": {
+                "pk": user.pk,
+                "name": user.display_name,
+                "system_user": user.profile.system_user,
+            },
+            "locale": {
+                "pk": locale.pk,
+                "code": locale.code,
+                "name": locale.name,
+            },
+            "entity": {
+                "pk": entity.pk,
+                "key": entity.key,
+            },
+            "resource": {
+                "pk": resource.pk,
+                "path": resource.path,
+                "format": resource.format,
+            },
+            "project": {
+                "pk": project.pk,
+                "slug": project.slug,
+                "name": project.name,
+            },
+        }
+
+        if action.translation:
+            data["translation"] = action.translation.serialize()
+
+        output.append(data)
+
+    return JsonResponse(
+        {
+            "actions": output,
+        }
+    )

--- a/pontoon/urls.py
+++ b/pontoon/urls.py
@@ -68,9 +68,9 @@ urlpatterns = [
     path("", include("pontoon.contributors.urls")),
     path("", include("pontoon.localizations.urls")),
     path("", include("pontoon.base.urls")),
+    path("", include("pontoon.api.urls")),
     path("", include("pontoon.translate.urls")),
     path("", include("pontoon.batch.urls")),
-    path("", include("pontoon.api.urls")),
     path("", include("pontoon.homepage.urls")),
     path("", include("pontoon.uxactionlog.urls")),
     # Team page: Must be at the end


### PR DESCRIPTION
Introduce an API endpoint to retrieve User action data on a given date for a given project:
`/api/v1/user-actions/YYYY-MM-DD/project/PROJECT-SLUG/`

Example:
[/api/v1/user-actions/2024-01-07/project/thunderbird/](https://mozilla-pontoon-staging.herokuapp.com/api/v1/user-actions/2024-01-07/project/thunderbird/)

The following actions are tracked:
* Translation created
* Translation deleted
* Translation approved
* Translation unapproved
* Translation rejected
* Translation unrejected

Notes:
* Authentication is required.
* The links above point to the stage server, which only has data until 2024-11-20. 
* Performance should be a bit better on the production instance.