### PR TITLE
Add a few required tools to the runtime docker image

### DIFF
--- a/docker/Dockerfile-mozcloud
+++ b/docker/Dockerfile-mozcloud
@@ -120,8 +120,11 @@ ENV PYTHONPATH=/app
 # Install only runtime dependencies
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
+        git \
         libmemcached11 \
         libpq5 \
+        mercurial \
+        openssh-client \
         postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The celery worker needs these tools to sync with github and h.m.o.