### PR TITLE
Fix #3614 Add ability to toggle between dashboard progress bar and detailed view

### DIFF
--- a/pontoon/base/static/css/table.css
+++ b/pontoon/base/static/css/table.css
@@ -69,6 +69,12 @@ table.table.project-list.hidden {
   width: 16px;
 }
 
+.table th.progress button {
+  float: right;
+  margin: -3px -10px -3px 0;
+  padding: 3px 12px;
+}
+
 .table-sort th.unreviewed-status i {
   margin: -13px 0 0 13px;
 }
@@ -314,6 +320,14 @@ table.table.project-list.hidden {
 }
 
 .table tr:hover .progress .legend {
+  display: block;
+}
+
+.table .progress.show-detailed-view .chart-wrapper {
+  display: none;
+}
+
+.table .progress.show-detailed-view .legend {
   display: block;
 }
 

--- a/pontoon/base/static/js/table.js
+++ b/pontoon/base/static/js/table.js
@@ -116,6 +116,31 @@ var Pontoon = (function (my) {
       })(),
 
       /*
+       * showDetailedView
+       *
+       * Toggle button to show/hide the detailed view in the progress column of tables.
+       */
+      showDetailedView: (function () {
+        $('body').on(
+          'click',
+          'table th.progress button#detailed-view-toggle',
+          function (e) {
+            // Do not reorder the list when clicking on the toggle button
+            e.stopPropagation();
+
+            $('td.progress').toggleClass('show-detailed-view');
+
+            const toggle = $('#detailed-view-toggle');
+            toggle.text(
+              $.trim(toggle.text()) === 'Show details'
+                ? 'Hide details'
+                : 'Show details',
+            );
+          },
+        );
+      })(),
+
+      /*
        * Sort table
        */
       sort: (function () {

--- a/pontoon/base/templates/widgets/progress_table_column.html
+++ b/pontoon/base/templates/widgets/progress_table_column.html
@@ -1,0 +1,9 @@
+{% macro header() %}
+  <th class="progress controls">
+    Progress
+    <i class="fas"></i>
+    <button class="button" id="detailed-view-toggle" title="Show details">
+      Show details
+    </button>
+  </th>
+{% endmacro %}

--- a/pontoon/localizations/templates/localizations/widgets/resource_list.html
+++ b/pontoon/localizations/templates/localizations/widgets/resource_list.html
@@ -1,5 +1,6 @@
 {% import 'widgets/latest_activity.html' as LatestActivity %}
 {% import 'widgets/progress_chart.html' as ProgressChart %}
+{% import 'widgets/progress_table_column.html' as ProgressTableColumn %}
 {% import 'widgets/deadline.html' as Deadline %}
 {% import 'widgets/priority.html' as Priority %}
 
@@ -24,7 +25,7 @@
       {% endif %}
 
       <th class="latest-activity">Latest Activity<i class="fas"></i></th>
-      <th class="progress">Progress<i class="fas"></i></th>
+      {{ ProgressTableColumn.header() }}
       <th class="unreviewed-status inverted" title="Unreviewed suggestions">
         <span class="fas fa-lightbulb"></span><i class="fas"></i>
       </th>

--- a/pontoon/projects/templates/projects/widgets/project_list.html
+++ b/pontoon/projects/templates/projects/widgets/project_list.html
@@ -1,5 +1,6 @@
 {% import 'widgets/latest_activity.html' as LatestActivity %}
 {% import 'widgets/progress_chart.html' as ProgressChart %}
+{% import 'widgets/progress_table_column.html' as ProgressTableColumn %}
 {% import 'widgets/deadline.html' as Deadline %}
 {% import 'widgets/priority.html' as Priority %}
 
@@ -13,7 +14,7 @@
         <th class="deadline">Target Date<i class="fas"></i></th>
         <th class="priority inverted">Priority<i class="fas"></i></th>
         <th class="latest-activity">Latest Activity<i class="fas"></i></th>
-        <th class="progress">Progress<i class="fas"></i></th>
+        {{ ProgressTableColumn.header() }}
         <th class="unreviewed-status inverted" title="Unreviewed suggestions">
           <span class="fas fa-lightbulb"></span><i class="fas"></i>
         </th>

--- a/pontoon/teams/templates/teams/widgets/team_list.html
+++ b/pontoon/teams/templates/teams/widgets/team_list.html
@@ -1,5 +1,6 @@
 {% import 'widgets/latest_activity.html' as LatestActivity %}
 {% import 'widgets/progress_chart.html' as ProgressChart %}
+{% import 'widgets/progress_table_column.html' as ProgressTableColumn %}
 
 {% macro header(request=False) %}
   <table class="table table-sort team-list item-list">
@@ -9,7 +10,7 @@
         <th class="code">Locale<i class="fas"></i></th>
         <th class="population">Speakers<i class="fas"></i></th>
         <th class="latest-activity">Latest Activity<i class="fas"></i></th>
-        <th class="progress">Progress<i class="fas"></i></th>
+        {{ ProgressTableColumn.header() }}
         <th class="unreviewed-status inverted" title="Unreviewed suggestions">
           <span class="fas fa-lightbulb"></span><i class="fas"></i>
         </th>


### PR DESCRIPTION
This adds a toggle button to always show the progress detailed view on the dashboard instead of only showing it on hover.

It currently doesn't implement a way to remember the user preference. This could be added in this patch or in a follow up patch. Any thought @mathjazz. 

<img width="1506" height="316" alt="image" src="https://github.com/user-attachments/assets/737c7762-af8d-4274-8af2-54ca06516b9e" />

Fixes #3614
