### PR TITLE
Translate Module: fix locale tab not updating for untranslated entity strings

### DIFF
--- a/translate/src/modules/entitydetails/components/EntityDetails.tsx
+++ b/translate/src/modules/entitydetails/components/EntityDetails.tsx
@@ -80,7 +80,7 @@ export function EntityDetails(): React.ReactElement<'section'> | null {
         dispatch(getTeamComments(entity, lc));
       }
     }
-  }, [selectedEntity]);
+  }, [activeTranslation, selectedEntity]);
 
   const navigateToPath = useCallback(
     (path: string) => checkUnsavedChanges(() => location.push(path)),


### PR DESCRIPTION
## Description
This PR is intended to fix the issue where untranslated entity strings in the translate module do not fetch the Locales Tab content properly, while translated entity strings do so successfully.

Fixes #3752.

## Additional Notes
~Need discussion on the usage of `useActiveTranslation()`. Is the memoization useful? Better ways to fix this problem?~