### PR TITLE
Bugfixes for the /settings page

### DIFF
--- a/pontoon/base/templates/widgets/toggle.html
+++ b/pontoon/base/templates/widgets/toggle.html
@@ -1,7 +1,7 @@
 {% macro button(field) %}
 <span class="toggle-button">
     {% for choice in field.field.choices %}
-    <button type="button" class="{% if field.value() == choice[0] %}active{% endif %}" data-attribute="{{ field.name }}" title="{{ choice[1] }}">{{ choice[0] }}</button>
+    <button type="button" value="{{ choice[0] }}" class="{% if field.value() == choice[0] %}active{% endif %}" data-attribute="{{ field.name }}" title="{{ choice[1] }}">{{ choice[0] }}</button>
     {% endfor %}
 </span>
 {% endmacro %}

--- a/pontoon/contributors/static/js/settings.js
+++ b/pontoon/contributors/static/js/settings.js
@@ -63,7 +63,7 @@ $(function () {
         self.toggleClass('enabled');
 
         // If notification type disabled, uncheck email checkbox
-        if (!self.is('.enabled')) {
+        if (self.parents('.notifications').length && !self.is('.enabled')) {
           const emailChecbox = self.next('.check-box');
           if (emailChecbox.length) {
             emailChecbox.removeClass('enabled');

--- a/pontoon/contributors/static/js/settings.js
+++ b/pontoon/contributors/static/js/settings.js
@@ -15,7 +15,7 @@ $(function () {
     }
 
     const attribute = self.data('attribute');
-    const value = self.text();
+    const value = self.val();
 
     $.ajax({
       url: '/api/v1/user/' + $('#profile input[name="username"]').val() + '/',


### PR DESCRIPTION
A couple of bugfixes for the /settings page:
* [Do not uncheck "Monthly activity summary" when unchecking "News and updates"](https://github.com/mozilla/pontoon/commit/92de6487050c5b022bd3524e5c29b75261e635f7)
* [Read toggle button value from the value attribute](https://github.com/mozilla/pontoon/commit/0598b862ad536587c4f1f75f0e3bfcd0927fca1a)