### PR TITLE
Enable context-sensitive autocompletion for placeholders

### DIFF
--- a/translate/src/modules/placeable/components/Highlight.tsx
+++ b/translate/src/modules/placeable/components/Highlight.tsx
@@ -1,50 +1,13 @@
 import { Localized } from '@fluent/react';
 import escapeRegExp from 'lodash.escaperegexp';
-import React, { useContext } from 'react';
+import React, { useContext, type ReactElement } from 'react';
 import { TermState } from '~/modules/terms';
 import { Location } from '~/context/Location';
 
 import './Highlight.css';
-import { ReactElement } from 'react';
+import { placeholder } from '../placeholder';
 
 let keyCounter = 0;
-
-const placeholder = (() => {
-  // HTML/XML <tags>
-  const html = '<(?:(?:"[^"]*")|(?:\'[^\']*\')|[^>])*>';
-  // Fluent & other similar {placeholders}
-  const curly = '{(?:(?:"[^"]*")|[^}])*}}?';
-  // All printf-ish formats, including Python's.
-  // Excludes Python's ` ` conversion flag, due to false positives -- https://github.com/mozilla/pontoon/issues/2988
-  const printf =
-    "%(?:\\d\\$|\\(.*?\\))?[-+0'#I]*[\\d*]*(?:\\.[\\d*])?(?:hh?|ll?|[jLtz])?[%@AaCcdEeFfGginopSsuXx]";
-  // Qt placeholders -- https://doc.qt.io/qt-5/qstring.html#arg
-  const qt = '%L?\\d{1,2}';
-  // HTML/XML &entities;
-  const entity = '&(?:[\\w.-]+|#(?:\\d{1,5}|x[a-fA-F0-9]{1,5})+);';
-  // $foo$ and $bar styles, used e.g. in webextension localization
-  const dollar = '\\$\\w+\\$?';
-
-  // all whitespace except for usual single spaces within the message
-  const spaces = '[\n\t]|(?:^| )[^\\S\n\t]+|[^\\S\n\t]+$|[^\\S \n\t]+';
-  // punctuation
-  const punct = '[™©®℃℉°±πθ×÷−√∞∆Σ′″‘’ʼ‚‛“”„‟«»£¥€…—–]+';
-  // \ escapes
-  const escape = '\\\\(?:[nrt\'"\\\\]|u[0-9A-Fa-f]{4}|(?=\\n))';
-  // Command-line --options and -s shorthands
-  const cli = '\\B(?:-\\w|--[\\w-]+)\\b';
-  // URL
-  const url =
-    // protocol       host         port          path & query                   end
-    '(?:ftp|https?)://\\w[\\w.]*\\w(?::\\d{1,5})?(?:/[\\w$.+!*(),;:@&=?/~#%-]*)?(?=$|[\\s\\]\'"}>),.])';
-
-  return new RegExp(
-    [html, curly, printf, qt, entity, dollar, spaces, punct, escape, cli, url]
-      .map((x) => `(?:${x})`)
-      .join('|'),
-    'g',
-  );
-})();
 
 /**
  * Component that marks placeables and terms in a string.

--- a/translate/src/modules/placeable/placeholder.ts
+++ b/translate/src/modules/placeable/placeholder.ts
@@ -1,0 +1,36 @@
+export const placeholder = (() => {
+  // HTML/XML <tags>
+  const html = '<(?:(?:"[^"]*")|(?:\'[^\']*\')|[^>])*>';
+  // Fluent & other similar {placeholders}
+  const curly = '{(?:(?:"[^"]*")|[^}])*}}?';
+  // All printf-ish formats, including Python's.
+  // Excludes Python's ` ` conversion flag, due to false positives -- https://github.com/mozilla/pontoon/issues/2988
+  const printf =
+    "%(?:\\d\\$|\\(.*?\\))?[-+0'#I]*[\\d*]*(?:\\.[\\d*])?(?:hh?|ll?|[jLtz])?[%@AaCcdEeFfGginopSsuXx]";
+  // Qt placeholders -- https://doc.qt.io/qt-5/qstring.html#arg
+  const qt = '%L?\\d{1,2}';
+  // HTML/XML &entities;
+  const entity = '&(?:[\\w.-]+|#(?:\\d{1,5}|x[a-fA-F0-9]{1,5})+);';
+  // $foo$ and $bar styles, used e.g. in webextension localization
+  const dollar = '\\$\\w+\\$?';
+
+  // all whitespace except for usual single spaces within the message
+  const spaces = '[\n\t]|(?:^| )[^\\S\n\t]+|[^\\S\n\t]+$|[^\\S \n\t]+';
+  // punctuation
+  const punct = '[™©®℃℉°±πθ×÷−√∞∆Σ′″‘’ʼ‚‛“”„‟«»£¥€…—–]+';
+  // \ escapes
+  const escape = '\\\\(?:[nrt\'"\\\\]|u[0-9A-Fa-f]{4}|(?=\\n))';
+  // Command-line --options and -s shorthands
+  const cli = '\\B(?:-\\w|--[\\w-]+)\\b';
+  // URL
+  const url =
+    // protocol       host         port          path & query                   end
+    '(?:ftp|https?)://\\w[\\w.]*\\w(?::\\d{1,5})?(?:/[\\w$.+!*(),;:@&=?/~#%-]*)?(?=$|[\\s\\]\'"}>),.])';
+
+  return new RegExp(
+    [html, curly, printf, qt, entity, dollar, spaces, punct, escape, cli, url]
+      .map((x) => `(?:${x})`)
+      .join('|'),
+    'g',
+  );
+})();

--- a/translate/src/modules/translationform/components/EditField.test.tsx
+++ b/translate/src/modules/translationform/components/EditField.test.tsx
@@ -37,7 +37,15 @@ function MockEditField({
       <MockStore store={store}>
         <Locale.Provider value={{ code: 'kg' } as Locale}>
           <EntityView.Provider
-            value={{ entity: { format, translation: {} } } as EntityView}
+            value={
+              {
+                entity: {
+                  format,
+                  original: `key = ${defaultValue}`,
+                  translation: {},
+                },
+              } as EntityView
+            }
           >
             <EditorActions.Provider
               value={{ setResultFromInput } as EditorActions}

--- a/translate/src/modules/translationform/components/EditField.tsx
+++ b/translate/src/modules/translationform/components/EditField.tsx
@@ -47,7 +47,11 @@ export const EditField = memo(
       const initView = useCallback(
         (parent: HTMLDivElement | null) => {
           if (parent) {
-            const extensions = getExtensions(entity.format, keyHandlers);
+            const extensions = getExtensions(
+              entity.format,
+              entity.original,
+              keyHandlers,
+            );
             if (readOnly) {
               extensions.push(
                 EditorState.readOnly.of(true),

--- a/translate/src/modules/translationform/utils/editFieldExtensions.test.ts
+++ b/translate/src/modules/translationform/utils/editFieldExtensions.test.ts
@@ -11,13 +11,13 @@ let currentTempView: EditorView | null = null;
 // Create a hidden view with the given document and extensions that
 // lives until the next call to `tempView`.
 // From: https://github.com/codemirror/view/blob/main/test/tempview.ts
-function tempView(doc = '', format: string): EditorView {
+function tempView(format: string, doc = ''): EditorView {
   if (currentTempView) {
     currentTempView.destroy();
     currentTempView = null;
   }
 
-  const extensions = getExtensions(format, {} as any);
+  const extensions = getExtensions(format, `key = ${doc}`, {} as any);
   currentTempView = new EditorView({
     state: EditorState.create({ doc, extensions }),
   });
@@ -35,7 +35,7 @@ function getAncestorWith(node: Node | null, attribute: string) {
 
 describe('spellcheck', () => {
   test('fluent mode', () => {
-    const view = tempView('foo { $bar }', 'fluent');
+    const view = tempView('fluent', 'foo { $bar }');
 
     const text = getAncestorWith(view.domAtPos(1).node, 'spellcheck');
     expect(text?.getAttribute('spellcheck')).toBe('true');
@@ -45,7 +45,7 @@ describe('spellcheck', () => {
   });
 
   test('common mode', () => {
-    const view = tempView('%1$s foo', 'common');
+    const view = tempView('plain', '%1$s foo');
 
     const text = getAncestorWith(view.domAtPos(7).node, 'spellcheck');
     expect(text?.getAttribute('spellcheck')).toBe('true');
@@ -58,24 +58,24 @@ describe('spellcheck', () => {
 describe('keyword', () => {
   describe('common mode', () => {
     test('i18next format', () => {
-      const view1 = tempView('{{name}} foo', 'common');
+      const view1 = tempView('plain', '{{name}} foo');
       const nameEl = getAncestorWith(view1.domAtPos(1).node, 'dir');
       expect(nameEl?.textContent).toBe('{{name}}');
 
-      const view2 = tempView('{{balance, money}} foo', 'common');
+      const view2 = tempView('plain', '{{balance, money}} foo');
       const balanceEl = getAncestorWith(view2.domAtPos(1).node, 'dir');
       expect(balanceEl?.textContent).toBe('{{balance, money}}');
 
       const view3 = tempView(
+        'plain',
         '{{num, number(minimumFractionDigits: 2)}} foo',
-        'common',
       );
       const numEl = getAncestorWith(view3.domAtPos(1).node, 'dir');
       expect(numEl?.textContent).toBe(
         '{{num, number(minimumFractionDigits: 2)}}',
       );
 
-      const view4 = tempView('{{value, formatter1, formatter2}} foo', 'common');
+      const view4 = tempView('plain', '{{value, formatter1, formatter2}} foo');
       const valueEl = getAncestorWith(view4.domAtPos(1).node, 'dir');
       expect(valueEl?.textContent).toBe('{{value, formatter1, formatter2}}');
     });

--- a/translate/src/utils/message/editMessageEntry.tsx
+++ b/translate/src/utils/message/editMessageEntry.tsx
@@ -77,7 +77,7 @@ function* genPatterns(
   }
 }
 
-function patternAsString(pattern: Model.Pattern) {
+export function patternAsString(pattern: Model.Pattern) {
   switch (pattern.length) {
     case 0:
       return '';


### PR DESCRIPTION
The original string is scanned with the same rules as we already use for its highlighting. If any highlights are detected, appropriate autocompletions are enabled; these will pop up automatically, or can be manually shown with Ctrl+Esc. A selected completion is accepted with Enter or Tab when the popup is visible, and it's dismissed with Esc or by focus change.

Automated tests are challenging for the editor, so this should be deployed to stage for manual testing when appropriate.