### PR TITLE
Fix search and replace for Fluent strings

### DIFF
--- a/pontoon/batch/tests/test_utils.py
+++ b/pontoon/batch/tests/test_utils.py
@@ -1,6 +1,15 @@
+import pytest
+
 from fluent.syntax import FluentParser, FluentSerializer
 
-from pontoon.batch.utils import ftl_find_and_replace
+from pontoon.base.models import Translation
+from pontoon.batch.utils import find_and_replace, ftl_find_and_replace
+from pontoon.test.factories import (
+    EntityFactory,
+    ProjectFactory,
+    ResourceFactory,
+    TranslationFactory,
+)
 
 
 parser = FluentParser()
@@ -32,3 +41,30 @@ def test_ftl_find_and_replace():
     )
 
     assert ftl_find_and_replace(complex_string, "find", "replace") == complex_replaced
+
+
+@pytest.mark.django_db
+def test_ftl_find_and_replace_non_text_value(locale_a, user_a):
+    complex_string = normalize(
+        """find =
+        .placeholder = find
+    """
+    )
+
+    project = ProjectFactory(slug="project", name="Project")
+    resource = ResourceFactory(project=project, path="resource.ftl", format="fluent")
+    entity = EntityFactory(resource=resource, string=complex_string)
+    translation = TranslationFactory(
+        entity=entity, locale=locale_a, string=complex_string
+    )
+
+    translations, translations_to_create, translations_with_errors = find_and_replace(
+        Translation.objects.filter(pk__in=[translation.pk]),
+        "placeholder",
+        "replace",
+        user_a,
+    )
+
+    assert len(translations) == 0
+    assert translations_to_create == []
+    assert translations_with_errors == []


### PR DESCRIPTION
If Search and replace Batch action is used on Fluent string and the search term has a match in Translation.string (serialized representation of a fluent string, including its syntax), but not in translation text values, rather than marking the string as rejected, we now skip it.