### PR TITLE
Use source syntax for translate-toolkit checks of XLIFF strings

### DIFF
--- a/pontoon/checks/libraries/__init__.py
+++ b/pontoon/checks/libraries/__init__.py
@@ -72,7 +72,9 @@ def run_checks(
 
         tt_patterns: list[tuple[str, str]] = []
         match res_format:
-            case Resource.Format.ANDROID:
+            case (
+                Resource.Format.ANDROID | Resource.Format.XCODE | Resource.Format.XLIFF
+            ):
                 src_msg = mf2_parse_message(entity.string)
                 tgt_msg = mf2_parse_message(string)
                 src0 = get_simple_preview(res_format, src_msg)

--- a/pontoon/checks/tests/test_libraries.py
+++ b/pontoon/checks/tests/test_libraries.py
@@ -162,3 +162,18 @@ def test_tt_android_plural_checks():
     # two: Starting punctuation, Ending whitespace
     # *: Starting punctuation
     assert checks == {"ttWarnings": ["Starting punctuation", "Ending whitespace"]}
+
+
+def test_tt_xcode_checks():
+    entity = MagicMock()
+    entity.resource.path = "xcode.xliff"
+    entity.resource.format = Resource.Format.XCODE
+    entity.resource.all.return_value = []
+    entity.string = "You can learn more {$arg @source=|%@|}."
+    entity.comment = ""
+    assert run_checks(
+        entity,
+        "en-US",
+        string="You can learn more",
+        use_tt_checks=True,
+    ) == {"ttWarnings": ["Ending punctuation", "Printf format string mismatch"]}


### PR DESCRIPTION
Fixes #3895

Partly the problem is also solved by #3921, which will remove the `Brackets` and `pythonbraceformat` false positives for visually identical strings, but this change will ensure that they won't show up when other issues are also present.