### PR TITLE
In UserActionsView API endpoint, do not return data for private projects if not visible for the user

### DIFF
--- a/pontoon/api/tests/test_views.py
+++ b/pontoon/api/tests/test_views.py
@@ -25,6 +25,29 @@ from pontoon.test.factories import (
 
 
 @pytest.mark.django_db
+def test_user_actions_project_not_visible(member):
+    client = APIClient()
+    client.force_authenticate(user=member.user)
+
+    private_project = ProjectFactory(
+        slug="private-project",
+        visibility="private",
+    )
+
+    date = now().strftime("%Y-%m-%d")
+
+    response = client.get(
+        f"/api/v2/user-actions/{date}/project/{private_project.slug}/",
+        HTTP_ACCEPT="application/json",
+    )
+
+    assert response.status_code == 403
+    assert response.data == {
+        "detail": "You do not have permission to access data for this project."
+    }
+
+
+@pytest.mark.django_db
 def test_dynamic_fields(django_assert_num_queries):
     expected_results = [
         {
@@ -1802,6 +1825,3 @@ def test_pretranslation_tm(member):
     )
 
     assert response.status_code == 400
-
-
-# Test Google AutoML

--- a/pontoon/api/views.py
+++ b/pontoon/api/views.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import generics
-from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -70,6 +70,10 @@ class UserActionsView(APIView):
         end_date = start_date + timedelta(days=1)
 
         project = generics.get_object_or_404(Project, slug=slug)
+        if not Project.objects.filter(pk=project.pk).visible_for(request.user).exists():
+            raise PermissionDenied(
+                "You do not have permission to access data for this project."
+            )
 
         actions = ActionLog.objects.filter(
             action_type__startswith="translation:",


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=2010105.