### PR TITLE
Generate target files for XLIFF if they are missing

### DIFF
--- a/pontoon/sync/core/entities.py
+++ b/pontoon/sync/core/entities.py
@@ -19,8 +19,6 @@ from pontoon.sync.formats.common import ParseError, VCSTranslation
 
 log = logging.getLogger(__name__)
 
-BILINGUAL_FORMATS = {"po", "xliff"}
-
 
 def sync_entities_from_repo(
     project: Project,
@@ -288,8 +286,8 @@ def is_translated_resource(
 ) -> bool:
     if locale is None:
         return False
-    if resource.format in BILINGUAL_FORMATS:
-        # For bilingual formats, only create TranslatedResource
+    if resource.format == "po":
+        # For gettext, only create TranslatedResource
         # if the resource exists for the locale.
         target, _ = paths.target(resource.path)
         if target is None:

--- a/pontoon/sync/core/translations_from_repo.py
+++ b/pontoon/sync/core/translations_from_repo.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from os.path import join, relpath, splitext
 
 from fluent.syntax import FluentParser
-from moz.l10n.formats import bilingual_extensions, l10n_extensions
+from moz.l10n.formats import l10n_extensions
 from moz.l10n.paths import L10nConfigPaths, L10nDiscoverPaths, parse_android_locale
 
 from django.core.paginator import Paginator
@@ -50,7 +50,7 @@ def sync_translations_from_repo(
     """(removed_resource_count, updated_translation_count)"""
     co = checkouts.target
     source_paths: set[str] = set(paths.ref_paths) if checkouts.source == co else set()
-    del_count = delete_removed_bilingual_resources(project, co, paths, source_paths)
+    del_count = delete_removed_gettext_resources(project, co, paths, source_paths)
 
     changed_target_paths = [
         path
@@ -80,7 +80,7 @@ def write_db_updates(
     add_translation_memory_entries(project, new_translations + updated_translations)
 
 
-def delete_removed_bilingual_resources(
+def delete_removed_gettext_resources(
     project: Project,
     target: Checkout,
     paths: L10nConfigPaths | L10nDiscoverPaths,
@@ -92,7 +92,7 @@ def delete_removed_bilingual_resources(
     removed_target_paths = (
         path
         for path in (join(target.path, co_path) for co_path in target.removed)
-        if path not in source_paths and splitext(path)[1] in bilingual_extensions
+        if path not in source_paths and splitext(path)[1] in {".po", ".pot"}
     )
     for target_path in removed_target_paths:
         ref = paths.find_reference(target_path)

--- a/pontoon/sync/tests/test_e2e.py
+++ b/pontoon/sync/tests/test_e2e.py
@@ -1,7 +1,7 @@
 import re
 
 from os import makedirs
-from os.path import join
+from os.path import isfile, join
 from tempfile import TemporaryDirectory
 from textwrap import dedent
 from unittest.mock import patch
@@ -32,7 +32,7 @@ from pontoon.sync.tests.utils import build_file_tree
 
 
 @pytest.mark.django_db
-def test_end_to_end():
+def test_kitchen_sink():
     mock_vcs = MockVersionControl(changes=([join("en-US", "c.ftl")], [], []))
     with (
         TemporaryDirectory() as root,
@@ -154,6 +154,144 @@ def test_end_to_end():
         )
         assert TranslatedResource.objects.filter(resource__project=project).count() == 6
         assert Sync.objects.get(project=project).status == Sync.Status.DONE
+
+
+@pytest.mark.django_db
+def test_add_resources():
+    mock_vcs = MockVersionControl(changes=None)
+    with (
+        TemporaryDirectory() as root,
+        patch("pontoon.sync.core.checkout.get_repo", return_value=mock_vcs),
+        patch("pontoon.sync.core.translations_to_repo.get_repo", return_value=mock_vcs),
+    ):
+        # Database setup
+        settings.MEDIA_ROOT = root
+        locale_de = LocaleFactory.create(code="de-Test", name="Test German")
+        repo_src = RepositoryFactory(
+            url="http://example.com/src-repo", source_repo=True
+        )
+        repo_tgt = RepositoryFactory(url="http://example.com/tgt-repo")
+        project = ProjectFactory.create(
+            name="add-resources",
+            locales=[locale_de],
+            repositories=[repo_src, repo_tgt],
+        )
+
+        # Filesystem setup
+        src_root = repo_src.checkout_path
+        makedirs(src_root)
+        file_pot = dedent("""
+            #
+            msgid ""
+            msgstr ""
+
+            msgid "source"
+            msgstr "source"
+        """)
+        file_xliff = dedent("""\
+            <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+              <file original="file.txt" source-language="en-US" target-language="en-US" datatype="plaintext">
+                <body>
+                  <trans-unit id="key">
+                    <source>source</source>
+                    <target>source</target>
+                  </trans-unit>
+                </body>
+              </file>
+            </xliff>
+        """)
+        build_file_tree(
+            src_root,
+            {
+                "en-US": {
+                    "file.ftl": "key = Message\n",
+                    "file.pot": file_pot,
+                    "file.xliff": file_xliff,
+                }
+            },
+        )
+
+        tgt_root = repo_tgt.checkout_path
+        makedirs(tgt_root)
+        build_file_tree(tgt_root, {"de-Test": {}})
+
+        # Sync with no translations
+        sync_project_task(project.pk)
+
+        # Test that entities are generated, translations are not, and FTL & XLIFF are localizable
+        assert {
+            (ent.resource.path, ent.key)
+            for ent in Entity.objects.filter(resource__project=project)
+        } == {
+            ("file.ftl", "key"),
+            ("file.po", "source"),
+            ("file.xliff", "file.txt\x04key"),
+        }
+        assert (
+            Translation.objects.filter(entity__resource__project=project).count() == 0
+        )
+        assert {
+            (tr.resource.path, tr.locale.code)
+            for tr in TranslatedResource.objects.filter(resource__project=project)
+        } == {("file.ftl", "de-Test"), ("file.xliff", "de-Test")}
+
+        # Add an XLIFF translation
+        TranslationFactory.create(
+            entity=Entity.objects.get(
+                resource__project=project, resource__path="file.xliff"
+            ),
+            locale=locale_de,
+            string="xliff translation",
+            active=True,
+            approved=True,
+        )
+        sync_project_task(project.pk)
+
+        # Test that gettext is not written, while XLIFF is
+        tgt_po_path = join(repo_tgt.checkout_path, "de-Test", "file.po")
+        tgt_xliff_path = join(repo_tgt.checkout_path, "de-Test", "file.xliff")
+        assert not isfile(tgt_po_path)
+        with open(tgt_xliff_path) as file:
+            assert file.read() == dedent("""\
+                <?xml version="1.0" encoding="utf-8"?>
+                <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+                  <file original="file.txt" source-language="en-US" target-language="de-Test" datatype="plaintext">
+                    <body>
+                      <trans-unit id="key">
+                        <source>source</source>
+                        <target>xliff translation</target>
+                      </trans-unit>
+                    </body>
+                  </file>
+                </xliff>
+            """)
+
+        # Add an empty target gettext file
+        with open(tgt_po_path, "x") as file:
+            file.write("\n")
+        sync_project_task(project.pk)
+
+        # Test that the gettext file is now localizable
+        assert {
+            (tr.resource.path, tr.locale.code)
+            for tr in TranslatedResource.objects.filter(resource__project=project)
+        } == {
+            ("file.ftl", "de-Test"),
+            ("file.po", "de-Test"),
+            ("file.xliff", "de-Test"),
+        }
+        with open(tgt_po_path) as file:
+            assert file.read() == dedent("""\
+                #
+                msgid ""
+                msgstr ""
+                "Language: de_Test\\n"
+                "Plural-Forms: nplurals=1; plural=;\\n"
+                "Generated-By: Pontoon\\n"
+
+                msgid "source"
+                msgstr ""
+            """)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Fixes #3573

As discussed in the issue, the gettext logic of requiring that each target file is created separately from Pontoon should not be applied to XLIFF files.

I was not able to find any mention of the current behaviour in any of our documentation.