### PR TITLE
Fix spelling of JavaScript across docs and comments

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -138,7 +138,7 @@ To format the Python and the JavaScript code at once you can use:
 
 Code formatting is explained in more detail in the following sections.
 
-To run the required linters on the Python and the Javascript code at once you can use:
+To run the required linters on the Python and the JavaScript code at once you can use:
 
 .. code-block:: shell
 
@@ -166,10 +166,10 @@ ignore that error (see `documentation <https://docs.astral.sh/ruff/linter/#error
 Note that in most cases, it is better to fix the issues than ignoring them.
 
 
-Javascript code conventions
+JavaScript code conventions
 ===========================
 
-Our Javascript code is automatically formatted using `Prettier <https://prettier.io/docs/en/index.html>`_.
+Our JavaScript code is automatically formatted using `Prettier <https://prettier.io/docs/en/index.html>`_.
 We enforce that in our Continuous Integration, so you will need to run
 prettier on your code before sending it for review.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -195,7 +195,7 @@ html_theme = "sphinx_rtd_theme"
 # Now only 'ja' uses this config value
 # html_search_options = {'type': 'default'}
 
-# The name of a javascript file (relative to the configuration directory) that
+# The name of a JavaScript file (relative to the configuration directory) that
 # implements a search results scorer. If empty, the default will be used.
 # html_search_scorer = 'scorer.js'
 

--- a/pontoon/base/models/locale.py
+++ b/pontoon/base/models/locale.py
@@ -105,7 +105,7 @@ class LocaleQuerySet(models.QuerySet):
             "errors",
             "warnings",
             "unreviewed",
-            # TODO: Add "missing" string field and prevent recalculation of field in javascript
+            # TODO: Add "missing" string field and prevent recalculation of field in JavaScript
         )
         return {row["id"]: row for row in data if row["total"]}
 

--- a/pontoon/base/models/project.py
+++ b/pontoon/base/models/project.py
@@ -109,7 +109,7 @@ class ProjectQuerySet(models.QuerySet):
             "errors",
             "warnings",
             "unreviewed",
-            # TODO: Add "missing" string field and prevent recalculation of field in javascript
+            # TODO: Add "missing" string field and prevent recalculation of field in JavaScript
         )
         return {row["id"]: row for row in data if row["total"]}
 

--- a/pontoon/base/templates/base.html
+++ b/pontoon/base/templates/base.html
@@ -57,7 +57,7 @@
 
     {% endblock %}
 
-    <!-- Javascript at the bottom for fast page loading -->
+    <!-- JavaScript at the bottom for fast page loading -->
     {% block site_js %}
       {{ providers_media_js(request) }}
       {% javascript 'base' %}

--- a/pontoon/base/templates/django/base.html
+++ b/pontoon/base/templates/django/base.html
@@ -115,7 +115,7 @@
       </div>
     </section>
 
-    <!-- Javascript at the bottom for fast page loading -->
+    <!-- JavaScript at the bottom for fast page loading -->
     {% providers_media_js %}
     <script type="text/javascript" charset="utf-8" src="{% static 'js/lib/jquery-3.6.1.js' %}"></script>
     <script type="text/javascript" charset="utf-8" src="{% static 'js/lib/nprogress.js' %}"></script>

--- a/translate/tsconfig.json
+++ b/translate/tsconfig.json
@@ -11,7 +11,7 @@
       "dom.iterable",
       "esnext"
     ] /* Specify library files to be included in the compilation. */,
-    // "allowJs": true,                             /* Allow javascript files to be compiled. */
+    // "allowJs": true,                             /* Allow JavaScript files to be compiled. */
     // "checkJs": true,                             /* Report errors in .js files. */
     "jsx": "react-jsx" /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */,
     // "declaration": true,                         /* Generates corresponding '.d.ts' file. */


### PR DESCRIPTION
Not exactly important, but it bothers me every time I stumble upon one 🦉 