### PR TITLE
Deprecate /api/v1/user-actions/

### DIFF
--- a/pontoon/api/urls.py
+++ b/pontoon/api/urls.py
@@ -87,26 +87,4 @@ urlpatterns = [
         name="swagger-ui",
     ),
     path("api/v2/", include(api_v2_patterns)),
-    # API v1
-    path(
-        "api/v1/",
-        include(
-            [
-                path(
-                    # User actions
-                    "user-actions/",
-                    include(
-                        [
-                            # In a given project
-                            path(
-                                "<str:date>/project/<slug:slug>/",
-                                views.get_user_actions,
-                                name="pontoon.api.get_user_actions.project",
-                            ),
-                        ]
-                    ),
-                ),
-            ]
-        ),
-    ),
 ]

--- a/pontoon/api/views.py
+++ b/pontoon/api/views.py
@@ -7,12 +7,9 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from django.contrib.auth.decorators import login_required
 from django.db.models import Prefetch, Q
-from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
 from django.utils.timezone import make_aware
-from django.views.decorators.http import require_GET
 
 from pontoon.actionlog.models import ActionLog
 from pontoon.api.filters import TermFilter, TranslationMemoryFilter
@@ -42,98 +39,6 @@ from .serializers import (
     TermSerializer,
     TranslationMemorySerializer,
 )
-
-
-@require_GET
-@login_required(redirect_field_name="", login_url="/403")
-def get_user_actions(request, date, slug):
-    try:
-        start_date = make_aware(datetime.strptime(date, "%Y-%m-%d"))
-    except ValueError:
-        return JsonResponse(
-            {
-                "error": "Invalid date format. Please use YYYY-MM-DD.",
-            },
-            status=400,
-        )
-
-    end_date = start_date + timedelta(days=1)
-
-    try:
-        project = Project.objects.get(slug=slug)
-    except Project.DoesNotExist:
-        return JsonResponse(
-            {
-                "error": "Project not found. Please use a valid project slug.",
-            },
-            status=404,
-        )
-
-    actions = ActionLog.objects.filter(
-        action_type__startswith="translation:",
-        created_at__gte=start_date,
-        created_at__lt=end_date,
-        translation__entity__resource__project=project,
-    )
-
-    actions = actions.prefetch_related(
-        "performed_by__profile",
-        "translation__entity__resource",
-        "translation__errors",
-        "translation__warnings",
-        "translation__locale",
-        "entity__resource",
-        "locale",
-    )
-
-    output = []
-
-    for action in actions:
-        user = action.performed_by
-        locale = action.locale or action.translation.locale
-        entity = action.entity or action.translation.entity
-        resource = entity.resource
-
-        data = {
-            "type": action.action_type,
-            "date": action.created_at,
-            "user": {
-                "pk": user.pk,
-                "name": user.display_name,
-                "username": user.username,
-                "system_user": user.profile.system_user,
-            },
-            "locale": {
-                "pk": locale.pk,
-                "code": locale.code,
-                "name": locale.name,
-            },
-            "entity": {
-                "pk": entity.pk,
-                "key": entity.key,
-            },
-            "resource": {
-                "pk": resource.pk,
-                "path": resource.path,
-                "format": resource.format,
-            },
-        }
-
-        if action.translation:
-            data["translation"] = action.translation.serialize()
-
-        output.append(data)
-
-    return JsonResponse(
-        {
-            "actions": output,
-            "project": {
-                "pk": project.pk,
-                "slug": project.slug,
-                "name": project.name,
-            },
-        }
-    )
 
 
 class UserActionsView(APIView):


### PR DESCRIPTION
## Description
This PR removes the API endpoint `/api/v1/user-actions/str:date/project/slug:slug/`, which will subsequently remove API v1 from the codebase.

Existing users of the endpoint can be directed to using `/api/v2/user-actions/str:date/project/slug:slug/`

Fixes #3705

## Additional Notes
We may need a discussion on notifying the relevant stakeholders for this change.
