### PR TITLE
Use the right docker compose command based on the user setup

### DIFF
--- a/bin/watch.sh
+++ b/bin/watch.sh
@@ -9,5 +9,5 @@ trap sigint_handler INT
 
 npx concurrently -n translate,server,pg -c cyan,magenta,green,red \
   'npm start -w translate' \
-  'docker-compose logs --tail=0 --follow --no-log-prefix server' \
-  'docker-compose logs --tail=0 --follow --no-log-prefix postgresql' \
+  'docker compose logs --tail=0 --follow --no-log-prefix server' \
+  'docker compose logs --tail=0 --follow --no-log-prefix postgresql'


### PR DESCRIPTION
Currently, `/bin/watch.sh` uses `docker-compose` command. The script fails to execute properly if the newer `docker compose` subcommand is installed instead of the legacy `docker-compose` command.

To ensure the script doesn't fail, this patch detects which command is available before passing it to `concurrently`.