### PR TITLE
Move badge notification code out of update_db_translations()

### DIFF
--- a/pontoon/sync/core/translations_from_repo.py
+++ b/pontoon/sync/core/translations_from_repo.py
@@ -29,7 +29,6 @@ from pontoon.base.models import (
 )
 from pontoon.checks import DB_FORMATS
 from pontoon.checks.utils import bulk_run_checks
-from pontoon.messaging.notifications import send_badge_notification
 from pontoon.sync.core.checkout import Checkout, Checkouts
 from pontoon.sync.core.paths import UploadPaths
 from pontoon.sync.formats import parse
@@ -77,13 +76,12 @@ def sync_translations_from_repo(
 
 def write_db_updates(
     project: Project, updates: Updates, user: User | None, now: datetime
-) -> tuple[str, int]:
-    badge_name, badge_level, updated_translations, new_translations = (
-        update_db_translations(project, updates, user, now)
+) -> None:
+    updated_translations, new_translations = update_db_translations(
+        project, updates, user, now
     )
     add_failed_checks(new_translations)
     add_translation_memory_entries(project, new_translations + updated_translations)
-    return badge_name, badge_level
 
 
 def delete_removed_bilingual_resources(
@@ -464,24 +462,10 @@ def update_db_translations(
             f"[{project.slug}] Created {str_n_translations(created)} from repo changes"
         )
 
-    badge_name = ""
-    badge_level = 0
     if actions:
-        translation_before_level = log_user.badges_translation_level
-        review_before_level = log_user.badges_review_level
-
         ActionLog.objects.bulk_create(actions)
-        if log_user.username != "pontoon-sync":
-            if log_user.badges_translation_level > translation_before_level:
-                badge_name = "Translation Champion"
-                badge_level = log_user.badges_translation_level
-                send_badge_notification(log_user, badge_name, badge_level)
-            if log_user.badges_review_level > review_before_level:
-                badge_name = "Review Master"
-                badge_level = log_user.badges_review_level
-                send_badge_notification(log_user, badge_name, badge_level)
 
-    return badge_name, badge_level, created, list(suggestions.values())
+    return created, list(suggestions.values())
 
 
 def str_n_translations(n: int | Sized) -> str:


### PR DESCRIPTION
Code that's specifically and only for manualy file imports should not be in the sync internals.

This PR also fixes a bug introduced in #3522, as the type hint for `update_db_translations()` was not updated, and the early return was also not updated:

https://github.com/mozilla/pontoon/blob/1278167d98ac9810eccaf98698718988a23f2038/pontoon/sync/core/translations_from_repo.py#L81-L83

https://github.com/mozilla/pontoon/blob/1278167d98ac9810eccaf98698718988a23f2038/pontoon/sync/core/translations_from_repo.py#L295-L302