### PR TITLE
fix: add comma flag to printf regex to correctly highlight  placeholder

### DIFF
--- a/translate/src/modules/placeable/components/Highlight.test.jsx
+++ b/translate/src/modules/placeable/components/Highlight.test.jsx
@@ -257,6 +257,7 @@ describe('specific marker', () => {
     ['There were %Id cows', '%Id'],
     ['There were %d %s', '%d', '%s'],
     ['%1$s was kicked by %2$s', '%1$s', '%2$s'],
+    ['You have %1$s items and %2$,d points', '%1$s', '%2$,d'],
     ['There were %Id cows', '%Id'],
     ["There were %'f cows", "%'f"],
     ['There were %#x cows', '%#x'],

--- a/translate/src/modules/placeable/placeholder.ts
+++ b/translate/src/modules/placeable/placeholder.ts
@@ -5,8 +5,9 @@ export const placeholder = (() => {
   const curly = '{(?:(?:"[^"]*")|[^}])*}}?';
   // All printf-ish formats, including Python's.
   // Excludes Python's ` ` conversion flag, due to false positives -- https://github.com/mozilla/pontoon/issues/2988
+  // Includes `,` (thousands-separator flag) used in Java/Android format strings, e.g. `%2$,d`
   const printf =
-    "%(?:\\d\\$|\\(.*?\\))?[-+0'#I]*[\\d*]*(?:\\.[\\d*])?(?:hh?|ll?|[jLtz])?[%@AaCcdEeFfGginopSsuXx]";
+    "%(?:\\d\\$|\\(.*?\\))?[-+0'#I,]*[\\d*]*(?:\\.[\\d*])?(?:hh?|ll?|[jLtz])?[%@AaCcdEeFfGginopSsuXx]";
   // Qt placeholders -- https://doc.qt.io/qt-5/qstring.html#arg
   const qt = '%L?\\d{1,2}';
   // HTML/XML &entities;

--- a/translate/src/modules/translationform/utils/editFieldModes.ts
+++ b/translate/src/modules/translationform/utils/editFieldModes.ts
@@ -84,7 +84,7 @@ export const fluentMode: StreamParser<Array<'expression' | 'literal' | 'tag'>> =
 // due to false positives.
 // https://github.com/mozilla/pontoon/issues/2988
 const printf =
-  /^%(\d\$|\(.*?\))?[-+0'#]*[\d*]*(\.[\d*])?(hh?|ll?|[jLtz])?[%@AacdEeFfGginopSsuXx]/;
+  /^%(\d\$|\(.*?\))?[-+0'#I,]*[\d*]*(\.[\d*])?(hh?|ll?|[jLtz])?[%@AacdEeFfGginopSsuXx]/;
 
 const pythonFormat = /^{[\w.[\]]*(![rsa])?(:.*?)?}/;
 


### PR DESCRIPTION
 ## Description
 The printf placeholder regex in Pontoon's translation editor did not include the , (comma) flag in its format specifier pattern. This caused placeholders like %2$,d, a valid Java/Android printf format that renders integers with thousands separators (e.g. 1,000), to go un-highlighted in the translate view, making them invisible to translators who need to preserve them in their translations.

 The fix adds , to the flags character class in the printf regex in both placeholder.ts (used for highlighting) and editFieldModes.ts (used for editor syntax),bringing them in sync and ensuring %2$,d is correctly identified and highlighted alongside other placeholders.

 ## Closes
 Fixes #4039 
 ## Screenshots
<img width="180" height="32" alt="Screenshot 2026-03-29 205402" src="https://github.com/user-attachments/assets/fcf9b040-1705-4a03-914a-7ec4d32f39bb" />
