### PR TITLE
Account for missing resource from previous sync implementation

### DIFF
--- a/pontoon/sync/core/translations_from_repo.py
+++ b/pontoon/sync/core/translations_from_repo.py
@@ -257,7 +257,7 @@ def find_db_updates(
         return None
 
     log.debug(f"[{project.slug}] Compiling updates...")
-    trans_res = {resources[db_path] for db_path, _, _ in translations}
+    trans_res = {resources[db_path] for db_path, _, _ in translations if db_path in resources}
     entities: dict[tuple[str, str], int] = {
         (e["resource__path"], e["key"] or e["string"]): e["id"]
         for e in Entity.objects.filter(resource__in=trans_res, obsolete=False)

--- a/pontoon/sync/core/translations_from_repo.py
+++ b/pontoon/sync/core/translations_from_repo.py
@@ -257,7 +257,9 @@ def find_db_updates(
         return None
 
     log.debug(f"[{project.slug}] Compiling updates...")
-    trans_res = {resources[db_path] for db_path, _, _ in translations if db_path in resources}
+    trans_res = {
+        resources[db_path] for db_path, _, _ in translations if db_path in resources
+    }
     entities: dict[tuple[str, str], int] = {
         (e["resource__path"], e["key"] or e["string"]): e["id"]
         for e in Entity.objects.filter(resource__in=trans_res, obsolete=False)


### PR DESCRIPTION
The `region.properties` files were previously ignored, and with no change to the source resource, normal sync hasn't noticed that they should be added.

A forced sync should be run for `seamonkey` to expose the files.