### PR TITLE
Messaging Center: fix notification preview overflow

### DIFF
--- a/pontoon/messaging/static/css/messaging.css
+++ b/pontoon/messaging/static/css/messaging.css
@@ -278,6 +278,10 @@
         display: none;
       }
     }
+
+    ul {
+      max-height: none;
+    }
   }
 
   #sent {


### PR DESCRIPTION
This PR fixes #3960.

The reason it was broken was due to the `ul` `max-height` being preset to `170px` while the `ul`'s created by the message preview applied this style.