### PR TITLE
Send logs to stdout instead of stderr

### DIFF
--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 import socket
+import sys
 
 from datetime import datetime
 from ipaddress import ip_address, ip_network
@@ -874,7 +875,7 @@ pontoon_file_handler = {
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
-    "handlers": {"console": {"class": "logging.StreamHandler"}},
+    "handlers": {"console": {"class": "logging.StreamHandler", "stream": sys.stdout}},
     "formatters": {
         "verbose": {"format": "[%(levelname)s:%(name)s] %(asctime)s %(message)s"},
     },


### PR DESCRIPTION
I'm not sure if this is going to fix #3888 completely, but also not sure how to test it more.

My assumption is that duplicated messages are coming from `log.debug()` ([example](https://github.com/mozilla/pontoon/blob/879bbabcd931598e242c2edde10f6e189f0cc720/pontoon/sync/core/translations_from_repo.py#L139)):
* Those are not displayed in prod.
* On DEV, debug messages are also printed, and anything printed is picked up as an error by GCP Logs.