### PR TITLE
Remove unnecessary border from notification emails

### DIFF
--- a/pontoon/messaging/templates/messaging/emails/notification_digest.html
+++ b/pontoon/messaging/templates/messaging/emails/notification_digest.html
@@ -105,6 +105,7 @@
         }
 
         .notifications li .item-content .description ul {
+            border: none;
             list-style: inside;
             padding-top: 10px;
         }


### PR DESCRIPTION
This PR fixes a regression introduced by https://github.com/mozilla/pontoon/pull/3456/commits/0d518e6cea8f7c726c3ed4fa101d8682fbc73718, which draws too many borders:

Before:
![Posnetek zaslona 2024-12-04 ob 16 08 32](https://github.com/user-attachments/assets/ea1bc867-47ee-4b90-8fb0-51631886a373)

After:
![Posnetek zaslona 2024-12-04 ob 16 09 09](https://github.com/user-attachments/assets/a271e133-5f72-40da-9f42-910764f1beef)
