### PR TITLE
Support variant keys of type NumberLiteral in Pretranslation of access keys

### DIFF
--- a/pontoon/base/fluent.py
+++ b/pontoon/base/fluent.py
@@ -12,6 +12,14 @@ def get_default_variant(variants):
             return variant
 
 
+def get_variant_key(variant):
+    """Return the key of the variant as represented in the syntax."""
+    if isinstance(variant.key, ast.NumberLiteral):
+        return variant.key.value
+
+    return variant.key.name
+
+
 def serialize_value(value):
     """Serialize AST value into a simple string.
 

--- a/pontoon/base/fluent.py
+++ b/pontoon/base/fluent.py
@@ -14,10 +14,8 @@ def get_default_variant(variants):
 
 def get_variant_key(variant):
     """Return the key of the variant as represented in the syntax."""
-    if isinstance(variant.key, ast.NumberLiteral):
-        return variant.key.value
-
-    return variant.key.name
+    key = variant.key
+    return key.value if isinstance(key, ast.NumberLiteral) else key.name
 
 
 def serialize_value(value):

--- a/pontoon/base/fluent.py
+++ b/pontoon/base/fluent.py
@@ -16,8 +16,6 @@ def get_variant_key(variant):
     """Return the key of the variant as represented in the syntax."""
     key = variant.key
     return key.value if isinstance(key, ast.NumberLiteral) else key.name
-
-
 def serialize_value(value):
     """Serialize AST value into a simple string.
 

--- a/pontoon/base/fluent.py
+++ b/pontoon/base/fluent.py
@@ -16,6 +16,8 @@ def get_variant_key(variant):
     """Return the key of the variant as represented in the syntax."""
     key = variant.key
     return key.value if isinstance(key, ast.NumberLiteral) else key.name
