### PR TITLE
Api/V2/: User-actions Endpoint

### DIFF
--- a/pontoon/api/urls.py
+++ b/pontoon/api/urls.py
@@ -51,6 +51,12 @@ api_v2_patterns = [
         views.ProjectLocaleIndividualView.as_view(),
         name="project-locale-individual",
     ),
+    path(
+        # User Actions
+        "user-actions/<str:date>/project/<slug:slug>/",
+        views.UserActionsView.as_view(),
+        name="user-actions",
+    ),
 ]
 urlpatterns = [
     # GraphQL endpoint. Serves the GraphiQL IDE if accessed with Accept: text/html.

--- a/pontoon/api/views.py
+++ b/pontoon/api/views.py
@@ -3,6 +3,8 @@ from datetime import datetime, timedelta
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import generics
 from rest_framework.exceptions import ValidationError
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from django.contrib.auth.decorators import login_required
 from django.db.models import Q
@@ -120,6 +122,83 @@ def get_user_actions(request, date, slug):
             },
         }
     )
+
+
+class UserActionsView(APIView):
+    def get(self, request, date, slug):
+        try:
+            start_date = make_aware(datetime.strptime(date, "%Y-%m-%d"))
+        except ValueError:
+            raise ValidationError("Bad Request in kwarg: 'date'.")
+
+        end_date = start_date + timedelta(days=1)
+
+        project = generics.get_object_or_404(Project, slug=slug)
+
+        actions = ActionLog.objects.filter(
+            action_type__startswith="translation:",
+            created_at__gte=start_date,
+            created_at__lt=end_date,
+            translation__entity__resource__project=project,
+        )
+
+        actions = actions.prefetch_related(
+            "performed_by__profile",
+            "translation__entity__resource",
+            "translation__errors",
+            "translation__warnings",
+            "translation__locale",
+            "entity__resource",
+            "locale",
+        )
+
+        output = []
+
+        for action in actions:
+            user = action.performed_by
+            locale = action.locale or action.translation.locale
+            entity = action.entity or action.translation.entity
+            resource = entity.resource
+
+            data = {
+                "type": action.action_type,
+                "date": action.created_at,
+                "user": {
+                    "pk": user.pk,
+                    "name": user.display_name,
+                    "system_user": user.profile.system_user,
+                },
+                "locale": {
+                    "pk": locale.pk,
+                    "code": locale.code,
+                    "name": locale.name,
+                },
+                "entity": {
+                    "pk": entity.pk,
+                    "key": entity.key,
+                },
+                "resource": {
+                    "pk": resource.pk,
+                    "path": resource.path,
+                    "format": resource.format,
+                },
+            }
+
+            if action.translation:
+                data["translation"] = action.translation.serialize()
+
+            output.append(data)
+
+        return Response(
+            {
+                "actions": output,
+                "project": {
+                    "pk": project.pk,
+                    "slug": project.slug,
+                    "name": project.name,
+                },
+            }
+        )
 
 
 class LocaleListView(generics.ListAPIView):

--- a/pontoon/api/views.py
+++ b/pontoon/api/views.py
@@ -126,6 +126,8 @@ def get_user_actions(request, date, slug):
 
 
 class UserActionsView(APIView):
+    permission_classes = [IsAuthenticated]
+
     def get(self, request, date, slug):
         try:
             start_date = make_aware(datetime.strptime(date, "%Y-%m-%d"))

--- a/pontoon/api/views.py
+++ b/pontoon/api/views.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import generics
 from rest_framework.exceptions import ValidationError
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 


### PR DESCRIPTION
This PR resolves #3680.

It creates a new endpoint at `/api/v2/user-actions/<str:date>/project/<slug:slug>/`, which lists out user actions on the specified day related to a specified project.

It mirrors the behavior of `/api/v1/user-actions/<str:date>/project/<slug:slug>/`. It requires the user to be signed in in order to be able to access the data.

Future action is needed to clean up the old endpoint `/api/v2/user-actions/<str:date>/project/<slug:slug>/`.
