### PR TITLE
Preserve warnings when loading translations

### DIFF
--- a/translate/src/context/Editor.tsx
+++ b/translate/src/context/Editor.tsx
@@ -393,22 +393,21 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
   }, [state, actions, status, machinery.translations]);
 
   useEffect(() => {
-    // Dismiss failed checks when the results change.
-    // Note that if the editor is updated simultaneously,
-    // setting failed checks needs to be delayed past this.
-    resetFailedChecks();
-
     // Changes in `result` need to be reflected in `UnsavedChanges`,
     // but the latter needs to be defined at a higher level to make it
     // available in `EntitiesList`. Therefore, that state is managed here.
     // Let's also avoid the calculation, unless it's actually required.
-    setUnsavedChanges(() => {
-      const { entry, initial, placeholders, sourceView } = state;
-      const next = sourceView
-        ? parseEntryFromFluentSource(entry, result[0].value)
-        : buildMessageEntry(entry, placeholders, result);
-      return !pojoEquals(initial, next);
-    });
+    const { entry, initial, placeholders, sourceView } = state;
+    const next = sourceView
+      ? parseEntryFromFluentSource(entry, result[0].value)
+      : buildMessageEntry(entry, placeholders, result);
+    const hasChanges = !pojoEquals(initial, next);
+
+    if (hasChanges) {
+      resetFailedChecks();
+    }
+
+    setUnsavedChanges(() => hasChanges);
   }, [result]);
 
   return (


### PR DESCRIPTION
Fixes #3625 

Previously, we were indiscriminately reseting failed checks every time the editor result changed, including at the initial load of a translation.

This fix checks whether the current editor content differs from the initial loaded content before clearing the warnings.

To test this issue:

1. Submit a string such as shown in the linked issue
2. Get a warning and click on the save anyway button
3. Click on the translated string to bring it back to the editor
4. Warning should exist

Previews 

1. Before submitting

<img width="1628" height="542" alt="BeforeSubmitting" src="https://github.com/user-attachments/assets/99f17388-9e2c-4c17-a30c-8e8bba24b747" />

2. Bring the string back to the editor after submitting 
<img width="1485" height="594" alt="LoadingAfterSubmission" src="https://github.com/user-attachments/assets/461e28f3-85be-4dbe-9c38-f9883147fa0d" />

3.  Check that you're able to edit with the correct string and save
<img width="1551" height="631" alt="SavesWhenReEdited" src="https://github.com/user-attachments/assets/b569d611-06e5-429f-a462-9b31786656a7" />

