### PR TITLE
Fix URL for Deploy to Heroku button in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you are looking to host your own instance of Pontoon, there are several ways 
 To deploy Pontoon to Heroku without leaving your web browser, click the **Deploy to
 Heroku** button below.
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/mozilla/pontoon)
 
 Alternatively, you can deploy to Heroku manually by following our
 [Deployment Documentation](https://mozilla-pontoon.readthedocs.io/en/latest/admin/deployment.html).


### PR DESCRIPTION
Before:
<img width="320" alt="Screenshot 2025-06-25 at 10 02 44 PM Medium" src="https://github.com/user-attachments/assets/a81aab01-f9c5-4f19-80f9-ad16b639ec9a" />

After:
<img width="320" alt="Screenshot 2025-06-25 at 10 06 11 PM Medium" src="https://github.com/user-attachments/assets/093b7636-b151-4285-a317-e8bec2fbc4d2" />