### PR TITLE
Only conditionally include Django Debug Toolbar URLs

### DIFF
--- a/pontoon/urls.py
+++ b/pontoon/urls.py
@@ -1,5 +1,3 @@
-import debug_toolbar
-
 from django.contrib import admin
 from django.contrib.auth import logout
 from django.urls import include, path, register_converter
@@ -74,8 +72,17 @@ urlpatterns = [
     path("", include("pontoon.batch.urls")),
     path("", include("pontoon.homepage.urls")),
     path("", include("pontoon.uxactionlog.urls")),
-    # Django Debug Toolbar
-    path("__debug__/", include(debug_toolbar.urls)),
-    # Team page: Must be at the end
+]
+
+# Conditionally include Django Debug Toolbar
+try:
+    import debug_toolbar
+
+    urlpatterns = [path("__debug__/", include(debug_toolbar.urls))] + urlpatterns
+except ModuleNotFoundError:
+    pass  # debug_toolbar not installed, skip it
+
+# Team page: Must be at the end
+urlpatterns += [
     path("<locale:locale>/", team, name="pontoon.teams.team"),
 ]

--- a/pontoon/urls.py
+++ b/pontoon/urls.py
@@ -78,7 +78,7 @@ urlpatterns = [
 try:
     import debug_toolbar
 
-    urlpatterns = [path("__debug__/", include(debug_toolbar.urls))] + urlpatterns
+    urlpatterns += [path("__debug__/", include(debug_toolbar.urls))]
 except ModuleNotFoundError:
     pass  # debug_toolbar not installed, skip it
 


### PR DESCRIPTION
Without this fix, deploying Pontoon to prod fails, because `debug_toolbar` isn't installed there.