### PR TITLE
Reduce database queries on dashboards

### DIFF
--- a/pontoon/base/models/project.py
+++ b/pontoon/base/models/project.py
@@ -13,7 +13,7 @@ from pontoon.base.models.locale import Locale
 
 
 if TYPE_CHECKING:
-    from pontoon.base.models import Resource
+    from pontoon.base.models import ProjectLocale, Resource
 
 
 class Priority(models.IntegerChoices):
@@ -124,6 +124,7 @@ class Project(models.Model, AggregatedStats):
     slug = models.SlugField(unique=True)
     locales = models.ManyToManyField(Locale, through="ProjectLocale")
 
+    project_locale: BaseManager["ProjectLocale"]
     resources: BaseManager["Resource"]
 
     class DataSource(models.TextChoices):

--- a/pontoon/base/models/project.py
+++ b/pontoon/base/models/project.py
@@ -284,9 +284,11 @@ class Project(models.Model, AggregatedStats):
                 else None
             )
 
+        pl_fetched = getattr(self, "fetched_project_locale", None)
         project_locale = (
-            getattr(self, "fetched_project_locale", None)
-            or ProjectLocale.objects.filter(project=self, locale=locale).first()
+            pl_fetched[0]
+            if pl_fetched
+            else ProjectLocale.objects.filter(project=self, locale=locale).first()
         )
         return (
             project_locale.latest_translation.latest_activity

--- a/pontoon/base/models/project.py
+++ b/pontoon/base/models/project.py
@@ -278,10 +278,6 @@ class Project(models.Model, AggregatedStats):
 
         return ProjectLocale.get_latest_activity(self, locale)
 
-    @property
-    def avg_string_count(self):
-        return int(self.total_strings / self.enabled_locales)
-
     def resource_priority_map(self):
         """
         Returns a map of resource paths and highest priorities of resource tags.

--- a/pontoon/base/models/project.py
+++ b/pontoon/base/models/project.py
@@ -277,7 +277,22 @@ class Project(models.Model, AggregatedStats):
     def get_latest_activity(self, locale=None):
         from pontoon.base.models.project_locale import ProjectLocale
 
-        return ProjectLocale.get_latest_activity(self, locale)
+        if locale is None:
+            return (
+                self.latest_translation.latest_activity
+                if self.latest_translation
+                else None
+            )
+
+        project_locale = (
+            getattr(self, "fetched_project_locale", None)
+            or ProjectLocale.objects.filter(project=self, locale=locale).first()
+        )
+        return (
+            project_locale.latest_translation.latest_activity
+            if project_locale and project_locale.latest_translation
+            else None
+        )
 
     def resource_priority_map(self):
         """

--- a/pontoon/base/models/project_locale.py
+++ b/pontoon/base/models/project_locale.py
@@ -1,7 +1,6 @@
 from django.contrib.auth.models import Group
 from django.db import models
 
-from pontoon.base import utils
 from pontoon.base.aggregated_stats import AggregatedStats
 from pontoon.base.models.locale import Locale
 from pontoon.base.models.project import Project
@@ -79,35 +78,3 @@ class ProjectLocale(models.Model, AggregatedStats):
             project=self.project.name,
             locale=self.locale.code,
         )
-
-    @classmethod
-    def get_latest_activity(cls, self, extra=None):
-        """
-        Get the latest activity within project, locale
-        or combination of both.
-
-        :param self: object to get data for,
-            instance of Project or Locale
-        :param extra: extra filter to be used,
-            instance of Project or Locale
-        """
-        latest_translation = None
-
-        if getattr(self, "fetched_project_locale", None):
-            if self.fetched_project_locale:
-                latest_translation = self.fetched_project_locale[0].latest_translation
-
-        elif extra is None:
-            latest_translation = self.latest_translation
-
-        else:
-            project = self if isinstance(self, Project) else extra
-            locale = self if isinstance(self, Locale) else extra
-            project_locale = utils.get_object_or_none(
-                ProjectLocale, project=project, locale=locale
-            )
-
-            if project_locale is not None:
-                latest_translation = project_locale.latest_translation
-
-        return latest_translation.latest_activity if latest_translation else None

