### PR TITLE
Document GOOGLE_APPLICATION_CREDENTIALS

### DIFF
--- a/docs/admin/deployment.rst
+++ b/docs/admin/deployment.rst
@@ -204,6 +204,10 @@ you create:
    Optional. Set your `Google Cloud AutoML Translation`_ model ID to use custom machine
    translation engine by Google.
 
+``GOOGLE_APPLICATION_CREDENTIALS``
+   Optional. Path to a Google Cloud service account JSON key file
+   used by Google client libraries for authentication.
+
 ``INACTIVE_CONTRIBUTOR_PERIOD``
    Optional. Number of months in which the contributor needs to log in in order not to
    receive the inactive account email. The default value is 6.


### PR DESCRIPTION
Fixes #3427

This PR adds documentation for the GOOGLE_APPLICATION_CREDENTIALS environment variable, which was introduced in #2873 but never documented.

The variable is used by pontoon/machinery/utils.py for Google Cloud Translation API with glosary support.

Changes:
- Added GOOGLE_APPLICATION_CREDENTIALS documentation in deployment.rst
- Referenced the Heroku buildpack for deployment context.

To review:
- Check the documentation is added in the right location.
-  Verify the RST syntax

How I tested the changes:
- Confirmed the variable is used in the codebase, by looking at the files in #2873 or git grep "GOOGLE_APPLICATION_CREDENTIALS" pontoon/
-  Confirmed it's not in the docs grep -r "GOOGLE_APPLICATION_CREDENTIALS" docs/

Documentation preview
<img width="736" height="131" alt="Screenshot 2026-01-28 at 08 09 55" src="https://github.com/user-attachments/assets/f1001db6-3c1d-46e6-8809-19f2c0c02529" />


