### PR TITLE
Highlight HTML attribute values in editor

### DIFF
--- a/translate/src/modules/translationform/utils/editFieldExtensions.ts
+++ b/translate/src/modules/translationform/utils/editFieldExtensions.ts
@@ -82,7 +82,7 @@ const style = HighlightStyle.define([
   }, // <...>
   { tag: tags.brace, color: '#872bff', fontWeight: 'bold', whiteSpace: 'pre' }, // { }
   { tag: tags.name, color: '#872bff', whiteSpace: 'pre' }, // {...}
-  { tag: [tags.quote, tags.literal], color:'#3e9682', whiteSpace: 'pre-wrap' }, // "..."
+  { tag: [tags.quote, tags.literal], color: '#3e9682', whiteSpace: 'pre-wrap' }, // "..."
   { tag: tags.string, whiteSpace: 'pre-wrap' },
 ]);
 


### PR DESCRIPTION
Fixes #3492

HTML atribute values were not being highlighted as placeables in the translation editor, even though the attribute names were highlihted.

Added color to match the teal highlighting used in bracket and tags names.

To test:
Paste this in the editor and save:
Protect your inbox from spam by using a free <label data-l10n-name="firefox-relay-learn-more-url">email mask</label> to hide your real address. Emails from <label data-l10n-name="firefox-fxa-and-relay-offer-domain">this site</label> will still come to your inbox, but with your email hidden.

Then click back on it from the left side with all the strings to bring the above string and it's translation into the editor. Both HMTL attributes and their values should be highlighted.


Editor preview
<img width="1485" height="440" alt="Screenshot 2026-01-31 at 18 37 02" src="https://github.com/user-attachments/assets/9c8cf8ad-6352-4056-8324-22d5c50666c6" />