--- a/pontoon/base/models/user.py
+++ b/pontoon/base/models/user.py
@@ -165,19 +165,19 @@ def user_role(self, managers=None, translators=None):
         if self in managers:
             return "Manager for " + ", ".join(managers[self])
     else:
-        if self.can_manage_locales:
-            return "Manager for " + ", ".join(
-                self.can_manage_locales.values_list("code", flat=True)
-            )
+        manager_for_locales = self.can_manage_locales.values_list("code", flat=True)
+        if manager_for_locales:
+            return "Manager for " + ", ".join(manager_for_locales)
 
     if translators is not None:
         if self in translators:
             return "Translator for " + ", ".join(translators[self])
     else:
-        if self.can_translate_locales:
-            return "Translator for " + ", ".join(
-                self.can_translate_locales.values_list("code", flat=True)
-            )
+        translator_for_locales = self.can_translate_locales.values_list(
+            "code", flat=True
+        )
+        if translator_for_locales:
+            return "Translator for " + ", ".join(translator_for_locales)
 
     return "Contributor"
 
@@ -315,7 +315,7 @@ def can_translate(self, locale, project):
     from pontoon.base.models.project_locale import ProjectLocale
 
     # Locale managers can translate all projects
-    if locale in self.can_manage_locales:
+    if self.has_perm("base.can_manage_locale", locale):
         return True
 
     project_locale = ProjectLocale.objects.get(project=project, locale=locale)

--- a/pontoon/base/tests/models/test_locale.py
+++ b/pontoon/base/tests/models/test_locale.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 

--- a/pontoon/base/tests/models/test_locale.py
+++ b/pontoon/base/tests/models/test_locale.py
@@ -1,8 +1,5 @@
-from unittest.mock import patch
 
 import pytest
-
-from pontoon.base.models import ProjectLocale
 
 
 @pytest.mark.django_db
