### PR TITLE
Prevent Search page dropdown text from being cut-off

### DIFF
--- a/pontoon/search/static/css/search.css
+++ b/pontoon/search/static/css/search.css
@@ -33,7 +33,10 @@
         .select .button {
           font-size: 16px;
           height: 32px;
-          padding: 8px 12px;
+
+          span {
+            line-height: 20px;
+          }
         }
       }
 


### PR DESCRIPTION
Fix #3956.