### PR TITLE
Search: default non-visible locales in locale selector to en-GB

### DIFF
--- a/pontoon/search/views.py
+++ b/pontoon/search/views.py
@@ -16,6 +16,14 @@ from pontoon.base.utils import get_project_locale_from_request, parse_bool, requ
 from pontoon.settings.base import SITE_URL
 
 
+def get_valid_locale_code(request, locale_code):
+    """Return a valid locale code, falling back to project locale or en-GB."""
+    visible_locales = Locale.objects.visible()
+    if not locale_code or not visible_locales.filter(code=locale_code).exists():
+        return get_project_locale_from_request(request, visible_locales) or "en-GB"
+    return locale_code
+
+
 def create_api_url(
     search,
     project,
@@ -74,15 +82,7 @@ def search(request):
 
     locales = list(Locale.objects.visible())
 
-    if (
-        not locale_code
-        or not Locale.objects.visible().filter(code=locale_code).exists()
-    ):
-        locale_code = (
-            get_project_locale_from_request(request, Locale.objects.visible())
-            or "en-GB"
-        )
-
+    locale_code = get_valid_locale_code(request, locale_code)
     locale = Locale.objects.get(code=locale_code)
 
     return render(
@@ -117,14 +117,7 @@ def search_results(request):
     search_match_case = parse_bool(request.GET.get("search_match_case"))
     search_match_whole_word = parse_bool(request.GET.get("search_match_whole_word"))
 
-    if (
-        not locale_code
-        or not Locale.objects.visible().filter(code=locale_code).exists()
-    ):
-        locale_code = (
-            get_project_locale_from_request(request, Locale.objects.visible())
-            or "en-GB"
-        )
+    locale_code = get_valid_locale_code(request, locale_code)
 
     if page:
         try:


### PR DESCRIPTION
This PR defaults locales like `en-US` to `en-GB`. This happens when Pontoon auto-detects locales based on the browser, which can return locale codes that are unsupported by the `/api/v2/locales/` API endpoint.

Fixes #3984.