### PR TITLE
Fix escaped quotes and newlines for Android strings

### DIFF
--- a/pontoon/base/migrations/0077_fix_android_newlines.py
+++ b/pontoon/base/migrations/0077_fix_android_newlines.py
@@ -1,0 +1,35 @@
+from re import compile
+
+from django.db import migrations
+
+
+def fix_android_newlines(apps, schema_editor):
+    esc_nl = compile(r"(?<!\\)\\n\s*")
+
+    Entity = apps.get_model("base", "Entity")
+    android_entities = Entity.objects.filter(
+        resource__format="xml", string__contains="\\n"
+    )
+    for ent in android_entities:
+        ent.string = esc_nl.sub(r"\\n\n", ent.string)
+    Entity.objects.bulk_update(android_entities, ["string"])
+
+    Translation = apps.get_model("base", "Translation")
+    android_translations = Translation.objects.filter(
+        entity__resource__format="xml", string__contains="\\n"
+    )
+    for trans in android_translations:
+        trans.string = esc_nl.sub(r"\\n\n", trans.string)
+    Translation.objects.bulk_update(android_translations, ["string"], batch_size=2000)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("base", "0076_remove_pontoon_intro_project"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=fix_android_newlines, reverse_code=migrations.RunPython.noop
+        ),
+    ]

--- a/pontoon/sync/core/translations_to_repo.py
+++ b/pontoon/sync/core/translations_to_repo.py
@@ -358,7 +358,8 @@ def set_translations(
         ]
 
 
-android_quotes = compile(r"(?<!\\)(['\"])")
+android_nl = compile(r"\s*\n\s*")
+android_esc = compile(r"(?<!\\)\\([nt])\s*")
 webext_placeholder = compile(r"\$([a-zA-Z0-9_@]+)\$|(\$[1-9])|\$(\$+)")
 
 
@@ -395,7 +396,11 @@ def set_translation(
     for tx in translations:
         if tx.entity.key == key:
             if res.format == Format.android:
-                entry.value = android_quotes.sub(r"\\\1", tx.string)
+                # Literal newlines \n and tabs \t are included in the string
+                entry.value = android_esc.sub(
+                    lambda m: "\n" if m[1] == "n" else "\t",
+                    android_nl.sub(" ", tx.string),
+                )
             elif (
                 res.format == Format.webext
                 and isinstance(entry.value, PatternMessage)

--- a/pontoon/sync/formats/xml.py
+++ b/pontoon/sync/formats/xml.py
@@ -28,7 +28,8 @@ def parse(res: Resource[Message]):
 
 
 esc_u = compile(r"(?<!\\)\\u[0-9]{4}")
-esc_char = compile(r"(?<!\\)\\(.)")
+esc_char = compile(r"(?<!\\)\\([^nt])")
+esc_nl = compile(r"(?<!\\)\\n\s*")
 ws_around_outer_tag = compile(r"^\s+(?=<)|(?<=>)\s+$")
 ws_before_block = compile(r"\s+(?=<(br|label|li|p|/?ul)\b)")
 ws_after_block = compile(r"((?<=<br>)|(?<=<br/>)|(?<=</ul>)|(?<=\\n))\s+")
@@ -40,6 +41,7 @@ def as_translation(order: int, entry: Entry[Message]):
     string = unescape(string)
     string = esc_u.sub(lambda m: chr(int(m[1])), string)
     string = esc_char.sub(r"\1", string)
+    string = esc_nl.sub(r"\\n\n", string)
     string = ws_around_outer_tag.sub("", string)
     string = ws_before_block.sub("\n", string)
     string = ws_after_block.sub("\n", string)


### PR DESCRIPTION
Fixes two related regressions from #3611, as literal `"` quotes are now showing up as `\\\"` double-escaped, and escaped newlines `\n` are showing up as `\\n`.

Also normalises the presentation of escaped newlines to always be followed by a literal newline, and drops any whitespace immediately after an escaped newline when serialising.