### PR TITLE
Community Health: change completion and missing strings calculation

### DIFF
--- a/pontoon/api/tests/test_views.py
+++ b/pontoon/api/tests/test_views.py
@@ -114,7 +114,7 @@ def test_locale(django_assert_num_queries):
     translated_resource.pretranslated_strings = 0
     translated_resource.strings_with_errors = 3
     translated_resource.strings_with_warnings = 2
-    translated_resource.missing_strings = 5
+    translated_resource.missing_strings = 10
     translated_resource.unreviewed_strings = 5
     translated_resource.save()
 
@@ -145,7 +145,7 @@ def test_locale(django_assert_num_queries):
         "pretranslated_strings": 0,
         "strings_with_warnings": 2,
         "strings_with_errors": 3,
-        "missing_strings": 5,
+        "missing_strings": 10,
         "unreviewed_strings": 5,
         "complete": False,
         "projects": ["terminology"],
@@ -161,7 +161,7 @@ def test_locale(django_assert_num_queries):
         "pretranslated_strings": 0,
         "strings_with_warnings": 2,
         "strings_with_errors": 3,
-        "missing_strings": 5,
+        "missing_strings": 10,
         "unreviewed_strings": 5,
         "complete": False,
     } in localizations
@@ -296,7 +296,7 @@ def test_project(django_assert_num_queries):
         translated_resource.pretranslated_strings = 0
         translated_resource.strings_with_errors = 3
         translated_resource.strings_with_warnings = 2
-        translated_resource.missing_strings = 5
+        translated_resource.missing_strings = 10
         translated_resource.unreviewed_strings = 5
         translated_resource.save()
 
@@ -325,7 +325,7 @@ def test_project(django_assert_num_queries):
         "pretranslated_strings": 0,
         "strings_with_warnings": 4,
         "strings_with_errors": 6,
-        "missing_strings": 10,
+        "missing_strings": 20,
         "unreviewed_strings": 10,
         "complete": False,
         "tags": [],
@@ -452,7 +452,7 @@ def test_project(django_assert_num_queries):
         "pretranslated_strings": 0,
         "strings_with_warnings": 2,
         "strings_with_errors": 3,
-        "missing_strings": 5,
+        "missing_strings": 10,
         "unreviewed_strings": 5,
         "complete": False,
     } in localizations
@@ -467,7 +467,7 @@ def test_project(django_assert_num_queries):
         "pretranslated_strings": 0,
         "strings_with_warnings": 2,
         "strings_with_errors": 3,
-        "missing_strings": 5,
+        "missing_strings": 10,
         "unreviewed_strings": 5,
         "complete": False,
     } in localizations
@@ -896,7 +896,7 @@ def test_project_locale(django_assert_num_queries):
         translated_resource.pretranslated_strings = 0
         translated_resource.strings_with_errors = 3
         translated_resource.strings_with_warnings = 2
-        translated_resource.missing_strings = 5
+        translated_resource.missing_strings = 10
         translated_resource.unreviewed_strings = 5
         translated_resource.save()
 
@@ -925,7 +925,7 @@ def test_project_locale(django_assert_num_queries):
             "pretranslated_strings": 0,
             "strings_with_warnings": 2,
             "strings_with_errors": 3,
-            "missing_strings": 5,
+            "missing_strings": 10,
             "unreviewed_strings": 5,
             "complete": False,
         },
@@ -934,7 +934,7 @@ def test_project_locale(django_assert_num_queries):
         "pretranslated_strings": 0,
         "strings_with_warnings": 2,
         "strings_with_errors": 3,
-        "missing_strings": 5,
+        "missing_strings": 10,
         "unreviewed_strings": 5,
         "complete": False,
         "project": {
@@ -954,7 +954,7 @@ def test_project_locale(django_assert_num_queries):
             "pretranslated_strings": 0,
             "strings_with_warnings": 4,
             "strings_with_errors": 6,
-            "missing_strings": 10,
+            "missing_strings": 20,
             "unreviewed_strings": 10,
             "complete": False,
         },

--- a/pontoon/base/aggregated_stats.py
+++ b/pontoon/base/aggregated_stats.py
@@ -41,22 +41,11 @@ class AggregatedStats:
 
     @property
     def missing_strings(self) -> int:
