### PR TITLE
Restore fix for Fluent references in advanced search options

### DIFF
--- a/translate/src/modules/search/components/SearchPanel.tsx
+++ b/translate/src/modules/search/components/SearchPanel.tsx
@@ -39,7 +39,9 @@ const SearchOption = ({
       }}
     >
       <i className='fas'></i>
-      <Localized id={`search-SearchPanel--option-name-${slug}`}>
+      <Localized
+        id={`search-SearchPanel--option-name-${slug.replace(/_/g, '-')}`}
+      >
         <span className='label'>{name}</span>
       </Localized>
     </li>


### PR DESCRIPTION
This was fixed in #3508, but lost in the rebase of #3509