### PR TITLE
Translate Module: reset machinery/concordance search results upon entity change

### DIFF
--- a/translate/src/context/SearchData.tsx
+++ b/translate/src/context/SearchData.tsx
@@ -73,7 +73,16 @@ export function SearchProvider({ children }: { children: React.ReactElement }) {
 
   const { setInput, query, page, fetching } = search;
 
-  useEffect(() => setInput(''), [entity]);
+  useEffect(() => {
+    setSearch((prev) => ({
+      ...prev,
+      fetching: false,
+      input: '',
+      query: '',
+      results: [],
+      hasMore: false,
+    }));
+  }, [entity]);
 
   useEffect(() => {
     if (fetching) {


### PR DESCRIPTION
This PR refreshes the Machinery/Concordance Search list of translations upon an Entity change from the user in the translate module.

Fixes #3663.
