### PR TITLE
Add indentation to Translation comments

### DIFF
--- a/translate/src/modules/comments/components/CommentsList.css
+++ b/translate/src/modules/comments/components/CommentsList.css
@@ -8,6 +8,10 @@
   margin-top: -16px; /* Offset editor height(-2px normal mode gap + -14px edit mode gap) */
 }
 
+.comments-list .comment.is-editing .add-comment {
+  margin-left: 0;
+}
+
 .comments-list .pinned-comments > * {
   padding: 0 8px;
 }
@@ -30,7 +34,7 @@
 
 .comments-list .comment {
   display: flex;
-  margin-left: 0px;
+  margin-left: 58px;
 }
 
 .comments-list .comment .user-avatar {


### PR DESCRIPTION

Fixes #4042

Fixing comments indentation introduced by https://github.com/mozilla/pontoon/pull/4024

<img width="1584" height="814" alt="Screenshot 2026-03-26 at 20 45 55" src="https://github.com/user-attachments/assets/8a241f5e-30b6-497c-b7d1-2203b0f2491d" />


