### PR TITLE
Notifications: prevent translation notifications from disabled projects

### DIFF
--- a/pontoon/messaging/management/commands/send_review_notifications.py
+++ b/pontoon/messaging/management/commands/send_review_notifications.py
@@ -30,6 +30,7 @@ class Command(BaseCommand):
         for suggestion in Translation.objects.filter(
             (Q(approved_date__gt=start) | Q(rejected_date__gt=start))
             & Q(user__profile__review_notifications=True)
+            & Q(entity__resource__project__disabled=False)
         ):
             author = suggestion.user
             locale = suggestion.locale


### PR DESCRIPTION
## Description
This fix prevents translation updates (approvals, rejections etc.) from disabled projects to showing up in the notification feed in the translate module (bell) and the notifications page.

Fixes #3714 and #2340.