### PR TITLE
Bug Fix #3544: Remove In-Progress Syncs from Sync Error Page

### DIFF
--- a/pontoon/sync/views.py
+++ b/pontoon/sync/views.py
@@ -75,7 +75,11 @@ def sync_log_errors(request: HttpRequest):
 
     sync_events = (
         Sync.objects.filter(project__disabled=False)
-        .exclude(Q(status=Sync.Status.DONE) | Q(status=Sync.Status.NO_CHANGES))
+        .exclude(
+            Q(status=Sync.Status.DONE)
+            | Q(status=Sync.Status.NO_CHANGES)
+            | Q(status=Sync.Status.IN_PROGRESS)
+        )
         .order_by("-start_time")
         .select_related("project")
     )


### PR DESCRIPTION
This fixes #3544 by changing the view associated with querying Syncs, excluding Syncs that have the "In-Progress" status.