### PR TITLE
fix(loaddb): use psql instead of pg_restore for SQL dump files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ loaddb:
 	# Note: docker-compose doesn't support the `-i` (--interactive) argument
 	# that we need to send the dump file through STDIN. We thus are forced to
 	# use docker here instead.
-	"${DOCKER}" exec -i `"${DC}" ps -q postgresql` psql -U pontoon < "${DB_DUMP_FILE}"
+	"${DOCKER}" exec -i `"${DC}" ps -q postgresql` psql -U pontoon -d pontoon < "${DB_DUMP_FILE}"
 
 sync-projects:
 	"${DC}" run --rm server .//manage.py sync_projects $(opts)


### PR DESCRIPTION
Fix database restore in make loaddb by switching from pg_restore to psql for SQL dump files.

fixes #3755.

## Behavior after the fix

### 1. Make Dump DB

```console
$ make dumpdb
"/usr/bin/docker" exec -t `"/usr/local/bin/docker-compose" ps -q postgresql` pg_dumpall -c -U pontoon > dump_`date +%d-%m-%Y"_"%H_%M_%S`.sql
```

### 2. Load DB

```console
$ make loaddb DB_DUMP_FILE=dump_25-01-2026_10_57_08.sql 
# Stop connections to the database so we can drop it.
"/usr/local/bin/docker-compose" stop server
[+] stop 1/1
 ✔ Container pontoon-server-1 Stopped                                                                                                                                                                                                   0.0s
# Make sure the postgresql container is running.
"/usr/local/bin/docker-compose" start postgresql
"/usr/local/bin/docker-compose" exec postgresql dropdb -U pontoon pontoon
"/usr/local/bin/docker-compose" exec postgresql createdb -U pontoon pontoon
# Note: docker-compose doesn't support the `-i` (--interactive) argument
# that we need to send the dump file through STDIN. We thus are forced to
# use docker here instead.
"/usr/bin/docker" exec -i `"/usr/local/bin/docker-compose" ps -q postgresql` psql -U pontoon < "dump_25-01-2026_10_57_08.sql"
SET
SET
SET
ERROR:  cannot drop the currently open database
ERROR:  current user cannot be dropped
ERROR:  role "pontoon" already exists
ALTER ROLE
SET
SET
SET
SET
SET
 set_config 
------------
 
(1 row)

SET
SET
SET
SET
UPDATE 1
DROP DATABASE
CREATE DATABASE
ALTER DATABASE
You are now connected to database "template1" as user "pontoon".
SET
SET
SET
SET
SET
 set_config 
------------
 
(1 row)

SET
SET
SET
SET
COMMENT
ALTER DATABASE
You are now connected to database "template1" as user "pontoon".
SET
SET
SET
SET
SET
 set_config 
------------
 
(1 row)

SET
SET
SET
SET
REVOKE
GRANT
SET
SET
SET
SET
SET
 set_config 
------------
 
(1 row)

SET
SET
SET
SET
ERROR:  database "pontoon" already exists
ALTER DATABASE
You are now connected to database "pontoon" as user "pontoon".
SET
SET
SET
SET
SET
 set_config 
------------
 
(1 row)

SET
SET
SET
SET
SET
SET
SET
SET
SET
 set_config 
------------
 
(1 row)

SET
SET
SET
SET
DROP DATABASE
CREATE DATABASE
ALTER DATABASE
You are now connected to database "postgres" as user "pontoon".
SET
SET
SET
SET
SET
 set_config 
------------
 
(1 row)

SET
SET
SET
SET
COMMENT

```