### PR TITLE
Add functionality for counting batch actions

### DIFF
--- a/pontoon/batch/tests/test_views.py
+++ b/pontoon/batch/tests/test_views.py
@@ -144,6 +144,7 @@ def test_batch_approve_valid_translations(
     assert response.json() == {
         "count": 1,
         "invalid_translation_count": 0,
+        "badge_update": {},
     }
 
     translation_dtd_unapproved.refresh_from_db()
@@ -170,6 +171,7 @@ def test_batch_approve_invalid_translations(
     assert response.json() == {
         "count": 0,
         "invalid_translation_count": 1,
+        "badge_update": {},
     }
 
     translation_dtd_invalid_unapproved.refresh_from_db()
@@ -195,6 +197,7 @@ def test_batch_find_and_replace_valid_translations(
     assert response.json() == {
         "count": 1,
         "invalid_translation_count": 0,
+        "badge_update": {},
     }
 
     translation = translation_dtd_unapproved.entity.translation_set.last()
@@ -224,6 +227,7 @@ def test_batch_find_and_replace_invalid_translations(
     assert response.json() == {
         "count": 0,
         "invalid_translation_count": 1,
+        "badge_update": {},
     }
 
     translation = translation_dtd_unapproved.entity.translation_set.last()

--- a/pontoon/batch/views.py
+++ b/pontoon/batch/views.py
@@ -114,7 +114,11 @@ def batch_edit_translations(request):
     invalid_translation_count = len(action_status.get("invalid_translation_pks", []))
     if action_status["count"] == 0:
         return JsonResponse(
-            {"count": 0, "invalid_translation_count": invalid_translation_count}
+            {
+                "count": 0,
+                "invalid_translation_count": invalid_translation_count,
+                "badge_update": action_status["badge_update"],
+            }
         )
 
     tr_pks = [tr.pk for tr in action_status["translated_resources"]]
@@ -145,5 +149,6 @@ def batch_edit_translations(request):
         {
             "count": action_status["count"],
             "invalid_translation_count": invalid_translation_count,
+            "badge_update": action_status["badge_update"],
         }
     )

--- a/translate/src/api/entity.ts
+++ b/translate/src/api/entity.ts
@@ -8,6 +8,7 @@ import type {
   EntityTranslation,
   HistoryTranslation,
 } from './translation';
+import type { BatchBadgeUpdate } from '../modules/batchactions/actions';
 
 /**
  * String that needs to be translated, along with its current metadata,
@@ -42,7 +43,11 @@ export type EntitySiblings = {
 };
 
 type BatchEditResponse =
-  | { count: number; invalid_translation_count?: number }
+  | {
+      count: number;
+      invalid_translation_count?: number;
+      badge_update?: BatchBadgeUpdate;
+    }
   | { error: true };
 
 export async function batchEditEntities(

--- a/translate/src/modules/batchactions/actions.ts
+++ b/translate/src/modules/batchactions/actions.ts
@@ -14,10 +14,16 @@ export const RESET_BATCHACTIONS_RESPONSE = 'batchactions/RESET_RESPONSE';
 export const TOGGLE_BATCHACTIONS = 'batchactions/TOGGLE';
 export const UNCHECK_BATCHACTIONS = 'batchactions/UNCHECK';
 
+export type BatchBadgeUpdate = {
+  name: string | null;
+  level: number | null;
+};
+
 export type ResponseType = {
   action: string;
   changedCount: number | null | undefined;
   invalidCount: number | null | undefined;
+  badgeUpdate: BatchBadgeUpdate | null | undefined;
   error: boolean | null | undefined;
 };
 
@@ -117,6 +123,10 @@ export const performAction =
     location: Location,
     action: 'approve' | 'reject' | 'replace',
     entityIds: number[],
+    showBadgeTooltip: (tooltip: {
+      badgeName: string | null;
+      badgeLevel: number | null;
+    }) => void,
     find?: string,
     replace?: string,
   ) =>
@@ -134,6 +144,10 @@ export const performAction =
     const response: ResponseType = {
       changedCount: 0,
       invalidCount: 0,
+      badgeUpdate: {
+        name: '',
+        level: 0,
+      },
       error: false,
       action,
     };
@@ -141,6 +155,14 @@ export const performAction =
     if ('count' in data) {
       response.changedCount = data.count;
       response.invalidCount = data.invalid_translation_count;
+      response.badgeUpdate = data.badge_update;
+
+      if (response.badgeUpdate?.level && response.badgeUpdate?.level > 0) {
+        showBadgeTooltip({
+          badgeName: response.badgeUpdate.name,
+          badgeLevel: response.badgeUpdate.level,
+        });
+      }
 
       if (data.count > 0) {
         dispatch(updateUI(location, entityIds));

--- a/translate/src/modules/batchactions/components/BatchActions.tsx
+++ b/translate/src/modules/batchactions/components/BatchActions.tsx
@@ -2,6 +2,7 @@ import { Localized } from '@fluent/react';
 import React, { useCallback, useContext, useEffect, useRef } from 'react';
 
 import { Location } from '~/context/Location';
+import { ShowBadgeTooltip } from '~/context/BadgeTooltip';
 import { useAppDispatch, useAppSelector } from '~/hooks';
 
 import { performAction, resetSelection, selectAll } from '../actions';
@@ -18,6 +19,7 @@ import { ReplaceAll } from './ReplaceAll';
 export function BatchActions(): React.ReactElement<'div'> {
   const batchactions = useAppSelector((state) => state[BATCHACTIONS]);
   const location = useContext(Location);
+  const showBadgeTooltip = useContext(ShowBadgeTooltip);
   const dispatch = useAppDispatch();
 
   const find = useRef<HTMLInputElement>(null);
@@ -43,13 +45,27 @@ export function BatchActions(): React.ReactElement<'div'> {
 
   const approveAll = useCallback(() => {
     if (!batchactions.requestInProgress) {
-      dispatch(performAction(location, 'approve', batchactions.entities));
+      dispatch(
+        performAction(
+          location,
+          'approve',
+          batchactions.entities,
+          showBadgeTooltip,
+        ),
+      );
     }
   }, [location, batchactions]);
 
   const rejectAll = useCallback(() => {
     if (!batchactions.requestInProgress) {
-      dispatch(performAction(location, 'reject', batchactions.entities));
+      dispatch(
+        performAction(
+          location,
+          'reject',
+          batchactions.entities,
+          showBadgeTooltip,
+        ),
+      );
     }
   }, [location, batchactions]);
 
@@ -67,6 +83,7 @@ export function BatchActions(): React.ReactElement<'div'> {
             location,
             'replace',
             batchactions.entities,
+            showBadgeTooltip,
             encodeURIComponent(fv),
             encodeURIComponent(rv),
           ),


### PR DESCRIPTION
Fix #3481 

This PR adds badge stat counting logic for batch actions. 

The initial commit is able to send the badge update logic to `translate/src/context/BadgeTooltip.tsx`, but the tooltip component doesn't seem to be rendering.


