### PR TITLE
Improve behavior of translation search page with browser's history

### DIFF
--- a/pontoon/search/static/js/search.js
+++ b/pontoon/search/static/js/search.js
@@ -144,22 +144,7 @@ $(function () {
   });
 
   $(window).on('popstate', function () {
-    url.href = window.location.href;
-    const search = url.searchParams.get('search');
-    currentPage = 1;
-    hasMore = false;
-
-    if (search) {
-      $('#entity-list').empty();
-      $('#no-results').hide();
-      $('.search-input').val(search);
-      const pages = parseInt(url.searchParams.get('pages')) || 1;
-      loadMoreEntries({ pages });
-    } else {
-      $('#entity-list').empty().hide();
-      $('#no-results').hide();
-      $('.search-input').val('');
-    }
+    location.reload();
   });
 
   if (url.searchParams.get('search')) {


### PR DESCRIPTION
This patch allows users of [https://pontoon.mozilla.org/search/](https://pontoon.mozilla.org/search/) to be able to click and the "back" and "forward" buttons on their browser to access historical searches, which is inline with expected search engine behaviour.

Fixes #3942.