### PR TITLE
API: change translation visibility in EntityIndividualView based on locale visibility

### DIFF
--- a/pontoon/api/views.py
+++ b/pontoon/api/views.py
@@ -304,9 +304,9 @@ class EntityIndividualView(RequestFieldsMixin, generics.RetrieveAPIView):
             qs = qs.prefetch_related(
                 Prefetch(
                     "translation_set",
-                    queryset=Translation.objects.filter(locale__in=locales, approved=True).select_related(
-                        "locale"
-                    ),
+                    queryset=Translation.objects.filter(
+                        locale__in=locales, approved=True
+                    ).select_related("locale"),
                     to_attr="filtered_translations",
                 )
             )


### PR DESCRIPTION
Based off a long line of misconfigured visibilities for locales like `bn-BD` and `bn-IN`.

A similar concept can be found on this bug: [bugzilla.mozilla.org/show_bug.cgi?id=2010104](url).