### PR TITLE
Include media/ in pytest norecursedirs

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 addopts = --doctest-glob='*.tst' --reuse-db
-norecursedirs = .git _build tmp* requirements commands/* node_modules/*
+norecursedirs = .git _build commands media node_modules requirements tmp*
 DJANGO_SETTINGS_MODULE = pontoon.settings
 


### PR DESCRIPTION
There's a file in `amo` that matches the default test file pattern:
`media/projects/amo/git@github.com:mozilla/olympia.git/conftest.py`.

This avoids matching that when running pytest.