### PR TITLE
Fix #3417: Add data migration to create project_managers group

### DIFF
--- a/pontoon/base/migrations/0106_create_project_managers_group.py
+++ b/pontoon/base/migrations/0106_create_project_managers_group.py
@@ -25,9 +25,10 @@ def create_pm_group(apps, schema_editor):
         model="project",
     )
 
-    permission = Permission.objects.get(
+    permission, _ = Permission.objects.get_or_create(
         codename="can_manage_project",
         content_type=project_content_type,
+        defaults={"name": "Can manage project"},
     )
 
     group.permissions.add(permission)


### PR DESCRIPTION
Fix #3417.

Creates a data migration file that checks if project_managers group exists; if not, it creates it. Checks if can_mange_project permission exists; if not, the migration file creates it. Finally, grant project_managers can_mange_project permission.