### PR TITLE
Update command to start just the postgresql container

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -94,7 +94,7 @@ can start just the postgresql container by running:
 
 .. code-block:: shell
 
-    $ docker-compose run postgresql -d
+    $ docker-compose up -d postgresql
 
 
 Interactive shell


### PR DESCRIPTION
This PR replaces the invalid command to start postgresql container with a working one:
* `up` starts the service as defined in `docker-compose.yml`
* `-d` means "detached" mode (runs in the background)
* `postgresql` is the name of the service