### PR TITLE
Install DEV requirements on stage if DJANGO_DEV is True

### DIFF
--- a/bin/post_compile
+++ b/bin/post_compile
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Install requirements/dev.txt on staging
+# Install development requirements in stage / production environment if enabled
 if [ "$DJANGO_DEV" = True ]; then
     echo "Installing dev requirements..."
     pip install --require-hashes -r requirements/dev.txt

--- a/bin/post_compile
+++ b/bin/post_compile
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Install requirements/dev.txt on staging
-if [ "$DJANGO_STAGE" = True ]; then
+if [ "$DJANGO_DEV" = True ]; then
     echo "Installing dev requirements..."
     pip install --require-hashes -r requirements/dev.txt
 fi


### PR DESCRIPTION
I think there's still value in being able to debug performance on stage with DDT and such, so I'm keeping the ability to install dev requirements through the same variable (`DJANGO_DEV`) that is also used to enable them in settings.