### PR TITLE
Reorder Django middlewares

### DIFF
--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -333,18 +333,18 @@ MIDDLEWARE = (
     "corsheaders.middleware.CorsMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.middleware.gzip.GZipMiddleware",
+    "pontoon.base.middleware.RaygunExceptionMiddleware",
     "pontoon.base.middleware.BlockedIpMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "allauth.account.middleware.AccountMiddleware",
+    "pontoon.base.middleware.ThrottleIpMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "csp.middleware.CSPMiddleware",
-    "pontoon.base.middleware.ThrottleIpMiddleware",
     "pontoon.base.middleware.EmailConsentMiddleware",
-    "pontoon.base.middleware.RaygunExceptionMiddleware",
 )
 
 CONTEXT_PROCESSORS = (


### PR DESCRIPTION
From https://docs.djangoproject.com/en/6.0/ref/middleware/#middleware-ordering

```
SessionMiddleware

Before any middleware that may raise an exception to trigger an error view (such as PermissionDenied) if you’re using CSRF_USE_SESSIONS.
```

Is the current order incorrect? Not sure if that's what is causing errors in the log on `django/middleware/csrf.py`