### PR TITLE
Run translate-toolkit checks separately for each gettext plural pattern, rather than the message as a whole

### DIFF
--- a/pontoon/checks/libraries/__init__.py
+++ b/pontoon/checks/libraries/__init__.py
@@ -1,4 +1,12 @@
+from moz.l10n.formats.mf2 import mf2_parse_message, mf2_serialize_pattern
+from moz.l10n.model import CatchallKey, Pattern, PatternMessage, SelectMessage
+
 from . import compare_locales, pontoon_db, pontoon_non_db, translate_toolkit
+
+
+def as_gettext(pattern: Pattern) -> str:
+    s = "".join(mf2_serialize_pattern(pattern))
+    return s.replace(r"\{", "{").replace(r"\}", "}")
 
 
 def run_checks(
@@ -21,17 +29,19 @@ def run_checks(
         * JsonResponse - If there are errors
         * None - If there's no errors and non-omitted warnings.
     """
-    pontoon_db_checks = pontoon_db.run_checks(entity, original, string)
-    pontoon_non_db_checks = pontoon_non_db.run_checks(entity, string)
+    checks = {}
+    checks.update(pontoon_db.run_checks(entity, original, string))
+    checks.update(pontoon_non_db.run_checks(entity, string))
 
     try:
         cl_checks = compare_locales.run_checks(entity, locale_code, string)
-    except compare_locales.UnsupportedStringError:
-        cl_checks = None
-    except compare_locales.UnsupportedResourceTypeError:
+        checks.update(cl_checks)
+    except (
+        compare_locales.UnsupportedStringError,
+        compare_locales.UnsupportedResourceTypeError,
+    ):
         cl_checks = None
 
-    tt_checks = {}
     resource_ext = entity.resource.format
 
     if use_tt_checks and resource_ext != "ftl":
@@ -44,15 +54,6 @@ def run_checks(
             "kdecomments",
             "untranslated",
         }
-
-        # gettext plurals are temporarily represented using MF2 syntax,
-        # with one/* variant keys in the source and 0/1/.../* in the translations.
-        if (
-            resource_ext == "po"
-            and original.startswith(".input")
-            and original.endswith("}}")
-        ):
-            tt_disabled_checks.add("numbers")
 
         # Some compare-locales checks overlap with Translate Toolkit checks
         if cl_checks is not None:
@@ -72,13 +73,35 @@ def run_checks(
                     ]
                 )
 
-        tt_checks = translate_toolkit.run_checks(
-            original, string, locale_code, tt_disabled_checks
-        )
-
-    checks = dict(tt_checks, **(cl_checks or {}))
-
-    checks.update(pontoon_db_checks)
-    checks.update(pontoon_non_db_checks)
+        tt_patterns: list[tuple[str, str]] = []
+        if resource_ext == "po":
+            src_msg = mf2_parse_message(original)
+            tgt_msg = mf2_parse_message(string)
+            if isinstance(src_msg, SelectMessage):
+                s0 = as_gettext(src_msg.variants[(CatchallKey(),)])
+                if isinstance(tgt_msg, SelectMessage):
+                    for keys, pattern in tgt_msg.variants.items():
+                        if keys == ("one",):
+                            src = as_gettext(src_msg.variants[keys])
+                        else:
+                            src = s0
+                        tt_patterns.append((src, as_gettext(pattern)))
+                else:
+                    tt_patterns.append((s0, as_gettext(tgt_msg.pattern)))
+            elif isinstance(tgt_msg, PatternMessage):
+                tt_patterns.append(
+                    (as_gettext(src_msg.pattern), as_gettext(tgt_msg.pattern))
+                )
+        else:
+            tt_patterns.append((original, string))
+        tt_warnings = {}
+        for src, tgt in tt_patterns:
+            tt_checks = translate_toolkit.run_checks(
+                src, tgt, locale_code, tt_disabled_checks
+            )
+            if tt_checks:
+                tt_warnings.update((w, None) for w in tt_checks["ttWarnings"])
+        if tt_warnings:
+            checks["ttWarnings"] = list(tt_warnings)
 
     return checks

--- a/pontoon/checks/tests/test_libraries.py
+++ b/pontoon/checks/tests/test_libraries.py
@@ -181,3 +181,20 @@ def test_tt_disabled_checks(
     assert not run_tt_checks_mock.assert_called_with(
         ANY, ANY, ANY, {"acronyms", "gconf", "kdecomments", "untranslated"}
     )
+
+
+def test_tt_gettext_checks():
+    entity = MagicMock()
+    entity.resource.path = "file.po"
+    entity.resource.format = Resource.Format.PO
+    entity.resource.all.return_value = []
+    entity.string = (
+        ".input {$n :number}\n.match $n\none {{One user}}\n* {{%(count)s Users}}"
+    )
+    entity.comment = ""
+    #                                         one: unchanged    two: has trailing whitespace  *: no warnings
+    string = ".input {$n :number}\n.match $n\none {{One user}}\ntwo {{%(count)s Users two }}\n* {{%(count)s Users:other}}"
+    checks = run_checks(
+        entity, "en-US", original=entity.string, string=string, use_tt_checks=True
+    )
+    assert checks == {"ttWarnings": ["Unchanged", "Ending whitespace"]}

--- a/pontoon/checks/tests/test_libraries.py
+++ b/pontoon/checks/tests/test_libraries.py
@@ -188,13 +188,25 @@ def test_tt_gettext_checks():
     entity.resource.path = "file.po"
     entity.resource.format = Resource.Format.PO
     entity.resource.all.return_value = []
-    entity.string = (
-        ".input {$n :number}\n.match $n\none {{One user}}\n* {{%(count)s Users}}"
-    )
+    entity.string = dedent("""\
+        .input {$n :number}
+        .match $n
+        one {{One user}}
+        * {{%(count)s Users}}""")
     entity.comment = ""
-    #                                         one: unchanged    two: has trailing whitespace  *: no warnings
-    string = ".input {$n :number}\n.match $n\none {{One user}}\ntwo {{%(count)s Users two }}\n* {{%(count)s Users:other}}"
+    string = dedent("""\
+        .input {$n :number}
+        .match $n
+        one {{One user}}
+        two {{two: %(count)s Users }}
+        * {{other: %(count)s Users}}""")
     checks = run_checks(
         entity, "en-US", original=entity.string, string=string, use_tt_checks=True
     )
-    assert checks == {"ttWarnings": ["Unchanged", "Ending whitespace"]}
+
+    # one: Unchanged
+    # two: Ending whitespace, Starting punctuation
+    # *: Starting punctuation
+    assert checks == {
+        "ttWarnings": ["Unchanged", "Ending whitespace", "Starting punctuation"]
+    }

--- a/pontoon/checks/tests/test_translate_toolkit.py
+++ b/pontoon/checks/tests/test_translate_toolkit.py
@@ -1,18 +1,26 @@
+import pytest
+
 from pontoon.checks.libraries.translate_toolkit import run_checks
 
 
-def test_tt_invalid_translation():
+@pytest.fixture()
+def mock_locale():
+    """Small mock of Locale object to make faster unit-tests."""
+    yield "en-US"
+
+
+def test_tt_invalid_translation(mock_locale):
     """
     Check if translate toolkit returns errors if chek
     """
     assert run_checks(
         "Original string",
         "Translation \\q",
-        "en-US",
+        mock_locale,
     ) == {"ttWarnings": ["Escapes"]}
 
 
-def test_tt_disabled_checks():
+def test_tt_disabled_checks(mock_locale):
     """
     Disabled checks should be respected by the run_checks.
     """
@@ -20,15 +28,15 @@ def test_tt_disabled_checks():
         run_checks(
             "Original string",
             "Translation \\q",
-            "en-US",
+            mock_locale,
             disabled_checks={"escapes"},
         )
         == {}
     )
 
 
-def test_tt_correct_translation():
+def test_tt_correct_translation(mock_locale):
     """
     Quality check should return empty dictionary if everything is okay (no warnings).
     """
-    assert run_checks("Original string", "Translation string", "en-US") == {}
+    assert run_checks("Original string", "Translation string", mock_locale) == {}

--- a/pontoon/checks/tests/test_translate_toolkit.py
+++ b/pontoon/checks/tests/test_translate_toolkit.py
@@ -1,26 +1,18 @@
-import pytest
-
 from pontoon.checks.libraries.translate_toolkit import run_checks
 
 
-@pytest.fixture()
-def mock_locale():
-    """Small mock of Locale object to make faster unit-tests."""
-    yield "en-US"
-
-
-def test_tt_invalid_translation(mock_locale):
+def test_tt_invalid_translation():
     """
     Check if translate toolkit returns errors if chek
     """
     assert run_checks(
         "Original string",
         "Translation \\q",
-        mock_locale,
+        "en-US",
     ) == {"ttWarnings": ["Escapes"]}
 
 
-def test_tt_disabled_checks(mock_locale):
+def test_tt_disabled_checks():
     """
     Disabled checks should be respected by the run_checks.
     """
@@ -28,15 +20,15 @@ def test_tt_disabled_checks(mock_locale):
         run_checks(
             "Original string",
             "Translation \\q",
-            mock_locale,
+            "en-US",
             disabled_checks={"escapes"},
         )
         == {}
     )
 
 
-def test_tt_correct_translation(mock_locale):
+def test_tt_correct_translation():
     """
     Quality check should return empty dictionary if everything is okay (no warnings).
     """
-    assert run_checks("Original string", "Translation string", mock_locale) == {}
+    assert run_checks("Original string", "Translation string", "en-US") == {}


### PR DESCRIPTION
Fixes #3750 

Rather than skipping all of the translate-toolkit checks as suggested in https://github.com/mozilla/pontoon/issues/3750#issuecomment-3151228293, let's run them separately for each of the patterns, as was done previously.

This uses the plural pattern of the source for all variants except for `one`.