### PR TITLE
migrate to rtl under /machinery, /originalstring, /otherlocales

### DIFF
--- a/translate/src/modules/history/components/HistoryTranslation.test.jsx
+++ b/translate/src/modules/history/components/HistoryTranslation.test.jsx
@@ -143,8 +143,10 @@ describe('<HistoryTranslationComponent>', () => {
 
       const { getAllByTitle } = render(
         <MockLocalizationProvider
-          resource={`history-translation--approved =
-                      .title = ${approvedTitle}`}
+          resources={[
+            `history-translation--approved =
+                      .title = ${approvedTitle}`,
+          ]}
         >
           <HistoryTranslationBase
             translation={translation}
@@ -165,8 +167,10 @@ describe('<HistoryTranslationComponent>', () => {
       };
       const { getAllByTitle } = render(
         <MockLocalizationProvider
-          resource={`history-translation--approved-anonymous =
-                      .title = ${approvedAnonymousTitle}`}
+          resources={[
+            `history-translation--approved-anonymous =
+                      .title = ${approvedAnonymousTitle}`,
+          ]}
         >
           <HistoryTranslationBase
             translation={translation}
@@ -187,8 +191,10 @@ describe('<HistoryTranslationComponent>', () => {
       };
       const { getAllByTitle } = render(
         <MockLocalizationProvider
-          resource={`history-translation--rejected =
-                      .title = ${rejectedTitle}`}
+          resources={[
+            `history-translation--rejected =
+                      .title = ${rejectedTitle}`,
+          ]}
         >
           <HistoryTranslationBase
             translation={translation}
@@ -209,8 +215,10 @@ describe('<HistoryTranslationComponent>', () => {
       };
       const { getAllByTitle } = render(
         <MockLocalizationProvider
-          resource={`history-translation--rejected-anonymous =
-                      .title = ${rejectedAnonymousTitle}`}
+          resources={[
+            `history-translation--rejected-anonymous =
+                      .title = ${rejectedAnonymousTitle}`,
+          ]}
         >
           <HistoryTranslationBase
             translation={translation}
@@ -227,8 +235,10 @@ describe('<HistoryTranslationComponent>', () => {
       const unreviewedTitle = 'test-unreviewed';
       const { getAllByTitle } = render(
         <MockLocalizationProvider
-          resource={`history-translation--unreviewed =
-                      .title = ${unreviewedTitle}`}
+          resources={[
+            `history-translation--unreviewed =
+                      .title = ${unreviewedTitle}`,
+          ]}
         >
           <HistoryTranslationBase
             translation={DEFAULT_TRANSLATION}

--- a/translate/src/modules/machinery/components/Machinery.test.jsx
+++ b/translate/src/modules/machinery/components/Machinery.test.jsx
@@ -1,21 +1,30 @@
 import React from 'react';
-import { mount } from 'enzyme';
 
 import { MachineryTranslations } from '~/context/MachineryTranslations';
 import { SearchData } from '~/context/SearchData';
 import { MockLocalizationProvider } from '~/test/utils';
 
 import { Machinery } from './Machinery';
-import { vi } from 'vitest';
+import { expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
 
 vi.mock('~/hooks', () => ({
   useAppDispatch: () => () => {},
   useAppSelector: () => {},
 }));
+const inputPlaceholder = 'test-search';
+const copyListItemTitle = 'test-copy';
 
 const mountMachinery = (translations, search) =>
-  mount(
-    <MockLocalizationProvider>
+  render(
+    <MockLocalizationProvider
+      resources={[
+        `machinery-Machinery--search-placeholder =
+            .placeholder = ${inputPlaceholder}`,
+        `machinery-Translation--copy = 
+            .title = ${copyListItemTitle} `,
+      ]}
+    >
       <MachineryTranslations.Provider
         value={{ source: 'source', translations }}
       >
@@ -40,14 +49,13 @@ const mountMachinery = (translations, search) =>
 
 describe('<Machinery>', () => {
   it('shows a search form', () => {
-    const wrapper = mountMachinery([], {});
-
-    expect(wrapper.find('.search-wrapper')).toHaveLength(1);
-    expect(wrapper.find('#machinery-search')).toHaveLength(1);
+    const { getByPlaceholderText, getByRole } = mountMachinery([], {});
+    getByPlaceholderText(inputPlaceholder);
+    getByRole('searchbox');
   });
 
   it('shows the correct number of translations', () => {
-    const wrapper = mountMachinery(
+    const { getAllByRole, getAllByTitle } = mountMachinery(
       [
         { original: '1', sources: [] },
         { original: '2', sources: [] },
@@ -61,12 +69,12 @@ describe('<Machinery>', () => {
       },
     );
 
-    expect(wrapper.find('MachineryTranslationComponent')).toHaveLength(5);
+    expect(getAllByRole('listitem')).toHaveLength(5);
+    expect(getAllByTitle(copyListItemTitle)).toHaveLength(5);
   });
 
   it('renders a reset button if a search query is present', () => {
-    const wrapper = mountMachinery([], { input: 'test', query: 'test' });
-
-    expect(wrapper.find('button')).toHaveLength(1);
+    const { getByRole } = mountMachinery([], { input: 'test', query: 'test' });
+    getByRole('button');
   });
 });

--- a/translate/src/modules/machinery/components/MachineryCount.test.jsx
+++ b/translate/src/modules/machinery/components/MachineryCount.test.jsx
@@ -1,13 +1,14 @@
 import React from 'react';
-import { mount } from 'enzyme';
 
 import { MachineryTranslations } from '~/context/MachineryTranslations';
 import { SearchData } from '~/context/SearchData';
 
 import { MachineryCount } from './MachineryCount';
+import { render } from '@testing-library/react';
+import { expect } from 'vitest';
 
 const mountMachineryCount = (translations, results) =>
-  mount(
+  render(
     <MachineryTranslations.Provider value={{ source: 'source', translations }}>
       <SearchData.Provider
         value={{
@@ -28,7 +29,7 @@ const mountMachineryCount = (translations, results) =>
 
 describe('<MachineryCount>', () => {
   it('shows the correct number of preferred translations', () => {
-    const wrapper = mountMachineryCount(
+    const { container } = mountMachineryCount(
       [
         { sources: ['translation-memory'] },
         { sources: ['translation-memory'] },
@@ -37,16 +38,16 @@ describe('<MachineryCount>', () => {
     );
 
     // There are only preferred results.
-    expect(wrapper.find('.count > span')).toHaveLength(1);
+    expect(container.querySelectorAll('.count > span')).toHaveLength(1);
 
     // And there are two of them.
-    expect(wrapper.find('.preferred').text()).toContain('2');
+    expect(container.querySelector('.preferred')).toHaveTextContent('2');
 
-    expect(wrapper.text()).not.toContain('+');
+    expect(container).not.toHaveTextContent('+');
   });
 
   it('shows the correct number of remaining translations', () => {
-    const wrapper = mountMachineryCount(
+    const { container } = mountMachineryCount(
       [
         { sources: ['microsoft'] },
         { sources: ['google'] },
@@ -59,17 +60,17 @@ describe('<MachineryCount>', () => {
     );
 
     // There are only remaining results.
-    expect(wrapper.find('.count > span')).toHaveLength(1);
-    expect(wrapper.find('.preferred')).toHaveLength(0);
+    expect(container.querySelectorAll('.count > span')).toHaveLength(1);
+    expect(container.querySelector('.preferred')).toBeNull();
 
     // And there are three of them.
-    expect(wrapper.find('.count > span').text()).toContain('5');
+    expect(container.querySelector('.count > span')).toHaveTextContent('5');
 
-    expect(wrapper.text()).not.toContain('+');
+    expect(container).not.toHaveTextContent('+');
   });
 
   it('shows the correct numbers of preferred and remaining translations', () => {
-    const wrapper = mountMachineryCount(
+    const { container } = mountMachineryCount(
       [
         { sources: ['translation-memory'] },
         { sources: ['translation-memory'] },
@@ -84,13 +85,14 @@ describe('<MachineryCount>', () => {
     );
 
     // There are both preferred and remaining, and the '+' sign.
-    expect(wrapper.find('.count > span')).toHaveLength(3);
+    expect(container.querySelectorAll('.count > span')).toHaveLength(3);
 
     // And each count is correct.
-    expect(wrapper.find('.preferred').text()).toContain('2');
-    expect(wrapper.find('.count > span').last().text()).toContain('5');
+    expect(container.querySelector('.preferred')).toHaveTextContent('2');
+    const spans = container.querySelectorAll('.count > span');
+    expect(spans[spans.length - 1]).toHaveTextContent('5');
 
     // And the final display is correct as well.
-    expect(wrapper.text()).toEqual('2+5');
+    expect(container).toHaveTextContent('2+5');
   });
 });

--- a/translate/src/modules/machinery/components/MachineryTranslationSource.test.jsx
+++ b/translate/src/modules/machinery/components/MachineryTranslationSource.test.jsx
@@ -1,29 +1,47 @@
 import React from 'react';
-import { shallow } from 'enzyme';
 
 import { MachineryTranslationSource } from './MachineryTranslationSource';
+import { render } from '@testing-library/react';
+
+import { MockLocalizationProvider } from '~/test/utils';
 
 const DEFAULT_TRANSLATION = {
   sources: ['translation-memory'],
 };
+const WrapMachineryTranslationSource = (props) => {
+  return (
+    <MockLocalizationProvider>
+      <MachineryTranslationSource {...props} />
+    </MockLocalizationProvider>
+  );
+};
+const translationMemoryTitle = 'TRANSLATION MEMORY';
+const googleTranslationTitle = 'GOOGLE TRANSLATE';
+const microsoftTranslationTitle = 'MICROSOFT TRANSLATOR';
+const microsoftTerminologyTitle = 'MICROSOFT';
+const caighdeanTranslationTitle = 'CAIGHDEAN';
 
 describe('<MachineryTranslationSource>', () => {
-  for (const [type, component] of [
-    ['translation-memory', 'TranslationMemory'],
-    ['google-translate', 'GoogleTranslation'],
-    ['microsoft-translator', 'MicrosoftTranslation'],
-    ['microsoft-terminology', 'MicrosoftTerminology'],
-    ['caighdean', 'CaighdeanTranslation'],
+  for (const [type, component, title] of [
+    ['translation-memory', 'TranslationMemory', translationMemoryTitle],
+    ['google-translate', 'GoogleTranslation', googleTranslationTitle],
+    ['microsoft-translator', 'MicrosoftTranslation', microsoftTranslationTitle],
+    [
+      'microsoft-terminology',
+      'MicrosoftTerminology',
+      microsoftTerminologyTitle,
+    ],
+    ['caighdean', 'CaighdeanTranslation', caighdeanTranslationTitle],
   ]) {
     it(`renders ${type} type for ${component} component correctly`, () => {
       const translation = {
         sources: [type],
       };
-      const wrapper = shallow(
-        <MachineryTranslationSource translation={translation} />,
+      const { getByText } = render(
+        <WrapMachineryTranslationSource translation={translation} />,
       );
 
-      expect(wrapper.find(component)).toHaveLength(1);
+      getByText(title);
     });
   }
 
@@ -31,11 +49,11 @@ describe('<MachineryTranslationSource>', () => {
     const translation = {
       sources: [...DEFAULT_TRANSLATION.sources, 'microsoft-terminology'],
     };
-    const wrapper = shallow(
-      <MachineryTranslationSource translation={translation} />,
+    const { getByText } = render(
+      <WrapMachineryTranslationSource translation={translation} />,
     );
 
-    expect(wrapper.find('TranslationMemory')).toHaveLength(1);
-    expect(wrapper.find('MicrosoftTerminology')).toHaveLength(1);
+    getByText(translationMemoryTitle);
+    getByText(microsoftTerminologyTitle);
   });
 });

--- a/translate/src/modules/machinery/components/source/CaighdeanTranslation.test.jsx
+++ b/translate/src/modules/machinery/components/source/CaighdeanTranslation.test.jsx
@@ -1,16 +1,23 @@
 import React from 'react';
-import { shallow } from 'enzyme';
 
 import { CaighdeanTranslation } from './CaighdeanTranslation';
+import { render } from '@testing-library/react';
+import { MockLocalizationProvider } from '~/test/utils';
 
 describe('<CaighdeanTranslation>', () => {
   it('renders the CaighdeanTranslation component properly', () => {
-    const wrapper = shallow(<CaighdeanTranslation />);
-
-    expect(wrapper.find('li')).toHaveLength(1);
-    expect(wrapper.find('Localized').props().id).toEqual(
-      'machinery-CaighdeanTranslation--translation-source',
+    const message = 'test-caighdean-translation';
+    const { getByRole, getByText } = render(
+      <MockLocalizationProvider
+        resources={[
+          `machinery-CaighdeanTranslation--translation-source = ${message}`,
+        ]}
+      >
+        <CaighdeanTranslation />
+      </MockLocalizationProvider>,
     );
-    expect(wrapper.find('li span').text()).toEqual('CAIGHDEAN');
+
+    getByRole('listitem');
+    getByText(message);
   });
 });

--- a/translate/src/modules/machinery/components/source/GoogleTranslation.test.jsx
+++ b/translate/src/modules/machinery/components/source/GoogleTranslation.test.jsx
@@ -1,17 +1,24 @@
 import React from 'react';
-import { shallow } from 'enzyme';
 
 import { GoogleTranslation } from './GoogleTranslation';
+import { fireEvent, render, within } from '@testing-library/react';
+import { MockLocalizationProvider } from '~/test/utils';
 
 describe('<GoogleTranslation>', () => {
   it('renders the GoogleTranslation component properly', () => {
-    const wrapper = shallow(<GoogleTranslation />);
-
-    expect(wrapper.find('li')).toHaveLength(1);
-    expect(wrapper.find('Localized').props().id).toEqual(
-      'machinery-GoogleTranslation--translation-source',
+    const message = 'test-source';
+    const { getByRole, getByText } = render(
+      <MockLocalizationProvider
+        resources={[
+          `machinery-GoogleTranslation--translation-source = ${message}`,
+        ]}
+      >
+        <GoogleTranslation />
+      </MockLocalizationProvider>,
     );
-    expect(wrapper.find('li span').text()).toEqual('GOOGLE TRANSLATE');
+
+    getByRole('listitem');
+    getByText(message);
   });
 
   it('renders the GoogleTranslation LLM features properly', () => {
@@ -19,22 +26,28 @@ describe('<GoogleTranslation>', () => {
       translation: 'Translated text here',
       original: 'Original text here',
     };
+    const message = 'test-source';
 
-    const wrapper = shallow(
-      <GoogleTranslation
-        isOpenAIChatGPTSupported={true}
-        translation={mockTranslation}
-      />,
+    const { container, getByRole } = render(
+      <MockLocalizationProvider
+        resources={[
+          `machinery-GoogleTranslation--translation-source = ${message}`,
+        ]}
+      >
+        <GoogleTranslation
+          isOpenAIChatGPTSupported={true}
+          translation={mockTranslation}
+        />
+      </MockLocalizationProvider>,
     );
 
-    expect(wrapper.find('li')).toHaveLength(1);
-    expect(wrapper.find('.selector Localized').first().props().id).toEqual(
-      'machinery-GoogleTranslation--translation-source',
-    );
-    expect(wrapper.find('span.translation-source')).toHaveLength(1);
-    expect(wrapper.find('.selector').props().onClick).toBeDefined();
-    expect(wrapper.find('span.translation-source').text()).toEqual(
-      'GOOGLE TRANSLATE',
-    );
+    getByRole('listitem');
+
+    expect(
+      container.querySelector('span.translation-source'),
+    ).toHaveTextContent(message);
+
+    fireEvent.click(container.querySelector('.selector'));
+    expect(within(getByRole('list')).getAllByRole('listitem')).toHaveLength(3);
   });
 });

--- a/translate/src/modules/machinery/components/source/MicrosoftTerminology.test.jsx
+++ b/translate/src/modules/machinery/components/source/MicrosoftTerminology.test.jsx
@@ -1,4 +1,3 @@
-import { mount } from 'enzyme';
 import React from 'react';
 
 import { Locale } from '~/context/Locale';
@@ -6,6 +5,7 @@ import { Locale } from '~/context/Locale';
 import { MockLocalizationProvider } from '~/test/utils';
 
 import { MicrosoftTerminology } from './MicrosoftTerminology';
+import { render } from '@testing-library/react';
 
 const LOCALE = { msTerminologyCode: 'en-US' };
 const PROPS = {
@@ -14,18 +14,21 @@ const PROPS = {
 
 describe('<MicrosoftTerminology>', () => {
   it('renders the MicrosoftTerminology component properly', () => {
-    const wrapper = mount(
+    const message = 'test-message';
+    const { getByRole } = render(
       <Locale.Provider value={LOCALE}>
-        <MockLocalizationProvider>
+        <MockLocalizationProvider
+          resources={[
+            `machinery-MicrosoftTerminology--translation-source = ${message}`,
+          ]}
+        >
           <MicrosoftTerminology original={PROPS.original} />
         </MockLocalizationProvider>
       </Locale.Provider>,
     );
 
-    expect(wrapper.find('li')).toHaveLength(1);
-    expect(wrapper.find('Localized').props().id).toEqual(
-      'machinery-MicrosoftTerminology--translation-source',
-    );
-    expect(wrapper.find('li span').text()).toEqual('MICROSOFT');
+    expect(
+      getByRole('listitem').querySelector('span.translation-source'),
+    ).toHaveTextContent(message);
   });
 });

--- a/translate/src/modules/machinery/components/source/MicrosoftTranslation.test.jsx
+++ b/translate/src/modules/machinery/components/source/MicrosoftTranslation.test.jsx
@@ -1,16 +1,24 @@
 import React from 'react';
-import { shallow } from 'enzyme';
 
 import { MicrosoftTranslation } from './MicrosoftTranslation';
+import { render } from '@testing-library/react';
+import { MockLocalizationProvider } from '~/test/utils';
 
 describe('<MicrosoftTranslation>', () => {
   it('renders the MicrosoftTranslation component properly', () => {
-    const wrapper = shallow(<MicrosoftTranslation />);
-
-    expect(wrapper.find('li')).toHaveLength(1);
-    expect(wrapper.find('Localized').props().id).toEqual(
-      'machinery-MicrosoftTranslation--translation-source',
+    const message = 'test-message';
+    const { getByRole } = render(
+      <MockLocalizationProvider
+        resources={[
+          `machinery-MicrosoftTranslation--translation-source = ${message}`,
+        ]}
+      >
+        <MicrosoftTranslation />
+      </MockLocalizationProvider>,
     );
-    expect(wrapper.find('li span').text()).toEqual('MICROSOFT TRANSLATOR');
+
+    expect(
+      getByRole('listitem').querySelector('span.translation-source'),
+    ).toHaveTextContent(message);
   });
 });

--- a/translate/src/modules/machinery/components/source/TranslationMemory.test.jsx
+++ b/translate/src/modules/machinery/components/source/TranslationMemory.test.jsx
@@ -1,35 +1,48 @@
 import React from 'react';
-import { shallow } from 'enzyme';
 
 import { TranslationMemory } from './TranslationMemory';
+import { render } from '@testing-library/react';
+import { expect } from 'vitest';
+import { MockLocalizationProvider } from '~/test/utils';
 
 describe('<TranslationMemory>', () => {
   it('renders the component without number of occurrences properly', () => {
-    const wrapper = shallow(<TranslationMemory />);
-
-    expect(wrapper.find('li')).toHaveLength(1);
-    expect(wrapper.find('Localized')).toHaveLength(1);
-
-    expect(wrapper.find('Localized').at(0).props().id).toEqual(
-      'machinery-TranslationMemory--translation-source',
+    const title = 'test-title';
+    const { getByRole } = render(
+      <MockLocalizationProvider
+        resources={[
+          `machinery-TranslationMemory--translation-source = ${title}`,
+        ]}
+      >
+        <TranslationMemory />
+      </MockLocalizationProvider>,
     );
-    expect(wrapper.find('li .translation-source').text()).toEqual(
-      'TRANSLATION MEMORY',
-    );
+
+    getByRole('listitem');
+    expect(
+      getByRole('listitem').querySelector('span.translation-source'),
+    ).toHaveTextContent(title);
   });
 
   it('renders the component with number of occurrences properly', () => {
-    const wrapper = shallow(<TranslationMemory itemCount={2} />);
-
-    expect(wrapper.find('li')).toHaveLength(1);
-    expect(wrapper.find('Localized')).toHaveLength(2);
-
-    expect(wrapper.find('Localized').at(1).props().id).toEqual(
-      'machinery-TranslationMemory--number-occurrences',
+    const occurrenceMsg = 'test-occurrence';
+    const title = 'test-title';
+    const { getByRole, getByText, container, getByTitle } = render(
+      <MockLocalizationProvider
+        resources={[
+          `machinery-TranslationMemory--number-occurrences = 
+                    .title = ${occurrenceMsg}`,
+          `machinery-TranslationMemory--translation-source = ${title}`,
+        ]}
+      >
+        <TranslationMemory itemCount={2} />
+      </MockLocalizationProvider>,
     );
-    expect(wrapper.find('sup').props().title).toEqual(
-      'Number of translation occurrences',
-    );
-    expect(wrapper.find('sup').text()).toContain('2');
+
+    getByRole('listitem');
+    getByText(title);
+
+    expect(container.querySelector('sup')).toHaveTextContent('2');
+    getByTitle(occurrenceMsg);
   });
 });

--- a/translate/src/modules/originalstring/components/RichString.test.jsx
+++ b/translate/src/modules/originalstring/components/RichString.test.jsx
@@ -1,9 +1,9 @@
 import ftl from '@fluent/dedent';
 import React from 'react';
-import { mount } from 'enzyme';
 
 import { editMessageEntry, parseEntry } from '~/utils/message';
 import { RichString } from './RichString';
+import { fireEvent, render } from '@testing-library/react';
 
 const ORIGINAL = ftl`
   song-title = Hello
@@ -14,20 +14,21 @@ const ORIGINAL = ftl`
 describe('<RichString>', () => {
   it('renders value and each attribute correctly', () => {
     const message = editMessageEntry(parseEntry('fluent', ORIGINAL));
-    const wrapper = mount(<RichString message={message} terms={{}} />);
+    const { container } = render(<RichString message={message} terms={{}} />);
 
-    expect(wrapper.find('Highlight')).toHaveLength(3);
+    const labels = container.querySelectorAll('label');
+    const highlights = container.querySelectorAll('td > span');
 
-    expect(wrapper.find('label').at(0).html()).toContain('Value');
-    expect(wrapper.find('Highlight').at(0).html()).toContain('Hello');
+    expect(highlights).toHaveLength(3);
 
-    expect(wrapper.find('label').at(1).html()).toContain('genre');
-    expect(wrapper.find('Highlight').at(1).html()).toContain('Pop');
+    expect(labels[0]).toHaveTextContent('Value');
+    expect(highlights[0]).toHaveTextContent('Hello');
 
-    expect(wrapper.find('label').at(2).html()).toContain('album');
-    expect(wrapper.find('Highlight').at(2).html()).toContain(
-      'Hello and Good Bye',
-    );
+    expect(labels[1]).toHaveTextContent('genre');
+    expect(highlights[1]).toHaveTextContent('Pop');
+
+    expect(labels[2]).toHaveTextContent('album');
+    expect(highlights[2]).toHaveTextContent('Hello and Good Bye');
   });
 
   it('renders select expression correctly', () => {
@@ -40,15 +41,15 @@ describe('<RichString>', () => {
       `;
 
     const message = editMessageEntry(parseEntry('fluent', input));
-    const wrapper = mount(<RichString message={message} terms={{}} />);
+    const { container } = render(<RichString message={message} terms={{}} />);
+    const labels = container.querySelectorAll('label');
+    const highlights = container.querySelectorAll('td > span');
 
-    expect(wrapper.find('Highlight')).toHaveLength(2);
+    expect(labels[0]).toHaveTextContent('variant-1');
+    expect(highlights[0]).toHaveTextContent('Hello!');
 
-    expect(wrapper.find('label').at(0).html()).toContain('variant-1');
-    expect(wrapper.find('Highlight').at(0).html()).toContain('Hello!');
-
-    expect(wrapper.find('label').at(1).html()).toContain('variant-2');
-    expect(wrapper.find('Highlight').at(1).html()).toContain('Good Bye!');
+    expect(labels[1]).toHaveTextContent('variant-2');
+    expect(highlights[1]).toHaveTextContent('Good Bye!');
   });
 
   it('renders select expression in attributes properly', () => {
@@ -67,32 +68,34 @@ describe('<RichString>', () => {
       `;
 
     const message = editMessageEntry(parseEntry('fluent', input));
-    const wrapper = mount(<RichString message={message} terms={{}} />);
+    const { container } = render(<RichString message={message} terms={{}} />);
 
-    expect(wrapper.find('label')).toHaveLength(4);
-    expect(wrapper.find('td > span')).toHaveLength(4);
+    const labels = container.querySelectorAll('label');
+    const highlights = container.querySelectorAll('td > span');
 
-    expect(wrapper.find('label').at(0).html()).toMatch(/label.*macosx/);
-    expect(wrapper.find('td > span').at(0).html()).toContain('Preferences');
+    expect(labels).toHaveLength(4);
+    expect(highlights).toHaveLength(4);
 
-    expect(wrapper.find('label').at(1).html()).toMatch(/label.*other/);
-    expect(wrapper.find('td > span').at(1).html()).toContain('Options');
+    expect(labels[0]).toHaveTextContent(/label.*macosx/);
+    expect(highlights[0]).toHaveTextContent('Preferences');
 
-    expect(wrapper.find('label').at(2).html()).toMatch(/accesskey.*macosx/);
-    expect(wrapper.find('td > span').at(2).html()).toContain('e');
+    expect(labels[1]).toHaveTextContent(/label.*other/);
+    expect(highlights[1]).toHaveTextContent('Options');
 
-    expect(wrapper.find('label').at(3).html()).toMatch(/accesskey.*other/);
-    expect(wrapper.find('td > span').at(3).html()).toContain('s');
+    expect(labels[2]).toHaveTextContent(/accesskey.*macosx/);
+    expect(labels[2]).toHaveTextContent('e');
+
+    expect(labels[3]).toHaveTextContent(/accesskey.*other/);
+    expect(labels[3]).toHaveTextContent('s');
   });
 
   it('calls the onClick function on click on .original', () => {
     const message = editMessageEntry(parseEntry('fluent', ORIGINAL));
     const spy = vi.fn();
-    const wrapper = mount(
+    const { container } = render(
       <RichString message={message} onClick={spy} terms={{}} />,
     );
-
-    wrapper.find('.original').simulate('click');
+    fireEvent.click(container.querySelector('.original'));
     expect(spy).toHaveBeenCalled();
   });
 });

--- a/translate/src/modules/otherlocales/components/OtherLocales.test.jsx
+++ b/translate/src/modules/otherlocales/components/OtherLocales.test.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import { shallow } from 'enzyme';
 
 import { OtherLocales } from './OtherLocales';
+import { render } from '@testing-library/react';
+import { createReduxStore, mountComponentWithStore } from '../../../test/store';
+import { MockLocalizationProvider } from '../../../test/utils';
 
 describe('<OtherLocales>', () => {
   it('shows the correct number of translations', () => {
@@ -29,15 +31,24 @@ describe('<OtherLocales>', () => {
       project: 'tmo',
     };
     const user = {};
-    const wrapper = shallow(
-      <OtherLocales
-        otherlocales={otherlocales}
-        parameters={params}
-        user={user}
-      />,
+    const store = createReduxStore();
+    const testTitle = 'test-title';
+    const resources = `otherlocales-Translation--copy =
+                        .title = ${testTitle}`;
+    const { getAllByTitle } = mountComponentWithStore(
+      OtherLocales,
+      store,
+      {
+        entity: { format: '' },
+        otherlocales: otherlocales,
+        parameters: params,
+        user,
+      },
+      undefined,
+      resources,
     );
 
-    expect(wrapper.find('OtherLocaleTranslationComponent')).toHaveLength(3);
+    expect(getAllByTitle(testTitle)).toHaveLength(3);
   });
 
   it('returns null while otherlocales are loading', () => {
@@ -45,23 +56,27 @@ describe('<OtherLocales>', () => {
       fetching: true,
     };
     const user = {};
-    const wrapper = shallow(
+    const { container } = render(
       <OtherLocales otherlocales={otherlocales} user={user} />,
     );
 
-    expect(wrapper.type()).toBeNull();
+    expect(container).toBeEmptyDOMElement();
   });
 
   it('renders a no results message if otherlocales is empty', () => {
+    const message = 'test-message';
     const otherlocales = {
       fetching: false,
       translations: [],
     };
     const user = {};
-    const wrapper = shallow(
-      <OtherLocales otherlocales={otherlocales} user={user} />,
+    const { getByText } = render(
+      <MockLocalizationProvider
+        resources={[`history-History--no-translations = ${message}`]}
+      >
+        <OtherLocales otherlocales={otherlocales} user={user} />,
+      </MockLocalizationProvider>,
     );
-
-    expect(wrapper.find('#history-history-no-translations')).toHaveLength(1);
+    getByText(message);
   });
 });

--- a/translate/src/modules/otherlocales/components/OtherLocales.tsx
+++ b/translate/src/modules/otherlocales/components/OtherLocales.tsx
@@ -29,7 +29,7 @@ export function OtherLocales({
   if (!translations.length) {
     return (
       <section className='other-locales'>
-        <Localized id='history-history-no-translations'>
+        <Localized id='history-History--no-translations'>
           <p>No translations available.</p>
         </Localized>
       </section>

--- a/translate/src/modules/otherlocales/components/OtherLocalesCount.test.jsx
+++ b/translate/src/modules/otherlocales/components/OtherLocalesCount.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { shallow } from 'enzyme';
 
 import { OtherLocalesCount } from './OtherLocalesCount';
+import { render } from '@testing-library/react';
 
 describe('<OtherLocalesCount>', () => {
   it('shows the correct number of preferred translations', () => {
@@ -21,15 +21,17 @@ describe('<OtherLocalesCount>', () => {
         },
       ],
     };
-    const wrapper = shallow(<OtherLocalesCount otherlocales={otherlocales} />);
+    const { container } = render(
+      <OtherLocalesCount otherlocales={otherlocales} />,
+    );
 
     // There are only preferred results.
-    expect(wrapper.find('.count > span')).toHaveLength(1);
+    expect(container.querySelector('.count > span')).toBeInTheDocument();
 
     // And there are two of them.
-    expect(wrapper.find('.preferred').text()).toContain('2');
+    expect(container.querySelector('.preferred')).toHaveTextContent('2');
 
-    expect(wrapper.text()).not.toContain('+');
+    expect(container).not.toHaveTextContent('+');
   });
 
   it('shows the correct number of other translations', () => {
@@ -52,16 +54,18 @@ describe('<OtherLocalesCount>', () => {
         },
       ],
     };
-    const wrapper = shallow(<OtherLocalesCount otherlocales={otherlocales} />);
+    const { container } = render(
+      <OtherLocalesCount otherlocales={otherlocales} />,
+    );
 
     // There are only remaining results.
-    expect(wrapper.find('.count > span')).toHaveLength(1);
-    expect(wrapper.find('.preferred')).toHaveLength(0);
+    expect(container.querySelector('.count > span')).toBeInTheDocument();
+    expect(container.querySelector('.preferred')).toBeNull();
 
     // And there are three of them.
-    expect(wrapper.find('.count > span').text()).toContain('3');
+    expect(container.querySelector('.count > span')).toHaveTextContent('3');
 
-    expect(wrapper.text()).not.toContain('+');
+    expect(container).not.toHaveTextContent('+');
   });
 
   it('shows the correct numbers of preferred and other translations', () => {
@@ -96,16 +100,19 @@ describe('<OtherLocalesCount>', () => {
         },
       ],
     };
-    const wrapper = shallow(<OtherLocalesCount otherlocales={otherlocales} />);
+    const { container } = render(
+      <OtherLocalesCount otherlocales={otherlocales} />,
+    );
 
     // There are both preferred and remaining, and the '+' sign.
-    expect(wrapper.find('.count > span')).toHaveLength(3);
+    expect(container.querySelectorAll('.count > span')).toHaveLength(3);
 
     // And each count is correct.
-    expect(wrapper.find('.preferred').text()).toContain('2');
-    expect(wrapper.find('.count > span').last().text()).toContain('3');
+    expect(container.querySelector('.preferred')).toHaveTextContent('2');
+    const spans = container.querySelectorAll('.count > span');
+    expect(spans[spans.length - 1]).toHaveTextContent('3');
 
     // And the final display is correct as well.
-    expect(wrapper.text()).toEqual('2+3');
+    expect(container).toHaveTextContent('2+3');
   });
 });

--- a/translate/src/test/store.jsx
+++ b/translate/src/test/store.jsx
@@ -28,10 +28,15 @@ export const createReduxStore = (initialState = {}) =>
     preloadedState: initialState,
   });
 
-export const MockStore = ({ children, store, history = HISTORY, resource }) => (
+export const MockStore = ({
+  children,
+  store,
+  history = HISTORY,
+  resources,
+}) => (
   <Provider store={store}>
     <LocationProvider history={history}>
-      <MockLocalizationProvider resource={resource}>
+      <MockLocalizationProvider resources={resources}>
         {children}
       </MockLocalizationProvider>
     </LocationProvider>
@@ -43,10 +48,10 @@ export const mountComponentWithStore = (
   store,
   props = {},
   history,
-  resource,
+  resources,
 ) =>
   render(
-    <MockStore store={store} history={history} resource={resource}>
+    <MockStore store={store} history={history} resources={resources}>
       <Component {...props} />
     </MockStore>,
   );

--- a/translate/src/test/utils.jsx
+++ b/translate/src/test/utils.jsx
@@ -4,59 +4,7 @@ import {
   Localized,
   ReactLocalization,
 } from '@fluent/react';
-import { shallow } from 'enzyme';
 import React from 'react';
-
-/*
- * Taken from https://github.com/mozilla/addons-frontend/blob/58d1315409f1ad6dc9b979440794df44c1128455/tests/unit/helpers.js#L276
- * Maybe that ought to be put into a library?
- */
-
-/*
- * Repeatedly render a component tree using enzyme.shallow() until
- * finding and rendering TargetComponent.
- *
- * This is useful for testing a component wrapped in one or more
- * HOCs (higher order components).
- *
- * The `componentInstance` parameter is a React component instance.
- * Example: <MyComponent {...props} />
- *
- * The `TargetComponent` parameter is the React class (or function) that
- * you want to retrieve from the component tree.
- */
-export function shallowUntilTarget(
-  componentInstance,
-  TargetComponent,
-  { maxTries = 10, shallowOptions = undefined, _shallow = shallow } = {},
-) {
-  if (!componentInstance) {
-    throw new Error('componentInstance parameter is required');
-  }
-  if (!TargetComponent) {
-    throw new Error('TargetComponent parameter is required');
-  }
-
-  let root = _shallow(componentInstance, shallowOptions);
-
-  if (typeof root.type() === 'string') {
-    // If type() is a string then it's a DOM Node.
-    // If it were wrapped, it would be a React component.
-    throw new Error('Cannot unwrap this component because it is not wrapped');
-  }
-
-  for (let tries = 1; tries <= maxTries; tries++) {
-    if (root.is(TargetComponent)) {
-      // Now that we found the target component, render it.
-      return root.shallow(shallowOptions);
-    }
-    // Unwrap the next component in the hierarchy.
-    root = root.dive();
-  }
-
-  throw new Error(`Could not find ${TargetComponent} in rendered
-        instance: ${componentInstance}; gave up after ${maxTries} tries`);
-}
 
 /*
  * Wait until `ms` milliseconds have passed.
@@ -82,12 +30,16 @@ export function findLocalizedById(wrapper, id) {
  * Mock the @fluent/react LocalizationProvider,
  * which is required as a wrapper for Localization.
  */
-export function MockLocalizationProvider({ children, resource }) {
+export function MockLocalizationProvider({ children, resources }) {
   const bundle = new FluentBundle('en-US');
-  if (resource) {
-    const fluentResource = new FluentResource(resource);
-    bundle.addResource(fluentResource);
-  }
+  const resourceList = Array.isArray(resources) ? resources : [resources];
+
+  resourceList.forEach((res) => {
+    if (res) {
+      const fluentResource = new FluentResource(res);
+      bundle.addResource(fluentResource);
+    }
+  });
   const l10n = new ReactLocalization([bundle], null);
 
   // https://github.com/projectfluent/fluent.js/issues/411


### PR DESCRIPTION
Continuation of previous MR https://github.com/mozilla/pontoon/pull/3992 the migration of enzyme test to @testing-library/react under task https://github.com/mozilla/pontoon/issues/3767