### PR TITLE
add the SECURE_SSL_REDIRECT env var

### DIFF
--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -275,6 +275,10 @@ you create:
    A list of strings representing the host/domain names the site can serve.
    Defaults to ``.localhost, 127.0.0.1, [::1]``, should always be set in production.
 
+``SECURE_SSL_REDIRECT``
+   Tells Django to not respond with a redirect when the app is accessed using the `http`
+   protocol. Read more at: https://docs.djangoproject.com/en/5.1/ref/settings/#secure-ssl-redirect
+
 ``SSH_CONFIG``
    Contents of the ``~/.ssh/config`` file used when Pontoon connects to VCS
    servers via SSH. Used for disabling strict key checking and setting the

--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -276,8 +276,9 @@ you create:
    Defaults to ``.localhost, 127.0.0.1, [::1]``, should always be set in production.
 
 ``SECURE_SSL_REDIRECT``
-   Tells Django to not respond with a redirect when the app is accessed using the `http`
-   protocol. Read more at: https://docs.djangoproject.com/en/5.1/ref/settings/#secure-ssl-redirect
+   Optional. If True, redirects all non-HTTPS requests to HTTPS. Default value is `True`.
+
+   Learn more at: https://docs.djangoproject.com/en/5.1/ref/settings/#secure-ssl-redirect
 
 ``SSH_CONFIG``
    Contents of the ``~/.ssh/config`` file used when Pontoon connects to VCS

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -913,7 +913,7 @@ SECURE_CONTENT_TYPE_NOSNIFF = True
 SECURE_BROWSER_XSS_FILTER = True
 
 # Redirect non-HTTPS requests to HTTPS
-SECURE_SSL_REDIRECT = not (DEBUG or os.environ.get("CI", False))
+SECURE_SSL_REDIRECT = os.environ.get("SECURE_SSL_REDIRECT", "True") == "True" and (not (DEBUG or os.environ.get("CI", False)))
 
 # Content-Security-Policy headers
 CSP_DEFAULT_SRC = ("'none'",)

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -913,7 +913,9 @@ SECURE_CONTENT_TYPE_NOSNIFF = True
 SECURE_BROWSER_XSS_FILTER = True
 
 # Redirect non-HTTPS requests to HTTPS
-SECURE_SSL_REDIRECT = os.environ.get("SECURE_SSL_REDIRECT", "True") == "True" and (not (DEBUG or os.environ.get("CI", False)))
+SECURE_SSL_REDIRECT = (
+    os.environ.get("SECURE_SSL_REDIRECT", "True") != "False" and not DEV
+)
 
 # Content-Security-Policy headers
 CSP_DEFAULT_SRC = ("'none'",)


### PR DESCRIPTION
Hey, I am deploying the app behind a reverse proxy, which deals with this redirect. If I don't disable it I get an infinite redirect loop. This env var allows me to fix this issue.