### PR TITLE
Find plural categories based on language tag only

### DIFF
--- a/translate/src/utils/message/getEmptyMessage.test.js
+++ b/translate/src/utils/message/getEmptyMessage.test.js
@@ -168,7 +168,31 @@ describe('getEmptyMessage', () => {
       `);
   });
 
-  it('handles plural messages for special locales', () => {
+  for (const code of ['fr', 'fr-BE', 'ca-valencia']) {
+    it(`handles plural messages for Romance locales (${code})`, () => {
+      const source = parseEntry(
+        'fluent',
+        ftl`
+      selector-multi =
+        { $num ->
+            [one] ONE
+           *[other] OTHER
+        }
+      `,
+      );
+      const entry = getEmptyMessageEntry(source, { code });
+      expect(serializeEntry('fluent', entry)).toBe(ftl`
+      selector-multi =
+          { $num ->
+              [one] { "" }
+             *[other] { "" }
+          }
+
+      `);
+    });
+  }
+
+  it('handles plural messages for Slavic locales', () => {
     const source = parseEntry(
       'fluent',
       ftl`

--- a/translate/src/utils/message/getPluralCategories.ts
+++ b/translate/src/utils/message/getPluralCategories.ts
@@ -2,7 +2,7 @@ import { CLDR_PLURALS } from '../constants';
 
 export function getPluralCategories(code: string): Intl.LDMLPluralRule[] {
   // These special cases should be occasionally pruned on CLDR updates
-  switch (code) {
+  switch (new Intl.Locale(code).language) {
     case 'ace': // Acehnese
     case 'ilo': // Iloko
     case 'meh': // Mixteco Yucuhiti
@@ -24,17 +24,10 @@ export function getPluralCategories(code: string): Intl.LDMLPluralRule[] {
 
     // For the following, deliberately ignore the `many` rule for millions
     case 'ca': // Catalan
-    case 'ca-valencia': // Catalan (Valencian)
     case 'es': // Spanish
-    case 'es-AR': // Spanish (Argentina)
-    case 'es-CL': // Spanish (Spain)
-    case 'es-ES': // Spanish (Chile)
-    case 'es-MX': // Spanish (Mexico)
     case 'fr': // French
     case 'it': // Italian
     case 'pt': // Portuguese
-    case 'pt-BR': // Portuguese (Brazil)
-    case 'pt-PT': // Portuguese (Portugal)
       return ['one', 'other'];
   }
 


### PR DESCRIPTION
~There might be an issue filed about this, but I can't find it.~

Fix #3343.

With this change, adding a new variant of a language with customization in `getPluralCategories()` won't need to have that function updated to account for it.