+
+
 def serialize_value(value):
     """Serialize AST value into a simple string.
 

--- a/pontoon/base/tests/test_fluent.py
+++ b/pontoon/base/tests/test_fluent.py
@@ -7,6 +7,7 @@ from fluent.syntax import FluentParser
 
 from pontoon.base.fluent import (
     get_simple_preview,
+    get_variant_key,
     is_plural_expression,
 )
 
@@ -78,6 +79,28 @@ SIMPLE_TRANSLATION_TESTS = OrderedDict(
 def test_get_simple_preview(k):
     string, expected = SIMPLE_TRANSLATION_TESTS[k]
     assert get_simple_preview(string) == expected
+
+
+def test_get_variant_key():
+    # Return the key of the variant as represented in the syntax.
+    input = dedent(
+        """
+        my-entry =
+            { $num ->
+                [1] Hello!
+               *[other] World!
+            }`
+    """
+    )
+
+    message = parser.parse_entry(input)
+    element = message.value.elements[0]
+
+    variant = element.expression.variants[0]
+    assert get_variant_key(variant) == "1"
+
+    variant = element.expression.variants[1]
+    assert get_variant_key(variant) == "other"
 
 
 def test_is_plural_expression_not_select_expression():

--- a/pontoon/pretranslation/transformer.py
+++ b/pontoon/pretranslation/transformer.py
@@ -8,7 +8,7 @@ from fluent.syntax import ast as FTL
 from fluent.syntax.serializer import serialize_expression
 from fluent.syntax.visitor import Transformer
 
-from pontoon.base.fluent import is_plural_expression, get_variant_key
+from pontoon.base.fluent import get_variant_key, is_plural_expression
 from pontoon.base.models import Locale
 
 
@@ -107,7 +107,8 @@ def extract_accesskey_candidates(message: FTL.Message, label: str, variant_key=N
                 elif isinstance(element.expression, FTL.SelectExpression):
                     variants = element.expression.variants
                     variant = next(
-                        (v for v in variants if get_variant_key(v) == variant_key), variants[0]
+                        (v for v in variants if get_variant_key(v) == variant_key),
+                        variants[0],
                     )
                     variant_element = variant.value.elements[0]
 
@@ -191,9 +192,7 @@ class ApplyPretranslation(Transformer):
 
         def set_accesskey(element, variant_key=None):
             if isinstance(element, FTL.TextElement) and len(element.value) <= 1:
-                candidates = extract_accesskey_candidates(
-                    self.entry, name, variant_key
-                )
+                candidates = extract_accesskey_candidates(self.entry, name, variant_key)
                 if candidates:
                     element.value = candidates[0]
                     return True

--- a/pontoon/pretranslation/transformer.py
+++ b/pontoon/pretranslation/transformer.py
@@ -8,7 +8,7 @@ from fluent.syntax import ast as FTL
 from fluent.syntax.serializer import serialize_expression
 from fluent.syntax.visitor import Transformer
 
-from pontoon.base.fluent import is_plural_expression
+from pontoon.base.fluent import is_plural_expression, get_variant_key
 from pontoon.base.models import Locale
 
 
@@ -96,7 +96,7 @@ def create_locale_plural_variants(node: FTL.SelectExpression, locale: Locale):
     node.variants = variants
 
 
-def extract_accesskey_candidates(message: FTL.Message, label: str, variant_name=None):
+def extract_accesskey_candidates(message: FTL.Message, label: str, variant_key=None):
     def get_source(names):
         for attribute in message.attributes:
             if attribute.id.name in names:
@@ -107,7 +107,7 @@ def extract_accesskey_candidates(message: FTL.Message, label: str, variant_name=
                 elif isinstance(element.expression, FTL.SelectExpression):
                     variants = element.expression.variants
                     variant = next(
-                        (v for v in variants if v.key.name == variant_name), variants[0]
+                        (v for v in variants if get_variant_key(v) == variant_key), variants[0]
                     )
                     variant_element = variant.value.elements[0]
 
@@ -189,10 +189,10 @@ class ApplyPretranslation(Transformer):
     def visit_Attribute(self, node: FTL.Pattern):
         name = node.id.name
 
-        def set_accesskey(element, variant_name=None):
+        def set_accesskey(element, variant_key=None):
             if isinstance(element, FTL.TextElement) and len(element.value) <= 1:
                 candidates = extract_accesskey_candidates(
-                    self.entry, name, variant_name
+                    self.entry, name, variant_key
                 )
                 if candidates:
                     element.value = candidates[0]
@@ -202,8 +202,11 @@ class ApplyPretranslation(Transformer):
             if self.locale.accesskey_localization:
                 element = node.value.elements[0]
 
+                # If the attribute is a simple text element, set accesskey
                 if set_accesskey(element):
                     return node
+
+                # If the attribute is a select expression, set accesskey for each variant
                 elif isinstance(element, FTL.Placeable) and isinstance(
                     element.expression, FTL.SelectExpression
                 ):
@@ -211,7 +214,8 @@ class ApplyPretranslation(Transformer):
                     processed_variants = 0
                     for variant in variants:
                         variant_element = variant.value.elements[0]
-                        if set_accesskey(variant_element, variant.key.name):
+
+                        if set_accesskey(variant_element, get_variant_key(variant)):
                             processed_variants += 1
                     if processed_variants == len(variants):
                         return node


### PR DESCRIPTION
Fix #3461.

The code that extracts access key candidates [expects](https://github.com/mozilla/pontoon/blob/e23b7dbdf857a0f2e931937d5c6dd6db17ceb3e0/pontoon/pretranslation/transformer.py#L109-L111) that if the _source_ attribute is a `SelectExpression`, its variant keys must have a `name` property. That's not the case for variant keys of type `NumberLiteral` ([example](https://pontoon.mozilla.org/sv-SE/firefox/all-resources/?string=313552)).

This is the code to reproduce the error:

```python
from pontoon.base.models import *
from pontoon.pretranslation.pretranslate import get_pretranslations

entity = Entity.objects.get(pk=313552)
locale = Locale.objects.get(code="sv-SE")

get_pretranslations(entity, locale, False)

Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/app/pontoon/pretranslation/pretranslate.py", line 56, in get_pretranslations
    pretranslate.visit(entry)
  File "/app/.heroku/python/lib/python3.11/site-packages/fluent/syntax/visitor.py", line 47, in visit
    return visit(node)
           ^^^^^^^^^^^
  File "/app/.heroku/python/lib/python3.11/site-packages/fluent/syntax/visitor.py", line 54, in generic_visit
    new_val = self.visit(child)
              ^^^^^^^^^^^^^^^^^
  File "/app/.heroku/python/lib/python3.11/site-packages/fluent/syntax/visitor.py", line 47, in visit
    return visit(node)
           ^^^^^^^^^^^
  File "/app/pontoon/pretranslation/transformer.py", line 205, in visit_Attribute
    if set_accesskey(element):
       ^^^^^^^^^^^^^^^^^^^^^^
  File "/app/pontoon/pretranslation/transformer.py", line 194, in set_accesskey
    candidates = extract_accesskey_candidates(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/pontoon/pretranslation/transformer.py", line 129, in extract_accesskey_candidates
    source = get_source(["label", "value", "aria-label"])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/pontoon/pretranslation/transformer.py", line 109, in get_source
    variant = next(
              ^^^^^
  File "/app/pontoon/pretranslation/transformer.py", line 110, in <genexpr>
    (v for v in variants if v.key.name == variant_name), variants[0]
                            ^^^^^^^^^^
AttributeError: 'NumberLiteral' object has no attribute 'name'
```