### PR TITLE
Revert plural category sort removal of #3874

### DIFF
--- a/translate/src/utils/message/getPluralCategories.ts
+++ b/translate/src/utils/message/getPluralCategories.ts
@@ -1,3 +1,5 @@
+import { CLDR_PLURALS } from '../constants';
+
 export function getPluralCategories(code: string): Intl.LDMLPluralRule[] {
   // These special cases should be occasionally pruned on CLDR updates
   switch (new Intl.Locale(code).language) {
@@ -38,6 +40,12 @@ export function getPluralCategories(code: string): Intl.LDMLPluralRule[] {
     return ['one', 'other'];
   }
 
+  // TODO: Sort won't be needed once https://github.com/tc39/ecma402/pull/918
+  // is adopted in all environments (e.g. Node.js 24 & later).
   const pr = new Intl.PluralRules(code);
-  return pr.resolvedOptions().pluralCategories;
+  const pc = pr.resolvedOptions().pluralCategories;
+  pc.sort((a, b) =>
+    CLDR_PLURALS.indexOf(a) < CLDR_PLURALS.indexOf(b) ? -1 : 1,
+  );
+  return pc;
 }


### PR DESCRIPTION
As identified in https://github.com/mozilla/pontoon/pull/3880#issuecomment-3702277247, the sorting isn't supported at least on Node.js 22. I'm not sure about browser support, but better safe than sorry.

@nishitmistry Fancy giving this a review to verify that this change lets the getEmptyMessage tests pass again?