### PR TITLE
Fix new contributor detection logic

### DIFF
--- a/pontoon/base/models/user.py
+++ b/pontoon/base/models/user.py
@@ -282,11 +282,12 @@ def can_translate(self, locale, project):
 
 
 def is_new_contributor(self, locale):
-    """Return True if the user hasn't made contributions to the locale yet."""
+    """Return True if the user has made just 1 contribution to the locale."""
     return (
-        not self.translation_set.filter(locale=locale)
+        self.translation_set.filter(locale=locale)
         .exclude(entity__resource__project__system_project=True)
-        .exists()
+        .count()
+        == 1
     )
 
 

--- a/pontoon/base/models/user.py
+++ b/pontoon/base/models/user.py
@@ -281,7 +281,7 @@ def can_translate(self, locale, project):
     return self.has_perm("base.can_translate_locale", locale)
 
 
-def is_new_contributor(self, locale):
+def has_one_contribution(self, locale):
     """Return True if the user has made just 1 contribution to the locale."""
     return (
         self.translation_set.filter(locale=locale)
@@ -500,7 +500,7 @@ User.add_to_class("badges_promotion_count", badges_promotion_count)
 User.add_to_class("has_approved_translations", has_approved_translations)
 User.add_to_class("top_contributed_locale", top_contributed_locale)
 User.add_to_class("can_translate", can_translate)
-User.add_to_class("is_new_contributor", is_new_contributor)
+User.add_to_class("has_one_contribution", has_one_contribution)
 User.add_to_class("notification_list", notification_list)
 User.add_to_class("menu_notifications", menu_notifications)
 User.add_to_class("unread_notifications_display", unread_notifications_display)

--- a/pontoon/translations/tests/test_views.py
+++ b/pontoon/translations/tests/test_views.py
@@ -218,6 +218,7 @@ def test_notify_managers_on_first_contribution(
     mock_notify,
     member,
     entity_a,
+    entity_b,
     locale_a,
     user_a,
     user_b,
@@ -241,6 +242,7 @@ def test_notify_managers_on_first_contribution(
     user_a.profile.new_contributor_notifications = True
     user_a.profile.save()
 
+    mock_notify.reset_mock()
     response = request_create_translation(
         member.client,
         entity=translation.entity.pk,
@@ -258,6 +260,26 @@ def test_notify_managers_on_first_contribution(
     notify_args = mock_notify.call_args[1]
     assert notify_args["recipient"] == user_a
     assert notify_args["category"] == "new_contributor"
+
+    # Check that the new contributor notification is only sent for the first contribution
+    second_translation = TranslationFactory(
+        entity=entity_b,
+        locale=locale_a,
+        user=user_b,
+        approved=True,
+        active=True,
+    )
+
+    mock_notify.reset_mock()
+    response = request_create_translation(
+        member.client,
+        entity=second_translation.entity.pk,
+        original=second_translation.entity.string,
+        locale=second_translation.locale.code,
+        translation="Second translation",
+    )
+
+    mock_notify.assert_not_called()
 
 
 @pytest.fixture

--- a/pontoon/translations/views.py
+++ b/pontoon/translations/views.py
@@ -128,8 +128,8 @@ def create_translation(request):
     # When user makes their first contribution to the team, notify team managers
     first_contribution = (
         not project.system_project
-        and user.is_new_contributor(locale)
         and user != project.contact
+        and user.is_new_contributor(locale)
     )
     if first_contribution:
         description = render_to_string(

--- a/pontoon/translations/views.py
+++ b/pontoon/translations/views.py
@@ -129,7 +129,7 @@ def create_translation(request):
     first_contribution = (
         not project.system_project
         and user != project.contact
-        and user.is_new_contributor(locale)
+        and user.has_one_contribution(locale)
     )
     if first_contribution:
         description = render_to_string(

--- a/pontoon/translations/views.py
+++ b/pontoon/translations/views.py
@@ -126,7 +126,11 @@ def create_translation(request):
         )
 
     # When user makes their first contribution to the team, notify team managers
-    first_contribution = not project.system_project and user.is_new_contributor(locale)
+    first_contribution = (
+        not project.system_project
+        and user.is_new_contributor(locale)
+        and user != project.contact
+    )
     if first_contribution:
         description = render_to_string(
             "messaging/notifications/new_contributor.html",


### PR DESCRIPTION
Fix #3476.

I've added a test that checks whether the new contributor notification is sent.

I've also excluded the notification to be sent when project manager makes the contribution to the locale.