### PR TITLE
Added stats_data_as_dict and changed stats_data

### DIFF
--- a/pontoon/base/models/locale.py
+++ b/pontoon/base/models/locale.py
@@ -105,6 +105,7 @@ class LocaleQuerySet(models.QuerySet):
             "errors",
             "warnings",
             "unreviewed",
+            # TODO: Add "missing" string field and prevent recalculation of field in javascript
         )
         return {row["id"]: row for row in data if row["total"]}
 

--- a/pontoon/base/models/project.py
+++ b/pontoon/base/models/project.py
@@ -109,6 +109,7 @@ class ProjectQuerySet(models.QuerySet):
             "errors",
             "warnings",
             "unreviewed",
+            # TODO: Add "missing" string field and prevent recalculation of field in javascript
         )
         return {row["id"]: row for row in data if row["total"]}
 

--- a/pontoon/projects/views.py
+++ b/pontoon/projects/views.py
@@ -114,7 +114,7 @@ def ajax_teams(request, slug):
         {
             "project": project,
             "locales": locales,
-            "locale_stats": locales.stats_data(project),
+            "locale_stats": locales.stats_data_as_dict(project),
             "latest_activities": latest_activities,
         },
     )

--- a/pontoon/projects/views.py
+++ b/pontoon/projects/views.py
@@ -31,7 +31,7 @@ def projects(request):
     if not projects:
         return render(request, "no_projects.html", {"title": "Projects"})
 
-    project_stats = projects.stats_data()
+    project_stats = projects.stats_data_as_dict()
     return render(
         request,
         "projects/projects.html",

--- a/pontoon/teams/views.py
+++ b/pontoon/teams/views.py
@@ -166,7 +166,7 @@ def ajax_projects(request, locale):
         "teams/includes/projects.html",
         {
             "locale": locale,
-            "project_stats": Project.objects.all().stats_data(locale),
+            "project_stats": Project.objects.all().stats_data_as_dict(locale),
             "latest_activities": latest_activities,
             "enabled_projects": enabled_projects,
             "projects_to_request": projects_to_request,

--- a/pontoon/teams/views.py
+++ b/pontoon/teams/views.py
@@ -66,7 +66,7 @@ def teams(request):
     if not locales:
         return render(request, "no_projects.html", {"title": "Teams"})
 
-    locale_stats = locales.stats_data()
+    locale_stats = locales.stats_data_as_dict()
     return render(
         request,
         "teams/teams.html",


### PR DESCRIPTION
stats_data now returns a LocaleQuerySet, which is required for our REST API implementation, while stats_data_as_dict retains the old behavior of returning a dictionary, which is used in the /teams page as well as an ajax render.