### PR TITLE
Fix: Changed min node version from 14 to 16.6.0

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -65,7 +65,7 @@ the ``URL`` will need to include both the PAT and username, e.g.
 JavaScript setup
 ================
 
-For working on the front-end, you need at least Node.js 16.6.0 and npm 7
+For working on the front-end, you need the latest versions of Node.js and npm
 (`installation instructions <https://docs.npmjs.com/downloading-and-installing-node-js-and-npm>`_).
 Parts of the front-end use `npm workspaces <https://docs.npmjs.com/cli/v7/using-npm/workspaces>`_,
 which are not supported by earlier npm versions.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -65,7 +65,7 @@ the ``URL`` will need to include both the PAT and username, e.g.
 JavaScript setup
 ================
 
-For working on the front-end, you need at least Node.js 14 and npm 7
+For working on the front-end, you need at least Node.js 16.6.0 and npm 7
 (`installation instructions <https://docs.npmjs.com/downloading-and-installing-node-js-and-npm>`_).
 Parts of the front-end use `npm workspaces <https://docs.npmjs.com/cli/v7/using-npm/workspaces>`_,
 which are not supported by earlier npm versions.

--- a/docs/dev/setup-virtualenv.rst
+++ b/docs/dev/setup-virtualenv.rst
@@ -17,7 +17,7 @@ This guide assumes you have already installed and set up the following:
 1. `Git <https://git-scm.com>`__
 2. `Python 3.11 <https://www.python.org>`__
 3. `uv <https://docs.astral.sh/uv/getting-started/installation/#standalone-installer>`_
-4. `Latest versions of Node.js <https://nodejs.org>`__ and `npm <https://www.npmjs.com>`__
+4. `Node.js <https://nodejs.org>`__ and `npm <https://www.npmjs.com>`__
 5. `PostgreSQL 15 <http://www.postgresql.org>`__
 
 These docs assume a Unix-like operating system, although the site should, in

--- a/docs/dev/setup-virtualenv.rst
+++ b/docs/dev/setup-virtualenv.rst
@@ -17,8 +17,7 @@ This guide assumes you have already installed and set up the following:
 1. `Git <https://git-scm.com>`__
 2. `Python 3.11 <https://www.python.org>`__
 3. `uv <https://docs.astral.sh/uv/getting-started/installation/#standalone-installer>`_
-4. `Node.js 18 <https://nodejs.org>`__ and `npm 9 <https://www.npmjs.com>`__ or
-   later
+4. `Latest versions of Node.js <https://nodejs.org>`__ and `npm <https://www.npmjs.com>`__
 5. `PostgreSQL 15 <http://www.postgresql.org>`__
 
 These docs assume a Unix-like operating system, although the site should, in

--- a/docs/dev/setup.rst
+++ b/docs/dev/setup.rst
@@ -14,7 +14,7 @@ Prerequisites
 
 1. Install `Docker <https://docs.docker.com/install/>`_.
 
-2. Install `Node.js 14 and npm 7 or later <https://docs.npmjs.com/downloading-and-installing-node-js-and-npm>`_.
+2. Install `Node.js 16.6.0 and npm 7 or later <https://docs.npmjs.com/downloading-and-installing-node-js-and-npm>`_.
 
 3. Install `make <https://www.gnu.org/software/make/>`_ using either your
    system's package manager (Linux) or Xcode command line developer tools (OSX).

--- a/docs/dev/setup.rst
+++ b/docs/dev/setup.rst
@@ -14,7 +14,7 @@ Prerequisites
 
 1. Install `Docker <https://docs.docker.com/install/>`_.
 
-2. Install `Node.js 16.6.0 and npm 7 or later <https://docs.npmjs.com/downloading-and-installing-node-js-and-npm>`_.
+2. Install `latest versions of Node.js and npm <https://docs.npmjs.com/downloading-and-installing-node-js-and-npm>`_.
 
 3. Install `make <https://www.gnu.org/software/make/>`_ using either your
    system's package manager (Linux) or Xcode command line developer tools (OSX).


### PR DESCRIPTION
Fix: #3633

According to https://nodejs.org/en/blog/release/v16.6.0, the `array.at` feature was introduced in `node v16.6.0`

Changed this in the docs.