@@ -22,18 +19,6 @@ def test_locale_latest_activity_without_latest(locale_b):
     is given, return None.
     """
     assert locale_b.get_latest_activity() is None
-
-
-@pytest.mark.django_db
-def test_locale_latest_activity_with_project(locale_a, project_a):
-    """
-    If a locale is given, defer to
-    ProjectLocale.get_latest_activity.
-    """
-    with patch.object(ProjectLocale, "get_latest_activity") as m:
-        m.return_value = "latest"
-        assert locale_a.get_latest_activity(project=project_a) == "latest"
-        assert m.call_args[0] == (locale_a, project_a)
 
 
 @pytest.mark.django_db

--- a/pontoon/base/tests/models/test_project.py
+++ b/pontoon/base/tests/models/test_project.py
@@ -4,7 +4,7 @@ import pytest
 
 from django.contrib.auth.models import AnonymousUser
 
-from pontoon.base.models import Project, ProjectLocale
+from pontoon.base.models import Project
 from pontoon.test.factories import LocaleFactory, ProjectFactory, ProjectLocaleFactory
 
 
@@ -18,29 +18,6 @@ def test_project_latest_activity_with_latest(project_a, translation_a):
 def test_project_latest_activity_without_latest(project_a):
     assert project_a.latest_translation is None
     assert project_a.get_latest_activity() is None
-
-
-@pytest.mark.django_db
-def test_project_latest_activity_doesnt_exist(project_a, locale_a):
-    assert not (
-        ProjectLocale.objects.filter(project=project_a, locale=locale_a).exists()
-    )
-    assert project_a.get_latest_activity(locale_a) is None
-
-
-@pytest.mark.django_db
-def test_project_latest_activity_no_latest(project_a, locale_a):
-    ProjectLocaleFactory.create(project=project_a, locale=locale_a)
-    assert project_a.get_latest_activity(locale_a) is None
-
-
-@pytest.mark.django_db
-def test_project_latest_activity_success(translation_a):
-    latest = translation_a.entity.resource.project.get_latest_activity(
-        translation_a.locale
-    )
-    assert latest
-    assert latest == translation_a.latest_activity
 
 
 @pytest.fixture

--- a/pontoon/base/tests/models/test_project_locale.py
+++ b/pontoon/base/tests/models/test_project_locale.py
@@ -1,44 +1,6 @@
 import pytest
 
-from pontoon.base.models import ProjectLocale
 from pontoon.test.factories import ProjectLocaleFactory
-
-
-@pytest.mark.django_db
-def test_projectlocale_latest_activity_doesnt_exist(project_a, locale_a):
-    """
-    If no ProjectLocale exists with the given project/locale,
-    return None.
-    """
-    assert not (
-        ProjectLocale.objects.filter(project=project_a, locale=locale_a).exists()
-    )
-    assert ProjectLocale.get_latest_activity(project_a, locale_a) is None
-
-
-@pytest.mark.django_db
-def test_projectlocale_latest_activity_no_latest(project_a, locale_a):
-    """
-    If the matching ProjectLocale has no latest_translation, return
-    None.
-    """
-    ProjectLocaleFactory.create(project=project_a, locale=locale_a)
-    assert ProjectLocale.get_latest_activity(project_a, locale_a) is None
-
-
-@pytest.mark.django_db
-def test_projectlocale_latest_activity_success(translation_a):
-    """
-    If the matching ProjectLocale has a latest_translation, return
-    it's latest_activity.
-    """
-    project = translation_a.entity.resource.project
-    locale = translation_a.locale
-    assert ProjectLocale.get_latest_activity(project, locale)
-    assert (
-        ProjectLocale.get_latest_activity(project, locale)
-        == translation_a.latest_activity
-    )
 
 
 @pytest.mark.django_db

--- a/pontoon/base/tests/test_utils.py
+++ b/pontoon/base/tests/test_utils.py
@@ -5,11 +5,9 @@ from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
 
-from pontoon.base.models import Project
 from pontoon.base.utils import (
     aware_datetime,
     get_m2m_changes,
-    get_object_or_none,
     get_search_phrases,
     is_email,
     latest_datetime,
@@ -575,12 +573,6 @@ def test_get_m2m_mixed(user_a, user_b, user_c):
     assert user_a in changes[0]
     assert user_c in changes[0]
     assert [user_b] == changes[1]
-
-
-@pytest.mark.django_db
-def test_util_base_get_object_or_none(project_a):
-    assert get_object_or_none(Project, slug="does-not-exist") is None
-    assert get_object_or_none(Project, slug=project_a.slug) == project_a
 
 
 def test_util_base_latest_datetime():

--- a/pontoon/base/utils.py
+++ b/pontoon/base/utils.py
@@ -65,17 +65,6 @@ def group_dict_by(list_of_dicts, key):
     return group
 
 
-def get_object_or_none(model, *args, **kwargs):
-    """
-    Get an instance of the given model, returning None instead of
-    raising an error if an instance cannot be found.
-    """
-    try:
-        return model.objects.get(*args, **kwargs)
-    except model.DoesNotExist:
-        return None
-
-
 def is_ajax(request):
     """
     Checks whether the given request is an AJAX request.

--- a/pontoon/contributors/templates/contributors/settings.html
+++ b/pontoon/contributors/templates/contributors/settings.html
@@ -275,7 +275,7 @@
                 title='Run Translate Toolkit checks before submitting translations')
                 }}
 
