### PR TITLE
Fix #3785 Remove editor hardcoded color values

### DIFF
--- a/pontoon/base/static/css/dark-theme.css
+++ b/pontoon/base/static/css/dark-theme.css
@@ -67,6 +67,7 @@
   --editor-menu-background: #272a2f;
   --editor-menu-color: #aaaaaa;
   --editor-menu-action-button-color: #ffffff;
+  --editor-readonly-background: #c7cacf;
   --time-range-handles: #272a2f;
 
   /* Highlights */
@@ -76,6 +77,13 @@
   --diff-ins-color: #9cd699;
   --search-color: #ffa10f;
   --search-background: #676054;
+  --tags-brace-color: #872bff;
+  --tags-bracket-color: #3e9682;
+  --tags-keyword-color: #872bff;
+  --tags-literal-color: #3e9682;
+  --tags-name-color: #872bff;
+  --tags-quote-color: #3e9682;
+  --tags-tag-name-color: #3e9682;
 
   /* Chart colors */
   --green-blue: #4fc4f666;

--- a/pontoon/base/static/css/light-theme.css
+++ b/pontoon/base/static/css/light-theme.css
@@ -67,6 +67,7 @@
   --editor-menu-background: #ffffff;
   --editor-menu-color: #555555;
   --editor-menu-action-button-color: #000000;
+  --editor-readonly-background: #c7cacf;
   --time-range-handles: #888888;
 
   /* Highlights */
@@ -76,6 +77,13 @@
   --diff-ins-color: #42983e;
   --search-color: #ffa10f;
   --search-background: #fff4e2;
+  --tags-brace-color: #872bff;
+  --tags-bracket-color: #3e9682;
+  --tags-keyword-color: #872bff;
+  --tags-literal-color: #3e9682;
+  --tags-name-color: #872bff;
+  --tags-quote-color: #3e9682;
+  --tags-tag-name-color: #3e9682;
 
   /* Chart colors */
   --green-blue: #4fc4f666;

--- a/translate/src/modules/translationform/components/TranslationForm.css
+++ b/translate/src/modules/translationform/components/TranslationForm.css
@@ -146,7 +146,7 @@
 
 .editor input[readonly],
 .editor .readonly .cm-editor {
-  background: #c7cacf;
+  background: var(--editor-readonly-background);
   cursor: default;
 }
 

--- a/translate/src/modules/translationform/utils/editFieldExtensions.css
+++ b/translate/src/modules/translationform/utils/editFieldExtensions.css
@@ -1,0 +1,42 @@
+.tags-brace {
+  color: var(--tags-brace-color);
+  font-weight: bold;
+  white-space: pre;
+}
+
+.tags-bracket {
+  color: var(--tags-bracket-color);
+  font-family: monospace;
+  white-space: pre;
+}
+
+.tags-keyword {
+  color: var(--tags-keyword-color);
+  font-family: monospace;
+  white-space: pre;
+}
+
+.tags-literal {
+  color: var(--tags-literal-color);
+  white-space: pre-wrap;
+}
+
+.tags-name {
+  color: var(--tags-name-color);
+  white-space: pre;
+}
+
+.tags-quote {
+  color: var(--tags-quote-color);
+  white-space: pre-wrap;
+}
+
+.tags-tag-name {
+  color: var(--tags-tag-name-color);
+  font-family: monospace;
+  white-space: pre;
+}
+
+.tags-string {
+  white-space: pre-wrap;
+}

--- a/translate/src/modules/translationform/utils/editFieldExtensions.ts
+++ b/translate/src/modules/translationform/utils/editFieldExtensions.ts
@@ -34,6 +34,7 @@ import {
 } from './editFieldShortcuts';
 import { fluentMode, commonMode, webextMode } from './editFieldModes';
 import { Message } from '@mozilla/l10n';
+import './editFieldExtensions.css';
 
 /**
  * Key handlers depend on application state,
@@ -68,22 +69,14 @@ export function useKeyHandlers() {
 }
 
 const style = HighlightStyle.define([
-  {
-    tag: tags.keyword,
-    color: '#872bff',
-    fontFamily: 'monospace',
-    whiteSpace: 'pre',
-  }, // printf
-  {
-    tag: [tags.bracket, tags.tagName],
-    color: '#3e9682',
-    fontFamily: 'monospace',
-    whiteSpace: 'pre',
-  }, // <...>
-  { tag: tags.brace, color: '#872bff', fontWeight: 'bold', whiteSpace: 'pre' }, // { }
-  { tag: tags.name, color: '#872bff', whiteSpace: 'pre' }, // {...}
-  { tag: [tags.quote, tags.literal], color: '#3e9682', whiteSpace: 'pre-wrap' }, // "..."
-  { tag: tags.string, whiteSpace: 'pre-wrap' },
+  { tag: tags.keyword, class: 'tags-keyword' }, // printf
+  { tag: tags.bracket, class: 'tags-bracket' }, // <...>
+  { tag: tags.tagName, class: 'tags-tag-name' }, // <...>
+  { tag: tags.brace, class: 'tags-brace' }, // { }
+  { tag: tags.name, class: 'tags-name' }, // {...}
+  { tag: tags.quote, class: 'tags-quote' }, // "..."
+  { tag: tags.literal, class: 'tags-literal' }, // "..."
+  { tag: tags.string },
 ]);
 
 export const getExtensions = (


### PR DESCRIPTION
Fix #3785.

This removes the hardcoded color (and more) values by moving the color values to Pontoon CSS theme files and a CSS file for the editFieldExtensions component.