### PR TITLE
Make Django Debug Toolbar easier to turn on/off

### DIFF
--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -120,6 +120,9 @@ you create:
    Controls ``DEBUG`` mode for the site. Should be set to `False` in
    production.
 
+``DJANGO_DEBUG_TOOLBAR``
+   Enables Django Debug Toolbar (default: ``False``) if ``DJANGO_DEV`` set to `True`.
+
 ``DJANGO_DEV``
    Signifies whether this is a development server or not. Should be `False` in
    production.

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -34,6 +34,8 @@ DEV = os.environ.get("DJANGO_DEV", "False") != "False"
 
 DEBUG = os.environ.get("DJANGO_DEBUG", "False") != "False"
 
+DJANGO_DEBUG_TOOLBAR = os.environ.get("DJANGO_DEBUG_TOOLBAR", "False") != "False"
+
 HEROKU_DEMO = os.environ.get("HEROKU_DEMO", "False") != "False"
 
 LOGOUT_REDIRECT_URL = "/"

--- a/pontoon/settings/dev.py
+++ b/pontoon/settings/dev.py
@@ -42,3 +42,8 @@ TEMPLATES[0]["OPTIONS"]["match_regex"] = re.compile(
 )
 
 GRAPHENE = {"MIDDLEWARE": ["graphene_django.debug.DjangoDebugMiddleware"]}
+
+if base.DJANGO_DEBUG_TOOLBAR:
+    DEBUG_TOOLBAR_CONFIG = {
+        "SHOW_TOOLBAR_CALLBACK": lambda request: True,
+    }

--- a/pontoon/urls.py
+++ b/pontoon/urls.py
@@ -1,3 +1,5 @@
+import debug_toolbar
+
 from django.contrib import admin
 from django.contrib.auth import logout
 from django.urls import include, path, register_converter
@@ -72,6 +74,8 @@ urlpatterns = [
     path("", include("pontoon.batch.urls")),
     path("", include("pontoon.homepage.urls")),
     path("", include("pontoon.uxactionlog.urls")),
+    # Django Debug Toolbar
+    path("__debug__/", include(debug_toolbar.urls)),
     # Team page: Must be at the end
     path("<locale:locale>/", team, name="pontoon.teams.team"),
 ]


### PR DESCRIPTION
Testing performance of https://github.com/mozilla/pontoon/pull/3666 is easier with Django Debug Toolbar than `debug_sql()`. Since Django Debug Toolbar is installed and made available in the local development environment, we should make it easy to turn it on or off.