### PR TITLE
Make user disabled message more visible

### DIFF
--- a/pontoon/contributors/static/css/profile.css
+++ b/pontoon/contributors/static/css/profile.css
@@ -48,7 +48,7 @@ h2 {
   border-bottom-left-radius: 6px;
   border-bottom-right-radius: 6px;
   background: var(--dark-grey-1);
-  color: var(--light-grey-6);
+  color: var(--user-admin);
 }
 
 .avatar .status span {


### PR DESCRIPTION
I was reviewing disabled profile users ([example](https://pontoon.mozilla.org/contributors/Dnlau96/)), and the warning is barely visible even knowing where it is. I think it makes sense to show it in red, as other administrator related content.

<img width="444" alt="Screenshot 2025-04-15 alle 09 33 42" src="https://github.com/user-attachments/assets/6a6a5962-5ba7-4b35-a7f1-823da8014b6c" />
