### PR TITLE
Exclude private projects from TM search endpoint

### DIFF
--- a/pontoon/api/filters.py
+++ b/pontoon/api/filters.py
@@ -3,6 +3,7 @@ from django_filters import CharFilter, FilterSet
 from django.db.models import Q
 
 from pontoon.base.models import (
+    Project,
     TranslationMemoryEntry,
 )
 from pontoon.terminology.models import (
@@ -40,3 +41,8 @@ class TranslationMemoryFilter(FilterSet):
 
     def filter_locale(self, queryset, name, value):
         return queryset.filter(locale__code=value)
+
+    @property
+    def qs(self):
+        qs = super().qs
+        return qs.exclude(project__visibility=Project.Visibility.PRIVATE)

--- a/pontoon/api/tests/test_views.py
+++ b/pontoon/api/tests/test_views.py
@@ -972,6 +972,20 @@ def test_tm_search(django_assert_num_queries):
         string="Entity B",
         resource=resource_b,
     )
+    project_private = ProjectFactory(
+        slug="project_private",
+        name="Project Private",
+        visibility="private",
+    )
+    resource_private = ResourceFactory.create(
+        project=project_private,
+        path=f"resource_{project_private.slug}.po",
+        format="po",
+    )
+    entity_private = EntityFactory.create(
+        string="Entity Private",
+        resource=resource_private,
+    )
     TranslationMemoryEntry.objects.create(
         source="Hello",
         target="Hola",
@@ -993,8 +1007,15 @@ def test_tm_search(django_assert_num_queries):
         project=project_b,
         entity=entity_b,
     )
+    TranslationMemoryEntry.objects.create(
+        source="Hello",
+        target="Hola",
+        locale=locale_a,
+        project=project_private,
+        entity=entity_private,
+    )
 
-    with django_assert_num_queries(4):
+    with django_assert_num_queries(2):
         response = APIClient().get("/api/v2/search/tm/?text=hello&locale=kg")
 
     assert response.status_code == 200

--- a/pontoon/api/views.py
+++ b/pontoon/api/views.py
@@ -369,7 +369,7 @@ class TermSearchListView(generics.ListAPIView):
     serializer_class = TermSerializer
     filter_backends = [DjangoFilterBackend]
     filterset_class = TermFilter
-    queryset = Term.objects.select_related("translations__locale")
+    queryset = Term.objects.prefetch_related("translations__locale")
 
 
 class TranslationMemorySearchListView(generics.ListAPIView):


### PR DESCRIPTION
Translations from private projects should not be returned by the TranslationMemory search endpoint.

I've also simplified the code a little.