### PR TITLE
Fixes db migration with PostgreSQL 17

### DIFF
--- a/pontoon/base/migrations/0081_fix_android_spaces.py
+++ b/pontoon/base/migrations/0081_fix_android_spaces.py
@@ -16,7 +16,7 @@ WITH tm AS (
     FROM base_translationmemoryentry m
     JOIN base_translation t ON t.id = m.translation_id
     WHERE
-        m.target SIMILAR TO '%[^\S \n]%' AND
+        m.target SIMILAR TO '%[^[^[:space:]] \n]%' AND
         t.string != m.target
 )
 UPDATE base_translation AS t


### PR DESCRIPTION
An error occurs when running the database migration 81 on PostgreSQL 17 (I have not tested on PostgreSQL 16, and it works with PostgreSQL 15):

    django.db.utils.DataError: invalid regular expression: invalid escape \ sequence

This PR just replaces a `\S` escape sequence by `[^[:space:]]` that is equivalent¹ but that works fine on PG17. :)

¹ Doc: https://www.postgresql.org/docs/current/functions-matching.html#:~:text=matches%20any%20non-whitespace%20character