### PR TITLE
Fix `make build-translate` dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,12 +45,12 @@ translate/dist:
 	make build-translate
 .server-build:
 	make build-server
-node_modules:
+node_modules/.package-lock.json: package-lock.json
 	npm install
 
 build: build-translate build-server
 
-build-translate: node_modules
+build-translate: node_modules/.package-lock.json
 	npm run build -w translate
 
 build-server: server-env translate/dist


### PR DESCRIPTION
Fixes #3728.

Rather than depending on `node_modules/`, depend on `nodes_modules/.package-lock.json`, a [hidden lockfile](https://docs.npmjs.com/cli/v9/configuring-npm/package-lock-json#hidden-lockfiles), that we then say has the root `package-lock.json` as its dependency.

This way, an update in node dependencies will get picked up correctly by `make`. 