### PR TITLE
Ignore `%%` and `%n` when checking Android placeholders

### DIFF
--- a/pontoon/checks/libraries/custom.py
+++ b/pontoon/checks/libraries/custom.py
@@ -80,7 +80,7 @@ def run_custom_checks(entity: Entity, string: str) -> dict[str, list[str]]:
                     for el in pattern:
                         if isinstance(el, str):
                             pattern_pct_count += el.count("%")
-                        else:
+                        elif not (isinstance(el, Expression) and el.arg in ("%", "\n")):
                             orig_ph_strings.add(preview_placeholder(el))
                     orig_pct_count = max(orig_pct_count, pattern_pct_count)
             except ValueError:
@@ -106,7 +106,7 @@ def run_custom_checks(entity: Entity, string: str) -> dict[str, list[str]]:
                     for el in android_msg.pattern:
                         if isinstance(el, str):
                             pattern_pct_count += el.count("%")
-                        else:
+                        elif not (isinstance(el, Expression) and el.arg in ("%", "\n")):
                             ps = preview_placeholder(el)
                             if ps in orig_ph_strings:
                                 found_ps.add(ps)

--- a/pontoon/checks/tests/test_custom.py
+++ b/pontoon/checks/tests/test_custom.py
@@ -315,6 +315,13 @@ def test_android_bad_html():
     }
 
 
+def test_android_extra_percent():
+    original = "Source percent"
+    translation = "Translation {|%| @source=|%%|}"
+    entity = mock_entity("android", string=original)
+    assert run_custom_checks(entity, translation) == {}
+
+
 def test_webext_literal_index_placeholder_as_placeholder():
     original = "Source string with a {$arg1 @source=|$1|}"
     translation = "Translation with a {$arg1 @source=|$1|}"


### PR DESCRIPTION
Patch for mozilla/moz-l10n#132