### PR TITLE
Mostly fix badly normalised Android spaces

### DIFF
--- a/pontoon/base/migrations/0081_fix_android_spaces.py
+++ b/pontoon/base/migrations/0081_fix_android_spaces.py
@@ -1,0 +1,29 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("base", "0080_project_date_modified"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            r"""
+WITH tm AS (
+    SELECT
+        t.id,
+        regexp_replace(trim(BOTH FROM m.target), '\s\s+', ' ', 'g') AS string
+    FROM base_translationmemoryentry m
+    JOIN base_translation t ON t.id = m.translation_id
+    WHERE
+        m.target SIMILAR TO '%[^\S \n]%' AND
+        t.string != m.target
+)
+UPDATE base_translation AS t
+SET string = tm.string
+FROM tm
+WHERE t.id = tm.id AND
+    t.string = regexp_replace(tm.string, '[^\S \n]', ' ', 'g');
+"""
+        ),
+    ]


### PR DESCRIPTION
Mostly fixes #3672

This migration fixes a bit over 1500 Android strings, which is at least three quarters of the strings for which the non-default spaces should have been taken into use after #3611. A little over 500 translations with differences between the TM and the translations table are left unchanged, as they involve other, more complicated whitespace fixes around inline HTML elements.