### PR TITLE
Fix #3497: Recipient count displays email recipients for email-only m…

### DIFF
--- a/pontoon/messaging/views.py
+++ b/pontoon/messaging/views.py
@@ -98,7 +98,7 @@ def get_recipients(form):
     recipients = User.objects.none()
 
     """
-    Filter recipients by user role, locale, project and email/notification opt:
+    Filter recipients by user role, locale, project and email opt-in status:
     - Contributors of selected Locales and Projects
     - Managers of selected Locales
     - Translators of selected Locales

--- a/pontoon/messaging/views.py
+++ b/pontoon/messaging/views.py
@@ -98,10 +98,11 @@ def get_recipients(form):
     recipients = User.objects.none()
 
     """
-    Filter recipients by user role, locale and project:
+    Filter recipients by user role, locale, project and email/notification opt:
     - Contributors of selected Locales and Projects
     - Managers of selected Locales
     - Translators of selected Locales
+    - Email/Notification opt
     """
     locale_ids = sorted(split_ints(form.cleaned_data.get("locales")))
     project_ids = form.cleaned_data.get("projects")
@@ -237,6 +238,11 @@ def get_recipients(form):
         rejected_filters = rejected.values_list("rejected_user", flat=True).distinct()
         review_filters = approved_filters.union(rejected_filters)
         recipients = recipients.filter(pk__in=review_filters)
+
+    if form.cleaned_data.get("email") and not form.cleaned_data.get("notification"):
+        recipients = recipients & User.objects.filter(
+            profile__email_communications_enabled=True
+        )
 
     return recipients
 

--- a/pontoon/messaging/views.py
+++ b/pontoon/messaging/views.py
@@ -102,7 +102,7 @@ def get_recipients(form):
     - Contributors of selected Locales and Projects
     - Managers of selected Locales
     - Translators of selected Locales
-    - Email/Notification opt
+    - Email/Notification opt-in status
     """
     locale_ids = sorted(split_ints(form.cleaned_data.get("locales")))
     project_ids = form.cleaned_data.get("projects")


### PR DESCRIPTION
…essages

This feature fixes #3497  the bug where if someone wished to send a message email only, the message center's review message section displayed the count of people who would recieve a message if it was both a notification and an email, not solely the email-only recipients.

Before:
<img width="637" alt="image" src="https://github.com/user-attachments/assets/aa94d09a-e63d-4143-9714-e549bbe2404b" />
<img width="663" alt="image" src="https://github.com/user-attachments/assets/6ae53cdd-f4f1-4e69-afc9-3b3a455ca046" />

After:
<img width="664" alt="image" src="https://github.com/user-attachments/assets/9740ddcc-0c1a-492d-86ca-f572563df98e" />

To be clear, solely selecting "Email" in the Message Type is the only way for this to work, which is in line with the logic described in the bug report.