### PR TITLE
Fix missing string count in Monthly activity summary

### DIFF
--- a/pontoon/insights/models.py
+++ b/pontoon/insights/models.py
@@ -23,6 +23,16 @@ class InsightsSnapshot(models.Model):
     strings_with_warnings = models.PositiveIntegerField(default=0)
     unreviewed_strings = models.PositiveIntegerField(default=0)
 
+    @property
+    def missing_strings(self):
+        return (
+            self.total_strings
+            - self.approved_strings
+            - self.pretranslated_strings
+            - self.strings_with_errors
+            - self.strings_with_warnings
+        )
+
     # Active users
     total_managers = models.PositiveIntegerField(default=0)
     total_reviewers = models.PositiveIntegerField(default=0)

--- a/pontoon/insights/tests/test_models.py
+++ b/pontoon/insights/tests/test_models.py
@@ -1,0 +1,20 @@
+import pytest
+
+from pontoon.base.models import Locale
+from pontoon.insights.models import LocaleInsightsSnapshot
+
+
+@pytest.mark.django_db
+def test_missing_strings_property_locale_snapshot():
+    snapshot = LocaleInsightsSnapshot.objects.create(
+        locale=Locale.objects.create(code="locale-code", name="Locale Name"),
+        total_strings=100,
+        approved_strings=40,
+        pretranslated_strings=20,
+        strings_with_errors=5,
+        strings_with_warnings=10,
+        completion=0.4,
+    )
+
+    expected_missing = 100 - 40 - 20 - 5 - 10
+    assert snapshot.missing_strings == expected_missing


### PR DESCRIPTION
Fix #3659 by restoring the `InsightsSnapshot.missing_strings` property removed in https://github.com/mozilla/pontoon/pull/3536.