### PR TITLE
Include newly added files in sync and pretranslation

### DIFF
--- a/pontoon/sync/core/entities.py
+++ b/pontoon/sync/core/entities.py
@@ -72,12 +72,14 @@ def sync_resources_from_repo(
         renamed_paths = rename_resources(project, paths, checkout)
         removed_paths = remove_resources(project, paths, checkout)
         old_res_added_ent_count, changed_paths = update_resources(project, updates, now)
-        new_res_added_ent_count, _ = add_resources(project, updates, changed_paths, now)
+        new_res_added_ent_count, added_paths = add_resources(
+            project, updates, changed_paths, now
+        )
         update_translated_resources(project, locale_map, paths)
 
     return (
         old_res_added_ent_count + new_res_added_ent_count,
-        renamed_paths | changed_paths,
+        renamed_paths | changed_paths | added_paths,
         removed_paths,
     )
 

--- a/pontoon/sync/tests/test_entities.py
+++ b/pontoon/sync/tests/test_entities.py
@@ -176,7 +176,7 @@ def test_add_resource():
         # Test
         assert sync_resources_from_repo(
             project, locale_map, mock_checkout, paths, now
-        ) == (3, set(), set())
+        ) == (3, {"c.ftl"}, set())
         res_c = project.resources.get(path="c.ftl")
         TranslatedResource.objects.get(resource=res_c)
         assert set(tuple(ent.key) for ent in Entity.objects.filter(resource=res_c)) == {


### PR DESCRIPTION
Fixes #2902.

This seems too easy of a fix, so I might be off. I don't understand why `added_files` wasn't included before, and we have some [safeguards](https://github.com/mozilla/pontoon/blob/main/pontoon/sync/core/translations_to_repo.py#L231-L232) against writing empty target files.