### PR TITLE
Fix misleading CSRF_TRUSTED_ORIGINS variable description

### DIFF
--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -290,10 +290,12 @@ you create:
    Learn more in the `Django documentation <https://docs.djangoproject.com/en/5.1/ref/settings/#secure-ssl-redirect>`_.
 
 ``CSRF_TRUSTED_ORIGINS``
-   Optional. A list of trusted origins for unsafe requests. It should contain the domains
-   where the app is available, seperated by comma. The setting also supports subdomains, so you could
-   add `https://*.example.com`, for example, to allow access from all
-   subdomains of `example.com`. Default value is `""`.
+   Optional. A comma-separated list of trusted origins for unsafe requests.
+   It should contain the domains where the app is available.
+   The setting also supports subdomains,
+   so you could add ``https://*.example.com``, for example,
+   to allow access from all subdomains of ``example.com``.
+   Default value is an empty string.
    Learn more in the `Django documentation <https://docs.djangoproject.com/en/5.1/ref/settings/#csrf-trusted-origins>`_.
 
 ``SSH_CONFIG``


### PR DESCRIPTION
https://github.com/mozilla/pontoon/blob/22aa0af2748375a88e8ad517fbf427dfeaee2440/pontoon/settings/base.py#L832

The code expects a string like `"a,b,c”`, not a list `['a','b','c']`