### PR TITLE
Return correct results with distinct locales in /locales

### DIFF
--- a/pontoon/api/views.py
+++ b/pontoon/api/views.py
@@ -126,7 +126,7 @@ class LocaleListView(generics.ListAPIView):
     serializer_class = NestedLocaleSerializer
 
     def get_queryset(self):
-        locales = Locale.objects.prefetch_related("project_locale__project")
+        locales = Locale.objects.prefetch_related("project_locale__project").distinct()
         return locales.stats_data()
 
 


### PR DESCRIPTION
Resolves #3698.

It is important to note that the new api follows the implementation of the /teams page, which excludes the locales "en-US", "en", "bn-IN" and "bn-BD". The reason is that added these locales changes the missing_strings, total_strings fields in /locales to incorrect inflated values.