### PR TITLE
Update docker compose command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-DC := $(shell which docker-compose)
 DOCKER := $(shell which docker)
 
 # *IMPORTANT*
@@ -54,7 +53,7 @@ build-translate: node_modules
 	npm run build -w translate
 
 build-server: server-env translate/dist
-	"${DC}" build --build-arg USER_ID=$(USER_ID) --build-arg GROUP_ID=$(GROUP_ID) server
+	"${DOCKER}" compose build --build-arg USER_ID=$(USER_ID) --build-arg GROUP_ID=$(GROUP_ID) server
 	touch .server-build
 
 server-env:
@@ -67,12 +66,12 @@ server-env:
 	fi
 
 setup: .server-build
-	"${DC}" run server //app/docker/server_setup.sh
+	"${DOCKER}" compose run server //app/docker/server_setup.sh
 
 run: translate/dist .server-build
-	"${DC}" up --detach
+	"${DOCKER}" compose up --detach
 	bash -c 'set -m; bash ./bin/watch.sh'
-	"${DC}" stop
+	"${DOCKER}" compose stop
 
 clean:
 	rm -rf translate/dist .server-build
@@ -81,7 +80,7 @@ clean:
 	@container=$$(${DOCKER} ps -q --filter ancestor=local/pontoon | head -n 1); \
 	if [ -z "$$container" ]; then \
   		echo "Trying to start the container" >&2; \
-		"${DC}" up --detach; \
+		"${DOCKER}" compose up --detach; \
   		container=$$(${DOCKER} ps -q --filter ancestor=local/pontoon | head -n 1); \
 		if [ -z "$$container" ]; then \
 			echo "Error: No container running based on local/pontoon. Try running 'make build'." >&2; \
@@ -108,7 +107,7 @@ jest:
 
 test-server: pytest
 pytest:
-	"${DC}" run ${run_opts} --rm server pytest --cov-report=xml:pontoon/coverage.xml --cov=. $(opts)
+	"${DOCKER}" compose run ${run_opts} --rm server pytest --cov-report=xml:pontoon/coverage.xml --cov=. $(opts)
 
 format: prettier ruff
 
@@ -127,35 +126,35 @@ check-prettier:
 	npm run check-prettier
 
 ruff:
-	"${DC}" run --rm server ruff check --fix
-	"${DC}" run --rm server ruff format
+	"${DOCKER}" compose run --rm server ruff check --fix
+	"${DOCKER}" compose run --rm server ruff format
 
 check-ruff:
-	"${DC}" run --rm server ruff check
-	"${DC}" run --rm server ruff format --check
+	"${DOCKER}" compose run --rm server ruff check
+	"${DOCKER}" compose run --rm server ruff format --check
 
 dropdb:
-	"${DC}" down --volumes postgresql
+	"${DOCKER}" compose down --volumes postgresql
 
 dumpdb:
-	"${DOCKER}" exec -t `"${DC}" ps -q postgresql` pg_dumpall -c -U pontoon > dump_`date +%d-%m-%Y"_"%H_%M_%S`.sql
+	"${DOCKER}" exec -t `"${DOCKER}" compose ps -q postgresql` pg_dumpall -c -U pontoon > dump_`date +%d-%m-%Y"_"%H_%M_%S`.sql
 
 loaddb:
 	# Stop connections to the database so we can drop it.
-	-"${DC}" stop server
+	-"${DOCKER}" compose stop server
 	# Make sure the postgresql container is running.
-	-"${DC}" start postgresql
-	-"${DC}" exec postgresql dropdb -U pontoon pontoon
-	"${DC}" exec postgresql createdb -U pontoon pontoon
+	-"${DOCKER}" compose start postgresql
+	-"${DOCKER}" compose exec postgresql dropdb -U pontoon pontoon
+	"${DOCKER}" compose exec postgresql createdb -U pontoon pontoon
 	# Note: docker-compose doesn't support the `-i` (--interactive) argument
 	# that we need to send the dump file through STDIN. We thus are forced to
 	# use docker here instead.
-	"${DOCKER}" exec -i `"${DC}" ps -q postgresql` pg_restore -U pontoon -d pontoon -O < "${DB_DUMP_FILE}"
+	"${DOCKER}" exec -i `"${DOCKER}" compose ps -q postgresql` pg_restore -U pontoon -d pontoon -O < "${DB_DUMP_FILE}"
 
 sync-projects:
-	"${DC}" run --rm server .//manage.py sync_projects $(opts)
+	"${DOCKER}" compose run --rm server .//manage.py sync_projects $(opts)
 
 requirements:
 	# Pass --upgrade to upgrade all dependencies
 	# The arguments are passed through to `uv pip compile`
-	"${DC}" run --rm server //app/docker/compile_requirements.sh ${opts}
+	"${DOCKER}" compose run --rm server //app/docker/compile_requirements.sh ${opts}


### PR DESCRIPTION
The old docker-compose command (with a dash) is not installed by default in Docker Desktop versions starting from mid-2022.