### PR TITLE
Profile Page: Add text wrapping to username and bio text displays

### DIFF
--- a/pontoon/contributors/static/css/profile.css
+++ b/pontoon/contributors/static/css/profile.css
@@ -59,6 +59,7 @@ h2 {
 .display-name {
   font-size: 24px;
   padding-bottom: 0;
+  overflow-wrap: break-word;
 }
 
 .username {


### PR DESCRIPTION
## Description
Before, specific strings of specified length which had no spaces or hyphens would overflow into neighbouring objects.

Fixes #3861.

## Screenshots (if applicable)
Before:
<img width="1191" height="645" alt="image" src="https://github.com/user-attachments/assets/3a8750a1-57c2-4c61-846b-1f661cea7feb" />

After:
<img width="1039" height="698" alt="image" src="https://github.com/user-attachments/assets/1f89af50-028e-4a50-b8ae-c2ca0bea8b43" />
