### PR TITLE
Fix messages.json serialization for messages with $placeholders$

### DIFF
--- a/pontoon/sync/core/translations_to_repo.py
+++ b/pontoon/sync/core/translations_to_repo.py
@@ -5,16 +5,19 @@ from datetime import datetime
 from itertools import groupby
 from os import makedirs, remove
 from os.path import commonpath, dirname, isfile, join, normpath
+from re import finditer
 
 from moz.l10n.formats import Format
 from moz.l10n.model import (
     Entry,
+    Expression,
     Id,
     Metadata,
     PatternMessage,
     Resource,
     Section,
     SelectMessage,
+    VariableRef,
 )
 from moz.l10n.paths import L10nConfigPaths, L10nDiscoverPaths
 from moz.l10n.resource import parse_resource, serialize_resource
@@ -387,6 +390,50 @@ def set_translation(
             elif fuzzy_flag in entry.meta:
                 entry.meta = [m for m in entry.meta if m != fuzzy_flag]
             return True
+        case Format.webext:
+            for tx in translations:
+                if tx.entity.key == key:
+                    if (
+                        isinstance(entry.value, PatternMessage)
+                        and entry.value.declarations
+                    ):
+                        # With a message value, placeholders in string parts would have their
+                        # $ characters doubled to escape them.
+                        entry.value.pattern = []
+                        pos = 0
+                        for m in finditer(
+                            r"\$([a-zA-Z0-9_@]+)\$|(\$[1-9])|\$(\$+)", tx.string
+                        ):
+                            start = m.start()
+                            if start > pos:
+                                entry.value.pattern.append(tx.string[pos:start])
+                            if m[1]:
+                                ph_name = m[1].replace("@", "_")
+                                if ph_name[0].isdigit():
+                                    ph_name = f"_{ph_name}"
+                                ph_name = next(
+                                    (
+                                        name
+                                        for name in entry.value.declarations
+                                        if name.lower() == ph_name.lower()
+                                    ),
+                                    ph_name,
+                                )
+                                pass
+                            else:
+                                ph_name = m[0]
+                            entry.value.pattern.append(
+                                Expression(
+                                    VariableRef(ph_name), attributes={"source": m[0]}
+                                )
+                            )
+                            pos = m.end()
+                        if pos < len(tx.string):
+                            entry.value.pattern.append(tx.string[pos:])
+                    else:
+                        entry.value = tx.string
+                    return True
+            return False
         case _:
             for tx in translations:
                 if tx.entity.key == key:


### PR DESCRIPTION
In some manual testing I noticed that [mozilla-l10n/mozilla-vpn-extension-l10n@8998785](https://github.com/mozilla-l10n/mozilla-vpn-extension-l10n/commit/8998785057cee071b1f47b5c0ab7674f12eac2a3) had dropped the `"placeholders"` objects from its serializations, as a regression from #3587.

This is due to `pontoon.sync.core.translations_to_repo.set_translation()` setting the entry value to a string (rather than a properly parsed moz.l10n `Message`), which drops the declarations representing said `"placeholders"` from the output.

To fix this, we need to do a minimal parse of the webextension message so that we end up with the right serialization. Once #3611 updates moz.l10n to 0.7.0, its `webext_parse_message()` could replace the code inlined here.

The `mozilla-vpn-extension` project will need a `--force` sync once this lands to fix its data.