### PR TITLE
Highlight placeables in the Translation Memory Tab

### DIFF
--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -24,8 +24,9 @@ from django.utils.html import escape
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.safestring import mark_safe
 
-from pontoon.base.simple_preview import get_simple_preview
 from pontoon.base.placeables import get_placeables
+from pontoon.base.simple_preview import get_simple_preview
+
 
 register = template.Library()
 

--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -25,7 +25,7 @@ from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.safestring import mark_safe
 
 from pontoon.base.simple_preview import get_simple_preview
-
+from pontoon.base.placeables import get_placeables
 
 register = template.Library()
 
@@ -84,6 +84,24 @@ def static(path):
 def full_static(path):
     """Generate an absolute URL for a static file."""
     return urljoin(settings.SITE_URL, static(path))
+
+
+@library.filter
+def highlight_placeables(text):
+    if not text:
+        return text
+
+    placeables = get_placeables(text)
+    escaped = html.escape(text)
+
+    for p in placeables:
+        escaped_p = html.escape(p)
+        escaped = escaped.replace(
+            escaped_p,
+            f'<mark class="placeable" data-match="{escaped_p}">{escaped_p}</mark>',
+        )
+
+    return markupsafe.Markup(escaped)
 
 
 @library.filter

--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -93,9 +93,10 @@ def highlight_placeables(text):
         return text
 
     placeables = get_placeables(text)
-    escaped = html.escape(text)
 
-    for p in placeables:
+    escaped = str(text) if isinstance(text, markupsafe.Markup) else html.escape(text)
+
+    for p in sorted(placeables, key=len, reverse=True):
         escaped_p = html.escape(p)
         escaped = escaped.replace(
             escaped_p,
@@ -322,7 +323,11 @@ def highlight_matches(
     if not search_query:
         return text
 
-    escaped_text = escape(text)
+    if isinstance(text, markupsafe.Markup):
+        escaped_text = str(text)
+    else:
+        escaped_text = escape(text)
+
     flags = 0 if match_case_enabled else re.IGNORECASE
 
     if advanced:

--- a/pontoon/teams/static/css/translation_memory.css
+++ b/pontoon/teams/static/css/translation_memory.css
@@ -124,7 +124,7 @@
           }
 
           mark.placeable {
-            background: var(--grey-3);
+            background: var(--dark-grey-2);
             border: 1px solid var(--light-grey-1);
             border-radius: 2px;
             color: var(--light-grey-6);

--- a/pontoon/teams/static/css/translation_memory.css
+++ b/pontoon/teams/static/css/translation_memory.css
@@ -123,6 +123,16 @@
             border-radius: 3px;
           }
 
+          mark.placeable {
+            background: var(--grey-3);
+            border: 1px solid var(--light-grey-1);
+            border-radius: 2px;
+            color: var(--light-grey-6);
+            font-style: normal;
+            font-weight: normal;
+            margin: 0 1px;
+          }
+
           .empty {
             border: 1px solid var(--main-border-1);
             border-radius: 3px;

--- a/pontoon/teams/templates/teams/widgets/translation_memory_entries.html
+++ b/pontoon/teams/templates/teams/widgets/translation_memory_entries.html
@@ -13,11 +13,11 @@
 {% for entry in tm_entries %}
   <tr data-ids="{{ entry.ids }}">
     <td class="source text">
-      {{ linkify(entry.source|highlight_matches(search_query), entry.entity_ids) }}
+      {{ linkify(entry.source|highlight_placeables|highlight_matches(search_query), entry.entity_ids) }}
     </td>
     <td class="target text">
       <div class="content-wrapper">
-        {{ linkify(entry.target|highlight_matches(search_query), entry.entity_ids) }}
+        {{ linkify(entry.source|highlight_placeables|highlight_matches(search_query), entry.entity_ids) }}
       </div>
       <textarea>{{ entry.target }}</textarea>
     </td>

--- a/pontoon/teams/templates/teams/widgets/translation_memory_entries.html
+++ b/pontoon/teams/templates/teams/widgets/translation_memory_entries.html
@@ -17,7 +17,7 @@
     </td>
     <td class="target text">
       <div class="content-wrapper">
-        {{ linkify(entry.source|highlight_placeables|highlight_matches(search_query), entry.entity_ids) }}
+        {{ linkify(entry.target|highlight_placeables|highlight_matches(search_query), entry.entity_ids) }}
       </div>
       <textarea>{{ entry.target }}</textarea>
     </td>


### PR DESCRIPTION
Fixes #3445 

Placeables are now highlighted in this view: http://localhost:8000/sl/translation-memory/

To test, navigate to that link and see if they're highlighted.