### PR TITLE
Only PMs should be able to pin and unpin comments

### DIFF
--- a/pontoon/base/tests/models/test_comment.py
+++ b/pontoon/base/tests/models/test_comment.py
@@ -1,38 +1,36 @@
 import pytest
 
-from pontoon.test.factories import (
-    ProjectFactory,
-    TeamCommentFactory,
-    TranslationCommentFactory,
-)
+from pontoon.test.factories import ProjectFactory
 
 
 @pytest.mark.django_db
-def test_serialize_comments():
-    tr = TranslationCommentFactory.create()
-    team = TeamCommentFactory.create()
+def test_serialize_comments(comment_a, team_comment_a):
     project = ProjectFactory.create()
 
-    assert tr.serialize(project.contact) == {
-        "author": tr.author.name_or_email,
-        "username": tr.author.username,
-        "user_banner": tr.author.banner(tr.translation.locale, project.contact),
-        "user_gravatar_url_small": tr.author.gravatar_url(88),
-        "created_at": tr.timestamp.strftime("%b %d, %Y %H:%M"),
-        "date_iso": tr.timestamp.isoformat(),
-        "content": tr.content,
-        "pinned": tr.pinned,
-        "id": tr.id,
+    assert comment_a.serialize(project.contact) == {
+        "author": comment_a.author.name_or_email,
+        "username": comment_a.author.username,
+        "user_banner": comment_a.author.banner(
+            comment_a.translation.locale, project.contact
+        ),
+        "user_gravatar_url_small": comment_a.author.gravatar_url(88),
+        "created_at": comment_a.timestamp.strftime("%b %d, %Y %H:%M"),
+        "date_iso": comment_a.timestamp.isoformat(),
+        "content": comment_a.content,
+        "pinned": comment_a.pinned,
+        "id": comment_a.id,
     }
 
-    assert team.serialize(project.contact) == {
-        "author": team.author.name_or_email,
-        "username": team.author.username,
-        "user_banner": team.author.banner(team.locale, project.contact),
-        "user_gravatar_url_small": team.author.gravatar_url(88),
-        "created_at": team.timestamp.strftime("%b %d, %Y %H:%M"),
-        "date_iso": team.timestamp.isoformat(),
-        "content": team.content,
-        "pinned": team.pinned,
-        "id": team.id,
+    assert team_comment_a.serialize(project.contact) == {
+        "author": team_comment_a.author.name_or_email,
+        "username": team_comment_a.author.username,
+        "user_banner": team_comment_a.author.banner(
+            team_comment_a.locale, project.contact
+        ),
+        "user_gravatar_url_small": team_comment_a.author.gravatar_url(88),
+        "created_at": team_comment_a.timestamp.strftime("%b %d, %Y %H:%M"),
+        "date_iso": team_comment_a.timestamp.isoformat(),
+        "content": team_comment_a.content,
+        "pinned": team_comment_a.pinned,
+        "id": team_comment_a.id,
     }

--- a/pontoon/base/tests/views/test_comment.py
+++ b/pontoon/base/tests/views/test_comment.py
@@ -1,0 +1,62 @@
+import pytest
+
+from django.contrib.auth.models import Permission
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+def test_pin_comment(member, client, comment_a):
+    url = reverse("pontoon.pin_comment")
+
+    # A non-privileged user cannot pin comments
+    response = member.client.post(
+        url, {"comment_id": comment_a.pk}, HTTP_X_REQUESTED_WITH="XMLHttpRequest"
+    )
+    assert response.status_code == 403
+
+    comment_a.refresh_from_db()
+    assert comment_a.pinned is False
+
+    # Grant the user the required permission
+    permission = Permission.objects.get(codename="can_manage_project")
+    member.user.user_permissions.add(permission)
+    member.user.refresh_from_db()
+
+    # The user with can_manage_project permission can pin comments
+    response = member.client.post(
+        url, {"comment_id": comment_a.pk}, HTTP_X_REQUESTED_WITH="XMLHttpRequest"
+    )
+    assert response.status_code == 200
+
+    comment_a.refresh_from_db()
+    assert comment_a.pinned is True
+
+
+@pytest.mark.django_db
+def test_unpin_comment(member, client, team_comment_a):
+    url = reverse("pontoon.unpin_comment")
+    team_comment_a.pinned = True
+    team_comment_a.save()
+
+    # A non-privileged user cannot unpin comments
+    response = member.client.post(
+        url, {"comment_id": team_comment_a.pk}, HTTP_X_REQUESTED_WITH="XMLHttpRequest"
+    )
+    assert response.status_code == 403
+
+    team_comment_a.refresh_from_db()
+    assert team_comment_a.pinned is True
+
+    # Grant the user the required permission
+    permission = Permission.objects.get(codename="can_manage_project")
+    member.user.user_permissions.add(permission)
+    member.user.refresh_from_db()
+
+    # The user with can_manage_project permission can unpin comments
+    response = member.client.post(
+        url, {"comment_id": team_comment_a.pk}, HTTP_X_REQUESTED_WITH="XMLHttpRequest"
+    )
+    assert response.status_code == 200
+
+    team_comment_a.refresh_from_db()
+    assert team_comment_a.pinned is False

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -684,6 +684,12 @@ def add_comment(request):
 @transaction.atomic
 def pin_comment(request):
     """Update a comment as pinned"""
+    if not request.user.has_perm("base.can_manage_project"):
+        return JsonResponse(
+            {"status": False, "message": "Forbidden: You can't pin comments."},
+            status=403,
+        )
+
     comment_id = request.POST.get("comment_id", None)
     if not comment_id:
         return JsonResponse({"status": False, "message": "Bad Request"}, status=400)
@@ -703,6 +709,12 @@ def pin_comment(request):
 @transaction.atomic
 def unpin_comment(request):
     """Update a comment as unpinned"""
+    if not request.user.has_perm("base.can_manage_project"):
+        return JsonResponse(
+            {"status": False, "message": "Forbidden: You can't unpin comments."},
+            status=403,
+        )
+
     comment_id = request.POST.get("comment_id", None)
     if not comment_id:
         return JsonResponse({"status": False, "message": "Bad Request"}, status=400)

--- a/pontoon/test/fixtures/base.py
+++ b/pontoon/test/fixtures/base.py
@@ -188,4 +188,15 @@ def tag_a(resource_a, project_a, locale_a):
         project=project_a,
     )
     tag.resources.add(resource_a)
+
     return tag
+
+
+@pytest.fixture
+def comment_a():
+    return factories.TranslationCommentFactory()
+
+
+@pytest.fixture
+def team_comment_a():
+    return factories.TeamCommentFactory()


### PR DESCRIPTION
Fix #3597.

While frontend prevents non-PMs to pin or unpin comments, the backend allows any authenticated user to do so.