### PR TITLE
Feature: WarningFailedChecksComponent && update EditorMenu

### DIFF
--- a/translate/src/modules/editor/components/EditorMenu.tsx
+++ b/translate/src/modules/editor/components/EditorMenu.tsx
@@ -17,6 +17,7 @@ import { FailedChecks } from './FailedChecks';
 import { FtlSwitch } from './FtlSwitch';
 import { KeyboardShortcuts } from './KeyboardShortcuts';
 import { TranslationLength } from './TranslationLength';
+import { WarningFailedChecks } from './WarningFailedChecks';
 
 /**
  * Shows a menu bar used to control the Editor.
@@ -99,6 +100,9 @@ function MenuContent() {
           </button>
         </Localized>
         <EditorMainAction />
+      </div>
+      <div>
+        <WarningFailedChecks />
       </div>
     </>
   );

--- a/translate/src/modules/editor/components/WarningFailedChecks.tsx
+++ b/translate/src/modules/editor/components/WarningFailedChecks.tsx
@@ -1,0 +1,35 @@
+import { Localized } from '@fluent/react';
+import React, { useContext } from 'react';
+import { FailedChecksData } from '~/context/FailedChecksData';
+import './FailedChecks.css';
+
+/**
+ * Displays a list of failed checks (errors and warnings) without any actions.
+ */
+export function WarningFailedChecks(): null | React.ReactElement<'div'> {
+    const { errors, warnings } = useContext(FailedChecksData);
+
+    if (!errors.length && !warnings.length) {
+        return null;
+    }
+
+    return (
+        <div className='failed-checks'>
+            <Localized id='editor-FailedChecks--title'>
+                <p className='title'>THE FOLLOWING CHECKS HAVE FAILED</p>
+            </Localized>
+            <ul>
+                {errors.map((error, key) => (
+                    <li className='error' key={key}>
+                        {error}
+                    </li>
+                ))}
+                {warnings.map((warning, key) => (
+                    <li className='warning' key={key}>
+                        {warning}
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+}


### PR DESCRIPTION
Addresses #3625 ,

Still not complete due to the inability  to reflect the changes locally in a browser. I  restarted the docker container, the `dist/translate.js` updated appropriately though reloading the browser window no changes reflects.