-                {% if user.can_translate_locales %}
+                {% if user.can_translate_locales.exists() %}
                 {{ Checkbox.checkbox(
                 'Make suggestions',
                 class='force-suggestions',

--- a/pontoon/projects/templates/projects/includes/teams.html
+++ b/pontoon/projects/templates/projects/includes/teams.html
@@ -23,7 +23,7 @@
     {% set chart_link = url('pontoon.translate', locale.code, project.slug, 'all-resources') %}
 
     {% if not tag %}
-      {% set latest_activity = locale.get_latest_activity(project) %}
+      {% set latest_activity = latest_activities.get(locale.id) %}
       {% set chart = locale_stats.get(locale.id, {'total': 0}) %}
     {% endif %}
     {% if locale.code in locale_projects %}

--- a/pontoon/projects/templates/projects/widgets/project_list.html
+++ b/pontoon/projects/templates/projects/widgets/project_list.html
@@ -22,7 +22,7 @@
     <tbody>
 {% endmacro %}
 
-{% macro item(project, main_link, chart_link, latest_activity, chart, class='limited', allStrings=False, request=False, link_parameter=False) %}
+{% macro item(project, main_link, chart_link, latest_activity, chart, class='limited', all_strings=False, request=False, link_parameter=False) %}
   <tr class="{{ class }}">
     <td class="name" data-slug="{{ project.slug }}">
       <h4>
@@ -45,7 +45,7 @@
         <span class="not-ready">Not synced yet</span>
       {% endif %}
     </td>
-    {% if allStrings %}
+    {% if all_strings %}
       <td class="all-strings">
         {% if chart.total %}
           <span>{{ (chart.total / project.enabled_locales) | int | intcomma }}</span>

--- a/pontoon/projects/templates/projects/widgets/project_list.html
+++ b/pontoon/projects/templates/projects/widgets/project_list.html
@@ -48,7 +48,7 @@
     {% if request %}
       <td class="all-strings">
         {% if chart.total %}
-          <span>{{ project.avg_string_count|intcomma }}</span>
+          <span>{{ (chart.total / project.enabled_locales) | int | intcomma }}</span>
         {% else %}
           <span class="not-ready">Not synced yet</span>
         {% endif %}

--- a/pontoon/projects/templates/projects/widgets/project_list.html
+++ b/pontoon/projects/templates/projects/widgets/project_list.html
@@ -22,7 +22,7 @@
     <tbody>
 {% endmacro %}
 
-{% macro item(project, main_link, chart_link, latest_activity, chart, class='limited', request=False, link_parameter=False) %}
+{% macro item(project, main_link, chart_link, latest_activity, chart, class='limited', allStrings=False, request=False, link_parameter=False) %}
   <tr class="{{ class }}">
     <td class="name" data-slug="{{ project.slug }}">
       <h4>
@@ -45,7 +45,7 @@
         <span class="not-ready">Not synced yet</span>
       {% endif %}
     </td>
-    {% if request %}
+    {% if allStrings %}
       <td class="all-strings">
         {% if chart.total %}
           <span>{{ (chart.total / project.enabled_locales) | int | intcomma }}</span>
@@ -53,6 +53,8 @@
           <span class="not-ready">Not synced yet</span>
         {% endif %}
       </td>
+    {% endif %}
+    {% if request %}
       <td class="check fas fa-fw"></td>
     {% endif %}
   </tr>

--- a/pontoon/teams/templates/teams/includes/projects.html
+++ b/pontoon/teams/templates/teams/includes/projects.html
@@ -44,7 +44,7 @@
     {% set latest_activity = latest_activities.get(project.id) %}
     {% set chart = project_stats.get(project.id, {'total': 0}) %}
 
-    {{ ProjectList.item(project, main_link, chart_link, latest_activity, chart, class='', allStrings=True, request=True, link_parameter=True) }}
+    {{ ProjectList.item(project, main_link, chart_link, latest_activity, chart, class='', all_strings=True, request=True, link_parameter=True) }}
   {% endfor %}
 
   {{ ProjectList.footer(request=True) }}

--- a/pontoon/teams/templates/teams/includes/projects.html
+++ b/pontoon/teams/templates/teams/includes/projects.html
@@ -35,7 +35,7 @@
       {% set class = class + ' pretranslated' %}
     {% endif %}
 
-    {{ ProjectList.item(project, main_link, chart_link, latest_activity, chart, class, request=False, link_parameter=True) }}
+    {{ ProjectList.item(project, main_link, chart_link, latest_activity, chart, class, request=True, link_parameter=True) }}
   {% endfor %}
 
   {% for project in projects_to_request %}
@@ -44,7 +44,7 @@
     {% set latest_activity = latest_activities.get(project.id) %}
     {% set chart = project_stats.get(project.id, {'total': 0}) %}
 
-    {{ ProjectList.item(project, main_link, chart_link, latest_activity, chart, '', request=True, link_parameter=True) }}
+    {{ ProjectList.item(project, main_link, chart_link, latest_activity, chart, class='', allStrings=True, request=True, link_parameter=True) }}
   {% endfor %}
 
   {{ ProjectList.footer(request=True) }}

--- a/pontoon/teams/templates/teams/includes/projects.html
+++ b/pontoon/teams/templates/teams/includes/projects.html
@@ -1,13 +1,13 @@
 {% import 'projects/widgets/project_list.html' as ProjectList with context %}
 
 <div class="projects items">
-  <menu class="controls {% if no_visible_projects %}no-projects{% endif %}">
+  <menu class="controls {% if not enabled_projects %}no-projects{% endif %}">
     <div class="search-wrapper small clearfix">
       <div class="icon fas fa-search"></div>
       <input class="table-filter" type="search" autocomplete="off" autofocus placeholder="Filter projects">
     </div>
 
-    {% if project_request_enabled %}
+    {% if projects_to_request %}
     <button class="request-toggle button small request-projects">
       <span class="fas fa-chevron-right"></span>
     </button>
@@ -20,32 +20,37 @@
     {% endif %}
   </menu>
 
-  {{ ProjectList.header(request=True, visible=not no_visible_projects) }}
+  {{ ProjectList.header(request=True, visible=enabled_projects) }}
 
-  {% for project in projects %}
+  {% for project in enabled_projects %}
     {% set main_link = url('pontoon.projects.project', project.slug) %}
     {% set chart_link = url('pontoon.translate', locale.code, project.slug, 'all-resources') %}
-    {% set latest_activity = project.get_latest_activity(locale) %}
+    {% set latest_activity = latest_activities.get(project.id) %}
     {% set chart = project_stats.get(project.id, {'total': 0}) %}
-    {% if project in enabled_projects %}
-      {% set class = 'limited' %}
-      {% if project in pretranslated_projects %}
-        {% set class = class + ' pretranslated' %}
-      {% endif %}
-      {% if chart %}
-        {% set main_link = url('pontoon.localizations.localization', locale.code, project.slug) %}
-      {% endif %}
-    {% else %}
-      {% set class = '' %}
+    {% if chart %}
+      {% set main_link = url('pontoon.localizations.localization', locale.code, project.slug) %}
+    {% endif %}
+    {% set class = 'limited' %}
+    {% if project.id in pretranslated_project_ids %}
+      {% set class = class + ' pretranslated' %}
     {% endif %}
 
-    {{ ProjectList.item(project, main_link, chart_link, latest_activity, chart, class, request=True, link_parameter=True) }}
+    {{ ProjectList.item(project, main_link, chart_link, latest_activity, chart, class, request=False, link_parameter=True) }}
+  {% endfor %}
+
+  {% for project in projects_to_request %}
+    {% set main_link = url('pontoon.projects.project', project.slug) %}
+    {% set chart_link = url('pontoon.translate', locale.code, project.slug, 'all-resources') %}
+    {% set latest_activity = latest_activities.get(project.id) %}
+    {% set chart = project_stats.get(project.id, {'total': 0}) %}
+
+    {{ ProjectList.item(project, main_link, chart_link, latest_activity, chart, '', request=True, link_parameter=True) }}
   {% endfor %}
 
   {{ ProjectList.footer(request=True) }}
 
 </div>
 
-{% if no_visible_projects %}
+{% if not enabled_projects %}
 <p class="no-results">No projects enabled for the team yet.</p>
 {% endif %}

--- a/pontoon/teams/views.py
+++ b/pontoon/teams/views.py
@@ -3,6 +3,8 @@ import logging
 import re
 import xml.etree.ElementTree as ET
 
+from typing import cast
+
 import bleach
 
 from guardian.decorators import permission_required_or_403
@@ -15,8 +17,9 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.mail import EmailMessage
 from django.core.paginator import Paginator
 from django.db import transaction
-from django.db.models import Count, Prefetch, Q, TextField
+from django.db.models import Count, F, Prefetch, Q, TextField
 from django.db.models.functions import Cast
+from django.db.models.manager import BaseManager
 from django.http import (
     Http404,
     HttpResponse,
@@ -41,6 +44,8 @@ from pontoon.base.models import (
     TranslationMemoryEntry,
     User,
 )
+from pontoon.base.models.project_locale import ProjectLocale
+from pontoon.base.models.translation import Translation
 from pontoon.base.utils import get_locale_or_redirect, require_AJAX
 from pontoon.contributors.views import ContributorsMixin
 from pontoon.insights.utils import get_locale_insights
@@ -102,47 +107,64 @@ def ajax_projects(request, locale):
     """Team Projects tab."""
     locale = get_object_or_404(Locale, code=locale)
 
-    projects = (
-        Project.objects.visible()
-        .visible_for(request.user)
-        .filter(Q(locales=locale) | Q(can_be_requested=True))
-        .prefetch_project_locale(locale)
-        .order_by("name")
+    projects = cast(
+        BaseManager[Project],
+        Project.objects.visible().visible_for(request.user),
+    ).order_by("name")
+
+    enabled_projects = list(projects.filter(locales=locale))
+
+    latest_activities = {
+        trans.project_id: trans.latest_activity
+        for trans in Translation.objects.filter(
+            id__in=(project.latest_translation_id for project in enabled_projects)
+        )
+        .select_related("user", "approved_user")
+        .annotate(project_id=F("entity__resource__project__id"))
+    }
+
+    projects_to_request = (
+        projects.exclude(locales=locale)
+        .filter(can_be_requested=True)
         .annotate(enabled_locales=Count("project_locale", distinct=True))
+        if request.user.is_authenticated
+        else []
     )
 
-    enabled_projects = projects.filter(locales=locale)
-    no_visible_projects = enabled_projects.count() == 0
-
-    project_request_enabled = (
-        request.user.is_authenticated and projects.exclude(locales=locale).count() > 0
-    )
-
-    pretranslated_projects = enabled_projects.filter(
-        project_locale__pretranslation_enabled=True, project_locale__locale=locale
-    )
-
-    pretranslation_request_enabled = (
-        request.user.is_authenticated
-        and locale in request.user.can_translate_locales
-        and locale.code in settings.GOOGLE_AUTOML_SUPPORTED_LOCALES
-        and pretranslated_projects.count() < enabled_projects.count()
-    )
-
-    if not projects:
+    if not enabled_projects and not projects_to_request:
         raise Http404
+
+    if (
+        request.user.is_authenticated
+        and locale.code in settings.GOOGLE_AUTOML_SUPPORTED_LOCALES
+    ):
+        pretranslated_project_ids = set(
+            ProjectLocale.objects.filter(
+                locale=locale,
+                pretranslation_enabled=True,
+                project__in=enabled_projects,
+            )
+            .order_by()
+            .values_list("project_id", flat=True)
+        )
+        pretranslation_request_enabled = (
+            len(pretranslated_project_ids) < len(enabled_projects)
+            and request.user.can_translate_locales.filter(id=locale.id).exists()
+        )
+    else:
+        pretranslated_project_ids = set()
+        pretranslation_request_enabled = False
 
     return render(
         request,
         "teams/includes/projects.html",
         {
             "locale": locale,
-            "projects": projects,
             "project_stats": Project.objects.all().stats_data(locale),
+            "latest_activities": latest_activities,
             "enabled_projects": enabled_projects,
-            "no_visible_projects": no_visible_projects,
-            "project_request_enabled": project_request_enabled,
-            "pretranslated_projects": pretranslated_projects,
+            "projects_to_request": projects_to_request,
+            "pretranslated_project_ids": pretranslated_project_ids,
             "pretranslation_request_enabled": pretranslation_request_enabled,
         },
     )

--- a/pontoon/teams/views.py
+++ b/pontoon/teams/views.py
@@ -665,7 +665,7 @@ def request_pretranslation(request, locale):
     locale = get_object_or_404(Locale, code=locale)
 
     # Validate user
-    if locale not in user.can_translate_locales:
+    if not user.has_perm("base.can_translate_locale", locale):
         return HttpResponseBadRequest(
             "Bad Request: Requester is not a translator or manager for the locale"
         )


### PR DESCRIPTION
Fixes #3545 

This should speed things up a bit. Two related changes are included to resolve the identified inefficiencies, and a couple of the `Locale` methods are dropped/simplified to match current usage. The `ProjectLocale.get_latest_activity()` function is split into two separate implementations on `Locale` and `Project`, as they are now rather different, and the `get_object_or_none()` utility is dropped as obsolete.