### PR TITLE
Consider missing Android placeholders as errors if translation has extra `%` signs

### DIFF
--- a/pontoon/checks/libraries/custom.py
+++ b/pontoon/checks/libraries/custom.py
@@ -72,17 +72,17 @@ def run_custom_checks(entity: Entity, string: str) -> dict[str, list[str]]:
                 errors.append(f"Parse error: {e}")
 
             orig_pct_count = 0
-            orig_ps: set[str] = set()
+            orig_ph_strings: set[str] = set()
             try:
                 orig_msg = mf2_parse_message(entity.string)
                 for pattern in get_patterns(orig_msg):
-                    ppc = 0
+                    pattern_pct_count = 0
                     for el in pattern:
                         if isinstance(el, str):
-                            ppc += el.count("%")
+                            pattern_pct_count += el.count("%")
                         else:
-                            orig_ps.add(preview_placeholder(el))
-                    orig_pct_count = max(orig_pct_count, ppc)
+                            orig_ph_strings.add(preview_placeholder(el))
+                    orig_pct_count = max(orig_pct_count, pattern_pct_count)
             except ValueError:
                 orig_msg = None
 
@@ -102,20 +102,20 @@ def run_custom_checks(entity: Entity, string: str) -> dict[str, list[str]]:
                     android_msg = android_parse_message(
                         escape(get_simple_preview(Resource.Format.ANDROID, pattern))
                     )
-                    ppc = 0
+                    pattern_pct_count = 0
                     for el in android_msg.pattern:
                         if isinstance(el, str):
-                            ppc += el.count("%")
+                            pattern_pct_count += el.count("%")
                         else:
                             ps = preview_placeholder(el)
-                            if ps in orig_ps:
+                            if ps in orig_ph_strings:
                                 found_ps.add(ps)
                             else:
                                 errors.append(
                                     f"Placeholder {ps} not found in reference"
                                 )
-                    pct_count = max(pct_count, ppc)
-                for ps in orig_ps:
+                    pct_count = max(pct_count, pattern_pct_count)
+                for ps in orig_ph_strings:
                     if ps not in found_ps:
                         ew_list = errors if pct_count > orig_pct_count else warnings
                         ew_list.append(f"Placeholder {ps} not found in translation")

--- a/pontoon/checks/tests/test_custom.py
+++ b/pontoon/checks/tests/test_custom.py
@@ -214,6 +214,24 @@ def test_android_same_placeholder():
     assert run_custom_checks(entity, translation) == {}
 
 
+def test_android_plural_placeholders():
+    original = """
+        .input {$n :number}
+        .match $n
+        one {{One item}}
+        * {{{$arg1 :number @source=|%1$d|} items}}
+    """
+    translation = """
+        .input {$n :number}
+        .match $n
+        one {{{$arg1 :number @source=|%1$d|} item}}
+        many {{{$arg1 :number @source=|%1$d|} items}}
+        * {{{$arg1 :number @source=|%1$d|} items}}
+    """
+    entity = mock_entity("android", string=original)
+    assert run_custom_checks(entity, translation) == {}
+
+
 def test_android_missing_placeholder():
     original = "Source string with a {$arg1 :string @source=|%1$s|}"
     translation = "Translation"


### PR DESCRIPTION
Fixes #4035
See also [bug 2025733](https://bugzilla.mozilla.org/show_bug.cgi?id=2025733)

This should cover the cases where a placeholder is mistyped so that it doesn't parse as an Android placeholder, but still at least starts with a `%` character.