### PR TITLE
Configurable day to send weekly notification digest emails on

### DIFF
--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -217,6 +217,11 @@ you create:
    Optional. Name to give to this app on New Relic. Required if you're using
    New Relic.
 
+``NOTIFICATION_DIGEST_DAY``
+   Optional. Integer representing a day of the week on which the weekly notification
+   digest email will be sent. 0 represents Monday, 6 represents Sunday. The default
+   value is 4 (Friday).
+
 ``OPENAI_API_KEY``
    Optional. Set your `OpenAI API` key to add the ability to refine machine
    translations using ChatGPT.

--- a/pontoon/messaging/management/commands/send_notification_emails.py
+++ b/pontoon/messaging/management/commands/send_notification_emails.py
@@ -1,5 +1,6 @@
+from django.conf import settings
 from django.core.management.base import BaseCommand
-from django.utils.timezone import now
+from django.utils.timezone import datetime
 
 from pontoon.messaging.emails import send_notification_digest
 
@@ -11,5 +12,5 @@ class Command(BaseCommand):
         send_notification_digest(frequency="Daily")
 
         # Only send weekly digests on Saturdays
-        if now().isoweekday() == 6:
+        if datetime.today().weekday() == settings.NOTIFICATION_DIGEST_DAY:
             send_notification_digest(frequency="Weekly")

--- a/pontoon/messaging/management/commands/send_notification_emails.py
+++ b/pontoon/messaging/management/commands/send_notification_emails.py
@@ -11,6 +11,6 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         send_notification_digest(frequency="Daily")
 
-        # Only send weekly digests on Saturdays
+        # Send the weekly notification digest only on the configured day (e.g. Friday)
         if datetime.today().weekday() == settings.NOTIFICATION_DIGEST_DAY:
             send_notification_digest(frequency="Weekly")

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -1115,8 +1115,14 @@ DJANGO_NOTIFICATIONS_CONFIG = {
 NOTIFICATIONS_MAX_COUNT = 7
 
 # Integer representing a day of the week on which the `send_suggestion_notifications`
-# management command will run.
+# management command will run. 0 represents Monday, 6 represents Sunday. The default
+# value is 4 (Friday).
 SUGGESTION_NOTIFICATIONS_DAY = os.environ.get("SUGGESTION_NOTIFICATIONS_DAY", 4)
+
+# Integer representing a day of the week on which the weekly notification digest
+# email will be sent. 0 represents Monday, 6 represents Sunday. The default value
+# is 4 (Friday).
+NOTIFICATION_DIGEST_DAY = os.environ.get("NOTIFICATION_DIGEST_DAY", 4)
 
 # Date from which badge data collection starts
 badges_start_date = os.environ.get("BADGES_START_DATE", "1970-01-01")


### PR DESCRIPTION
Let's not hardcode the day on which to send weekly notification digest emails. That way we can also make sure it includes the (weekly) suggestion notifications, for which the sending day can also be configured.