### PR TITLE
migrate test under /context, /batchactions, / comments, /diff, /editor to rtl

### DIFF
--- a/translate/src/context/EntityView.test.jsx
+++ b/translate/src/context/EntityView.test.jsx
@@ -1,9 +1,9 @@
-import { mount } from 'enzyme';
 import React, { useContext } from 'react';
 
 import { EntityView, EntityViewProvider } from './EntityView';
 import { Locale } from './Locale';
 import { Location } from './Location';
+import { render } from '@testing-library/react';
 
 const ENTITIES = [
   { pk: 1, original: 'hello' },
@@ -21,7 +21,7 @@ describe('<EntityViewProvider', () => {
       return null;
     };
 
-    const wrapper = mount(
+    const { rerender } = render(
       <Location.Provider value={{ entity: 1 }}>
         <Locale.Provider value={{ cldrPlurals: [1, 5] }}>
           <EntityViewProvider>
@@ -33,7 +33,15 @@ describe('<EntityViewProvider', () => {
 
     expect(view).toMatchObject({ entity: ENTITIES[0] });
 
-    wrapper.setProps({ value: { entity: 2 } });
+    rerender(
+      <Location.Provider value={{ entity: 2 }}>
+        <Locale.Provider value={{ cldrPlurals: [1, 5] }}>
+          <EntityViewProvider>
+            <Spy />
+          </EntityViewProvider>
+        </Locale.Provider>
+      </Location.Provider>,
+    );
 
     expect(view).toMatchObject({ entity: ENTITIES[1] });
   });

--- a/translate/src/context/EntityView.tsx
+++ b/translate/src/context/EntityView.tsx
@@ -11,7 +11,6 @@ import type { EntityTranslation } from '~/api/translation';
 import { ENTITIES } from '~/modules/entities/reducer';
 import { useAppSelector } from '~/hooks';
 
-import { Locale } from './Locale';
 import { Location } from './Location';
 
 const emptyEntity: Entity = {

--- a/translate/src/context/FailedChecksData.test.jsx
+++ b/translate/src/context/FailedChecksData.test.jsx
@@ -1,9 +1,9 @@
-import { mount } from 'enzyme';
 import React, { useContext } from 'react';
 
 import * as EntityView from './EntityView';
 import { FailedChecksData, FailedChecksProvider } from './FailedChecksData';
 import { vi } from 'vitest';
+import { act, render } from '@testing-library/react';
 
 describe('FailedChecksProvider', () => {
   beforeAll(() => {
@@ -25,7 +25,7 @@ describe('FailedChecksProvider', () => {
       failedChecks = useContext(FailedChecksData);
       return null;
     };
-    const wrapper = mount(
+    const { rerender } = render(
       <FailedChecksProvider>
         <Spy />
       </FailedChecksProvider>,
@@ -42,7 +42,12 @@ describe('FailedChecksProvider', () => {
       warnings: ['Warning1'],
       approved: true,
     });
-    wrapper.setProps({});
+
+    rerender(
+      <FailedChecksProvider>
+        <Spy />
+      </FailedChecksProvider>,
+    );
 
     expect(failedChecks).toMatchObject({
       errors: ['Error1'],
@@ -63,7 +68,7 @@ describe('FailedChecksProvider', () => {
       failedChecks = useContext(FailedChecksData);
       return null;
     };
-    mount(
+    render(
       <FailedChecksProvider>
         <Spy />
       </FailedChecksProvider>,

--- a/translate/src/context/Location.test.jsx
+++ b/translate/src/context/Location.test.jsx
@@ -1,16 +1,29 @@
-import { shallow } from 'enzyme';
-import React from 'react';
+import React, { useContext } from 'react';
 
-import { LocationProvider } from './Location';
+import { LocationProvider, Location } from './Location';
+import { render } from '@testing-library/react';
+import { vi } from 'vitest';
 
 describe('LocationProvider', () => {
   it('correctly parses the pathname', () => {
+    let view;
+    const Spy = () => {
+      view = useContext(Location);
+      return null;
+    };
+
     const history = {
       location: { pathname: '/kg/waterwolf/path/to/RESOURCE.po/', search: '' },
+      listen: vi.fn(),
     };
-    const wrapper = shallow(<LocationProvider history={history} />);
 
-    expect(wrapper.prop('value')).toMatchObject({
+    render(
+      <LocationProvider history={history}>
+        <Spy />
+      </LocationProvider>,
+    );
+
+    expect(view).toMatchObject({
       locale: 'kg',
       project: 'waterwolf',
       resource: 'path/to/RESOURCE.po',
@@ -20,15 +33,25 @@ describe('LocationProvider', () => {
   });
 
   it('correctly parses a query string', () => {
+    let view;
+    const Spy = () => {
+      view = useContext(Location);
+      return null;
+    };
     const history = {
       location: {
         pathname: '/kg/waterwolf/path/',
         search: '?status=missing,warnings&string=42',
       },
+      listen: vi.fn(),
     };
-    const wrapper = shallow(<LocationProvider history={history} />);
+    render(
+      <LocationProvider history={history}>
+        <Spy />
+      </LocationProvider>,
+    );
 
-    expect(wrapper.prop('value')).toMatchObject({
+    expect(view).toMatchObject({
       locale: 'kg',
       project: 'waterwolf',
       resource: 'path',
@@ -38,15 +61,24 @@ describe('LocationProvider', () => {
   });
 
   it('correctly parses a query string with a list', () => {
+    let view;
+    const Spy = () => {
+      view = useContext(Location);
+      return null;
+    };
     const history = {
       location: {
         pathname: '/kg/waterwolf/path/',
         search: '?status=missing,warnings&list=13,42,99&string=42',
       },
+      listen: vi.fn(),
     };
-    const wrapper = shallow(<LocationProvider history={history} />);
-
-    expect(wrapper.prop('value')).toMatchObject({
+    render(
+      <LocationProvider history={history}>
+        <Spy />
+      </LocationProvider>,
+    );
+    expect(view).toMatchObject({
       locale: 'kg',
       project: 'waterwolf',
       resource: 'path',

--- a/translate/src/modules/batchactions/components/ApproveAll.test.jsx
+++ b/translate/src/modules/batchactions/components/ApproveAll.test.jsx
@@ -18,6 +18,10 @@ const WrapApproveAll = (props) => (
     <ApproveAll {...props} />
   </MockLocalizationProvider>
 );
+const defaultText = /APPROVE ALL/i;
+const errorText = /SOMETHING WENT WRONG/i;
+const successText = /STRINGS APPROVED/i;
+const invalidText = /FAILED/i;
 
 describe('<ApproveAll>', () => {
   it('renders default button correctly', () => {
@@ -25,10 +29,10 @@ describe('<ApproveAll>', () => {
       <WrapApproveAll batchactions={DEFAULT_BATCH_ACTIONS} />,
     );
 
-    getByRole('button', { name: /APPROVE ALL/i });
-    expect(queryByText(/SOMETHING WENT WRONG/i)).toBeNull();
-    expect(queryByText(/STRINGS APPROVED/i)).toBeNull();
-    expect(queryByText(/FAILED/i)).toBeNull();
+    getByRole('button', { name: defaultText });
+    expect(queryByText(errorText)).toBeNull();
+    expect(queryByText(successText)).toBeNull();
+    expect(queryByText(invalidText)).toBeNull();
     expect(container.querySelector('.fas')).toBeNull();
   });
 
@@ -44,10 +48,10 @@ describe('<ApproveAll>', () => {
         }}
       />,
     );
-    getByRole('button', { name: /SOMETHING WENT WRONG/i });
-    expect(queryByText(/APPROVE ALL/i)).toBeNull();
-    expect(queryByText(/STRINGS APPROVED/i)).toBeNull();
-    expect(queryByText(/FAILED/i)).toBeNull();
+    expect(queryByText(defaultText)).toBeNull();
+    getByRole('button', { name: errorText });
+    expect(queryByText(successText)).toBeNull();
+    expect(queryByText(invalidText)).toBeNull();
     expect(container.querySelector('.fas')).toBeNull();
   });
 
@@ -63,10 +67,10 @@ describe('<ApproveAll>', () => {
         }}
       />,
     );
-    getByRole('button', { name: /STRINGS APPROVED/i });
-    expect(queryByText(/APPROVE ALL/i)).toBeNull();
-    expect(queryByText(/SOMETHING WENT WRONG/i)).toBeNull();
-    expect(queryByText(/FAILED/i)).toBeNull();
+    expect(queryByText(defaultText)).toBeNull();
+    expect(queryByText(errorText)).toBeNull();
+    getByRole('button', { name: successText });
+    expect(queryByText(invalidText)).toBeNull();
     expect(container.querySelector('.fas')).toBeNull();
   });
 
@@ -84,9 +88,10 @@ describe('<ApproveAll>', () => {
       />,
     );
 
-    getByRole('button', { name: /^(?=.*STRINGS APPROVED)(?=.*FAILED).*/i });
-    expect(queryByText(/APPROVE ALL/i)).toBeNull();
-    expect(queryByText(/SOMETHING WENT WRONG/i)).toBeNull();
+    expect(queryByText(defaultText)).toBeNull();
+    expect(queryByText(errorText)).toBeNull();
+    const button = getByRole('button', { name: successText });
+    expect(button).toHaveTextContent(invalidText);
     expect(container.querySelector('.fas')).toBeNull();
   });
 

--- a/translate/src/modules/batchactions/components/ApproveAll.test.jsx
+++ b/translate/src/modules/batchactions/components/ApproveAll.test.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { mount } from 'enzyme';
 
 import { MockLocalizationProvider } from '~/test/utils';
 
 import { ApproveAll } from './ApproveAll';
 import { vi } from 'vitest';
+import { fireEvent, render } from '@testing-library/react';
 
 const DEFAULT_BATCH_ACTIONS = {
   entities: [],
@@ -21,20 +21,19 @@ const WrapApproveAll = (props) => (
 
 describe('<ApproveAll>', () => {
   it('renders default button correctly', () => {
-    const wrapper = mount(
+    const { container, getByRole, queryByText } = render(
       <WrapApproveAll batchactions={DEFAULT_BATCH_ACTIONS} />,
     );
 
-    expect(wrapper.find('.approve-all')).toHaveLength(1);
-    expect(wrapper.find('#batchactions-ApproveAll--default')).toHaveLength(1);
-    expect(wrapper.find('#batchactions-ApproveAll--error')).toHaveLength(0);
-    expect(wrapper.find('#batchactions-ApproveAll--success')).toHaveLength(0);
-    expect(wrapper.find('#batchactions-ApproveAll--invalid')).toHaveLength(0);
-    expect(wrapper.find('.fas')).toHaveLength(0);
+    getByRole('button', { name: /APPROVE ALL/i });
+    expect(queryByText(/SOMETHING WENT WRONG/i)).toBeNull();
+    expect(queryByText(/STRINGS APPROVED/i)).toBeNull();
+    expect(queryByText(/FAILED/i)).toBeNull();
+    expect(container.querySelector('.fas')).toBeNull();
   });
 
   it('renders error button correctly', () => {
-    const wrapper = mount(
+    const { container, getByRole, queryByText } = render(
       <WrapApproveAll
         batchactions={{
           ...DEFAULT_BATCH_ACTIONS,
@@ -45,17 +44,15 @@ describe('<ApproveAll>', () => {
         }}
       />,
     );
-
-    expect(wrapper.find('.approve-all')).toHaveLength(1);
-    expect(wrapper.find('#batchactions-ApproveAll--default')).toHaveLength(0);
-    expect(wrapper.find('#batchactions-ApproveAll--error')).toHaveLength(1);
-    expect(wrapper.find('#batchactions-ApproveAll--success')).toHaveLength(0);
-    expect(wrapper.find('#batchactions-ApproveAll--invalid')).toHaveLength(0);
-    expect(wrapper.find('.fas')).toHaveLength(0);
+    getByRole('button', { name: /SOMETHING WENT WRONG/i });
+    expect(queryByText(/APPROVE ALL/i)).toBeNull();
+    expect(queryByText(/STRINGS APPROVED/i)).toBeNull();
+    expect(queryByText(/FAILED/i)).toBeNull();
+    expect(container.querySelector('.fas')).toBeNull();
   });
 
   it('renders success button correctly', () => {
-    const wrapper = mount(
+    const { container, getByRole, queryByText } = render(
       <WrapApproveAll
         batchactions={{
           ...DEFAULT_BATCH_ACTIONS,
@@ -66,17 +63,15 @@ describe('<ApproveAll>', () => {
         }}
       />,
     );
-
-    expect(wrapper.find('.approve-all')).toHaveLength(1);
-    expect(wrapper.find('#batchactions-ApproveAll--default')).toHaveLength(0);
-    expect(wrapper.find('#batchactions-ApproveAll--error')).toHaveLength(0);
-    expect(wrapper.find('#batchactions-ApproveAll--success')).toHaveLength(1);
-    expect(wrapper.find('#batchactions-ApproveAll--invalid')).toHaveLength(0);
-    expect(wrapper.find('.fas')).toHaveLength(0);
+    getByRole('button', { name: /STRINGS APPROVED/i });
+    expect(queryByText(/APPROVE ALL/i)).toBeNull();
+    expect(queryByText(/SOMETHING WENT WRONG/i)).toBeNull();
+    expect(queryByText(/FAILED/i)).toBeNull();
+    expect(container.querySelector('.fas')).toBeNull();
   });
 
   it('renders success with invalid button correctly', () => {
-    const wrapper = mount(
+    const { container, getByRole, queryByText } = render(
       <WrapApproveAll
         batchactions={{
           ...DEFAULT_BATCH_ACTIONS,
@@ -89,18 +84,16 @@ describe('<ApproveAll>', () => {
       />,
     );
 
-    expect(wrapper.find('.approve-all')).toHaveLength(1);
-    expect(wrapper.find('#batchactions-ApproveAll--default')).toHaveLength(0);
-    expect(wrapper.find('#batchactions-ApproveAll--error')).toHaveLength(0);
-    expect(wrapper.find('#batchactions-ApproveAll--success')).toHaveLength(1);
-    expect(wrapper.find('#batchactions-ApproveAll--invalid')).toHaveLength(1);
-    expect(wrapper.find('.fas')).toHaveLength(0);
+    getByRole('button', { name: /^(?=.*STRINGS APPROVED)(?=.*FAILED).*/i });
+    expect(queryByText(/APPROVE ALL/i)).toBeNull();
+    expect(queryByText(/SOMETHING WENT WRONG/i)).toBeNull();
+    expect(container.querySelector('.fas')).toBeNull();
   });
 
   it('performs approve all action when Approve All button is clicked', () => {
     const mockApproveAll = vi.fn();
 
-    const wrapper = mount(
+    const { getByRole } = render(
       <WrapApproveAll
         batchactions={DEFAULT_BATCH_ACTIONS}
         approveAll={mockApproveAll}
@@ -108,7 +101,7 @@ describe('<ApproveAll>', () => {
     );
 
     expect(mockApproveAll).not.toHaveBeenCalled();
-    wrapper.find('.approve-all').simulate('click');
+    fireEvent.click(getByRole('button'));
     expect(mockApproveAll).toHaveBeenCalled();
   });
 });

--- a/translate/src/modules/batchactions/components/BatchActions.test.jsx
+++ b/translate/src/modules/batchactions/components/BatchActions.test.jsx
@@ -1,15 +1,13 @@
-import { shallow } from 'enzyme';
 import React from 'react';
 
 import * as Hooks from '~/hooks';
 import * as Actions from '../actions';
 import { BATCHACTIONS } from '../reducer';
 
-import { ApproveAll } from './ApproveAll';
 import { BatchActions } from './BatchActions';
-import { RejectAll } from './RejectAll';
-import { ReplaceAll } from './ReplaceAll';
 import { vi } from 'vitest';
+import { fireEvent, render } from '@testing-library/react';
+import { MockLocalizationProvider } from '~/test/utils';
 
 const DEFAULT_BATCH_ACTIONS = {
   entities: [],
@@ -40,46 +38,53 @@ describe('<BatchActions>', () => {
     Actions.selectAll.mockRestore();
   });
 
+  const WrapBatchAction = () => {
+    return (
+      <MockLocalizationProvider>
+        <BatchActions />
+      </MockLocalizationProvider>
+    );
+  };
+
   it('renders correctly', () => {
-    const wrapper = shallow(<BatchActions />);
+    const {
+      container,
+      getByRole,
+      getByText,
+      getByPlaceholderText,
+      getAllByRole,
+    } = render(<WrapBatchAction />);
 
-    expect(wrapper.find('.batch-actions')).toHaveLength(1);
+    expect(container.querySelector('.batch-actions')).toBeInTheDocument();
 
-    expect(wrapper.find('.topbar')).toHaveLength(1);
-    expect(wrapper.find('.selected-count')).toHaveLength(1);
-    expect(wrapper.find('.select-all')).toHaveLength(1);
+    expect(container.querySelector('.topbar')).toBeInTheDocument();
+    getByRole('button', { name: /STRINGS SELECTED/i });
+    getByRole('button', { name: /SELECT ALL/i });
 
-    expect(wrapper.find('.actions-panel')).toHaveLength(1);
+    expect(container.querySelector('.actions-panel')).toBeInTheDocument();
+    getByText(/Warning:/i);
 
-    expect(wrapper.find('#batchactions-BatchActions--warning')).toHaveLength(1);
+    getByText(/REVIEW TRANSLATIONS/i);
+    getByRole('button', { name: /APPROVE ALL/i });
+    getByRole('button', { name: /REJECT ALL/i });
+    getByRole('heading', { name: /FIND & REPLACE/i });
 
-    expect(
-      wrapper.find('#batchactions-BatchActions--review-heading'),
-    ).toHaveLength(1);
-    expect(wrapper.find(ApproveAll)).toHaveLength(1);
-    expect(wrapper.find(RejectAll)).toHaveLength(1);
-
-    expect(
-      wrapper.find('#batchactions-BatchActions--find-replace-heading'),
-    ).toHaveLength(1);
-    expect(wrapper.find('#batchactions-BatchActions--find')).toHaveLength(1);
-    expect(
-      wrapper.find('#batchactions-BatchActions--replace-with'),
-    ).toHaveLength(1);
-    expect(wrapper.find(ReplaceAll)).toHaveLength(1);
+    expect(getAllByRole('searchbox')).toHaveLength(2);
+    getByPlaceholderText(/FIND/i);
+    getByPlaceholderText(/REPLACE WITH/i);
+    getByRole('button', { name: /REPLACE ALL/i });
   });
 
   it('closes batch actions panel when the Close button with selected count is clicked', () => {
-    const wrapper = shallow(<BatchActions />);
-
-    wrapper.find('.selected-count').simulate('click');
+    const { getByRole } = render(<WrapBatchAction />);
+    fireEvent.click(getByRole('button', { name: /STRINGS SELECTED/i }));
     expect(Actions.resetSelection).toHaveBeenCalled();
   });
 
   it('selects all entities when the Select All button is clicked', () => {
-    const wrapper = shallow(<BatchActions />);
+    const { getByRole } = render(<WrapBatchAction />);
 
-    wrapper.find('.select-all').simulate('click');
+    fireEvent.click(getByRole('button', { name: /SELECT ALL/i }));
     expect(Actions.selectAll).toHaveBeenCalled();
   });
 });

--- a/translate/src/modules/batchactions/components/RejectAll.test.jsx
+++ b/translate/src/modules/batchactions/components/RejectAll.test.jsx
@@ -22,7 +22,7 @@ const defaultText = /REJECT ALL/i;
 const errorText = /SOMETHING WENT WRONG/i;
 const successText = /STRINGS REJECTED/i;
 const invalidText = /FAILED/i;
-const dailogBoxText = /ARE YOU SURE/i;
+const dialogBoxText = /ARE YOU SURE/i;
 
 describe('<RejectAll>', () => {
   it('renders default button correctly', () => {
@@ -108,7 +108,7 @@ describe('<RejectAll>', () => {
     );
     fireEvent.click(getByRole('button'));
     expect(mockRejectAll).not.toHaveBeenCalled();
-    getByText(dailogBoxText);
+    getByText(dialogBoxText);
   });
 
   it('performs reject all action when Reject All button is confirmed', () => {
@@ -123,7 +123,7 @@ describe('<RejectAll>', () => {
 
     expect(mockRejectAll).not.toHaveBeenCalled();
     fireEvent.click(getByRole('button', { name: defaultText }));
-    fireEvent.click(getByRole('button', { name: dailogBoxText }));
+    fireEvent.click(getByRole('button', { name: dialogBoxText }));
     expect(mockRejectAll).toHaveBeenCalledOnce();
   });
 });

--- a/translate/src/modules/batchactions/components/RejectAll.test.jsx
+++ b/translate/src/modules/batchactions/components/RejectAll.test.jsx
@@ -1,10 +1,10 @@
-import { mount } from 'enzyme';
 import React from 'react';
 
 import { MockLocalizationProvider } from '~/test/utils';
 
 import { RejectAll } from './RejectAll';
 import { vi } from 'vitest';
+import { fireEvent, render } from '@testing-library/react';
 
 const DEFAULT_BATCH_ACTIONS = {
   entities: [],
@@ -21,20 +21,19 @@ const WrapRejectAll = (props) => (
 
 describe('<RejectAll>', () => {
   it('renders default button correctly', () => {
-    const wrapper = mount(
+    const { getByRole, queryByText, container } = render(
       <WrapRejectAll batchactions={DEFAULT_BATCH_ACTIONS} />,
     );
 
-    expect(wrapper.find('.reject-all')).toHaveLength(1);
-    expect(wrapper.find('#batchactions-RejectAll--default')).toHaveLength(1);
-    expect(wrapper.find('#batchactions-RejectAll--error')).toHaveLength(0);
-    expect(wrapper.find('#batchactions-RejectAll--success')).toHaveLength(0);
-    expect(wrapper.find('#batchactions-RejectAll--invalid')).toHaveLength(0);
-    expect(wrapper.find('.fas')).toHaveLength(0);
+    getByRole('button', { name: /REJECT ALL/i });
+    expect(queryByText(/SOMETHING WENT WRONG/i)).toBeNull();
+    expect(queryByText(/STRINGS REJECTED/i)).toBeNull();
+    expect(queryByText(/FAILED/i)).toBeNull();
+    expect(container.querySelector('.fas')).toBeNull();
   });
 
   it('renders error button correctly', () => {
-    const wrapper = mount(
+    const { getByRole, queryByText, container } = render(
       <WrapRejectAll
         batchactions={{
           ...DEFAULT_BATCH_ACTIONS,
@@ -45,17 +44,15 @@ describe('<RejectAll>', () => {
         }}
       />,
     );
-
-    expect(wrapper.find('.reject-all')).toHaveLength(1);
-    expect(wrapper.find('#batchactions-RejectAll--default')).toHaveLength(0);
-    expect(wrapper.find('#batchactions-RejectAll--error')).toHaveLength(1);
-    expect(wrapper.find('#batchactions-RejectAll--success')).toHaveLength(0);
-    expect(wrapper.find('#batchactions-RejectAll--invalid')).toHaveLength(0);
-    expect(wrapper.find('.fas')).toHaveLength(0);
+    getByRole('button', { name: /SOMETHING WENT WRONG/i });
+    expect(queryByText(/REJECT ALL/i)).toBeNull();
+    expect(queryByText(/STRINGS REJECTED/i)).toBeNull();
+    expect(queryByText(/FAILED/i)).toBeNull();
+    expect(container.querySelector('.fas')).toBeNull();
   });
 
   it('renders success button correctly', () => {
-    const wrapper = mount(
+    const { getByRole, queryByText, container } = render(
       <WrapRejectAll
         batchactions={{
           ...DEFAULT_BATCH_ACTIONS,
@@ -67,16 +64,15 @@ describe('<RejectAll>', () => {
       />,
     );
 
-    expect(wrapper.find('.reject-all')).toHaveLength(1);
-    expect(wrapper.find('#batchactions-RejectAll--default')).toHaveLength(0);
-    expect(wrapper.find('#batchactions-RejectAll--error')).toHaveLength(0);
-    expect(wrapper.find('#batchactions-RejectAll--success')).toHaveLength(1);
-    expect(wrapper.find('#batchactions-RejectAll--invalid')).toHaveLength(0);
-    expect(wrapper.find('.fas')).toHaveLength(0);
+    getByRole('button', { name: /STRINGS REJECTED/i });
+    expect(queryByText(/REJECT ALL/i)).toBeNull();
+    expect(queryByText(/SOMETHING WENT WRONG/i)).toBeNull();
+    expect(queryByText(/FAILED/i)).toBeNull();
+    expect(container.querySelector('.fas')).toBeNull();
   });
 
   it('renders success with invalid button correctly', () => {
-    const wrapper = mount(
+    const { getByRole, queryByText, container } = render(
       <WrapRejectAll
         batchactions={{
           ...DEFAULT_BATCH_ACTIONS,
@@ -89,35 +85,30 @@ describe('<RejectAll>', () => {
       />,
     );
 
-    expect(wrapper.find('.reject-all')).toHaveLength(1);
-    expect(wrapper.find('#batchactions-RejectAll--default')).toHaveLength(0);
-    expect(wrapper.find('#batchactions-RejectAll--error')).toHaveLength(0);
-    expect(wrapper.find('#batchactions-RejectAll--success')).toHaveLength(1);
-    expect(wrapper.find('#batchactions-RejectAll--invalid')).toHaveLength(1);
-    expect(wrapper.find('.fas')).toHaveLength(0);
+    getByRole('button', { name: /^(?=.*STRINGS REJECTED)(?=.*FAILED).*/i });
+    expect(queryByText(/REJECT ALL/i)).toBeNull();
+    expect(queryByText(/SOMETHING WENT WRONG/i)).toBeNull();
+    expect(container.querySelector('.fas')).toBeNull();
   });
 
   it('raise confirmation warning when Reject All button is clicked', () => {
     const mockRejectAll = vi.fn();
 
-    const wrapper = mount(
+    const { getByRole, getByText } = render(
       <WrapRejectAll
         batchactions={DEFAULT_BATCH_ACTIONS}
         rejectAll={mockRejectAll}
       />,
     );
-
-    wrapper.find('.reject-all').simulate('click');
+    fireEvent.click(getByRole('button'));
     expect(mockRejectAll).not.toHaveBeenCalled();
-    expect(wrapper.find('#batchactions-RejectAll--confirmation')).toHaveLength(
-      1,
-    );
+    getByText(/ARE YOU SURE/i);
   });
 
   it('performs reject all action when Reject All button is confirmed', () => {
     const mockRejectAll = vi.fn();
 
-    const wrapper = mount(
+    const { getByRole } = render(
       <WrapRejectAll
         batchactions={DEFAULT_BATCH_ACTIONS}
         rejectAll={mockRejectAll}
@@ -125,8 +116,8 @@ describe('<RejectAll>', () => {
     );
 
     expect(mockRejectAll).not.toHaveBeenCalled();
-    wrapper.find('.reject-all').simulate('click');
-    wrapper.find('.reject-all').simulate('click');
-    expect(mockRejectAll).toHaveBeenCalled();
+    fireEvent.click(getByRole('button', { name: /REJECT ALL/i }));
+    fireEvent.click(getByRole('button', { name: /ARE YOU SURE/i }));
+    expect(mockRejectAll).toHaveBeenCalledOnce();
   });
 });

--- a/translate/src/modules/batchactions/components/RejectAll.test.jsx
+++ b/translate/src/modules/batchactions/components/RejectAll.test.jsx
@@ -18,6 +18,11 @@ const WrapRejectAll = (props) => (
     <RejectAll {...props} />
   </MockLocalizationProvider>
 );
+const defaultText = /REJECT ALL/i;
+const errorText = /SOMETHING WENT WRONG/i;
+const successText = /STRINGS REJECTED/i;
+const invalidText = /FAILED/i;
+const dailogBoxText = /ARE YOU SURE/i;
 
 describe('<RejectAll>', () => {
   it('renders default button correctly', () => {
@@ -25,10 +30,10 @@ describe('<RejectAll>', () => {
       <WrapRejectAll batchactions={DEFAULT_BATCH_ACTIONS} />,
     );
 
-    getByRole('button', { name: /REJECT ALL/i });
-    expect(queryByText(/SOMETHING WENT WRONG/i)).toBeNull();
-    expect(queryByText(/STRINGS REJECTED/i)).toBeNull();
-    expect(queryByText(/FAILED/i)).toBeNull();
+    getByRole('button', { name: defaultText });
+    expect(queryByText(errorText)).toBeNull();
+    expect(queryByText(successText)).toBeNull();
+    expect(queryByText(invalidText)).toBeNull();
     expect(container.querySelector('.fas')).toBeNull();
   });
 
@@ -44,10 +49,10 @@ describe('<RejectAll>', () => {
         }}
       />,
     );
-    getByRole('button', { name: /SOMETHING WENT WRONG/i });
-    expect(queryByText(/REJECT ALL/i)).toBeNull();
-    expect(queryByText(/STRINGS REJECTED/i)).toBeNull();
-    expect(queryByText(/FAILED/i)).toBeNull();
+    expect(queryByText(defaultText)).toBeNull();
+    getByRole('button', { name: errorText });
+    expect(queryByText(successText)).toBeNull();
+    expect(queryByText(invalidText)).toBeNull();
     expect(container.querySelector('.fas')).toBeNull();
   });
 
@@ -64,10 +69,10 @@ describe('<RejectAll>', () => {
       />,
     );
 
-    getByRole('button', { name: /STRINGS REJECTED/i });
-    expect(queryByText(/REJECT ALL/i)).toBeNull();
-    expect(queryByText(/SOMETHING WENT WRONG/i)).toBeNull();
-    expect(queryByText(/FAILED/i)).toBeNull();
+    expect(queryByText(defaultText)).toBeNull();
+    expect(queryByText(errorText)).toBeNull();
+    getByRole('button', { name: successText });
+    expect(queryByText(invalidText)).toBeNull();
     expect(container.querySelector('.fas')).toBeNull();
   });
 
@@ -85,9 +90,10 @@ describe('<RejectAll>', () => {
       />,
     );
 
-    getByRole('button', { name: /^(?=.*STRINGS REJECTED)(?=.*FAILED).*/i });
-    expect(queryByText(/REJECT ALL/i)).toBeNull();
-    expect(queryByText(/SOMETHING WENT WRONG/i)).toBeNull();
+    expect(queryByText(defaultText)).toBeNull();
+    expect(queryByText(errorText)).toBeNull();
+    const button = getByRole('button', { name: successText });
+    expect(button).toHaveTextContent(invalidText);
     expect(container.querySelector('.fas')).toBeNull();
   });
 
@@ -102,7 +108,7 @@ describe('<RejectAll>', () => {
     );
     fireEvent.click(getByRole('button'));
     expect(mockRejectAll).not.toHaveBeenCalled();
-    getByText(/ARE YOU SURE/i);
+    getByText(dailogBoxText);
   });
 
   it('performs reject all action when Reject All button is confirmed', () => {
@@ -116,8 +122,8 @@ describe('<RejectAll>', () => {
     );
 
     expect(mockRejectAll).not.toHaveBeenCalled();
-    fireEvent.click(getByRole('button', { name: /REJECT ALL/i }));
-    fireEvent.click(getByRole('button', { name: /ARE YOU SURE/i }));
+    fireEvent.click(getByRole('button', { name: defaultText }));
+    fireEvent.click(getByRole('button', { name: dailogBoxText }));
     expect(mockRejectAll).toHaveBeenCalledOnce();
   });
 });

--- a/translate/src/modules/batchactions/components/ReplaceAll.test.jsx
+++ b/translate/src/modules/batchactions/components/ReplaceAll.test.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { mount } from 'enzyme';
 
 import { MockLocalizationProvider } from '~/test/utils';
 
 import { ReplaceAll } from './ReplaceAll';
 import { vi } from 'vitest';
+import { fireEvent, render } from '@testing-library/react';
 
 const DEFAULT_BATCH_ACTIONS = {
   entities: [],
@@ -21,20 +21,19 @@ const WrapReplaceAll = (props) => (
 
 describe('<ReplaceAll>', () => {
   it('renders default button correctly', () => {
-    const wrapper = mount(
+    const { getByRole, queryByText, container } = render(
       <WrapReplaceAll batchactions={DEFAULT_BATCH_ACTIONS} />,
     );
 
-    expect(wrapper.find('.replace-all')).toHaveLength(1);
-    expect(wrapper.find('#batchactions-ReplaceAll--default')).toHaveLength(1);
-    expect(wrapper.find('#batchactions-ReplaceAll--error')).toHaveLength(0);
-    expect(wrapper.find('#batchactions-ReplaceAll--success')).toHaveLength(0);
-    expect(wrapper.find('#batchactions-ReplaceAll--invalid')).toHaveLength(0);
-    expect(wrapper.find('.fas')).toHaveLength(0);
+    getByRole('button', { name: /REPLACE ALL/i });
+    expect(queryByText(/SOMETHING WENT WRONG/i)).toBeNull();
+    expect(queryByText(/STRINGS REPLACED/i)).toBeNull();
+    expect(queryByText(/FAILED/i)).toBeNull();
+    expect(container.querySelector('.fas')).toBeNull();
   });
 
   it('renders error button correctly', () => {
-    const wrapper = mount(
+    const { getByRole, queryByText, container } = render(
       <WrapReplaceAll
         batchactions={{
           ...DEFAULT_BATCH_ACTIONS,
@@ -46,16 +45,15 @@ describe('<ReplaceAll>', () => {
       />,
     );
 
-    expect(wrapper.find('.replace-all')).toHaveLength(1);
-    expect(wrapper.find('#batchactions-ReplaceAll--default')).toHaveLength(0);
-    expect(wrapper.find('#batchactions-ReplaceAll--error')).toHaveLength(1);
-    expect(wrapper.find('#batchactions-ReplaceAll--success')).toHaveLength(0);
-    expect(wrapper.find('#batchactions-ReplaceAll--invalid')).toHaveLength(0);
-    expect(wrapper.find('.fas')).toHaveLength(0);
+    getByRole('button', { name: /SOMETHING WENT WRONG/i });
+    expect(queryByText(/REPLACE ALL/i)).toBeNull();
+    expect(queryByText(/STRINGS REPLACED/i)).toBeNull();
+    expect(queryByText(/FAILED/i)).toBeNull();
+    expect(container.querySelector('.fas')).toBeNull();
   });
 
   it('renders success button correctly', () => {
-    const wrapper = mount(
+    const { getByRole, queryByText, container } = render(
       <WrapReplaceAll
         batchactions={{
           ...DEFAULT_BATCH_ACTIONS,
@@ -66,17 +64,15 @@ describe('<ReplaceAll>', () => {
         }}
       />,
     );
-
-    expect(wrapper.find('.replace-all')).toHaveLength(1);
-    expect(wrapper.find('#batchactions-ReplaceAll--default')).toHaveLength(0);
-    expect(wrapper.find('#batchactions-ReplaceAll--error')).toHaveLength(0);
-    expect(wrapper.find('#batchactions-ReplaceAll--success')).toHaveLength(1);
-    expect(wrapper.find('#batchactions-ReplaceAll--invalid')).toHaveLength(0);
-    expect(wrapper.find('.fas')).toHaveLength(0);
+    getByRole('button', { name: /STRINGS REPLACED/i });
+    expect(queryByText(/REPLACE ALL/i)).toBeNull();
+    expect(queryByText(/SOMETHING WENT WRONG/i)).toBeNull();
+    expect(queryByText(/FAILED/i)).toBeNull();
+    expect(container.querySelector('.fas')).toBeNull();
   });
 
   it('renders success with invalid button correctly', () => {
-    const wrapper = mount(
+    const { getByRole, queryByText, container } = render(
       <WrapReplaceAll
         batchactions={{
           ...DEFAULT_BATCH_ACTIONS,
@@ -89,18 +85,16 @@ describe('<ReplaceAll>', () => {
       />,
     );
 
-    expect(wrapper.find('.replace-all')).toHaveLength(1);
-    expect(wrapper.find('#batchactions-ReplaceAll--default')).toHaveLength(0);
-    expect(wrapper.find('#batchactions-ReplaceAll--error')).toHaveLength(0);
-    expect(wrapper.find('#batchactions-ReplaceAll--success')).toHaveLength(1);
-    expect(wrapper.find('#batchactions-ReplaceAll--invalid')).toHaveLength(1);
-    expect(wrapper.find('.fas')).toHaveLength(0);
+    getByRole('button', { name: /^(?=.*STRINGS REPLACED)(?=.*FAILED).*/i });
+    expect(queryByText(/REPLACE ALL/i)).toBeNull();
+    expect(queryByText(/SOMETHING WENT WRONG/i)).toBeNull();
+    expect(container.querySelector('.fas')).toBeNull();
   });
 
   it('performs replace all action when Replace All button is clicked', () => {
     const mockReplaceAll = vi.fn();
 
-    const wrapper = mount(
+    const { getByRole } = render(
       <WrapReplaceAll
         batchactions={DEFAULT_BATCH_ACTIONS}
         replaceAll={mockReplaceAll}
@@ -108,7 +102,7 @@ describe('<ReplaceAll>', () => {
     );
 
     expect(mockReplaceAll).not.toHaveBeenCalled();
-    wrapper.find('.replace-all').simulate('click');
+    fireEvent.click(getByRole('button', { name: /REPLACE ALL/i }));
     expect(mockReplaceAll).toHaveBeenCalled();
   });
 });

--- a/translate/src/modules/batchactions/components/ReplaceAll.test.jsx
+++ b/translate/src/modules/batchactions/components/ReplaceAll.test.jsx
@@ -18,6 +18,10 @@ const WrapReplaceAll = (props) => (
     <ReplaceAll {...props} />
   </MockLocalizationProvider>
 );
+const defaultText = /REPLACE ALL/i;
+const errorText = /SOMETHING WENT WRONG/i;
+const successText = /STRINGS REPLACED/i;
+const invalidText = /FAILED/i;
 
 describe('<ReplaceAll>', () => {
   it('renders default button correctly', () => {
@@ -25,10 +29,10 @@ describe('<ReplaceAll>', () => {
       <WrapReplaceAll batchactions={DEFAULT_BATCH_ACTIONS} />,
     );
 
-    getByRole('button', { name: /REPLACE ALL/i });
-    expect(queryByText(/SOMETHING WENT WRONG/i)).toBeNull();
-    expect(queryByText(/STRINGS REPLACED/i)).toBeNull();
-    expect(queryByText(/FAILED/i)).toBeNull();
+    getByRole('button', { name: defaultText });
+    expect(queryByText(errorText)).toBeNull();
+    expect(queryByText(successText)).toBeNull();
+    expect(queryByText(invalidText)).toBeNull();
     expect(container.querySelector('.fas')).toBeNull();
   });
 
@@ -45,10 +49,10 @@ describe('<ReplaceAll>', () => {
       />,
     );
 
-    getByRole('button', { name: /SOMETHING WENT WRONG/i });
-    expect(queryByText(/REPLACE ALL/i)).toBeNull();
-    expect(queryByText(/STRINGS REPLACED/i)).toBeNull();
-    expect(queryByText(/FAILED/i)).toBeNull();
+    expect(queryByText(defaultText)).toBeNull();
+    getByRole('button', { name: errorText });
+    expect(queryByText(successText)).toBeNull();
+    expect(queryByText(invalidText)).toBeNull();
     expect(container.querySelector('.fas')).toBeNull();
   });
 
@@ -64,10 +68,10 @@ describe('<ReplaceAll>', () => {
         }}
       />,
     );
-    getByRole('button', { name: /STRINGS REPLACED/i });
-    expect(queryByText(/REPLACE ALL/i)).toBeNull();
-    expect(queryByText(/SOMETHING WENT WRONG/i)).toBeNull();
-    expect(queryByText(/FAILED/i)).toBeNull();
+    expect(queryByText(defaultText)).toBeNull();
+    expect(queryByText(errorText)).toBeNull();
+    getByRole('button', { name: successText });
+    expect(queryByText(invalidText)).toBeNull();
     expect(container.querySelector('.fas')).toBeNull();
   });
 
@@ -85,9 +89,10 @@ describe('<ReplaceAll>', () => {
       />,
     );
 
-    getByRole('button', { name: /^(?=.*STRINGS REPLACED)(?=.*FAILED).*/i });
-    expect(queryByText(/REPLACE ALL/i)).toBeNull();
-    expect(queryByText(/SOMETHING WENT WRONG/i)).toBeNull();
+    expect(queryByText(defaultText)).toBeNull();
+    expect(queryByText(errorText)).toBeNull();
+    const button = getByRole('button', { name: successText });
+    expect(button).toHaveTextContent(invalidText);
     expect(container.querySelector('.fas')).toBeNull();
   });
 
@@ -102,7 +107,7 @@ describe('<ReplaceAll>', () => {
     );
 
     expect(mockReplaceAll).not.toHaveBeenCalled();
-    fireEvent.click(getByRole('button', { name: /REPLACE ALL/i }));
+    fireEvent.click(getByRole('button', { name: defaultText }));
     expect(mockReplaceAll).toHaveBeenCalled();
   });
 });

--- a/translate/src/modules/comments/components/AddComment.test.jsx
+++ b/translate/src/modules/comments/components/AddComment.test.jsx
@@ -5,7 +5,6 @@ import { createReduxStore, mountComponentWithStore } from '~/test/store';
 
 import { AddComment } from './AddComment';
 import { vi } from 'vitest';
-import { fireEvent } from '@testing-library/react';
 
 const USER = {
   user: 'RSwanson',

--- a/translate/src/modules/comments/components/Comment.test.jsx
+++ b/translate/src/modules/comments/components/Comment.test.jsx
@@ -1,8 +1,15 @@
 import React from 'react';
-import { shallow } from 'enzyme';
 
 import { Comment } from './Comment';
-import { vi } from 'vitest';
+import { expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { MockLocalizationProvider } from '~/test/utils';
+
+vi.mock('react-time-ago', () => {
+  return {
+    default: () => null,
+  };
+});
 
 describe('<Comment>', () => {
   const DEFAULT_COMMENT = {
@@ -11,6 +18,7 @@ describe('<Comment>', () => {
     userGravatarUrlSmall: '',
     createdAt: '',
     dateIso: '',
+    userBanner: [],
     content:
       "What I hear when I'm being yelled at is people caring loudly at me.",
     translation: 0,
@@ -27,19 +35,18 @@ describe('<Comment>', () => {
 
   it('renders the correct text', () => {
     const deleteMock = vi.fn();
-    const wrapper = shallow(
-      <Comment
-        comment={DEFAULT_COMMENT}
-        key={DEFAULT_COMMENT.id}
-        user={DEFAULT_USER}
-        isTranslator={DEFAULT_ISTRANSLATOR}
-        deleteComment={deleteMock}
-      />,
+    const { getByText } = render(
+      <MockLocalizationProvider>
+        <Comment
+          comment={DEFAULT_COMMENT}
+          key={DEFAULT_COMMENT.id}
+          user={DEFAULT_USER}
+          isTranslator={DEFAULT_ISTRANSLATOR}
+          deleteComment={deleteMock}
+        />
+      </MockLocalizationProvider>,
     );
-
-    // Comments are hidden in a Linkify component.
-    const content = wrapper.find('Linkify').find('span').text();
-    expect(content).toEqual(
+    getByText(
       "What I hear when I'm being yelled at is people caring loudly at me.",
     );
   });
@@ -50,19 +57,19 @@ describe('<Comment>', () => {
       ...DEFAULT_COMMENT,
       ...{ username: 'Leslie_Knope', author: 'LKnope' },
     };
-    const wrapper = shallow(
-      <Comment
-        comment={comments}
-        key={comments.id}
-        user={DEFAULT_USER}
-        isTranslator={DEFAULT_ISTRANSLATOR}
-        deleteComment={deleteMock}
-      />,
+    const { getByRole } = render(
+      <MockLocalizationProvider>
+        <Comment
+          comment={comments}
+          key={comments.id}
+          user={DEFAULT_USER}
+          isTranslator={DEFAULT_ISTRANSLATOR}
+          deleteComment={deleteMock}
+        />
+      </MockLocalizationProvider>,
     );
 
-    const link = wrapper.find('a');
-    expect(link).toHaveLength(1);
-    expect(link.at(0).props().children).toEqual('LKnope');
-    expect(link.at(0).props().href).toEqual('/contributors/Leslie_Knope');
+    const link = getByRole('link', { name: /LKnope/i });
+    expect(link).toHaveAttribute('href', '/contributors/Leslie_Knope');
   });
 });

--- a/translate/src/modules/diff/components/TranslationDiff.test.jsx
+++ b/translate/src/modules/diff/components/TranslationDiff.test.jsx
@@ -1,26 +1,26 @@
 import React from 'react';
-import { mount } from 'enzyme';
 
 import { TranslationDiff } from './TranslationDiff';
+import { render } from '@testing-library/react';
 
 describe('<TranslationDiff>', () => {
   it('returns the correct diff for provided strings', () => {
-    const wrapper = mount(
+    const { getByText, container } = render(
       <TranslationDiff base={'abcdef'} target={'cdefgh'} />,
     );
 
-    expect(wrapper.find('ins')).toHaveLength(1);
-    expect(wrapper.find('del')).toHaveLength(1);
-    expect(wrapper.childAt(1).text()).toEqual('cdef');
+    getByText('gh', { selector: 'ins' });
+    getByText('ab', { selector: 'del' });
+    expect(container.childNodes[1]).toHaveTextContent(/^cdef$/);
   });
 
   it('returns the same string if provided strings are equal', () => {
-    const wrapper = mount(
+    const { container } = render(
       <TranslationDiff base={'abcdef'} target={'abcdef'} />,
     );
 
-    expect(wrapper.find('ins')).toHaveLength(0);
-    expect(wrapper.find('del')).toHaveLength(0);
-    expect(wrapper.text()).toEqual('abcdef');
+    expect(container.querySelector('ins')).toBeNull();
+    expect(container.querySelector('del')).toBeNull();
+    expect(container).toHaveTextContent(/^abcdef$/);
   });
 });

--- a/translate/src/modules/editor/components/EditorMainAction.test.jsx
+++ b/translate/src/modules/editor/components/EditorMainAction.test.jsx
@@ -1,4 +1,3 @@
-import { mount } from 'enzyme';
 import React, { useContext } from 'react';
 
 import * as Hooks from '~/hooks';
@@ -10,6 +9,7 @@ import * as UpdateTranslationStatus from '../hooks/useUpdateTranslationStatus';
 
 import { EditorMainAction } from './EditorMainAction';
 import { vi } from 'vitest';
+import { fireEvent, render } from '@testing-library/react';
 
 beforeAll(() => {
   vi.mock('react', async (importOriginal) => {
@@ -63,9 +63,8 @@ describe('<EditorMainAction>', () => {
       pk: 1,
     }));
 
-    const wrapper = mount(<EditorMainAction />);
-
-    wrapper.find('.action-approve').simulate('click');
+    const { getByRole } = render(<EditorMainAction />);
+    fireEvent.click(getByRole('button', { name: /APPROVE/i }));
     expect(spy.mock.calls).toMatchObject([[1, 'approve', false]]);
   });
 
@@ -74,18 +73,17 @@ describe('<EditorMainAction>', () => {
     SendTranslation.useSendTranslation.mockReturnValue(spy);
     Hooks.useAppSelector.mockReturnValue(true); // user.settings.forceSuggestions
 
-    const wrapper = mount(<EditorMainAction />);
-
-    wrapper.find('.action-suggest').simulate('click');
+    const { getByRole } = render(<EditorMainAction />);
+    fireEvent.click(getByRole('button', { name: /SUGGEST/i }));
     expect(spy.mock.calls).toMatchObject([[]]);
   });
 
   it('renders the Suggest button when user does not have permission', () => {
     Hooks.useAppSelector.mockReturnValue(true); // user.settings.forceSuggestions
 
-    const wrapper = mount(<EditorMainAction />);
+    const { getByRole } = render(<EditorMainAction />);
 
-    expect(wrapper.find('.action-suggest')).toHaveLength(1);
+    getByRole('button', { name: /SUGGEST/i });
   });
 
   it('shows a spinner and a disabled Suggesting button when running request', () => {
@@ -94,11 +92,12 @@ describe('<EditorMainAction>', () => {
     Hooks.useAppSelector.mockReturnValue(true); // user.settings.forceSuggestions
     vi.mocked(useContext).mockReturnValue({ busy: true }); // EditorData.busy
 
-    const wrapper = mount(<EditorMainAction />);
+    const { getByRole } = render(<EditorMainAction />);
+    const button = getByRole('button');
 
-    expect(wrapper.find('.action-suggest .fa-spin')).toHaveLength(1);
+    expect(button.querySelector('.fa-spin')).toBeInTheDocument();
 
-    wrapper.find('.action-suggest').simulate('click');
+    fireEvent.click(button);
     expect(spy).not.toHaveBeenCalled();
   });
 
@@ -106,9 +105,8 @@ describe('<EditorMainAction>', () => {
     const spy = vi.fn();
     SendTranslation.useSendTranslation.mockReturnValue(spy);
 
-    const wrapper = mount(<EditorMainAction />);
-
-    wrapper.find('.action-save').simulate('click');
+    const { getByRole } = render(<EditorMainAction />);
+    fireEvent.click(getByRole('button', { name: /SAVE/i }));
     expect(spy.mock.calls).toMatchObject([[]]);
   });
 
@@ -117,11 +115,11 @@ describe('<EditorMainAction>', () => {
     SendTranslation.useSendTranslation.mockReturnValue(spy);
     vi.mocked(useContext).mockReturnValue({ busy: true }); // EditorData.busy
 
-    const wrapper = mount(<EditorMainAction />);
+    const { getByRole } = render(<EditorMainAction />);
+    const button = getByRole('button');
 
-    expect(wrapper.find('.action-save .fa-spin')).toHaveLength(1);
-
-    wrapper.find('.action-save').simulate('click');
+    expect(button.querySelector('.fa-spin')).toBeInTheDocument();
+    fireEvent.click(button);
     expect(spy).not.toHaveBeenCalled();
   });
 });

--- a/translate/src/modules/editor/components/EditorMenu.test.jsx
+++ b/translate/src/modules/editor/components/EditorMenu.test.jsx
@@ -54,7 +54,6 @@ function expectHiddenSettingsAndActions({ container, queryByRole }) {
   expect(container.querySelector('.editor-settings')).toBeNull();
   expect(container.querySelector('.keyboard-shortcuts')).toBeNull();
   expect(container.querySelector('.translation-length')).toBeNull();
-  expect(queryByRole('button', { name: /^COPY$/i })).toBeNull();
 }
 
 describe('<EditorMenu>', () => {

--- a/translate/src/modules/editor/components/EditorSettings.test.jsx
+++ b/translate/src/modules/editor/components/EditorSettings.test.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { shallow } from 'enzyme';
 
 import { EditorSettings, EditorSettingsDialog } from './EditorSettings';
-import { vi } from 'vitest';
+import { beforeAll, vi } from 'vitest';
+import { fireEvent, render } from '@testing-library/react';
+import { MockLocalizationProvider } from '~/test/utils';
 
 vi.mock('react', async (importOriginal) => {
   const actual = await importOriginal();
@@ -33,71 +34,100 @@ function createEditorSettingsDialogForNonTranslator() {
   }));
 
   const toggleSettingMock = vi.fn();
-  const wrapper = shallow(
-    <EditorSettingsDialog
-      settings={{
-        runQualityChecks: false,
-        forceSuggestions: false,
-      }}
-      toggleSetting={toggleSettingMock}
-    />,
+  const wrapper = render(
+    <MockLocalizationProvider>
+      <EditorSettingsDialog
+        settings={{
+          runQualityChecks: false,
+          forceSuggestions: false,
+        }}
+        toggleSetting={toggleSettingMock}
+      />
+    </MockLocalizationProvider>,
   );
   return [wrapper, toggleSettingMock];
 }
 
 function createEditorSettingsDialog() {
   const toggleSettingMock = vi.fn();
-  const wrapper = shallow(
-    <EditorSettingsDialog
-      settings={{
-        runQualityChecks: false,
-        forceSuggestions: false,
-      }}
-      toggleSetting={toggleSettingMock}
-    />,
+  const wrapper = render(
+    <MockLocalizationProvider>
+      <EditorSettingsDialog
+        settings={{
+          runQualityChecks: false,
+          forceSuggestions: false,
+        }}
+        toggleSetting={toggleSettingMock}
+      />
+    </MockLocalizationProvider>,
   );
   return [wrapper, toggleSettingMock];
 }
 
 describe('<EditorSettingsDialog>', () => {
+  beforeAll(() => {
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+  });
   beforeEach(() => {
     vi.unmock('~/hooks/useTranslator');
   });
 
   it('does not show the forceSuggestions setting if user is not a translator', () => {
-    const [wrapper] = createEditorSettingsDialogForNonTranslator();
+    const [{ getAllByRole }] = createEditorSettingsDialogForNonTranslator();
 
-    expect(wrapper.find('.menu li').at(1).text()).not.toContain(
+    expect(getAllByRole('listitem')[1].textContent).not.toContain(
       'Force suggestions',
     );
   });
 
   it('toggles the runQualityChecks setting', () => {
-    const [wrapper, toggleSettingMock] = createEditorSettingsDialog();
+    const [{ getAllByRole, rerender }, toggleSettingMock] =
+      createEditorSettingsDialog();
 
     // Do it once to turn it on.
-    wrapper.find('.menu li').at(0).simulate('click');
+    fireEvent.click(getAllByRole('listitem')[0]);
     expect(toggleSettingMock.mock.calls).toMatchObject([['runQualityChecks']]);
 
     // Do it twice to turn it off.
-    wrapper.setProps({ settings: { runQualityChecks: true } });
+    rerender(
+      <MockLocalizationProvider>
+        <EditorSettingsDialog
+          settings={{
+            runQualityChecks: true,
+            forceSuggestions: false,
+          }}
+          toggleSetting={toggleSettingMock}
+        />
+      </MockLocalizationProvider>,
+    );
 
-    wrapper.find('.menu li').at(0).simulate('click');
+    fireEvent.click(getAllByRole('listitem')[0]);
     expect(toggleSettingMock).toHaveBeenCalledTimes(2);
     expect(toggleSettingMock).toHaveBeenCalledWith('runQualityChecks');
   });
 
   it('toggles the forceSuggestions setting', () => {
-    const [wrapper, toggleSettingMock] = createEditorSettingsDialog();
+    const [{ getAllByRole, rerender }, toggleSettingMock] =
+      createEditorSettingsDialog();
 
     // Do it once to turn it on.
-    wrapper.find('.menu li').at(1).simulate('click');
+    fireEvent.click(getAllByRole('listitem')[1]);
     expect(toggleSettingMock.mock.calls).toMatchObject([['forceSuggestions']]);
 
     // Do it twice to turn it off.
-    wrapper.setProps({ settings: { forceSuggestions: true } });
+    rerender(
+      <MockLocalizationProvider>
+        <EditorSettingsDialog
+          settings={{
+            runQualityChecks: false,
+            forceSuggestions: true,
+          }}
+          toggleSetting={toggleSettingMock}
+        />
+      </MockLocalizationProvider>,
+    );
 
-    wrapper.find('.menu li').at(1).simulate('click');
+    fireEvent.click(getAllByRole('listitem')[1]);
     expect(toggleSettingMock).toHaveBeenCalledTimes(2);
     expect(toggleSettingMock).toHaveBeenCalledWith('forceSuggestions');
   });
@@ -105,13 +135,17 @@ describe('<EditorSettingsDialog>', () => {
 
 describe('<EditorSettings>', () => {
   it('toggles the settings menu when clicking the gear icon', () => {
-    const wrapper = shallow(<EditorSettings />);
-    expect(wrapper.find('EditorSettingsDialog')).toHaveLength(0);
+    const { getByRole, queryByRole } = render(
+      <MockLocalizationProvider>
+        <EditorSettings settings={{}} />
+      </MockLocalizationProvider>,
+    );
+    expect(queryByRole('list')).toBeNull();
 
-    wrapper.find('.selector').simulate('click');
-    expect(wrapper.find('EditorSettingsDialog')).toHaveLength(1);
+    fireEvent.click(getByRole('button', { name: /SETTINGS/i }));
+    expect(queryByRole('list')).toBeInTheDocument();
 
-    wrapper.find('.selector').simulate('click');
-    expect(wrapper.find('EditorSettingsDialog')).toHaveLength(0);
+    fireEvent.click(getByRole('button', { name: /SETTINGS/i }));
+    expect(queryByRole('list')).toBeNull();
   });
 });

--- a/translate/src/modules/editor/components/EditorSettings.tsx
+++ b/translate/src/modules/editor/components/EditorSettings.tsx
@@ -104,6 +104,7 @@ export function EditorSettings({
     <div className='editor-settings'>
       <div
         className='selector fas fa-cog'
+        role='button'
         title='Settings'
         onClick={toggleVisible}
       />

--- a/translate/src/modules/editor/components/TranslationLength.test.jsx
+++ b/translate/src/modules/editor/components/TranslationLength.test.jsx
@@ -1,11 +1,11 @@
 import React, { useContext } from 'react';
-import { shallow } from 'enzyme';
 
 import { EditorData, EditorResult } from '~/context/Editor';
 import { EntityView } from '~/context/EntityView';
 
 import { TranslationLength } from './TranslationLength';
 import { vi } from 'vitest';
+import { render } from '@testing-library/react';
 
 describe('<TranslationLength>', () => {
   beforeAll(() => {
@@ -30,47 +30,47 @@ describe('<TranslationLength>', () => {
     ]);
     vi.mocked(useContext).mockImplementation((key) => context.get(key));
 
-    return shallow(<TranslationLength />);
+    return render(<TranslationLength />);
   }
 
   it('shows translation length and original string length', () => {
-    const wrapper = mountTranslationLength('', '12345', '1234567', '');
+    const { container } = mountTranslationLength('', '12345', '1234567', '');
 
-    const div = wrapper.find('.translation-vs-original');
-    expect(div.childAt(0).text()).toEqual('7');
-    expect(div.childAt(1).text()).toEqual('|');
-    expect(div.childAt(2).text()).toEqual('5');
+    const div = container.querySelector('.translation-vs-original');
+    expect(div.childNodes[0].textContent).toEqual('7');
+    expect(div.childNodes[1].textContent).toEqual('|');
+    expect(div.childNodes[2].textContent).toEqual('5');
   });
 
   it('shows translation length and plural original string length', () => {
-    const wrapper = mountTranslationLength('', '123456', '1234567', '');
+    const { container } = mountTranslationLength('', '123456', '1234567', '');
 
-    const div = wrapper.find('.translation-vs-original');
-    expect(div.childAt(2).text()).toEqual('6');
+    const div = container.querySelector('.translation-vs-original');
+    expect(div.childNodes[2].textContent).toEqual('6');
   });
 
   it('shows translation length and FTL original string length', () => {
-    const wrapper = mountTranslationLength(
+    const { container } = mountTranslationLength(
       'fluent',
       'key = 123456',
       '1234567',
       '',
     );
 
-    const div = wrapper.find('.translation-vs-original');
-    expect(div.childAt(0).text()).toEqual('7');
-    expect(div.childAt(2).text()).toEqual('6');
+    const div = container.querySelector('.translation-vs-original');
+    expect(div.childNodes[0].textContent).toEqual('7');
+    expect(div.childNodes[2].textContent).toEqual('6');
   });
 
   it('does not strip html from translation when calculating length', () => {
-    const wrapper = mountTranslationLength(
+    const { container } = mountTranslationLength(
       '',
       '12345',
       '12<span>34</span>56',
       '',
     );
 
-    const div = wrapper.find('.translation-vs-original');
-    expect(div.childAt(0).text()).toEqual('19');
+    const div = container.querySelector('.translation-vs-original');
+    expect(div.childNodes[0].textContent).toEqual('19');
   });
 });


### PR DESCRIPTION
- Continuation of previous MR https://github.com/mozilla/pontoon/pull/3909 the migration of enzyme test to @testing-library/react under task https://github.com/mozilla/pontoon/issues/3767

- [Editor.test.js](https://github.com/mozilla/pontoon/blob/main/translate/src/modules/editor/components/Editor.test.jsx) is untouched as the complexity with content editable [EditField](https://github.com/mozilla/pontoon/blob/main/translate/src/modules/translationform/components/EditField.tsx) component need extra effort and i think should be handled in separate branch. 