### PR TITLE
Only prefetch Locale API data that is required

### DIFF
--- a/pontoon/api/tests/test_views.py
+++ b/pontoon/api/tests/test_views.py
@@ -42,7 +42,7 @@ def test_dynamic_fields(django_assert_num_queries):
     results = sorted(response.data["results"], key=lambda loc: loc["code"])
 
     assert response.status_code == 200
-    assert response.data["count"] == 110
+    assert response.data["count"] == 108
     assert results == expected_results
 
 

--- a/pontoon/api/views.py
+++ b/pontoon/api/views.py
@@ -219,7 +219,7 @@ class LocaleListView(generics.ListAPIView):
     serializer_class = NestedLocaleSerializer
 
     def get_queryset(self):
-        qs = Locale.objects.all()
+        qs = Locale.objects.available()
 
         fields_param = self.request.query_params.get("fields", "")
         requested = set(f.strip() for f in fields_param.split(",") if f.strip())


### PR DESCRIPTION
We should file an issue to do the same for other views.