### PR TITLE
Fix incorrect display of recipient count when selecting contributor, translator or manager

### DIFF
--- a/pontoon/messaging/views.py
+++ b/pontoon/messaging/views.py
@@ -125,10 +125,9 @@ def get_recipients(form):
 
     translations = Translation.objects.all()
     if form.cleaned_data.get("contributors"):
-        non_contributors = User.objects.filter(
-            pk__in=manager_ids
-        ) | User.objects.filter(pk__in=translator_ids)
-        recipients = User.objects.exclude(Q(pk__in=non_contributors) | Q(pk=-1))
+        recipients = User.objects.exclude(
+            Q(pk__in=manager_ids) | Q(pk__in=translator_ids) | Q(pk=-1)
+        )
 
     if form.cleaned_data.get("managers"):
         recipients = recipients | User.objects.filter(pk__in=manager_ids)


### PR DESCRIPTION
This issue resolves #3758. It addresses 3 issues:

- Before, if no Locale/Project were toggled, there would be 0 Managers/Translators in the recipient count, while Contributors had recipients, which was misleading.
Now, if no Locale/Project is toggled, all locales and projects are automatically selected for User Role recipient counting.


- Before, selecting the Manager, Translator & Contributor user roles vs. selecting just the Contributor user role equated the same count of recipients.
Now, each selected role has its own respective recipient counts, meaning the Contributor role does not equal all recipients

- Before, deselecting Locale toggle or Project toggle did not actually deselect the Locales or Projects chosen, which made the recipient count incorrect.
Now, deselecting the Locale/Project toggles also deselects the now hidden Locales or Projects previously chosen, ensuring accurate user experience.
