### PR TITLE
Change default theme to system

### DIFF
--- a/pontoon/base/models/user_profile.py
+++ b/pontoon/base/models/user_profile.py
@@ -35,7 +35,7 @@ class UserProfile(models.Model):
     theme = models.CharField(
         choices=Themes.choices,
         max_length=20,
-        default=Themes.DARK,
+        default=Themes.SYSTEM,
     )
 
     # External accounts

--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -54,16 +54,16 @@ def return_url(request):
 
 @library.global_function
 def user_theme(user):
-    """Get user's theme or return 'dark' if user is not authenticated."""
+    """Get user's theme or return 'system' if user is not authenticated."""
     if user.is_authenticated:
         return user.profile.theme
-    return "dark"
+    return "system"
 
 
 @library.global_function
 def theme_class(request):
     """Get theme class name based on user preferences and system settings."""
-    theme = "dark"
+    theme = "system"
     user = request.user
 
     if user.is_authenticated:


### PR DESCRIPTION
Fix #3339 

This PR changes the default theme for all users to match their system preferences, regardless of if they're an authenticated user.

To reproduce results: After running the server, open `localhost:8000` in a new tab. Then, go into your computer's system settings and switch your preferred theme to the opposite of what you currently have selected. You should see Pontoon's theme also change at the same time you switch your preferred theme. 