### PR TITLE
Add ability to disable migrations on deploy

### DIFF
--- a/bin/post_compile
+++ b/bin/post_compile
@@ -14,8 +14,13 @@ npm ci
 echo "Building translate..."
 npm run build:prod
 
-echo "Running migrations..."
-./manage.py migrate --noinput
+# Run migrations unless they are explicitly disabled
+if [ "$DISABLE_MIGRATIONS" = True ]; then
+  echo "Skipping migrations (DISABLE_MIGRATIONS is True)."
+else
+  echo "Running migrations..."
+  python manage.py migrate --noinput
+fi
 
 echo "Collecting static files..."
 ./manage.py collectstatic --noinput


### PR DESCRIPTION
Pushing https://github.com/mozilla/pontoon/pull/3791 to prod fails, because the migration takes too long.

I'll try to run the migration in a separate step.