### PR TITLE
Replace Discourse with GitHub Discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you want to go further, you can:
   - [Staging](https://mozilla-pontoon-staging.herokuapp.com/)
   - [Production](https://pontoon.mozilla.org/)
 - For discussing Pontoon's development, get in touch with us on [chat.mozilla.org](https://chat.mozilla.org/#/room/#pontoon:mozilla.org)
-- For feedback, support, and 3rd party deployments, check out [Discourse](https://discourse.mozilla.org/c/pontoon/)
+- For feedback, support, and 3rd party deployments, check out [GitHub Discussions](https://github.com/mozilla/pontoon/discussions)
 
 ## License
 

--- a/contribute.json
+++ b/contribute.json
@@ -10,7 +10,7 @@
     "docs": "https://mozilla-pontoon.readthedocs.io/",
     "chat": "https://chat.mozilla.org/#/room/#pontoon:mozilla.org",
     "chat-contacts": ["mathjazz", "eemeli"],
-    "mailing-list": "https://discourse.mozilla.org/c/pontoon"
+    "mailing-list": "https://github.com/mozilla/pontoon/discussions"
   },
   "bugs": {
     "list": "https://github.com/mozilla/pontoon/issues",

--- a/docs/dev/first-contribution.rst
+++ b/docs/dev/first-contribution.rst
@@ -160,10 +160,8 @@ development. The first one is `chat.mozilla.org <https://chat.mozilla.org/>`_,
 used for real-time chat, quick questions, side-track conversations, etc.
 Find us in the `#pontoon channel <https://chat.mozilla.org/#/room/#pontoon:mozilla.org>`_.
 
-The second is discourse, a forum platform that we use for more long-term
-conversations. We use `Mozilla's community
-discourse <https://discourse.mozilla.org/>`_ instance, posting in the
-`pontoon category <https://discourse.mozilla.org/c/pontoon>`_.
+The second is `GitHub Discussions <https://github.com/mozilla/pontoon/discussions>`_,
+a forum platform that we use for more long-term conversations.
 
 These are both places that we strongly encourage you to join, and they
 are where you should introduce yourself, ask questions, show your work,

--- a/pontoon/base/templates/django/base.html
+++ b/pontoon/base/templates/django/base.html
@@ -77,7 +77,7 @@
 
                   <li><a href="{% url 'pontoon.terms' %}" rel="noopener noreferrer" target="_blank"><i class="fas fa-gavel fa-fw"></i>Terms of Use</a></li>
                   <li><a href="https://github.com/mozilla/pontoon/" rel="noopener noreferrer" target="_blank"><i class="fab fa-github fa-fw"></i>Hack it on GitHub</a></li>
-                  <li><a href="https://discourse.mozilla.org/c/pontoon" rel="noopener noreferrer" target="_blank"><i class="fas fa-comment-dots fa-fw"></i>Give Feedback</a></li>
+                  <li><a href="https://github.com/mozilla/pontoon/discussions" rel="noopener noreferrer" target="_blank"><i class="fas fa-comment-dots fa-fw"></i>Give Feedback</a></li>
                   <li><a href="https://mozilla-l10n.github.io/localizer-documentation/tools/pontoon/" rel="noopener noreferrer" target="_blank"><i class="fas fa-life-ring fa-fw"></i>Help</a></li>
 
                   <li class="horizontal-separator"></li>

--- a/pontoon/base/templates/header.html
+++ b/pontoon/base/templates/header.html
@@ -51,7 +51,7 @@
 
               <li><a href="{{ url('pontoon.terms') }}" rel="noopener noreferrer" target="_blank"><i class="fas fa-gavel fa-fw"></i>Terms of Use</a></li>
               <li><a href="https://github.com/mozilla/pontoon/" rel="noopener noreferrer" target="_blank"><i class="fab fa-github fa-fw"></i>Hack it on GitHub</a></li>
-              <li><a href="https://discourse.mozilla.org/c/pontoon" rel="noopener noreferrer" target="_blank"><i class="fas fa-comment-dots fa-fw"></i>Give Feedback</a></li>
+              <li><a href="https://github.com/mozilla/pontoon/discussions" rel="noopener noreferrer" target="_blank"><i class="fas fa-comment-dots fa-fw"></i>Give Feedback</a></li>
               <li><a href="https://mozilla-l10n.github.io/localizer-documentation/tools/pontoon/" rel="noopener noreferrer" target="_blank"><i class="fas fa-life-ring fa-fw"></i>Help</a></li>
 
               {% if user.is_authenticated %}

--- a/pontoon/homepage/templates/homepage_content.html
+++ b/pontoon/homepage/templates/homepage_content.html
@@ -116,7 +116,7 @@
           <a href="https://github.com/mozilla/pontoon/">Hack it on GitHub</a>
         </div>
         <div class="flex-col-3 contact">
-          <a href="https://discourse.mozilla.org/c/pontoon">Give Feedback</a>
+          <a href="https://github.com/mozilla/pontoon/discussions">Give Feedback</a>
         </div>
       </div>
     </div>

--- a/translate/src/modules/user/components/UserMenu.tsx
+++ b/translate/src/modules/user/components/UserMenu.tsx
@@ -204,7 +204,7 @@ export function UserMenuDialog({
           elems={{ glyph: <i className='fas fa-comment-dots fa-fw' /> }}
         >
           <a
-            href='https://discourse.mozilla.org/c/pontoon'
+            href='https://github.com/mozilla/pontoon/discussions'
             rel='noopener noreferrer'
             target='_blank'
           >


### PR DESCRIPTION
Before deployment, we should "lock" https://discourse.mozilla.org/c/pontoon/258 and pin a post pointing to GitHub Discussions.

After deployment, we should update references in the Homepage and Transaction email content, which are stored in the DB.