-        return (
-            self.total_strings
-            - self.approved_strings
-            - self.pretranslated_strings
-            - self.strings_with_errors
-            - self.strings_with_warnings
-        )
+        return self.total_strings - self.approved_strings - self.pretranslated_strings
 
     @property
     def complete(self) -> bool:
-        return (
-            self.total_strings
-            == self.approved_strings
-            + self.pretranslated_strings
-            + self.strings_with_warnings
-        )
+        return self.total_strings == self.approved_strings + self.strings_with_warnings
 
 
 def get_top_instances(qs, stats: dict[int, dict[str, int]]) -> dict[str, object] | None:
@@ -69,13 +58,7 @@ def get_top_instances(qs, stats: dict[int, dict[str, int]]) -> dict[str, object]
 
     def _missing(x: tuple[int, dict[str, int]]) -> int:
         _, d = x
-        return (
-            d["total"]
-            - d["approved"]
-            - d["pretranslated"]
-            - d["errors"]
-            - d["warnings"]
-        )
+        return d["total"] - d["approved"]
 
     max_total_id = max(stats.items(), key=lambda x: x[1]["total"])[0]
     max_approved_id = max(stats.items(), key=lambda x: x[1]["approved"])[0]

--- a/pontoon/base/models/locale.py
+++ b/pontoon/base/models/locale.py
@@ -79,14 +79,10 @@ class LocaleQuerySet(models.QuerySet):
             warnings=Sum("translatedresources__strings_with_warnings", default=0),
             unreviewed=Sum("translatedresources__unreviewed_strings", default=0),
         ).annotate(
-            missing=F("total")
-            - F("approved")
-            - F("pretranslated")
-            - F("errors")
-            - F("warnings"),
+            missing=F("total") - F("approved") - F("pretranslated"),
             is_complete=Case(
                 When(
-                    total=F("approved") + F("pretranslated") + F("warnings"),
+                    total=F("approved") + F("warnings"),
                     then=Value(True),
                 ),
                 default=Value(False),

--- a/pontoon/base/models/project.py
+++ b/pontoon/base/models/project.py
@@ -83,14 +83,10 @@ class ProjectQuerySet(models.QuerySet):
             warnings=Sum(f"{tr}__strings_with_warnings", default=0),
             unreviewed=Sum(f"{tr}__unreviewed_strings", default=0),
         ).annotate(
-            missing=F("total")
-            - F("approved")
-            - F("pretranslated")
-            - F("errors")
-            - F("warnings"),
+            missing=F("total") - F("approved") - F("pretranslated"),
             is_complete=Case(
                 When(
-                    total=F("approved") + F("pretranslated") + F("warnings"),
+                    total=F("approved") + F("warnings"),
                     then=Value(True),
                 ),
                 default=Value(False),

--- a/pontoon/base/models/project_locale.py
+++ b/pontoon/base/models/project_locale.py
@@ -51,11 +51,7 @@ class ProjectLocaleQuerySet(models.QuerySet):
             warnings=Sum(f"{tr}__strings_with_warnings", default=0),
             unreviewed=Sum(f"{tr}__unreviewed_strings", default=0),
         ).annotate(
-            missing=F("total")
-            - F("approved")
-            - F("pretranslated")
-            - F("errors")
-            - F("warnings"),
+            missing=F("total") - F("approved") - F("pretranslated"),
             is_complete=Case(
                 When(
                     total=F("approved") + F("pretranslated") + F("warnings"),

--- a/pontoon/base/static/js/progress-chart.js
+++ b/pontoon/base/static/js/progress-chart.js
@@ -28,10 +28,7 @@ $(function () {
           ? stats.missing / stats.all
           : 1 /* Draw "empty" progress if no projects enabled */,
       },
-      number = Math.floor(
-        (fraction.translated + fraction.pretranslated + fraction.warnings) *
-          100,
-      );
+      number = Math.floor((fraction.translated + fraction.warnings) * 100);
 
     // Update graph
     const canvas = this,

--- a/pontoon/base/static/js/table.js
+++ b/pontoon/base/static/js/table.js
@@ -125,8 +125,6 @@ var Pontoon = (function (my) {
               all = legend.find('.all .value').data('value') || 0,
               translated =
                 legend.find('.translated .value').data('value') / all || 0,
-              pretranslated =
-                legend.find('.pretranslated .value').data('value') / all || 0,
               warnings =
                 legend.find('.warnings .value').data('value') / all || 0;
 
@@ -134,7 +132,7 @@ var Pontoon = (function (my) {
               return 'not-ready';
             }
 
-            return translated + pretranslated + warnings;
+            return translated + warnings;
           }
 
           function getUnreviewed(el) {

--- a/pontoon/base/templates/widgets/heading_info.html
+++ b/pontoon/base/templates/widgets/heading_info.html
@@ -108,7 +108,7 @@
   {{ legend_item(
     title='Missing',
     class='missing',
-    value=(stats.total - stats.approved - stats.pretranslated - stats.warnings - stats.errors),
+    value=(stats.total - stats.approved - stats.pretranslated),
     link=(link + '?status=missing') if link else None)
   }}
 </ul>

--- a/pontoon/base/templates/widgets/progress_chart.html
+++ b/pontoon/base/templates/widgets/progress_chart.html
@@ -1,13 +1,13 @@
 {% macro span(chart, link, link_parameter=False, has_params=False) %}
 {% if chart != None %}
   <div class="chart-wrapper">
-    <span class="percent">{{ (100 * (chart.approved + chart.pretranslated + chart.warnings) / chart.total) | round(0, 'floor') | int }}%</span>
+    <span class="percent">{{ (100 * (chart.approved + chart.warnings) / chart.total) | round(0, 'floor') | int }}%</span>
     <span class="chart">
       <span class="translated" style="width:{{ (100 * chart.approved / chart.total) | round(1) }}%"></span>
       <span class="pretranslated" style="width:{{ (100 * chart.pretranslated / chart.total) | round(1) }}%"></span>
       <span class="warnings" style="width:{{ (100 * chart.warnings / chart.total) | round(1) }}%"></span>
       <span class="errors" style="width:{{ (100 * chart.errors / chart.total) | round(1) }}%"></span>
-      <span class="missing" style="width:{{ (100 * (chart.total - chart.approved - chart.pretranslated - chart.warnings - chart.errors) / chart.total) | round(1) }}%"></span>
+      <span class="missing" style="width:{{ (100 * (chart.total - chart.approved - chart.pretranslated) / chart.total) | round(1) }}%"></span>
     </span>
     <span class="unreviewed-status fas fa-lightbulb{% if chart.unreviewed > 0 %} pending{% endif %}"></span>
   </div>
@@ -46,7 +46,7 @@
       <li class="missing">
         <a href="{{ link }}{% if link_parameter %}{% if not has_params %}?{% else %}&{% endif %}status=missing{% endif %}">
           <div class="title">Missing</div>
-          {% set missing_strings = chart.total - chart.approved - chart.pretranslated - chart.warnings - chart.errors %}
+          {% set missing_strings = chart.total - chart.approved %}
           <div class="value" data-value="{{ missing_strings }}">{{ missing_strings|comma_or_prefix }}</div>
         </a>
       </li>

--- a/pontoon/insights/models.py
+++ b/pontoon/insights/models.py
@@ -25,13 +25,7 @@ class InsightsSnapshot(models.Model):
 
     @property
     def missing_strings(self):
-        return (
-            self.total_strings
-            - self.approved_strings
-            - self.pretranslated_strings
-            - self.strings_with_errors
-            - self.strings_with_warnings
-        )
+        return self.total_strings - self.approved_strings - self.pretranslated_strings
 
     # Active users
     total_managers = models.PositiveIntegerField(default=0)

--- a/pontoon/insights/tasks.py
+++ b/pontoon/insights/tasks.py
@@ -301,7 +301,7 @@ def projectlocale_insights(
         id = pls["projectlocale"]
         ad = activities.get(id, Activity(0))
         pl_completion = (
-            (pls["approved"] + pls["pretranslated"] + pls["warnings"]) / pls["total"]
+            (pls["approved"] + pls["warnings"]) / pls["total"]
             if pls["total"] > 0
             else 0.0
         )
@@ -491,11 +491,7 @@ def get_locale_insights_snapshot(
         ls_errors += ls["errors"]
         ls_warnings += ls["warnings"]
         ls_unreviewed += ls["unreviewed"]
-    ls_completion = (
-        (ls_approved + ls_pretranslated + ls_warnings) / ls_total
-        if ls_total > 0
-        else 0.0
-    )
+    ls_completion = (ls_approved + ls_warnings) / ls_total if ls_total > 0 else 0.0
 
     reviewers = translators | manager_logins.keys()
     active_users = {

--- a/pontoon/insights/tests/test_models.py
+++ b/pontoon/insights/tests/test_models.py
@@ -16,5 +16,5 @@ def test_missing_strings_property_locale_snapshot():
         completion=0.4,
     )
 
-    expected_missing = 100 - 40 - 20 - 5 - 10
+    expected_missing = 100 - 40 - 20
     assert snapshot.missing_strings == expected_missing

--- a/pontoon/localizations/templates/localizations/widgets/resource_list.html
+++ b/pontoon/localizations/templates/localizations/widgets/resource_list.html
@@ -35,7 +35,7 @@
 
     {% if deadline %}
     <td class="deadline">
-      {{ Deadline.deadline(resource.deadline, chart.total > 0 and chart.total == chart.approved + chart.pretranslated + chart.warnings) }}
+      {{ Deadline.deadline(resource.deadline, chart.total > 0 and chart.total == chart.approved + chart.warnings) }}
     </td>
     {% endif %}
 

--- a/pontoon/projects/templates/projects/widgets/project_list.html
+++ b/pontoon/projects/templates/projects/widgets/project_list.html
@@ -30,7 +30,7 @@
       </h4>
     </td>
     <td class="deadline">
-      {{ Deadline.deadline(project.deadline, chart.total > 0 and chart.total == chart.approved + chart.pretranslated + chart.warnings) }}
+      {{ Deadline.deadline(project.deadline, chart.total > 0 and chart.total == chart.approved + chart.warnings) }}
     </td>
     <td class="priority">
       {{ Priority.priority(project.priority) }}

--- a/translate/src/modules/resource/components/ResourceMenu.tsx
+++ b/translate/src/modules/resource/components/ResourceMenu.tsx
@@ -51,8 +51,7 @@ function ResourceMenuDialog({
   };
 
   const getProgress = (res: Resource) => {
-    const completeStrings =
-      res.approvedStrings + res.pretranslatedStrings + res.stringsWithWarnings;
+    const completeStrings = res.approvedStrings + res.stringsWithWarnings;
     const percent = Math.floor((completeStrings / res.totalStrings) * 100);
     return percent;
   };

--- a/translate/src/modules/resource/components/ResourcePercent.tsx
+++ b/translate/src/modules/resource/components/ResourcePercent.tsx
@@ -12,18 +12,10 @@ type Props = {
  * Render a resource item percentage.
  */
 export function ResourcePercent({
-  resource: {
-    approvedStrings,
-    pretranslatedStrings,
-    stringsWithWarnings,
-    totalStrings,
-  },
+  resource: { approvedStrings, stringsWithWarnings, totalStrings },
 }: Props): React.ReactElement<'span'> {
   const percent =
-    Math.floor(
-      ((approvedStrings + pretranslatedStrings + stringsWithWarnings) /
-        totalStrings) *
-        100,
-    ) + '%';
+    Math.floor(((approvedStrings + stringsWithWarnings) / totalStrings) * 100) +
+    '%';
   return <span className='percent'>{percent}</span>;
 }

--- a/translate/src/modules/resourceprogress/components/ResourceProgress.tsx
+++ b/translate/src/modules/resourceprogress/components/ResourceProgress.tsx
@@ -120,7 +120,7 @@ export function ResourceProgress(): React.ReactElement<'div'> | null {
     return null;
   }
 
-  const complete = stats.approved + stats.pretranslated + stats.warnings;
+  const complete = stats.approved + stats.warnings;
   const percent = Math.floor((complete / stats.total) * 100);
 
   return (


### PR DESCRIPTION
## Summary
This PR addresses Part 2 of the Community Health OKR where we change completion metrics to exclude pretranslations, which will provide a more accurate picture of if a project/locale is finished being localized.

The new completion formula is as follows:
`total == approved + warnings` instead of `total == approved + pretranslated + warnings`.

Changes to the `missing_strings` formula are also noted.
`missing_strings == total - approved - pretranslated` instead of
`missing_strings == total - approved - pretranslated - warnings - errors`.