### PR TITLE
Fix string shown when not matching filters

### DIFF
--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -215,6 +215,8 @@ def _get_paginated_entities(locale, preferred_source_locale, project, form, enti
     entities_to_map = entities_page.object_list
     requested_entity = form.cleaned_data["entity"] if page == 1 else None
 
+    if requested_entity and not entities.filter(pk=requested_entity).exists():
+        requested_entity = None
     return JsonResponse(
         {
             "entities": Entity.map_entities(


### PR DESCRIPTION
Fixes #3148

When a string ID is passed via the \'?string=\' URL parameter it was being appended to the entity list unconditionally by `map_entities() ` bypassing the active filters.

This checks whether the requested entity actually exists before pasing it through. If it does not exist, it is not displayed.

To review:
Check the changes in `_get_paginated_entities()`` in pontoon/base/views.py`.

To test:
I added a test that fails before the change and passes after the change in `pontoon/base/tests/views/test_entity.py`.

You can also find an approved/translated entity ID and append it in /<locale>/<project>/all-resources/?status=missing&string=<id> eg http://localhost:8000/sl/pontoon-test/all-resources/?status=missing&string=16

Before the fix, the string appears.
After the fix, the string doesn't appear.

