### PR TITLE
Fix advanced search options (missing Fluent strings, CSS)

### DIFF
--- a/translate/public/locale/en-US/translate.ftl
+++ b/translate/public/locale/en-US/translate.ftl
@@ -154,7 +154,7 @@ editor-FtlSwitch--active =
 editor-FailedChecks--close = ×
     .aria-label = Close failed checks popup
 editor-FailedChecks--title = THE FOLLOWING CHECKS HAVE FAILED
-editor-FailedChecks--save-anyway = SAVE ANYWAY 
+editor-FailedChecks--save-anyway = SAVE ANYWAY
 editor-FailedChecks--suggest-anyway = SUGGEST ANYWAY
 editor-FailedChecks--approve-anyway = APPROVE ANYWAY
 
@@ -468,7 +468,7 @@ interactivetour-InteractiveTour--comments-content =
     In the Comments tab you can discuss how to translate content with
     your fellow team members. It’s also the place where you can request
     more context about or report an issue in the source string.
-    
+
 interactivetour-InteractiveTour--machinery-title = Machinery
 interactivetour-InteractiveTour--machinery-content =
     The Machinery tab shows automated translation suggestions from
@@ -682,11 +682,15 @@ search-FiltersPanel--apply-filters =
 
 ## Search Options Panel
 
-search-SearchPanel--option-name-identifiers = Search in string identifiers
+search-SearchPanel--option-name-search_match_case = Match case
+search-SearchPanel--option-name-search_match_whole_word = Match whole word
+search-SearchPanel--option-name-search_identifiers = Search in string identifiers
+search-SearchPanel--option-name-search_rejected_translations = Include rejected translations
+search-SearchPanel--option-name-search_exclude_source_strings = Exclude source strings
 
 search-SearchPanel--heading = SEARCH OPTIONS
 
-search-SearchPanel--apply-options = APPLY SEARCH OPTIONS
+search-SearchPanel--apply-searchOptions = APPLY SEARCH OPTIONS
     .title = Apply Selected Search Options
 
 ## Time Range Filter
@@ -700,7 +704,7 @@ search-TimeRangeFilter--save-range = SAVE RANGE
 ## Term
 ## Shows term entry with its metadata
 
-term-Term--copy = 
+term-Term--copy =
     .title = Copy Into Translation
 
 term-Term--for-example = E.G.
@@ -709,9 +713,9 @@ term-Term--for-example = E.G.
 ## User Avatar
 ## Shows user Avatar with alt text
 
-user-UserAvatar--anon-alt-text = 
+user-UserAvatar--anon-alt-text =
     .alt = Anonymous User
-user-UserAvatar--alt-text = 
+user-UserAvatar--alt-text =
     .alt = User Profile
 
 ## User Menu

--- a/translate/public/locale/en-US/translate.ftl
+++ b/translate/public/locale/en-US/translate.ftl
@@ -682,15 +682,15 @@ search-FiltersPanel--apply-filters =
 
 ## Search Options Panel
 
-search-SearchPanel--option-name-search_match_case = Match case
-search-SearchPanel--option-name-search_match_whole_word = Match whole word
-search-SearchPanel--option-name-search_identifiers = Search in string identifiers
-search-SearchPanel--option-name-search_rejected_translations = Include rejected translations
-search-SearchPanel--option-name-search_exclude_source_strings = Exclude source strings
+search-SearchPanel--option-name-search-match-case = Match case
+search-SearchPanel--option-name-search-match-whole-word = Match whole word
+search-SearchPanel--option-name-search-identifiers = Search in string identifiers
+search-SearchPanel--option-name-search-rejected-translations = Include rejected translations
+search-SearchPanel--option-name-search-exclude-source-strings = Exclude source strings
 
 search-SearchPanel--heading = SEARCH OPTIONS
 
-search-SearchPanel--apply-searchOptions = APPLY SEARCH OPTIONS
+search-SearchPanel--apply-search-options = APPLY SEARCH OPTIONS
     .title = Apply Selected Search Options
 
 ## Time Range Filter

--- a/translate/src/modules/search/components/SearchPanel.css
+++ b/translate/src/modules/search/components/SearchPanel.css
@@ -95,10 +95,8 @@
     margin-bottom: 5px;
     margin-top: 8px;
 
-    &:hover,
-    .applied-count {
+    &:hover {
       color: var(--status-translated);
-      margin-top: 35px;
     }
   }
 }

--- a/translate/src/modules/search/components/SearchPanel.tsx
+++ b/translate/src/modules/search/components/SearchPanel.tsx
@@ -39,7 +39,9 @@ const SearchOption = ({
       }}
     >
       <i className='fa'></i>
-      <Localized id={`search-SearchPanel--option-name-${slug}`}>
+      <Localized
+        id={`search-SearchPanel--option-name-${slug.replace(/_/g, '-')}`}
+      >
         <span className='label'>{name}</span>
       </Localized>
     </li>
@@ -71,7 +73,7 @@ export function SearchPanelDialog({
         ))}
       </ul>
 
-      <Localized id='search-SearchPanel--apply-searchOptions'>
+      <Localized id='search-SearchPanel--apply-search-options'>
         <button
           title='Apply Selected Search Options'
           onClick={onApplyOptions}

--- a/translate/src/modules/search/components/SearchPanel.tsx
+++ b/translate/src/modules/search/components/SearchPanel.tsx
@@ -38,7 +38,7 @@ const SearchOption = ({
         onToggle();
       }}
     >
-      <i className='fa fa-w'></i>
+      <i className='fa'></i>
       <Localized id={`search-SearchPanel--option-name-${slug}`}>
         <span className='label'>{name}</span>
       </Localized>


### PR DESCRIPTION
For `fa-w`, see #3507 

The console is full or React errors when opening the panel. The edit removed a bunch of trailing whitespaces, which I think it's useful to remove anyway.