### PR TITLE
Call send_manual_emails() task asynchronously

### DIFF
--- a/pontoon/messaging/views.py
+++ b/pontoon/messaging/views.py
@@ -312,7 +312,7 @@ def send_message(request):
             if recipient.profile.email_communications_enabled
         ]
 
-        send_manual_emails(email_recipients, subject, body, is_transactional)
+        send_manual_emails.delay(email_recipients, subject, body, is_transactional)
 
     if not send_to_myself:
         message = form.save(commit=False)


### PR DESCRIPTION
That should have been done as part of #3493.