### PR TITLE
allow configuring the CSRF_TRUSTED_ORIGINS using an env var

### DIFF
--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -811,6 +811,11 @@ STATICFILES_DIRS = [
 allowed_hosts = os.environ.get("ALLOWED_HOSTS")
 ALLOWED_HOSTS = allowed_hosts.split(",") if allowed_hosts else []
 
+csrf_trusted_origins = os.environ.get("CSRF_TRUSTED_ORIGINS")
+
+if csrf_trusted_origins:
+    CSRF_TRUSTED_ORIGINS = csrf_trusted_origins.split(",")
+
 # Auth
 # The first hasher in this list will be used for new passwords.
 # Any other hasher in the list can be used for existing passwords.


### PR DESCRIPTION
I need to customize this env var when I run the app using a reverse proxy. Otherwise, all the form submissions will fail with a CSRF error. 