### PR TITLE
Translate: link project names in concordance search to corresponding views

### DIFF
--- a/pontoon/machinery/tests/test_views.py
+++ b/pontoon/machinery/tests/test_views.py
@@ -632,6 +632,7 @@ def test_view_concordance_search(client, project_a, locale_a, resource_a):
                         "project_name": "Project A",
                         "project_slug": "project_a",
                         "project_disabled": False,
+                        "project_locale_exists": False,
                         "entities": [entities[1].id],
                     }
                 ],
@@ -655,6 +656,7 @@ def test_view_concordance_search(client, project_a, locale_a, resource_a):
                         "project_name": "Project A",
                         "project_slug": "project_a",
                         "project_disabled": False,
+                        "project_locale_exists": False,
                         "entities": [entities[0].id],
                     }
                 ],
@@ -720,12 +722,14 @@ def test_view_concordance_search_multiple_project_names(
                         "project_name": project_a.name,
                         "project_slug": project_a.slug,
                         "project_disabled": project_a.disabled,
+                        "project_locale_exists": False,
                         "entities": [entities[0].id],
                     },
                     {
                         "project_name": project_b.name,
                         "project_slug": project_b.slug,
                         "project_disabled": project_b.disabled,
+                        "project_locale_exists": False,
                         "entities": [entities[0].id],
                     },
                 ],
@@ -738,6 +742,7 @@ def test_view_concordance_search_multiple_project_names(
                         "project_name": project_a.name,
                         "project_slug": project_a.slug,
                         "project_disabled": project_a.disabled,
+                        "project_locale_exists": False,
                         "entities": [entities[1].id],
                     }
                 ],
@@ -806,6 +811,7 @@ def test_view_concordance_search_remove_duplicates(
                         "project_name": project_a.name,
                         "project_slug": project_a.slug,
                         "project_disabled": project_a.disabled,
+                        "project_locale_exists": False,
                         "entities": [entities[0].id],
                     }
                 ],
@@ -818,6 +824,7 @@ def test_view_concordance_search_remove_duplicates(
                         "project_name": project_a.name,
                         "project_slug": project_a.slug,
                         "project_disabled": project_a.disabled,
+                        "project_locale_exists": False,
                         "entities": [entities[1].id],
                     }
                 ],
@@ -830,6 +837,7 @@ def test_view_concordance_search_remove_duplicates(
                         "project_name": project_a.name,
                         "project_slug": project_a.slug,
                         "project_disabled": project_a.disabled,
+                        "project_locale_exists": False,
                         "entities": [entities[1].id],
                     }
                 ],
@@ -902,6 +910,7 @@ def test_view_concordance_search_pagination(client, project_a, locale_a, resourc
                         "project_name": project_a.name,
                         "project_slug": project_a.slug,
                         "project_disabled": project_a.disabled,
+                        "project_locale_exists": False,
                         "entities": [entities[0].id],
                     }
                 ],
@@ -925,6 +934,7 @@ def test_view_concordance_search_pagination(client, project_a, locale_a, resourc
                         "project_name": project_a.name,
                         "project_slug": project_a.slug,
                         "project_disabled": project_a.disabled,
+                        "project_locale_exists": False,
                         "entities": [entities[1].id],
                     }
                 ],
@@ -989,6 +999,7 @@ def test_view_concordance_search_null_project_exclusion(
                         "project_name": project_a.name,
                         "project_slug": project_a.slug,
                         "project_disabled": project_a.disabled,
+                        "project_locale_exists": False,
                         "entities": [entities[1].id],
                     }
                 ],

--- a/pontoon/machinery/tests/test_views.py
+++ b/pontoon/machinery/tests/test_views.py
@@ -943,3 +943,56 @@ def test_view_concordance_search_pagination(client, project_a, locale_a, resourc
         "results": [],
         "has_next": False,
     }
+
+
+@pytest.mark.django_db
+def test_view_concordance_search_null_project_exclusion(
+    client, project_a, locale_a, resource_a
+):
+    entities = [
+        EntityFactory(
+            resource=resource_a,
+            string=x,
+            order=i,
+        )
+        for i, x in enumerate(["abaa", "abaf"])
+    ]
+
+    TranslationMemoryFactory.create(
+        entity=entities[0],
+        source=entities[0].string,
+        target="ccc",
+        locale=locale_a,
+        project=None,
+    )
+
+    TranslationMemoryFactory.create(
+        entity=entities[1],
+        source=entities[1].string,
+        target="cccbbb",
+        locale=locale_a,
+        project=project_a,
+    )
+
+    response = client.get(
+        "/concordance-search/",
+        {"text": "ccc", "locale": locale_a.code},
+    )
+    results = json.loads(response.content)
+    assert results == {
+        "results": [
+            {
+                "source": "abaf",
+                "target": "cccbbb",
+                "tmEntries": [
+                    {
+                        "projectName": project_a.name,
+                        "projectSlug": project_a.slug,
+                        "projectDisabled": project_a.disabled,
+                        "entities": [entities[1].id],
+                    }
+                ],
+            },
+        ],
+        "has_next": False,
+    }

--- a/pontoon/machinery/tests/test_views.py
+++ b/pontoon/machinery/tests/test_views.py
@@ -624,7 +624,18 @@ def test_view_concordance_search(client, project_a, locale_a, resource_a):
     result = json.loads(response.content)
     assert result == {
         "results": [
-            {"source": "aBaf", "target": "cCDd", "project_names": [project_a.name]}
+            {
+                "source": "aBaf",
+                "target": "cCDd",
+                "tmEntries": [
+                    {
+                        "projectName": "Project A",
+                        "projectSlug": "project_a",
+                        "projectDisabled": False,
+                        "entities": [entities[1].id],
+                    }
+                ],
+            }
         ],
         "has_next": False,
     }
@@ -636,7 +647,18 @@ def test_view_concordance_search(client, project_a, locale_a, resource_a):
     result = json.loads(response.content)
     assert result == {
         "results": [
-            {"source": "abaa", "target": "ccc", "project_names": [project_a.name]}
+            {
+                "source": "abaa",
+                "target": "ccc",
+                "tmEntries": [
+                    {
+                        "projectName": "Project A",
+                        "projectSlug": "project_a",
+                        "projectDisabled": False,
+                        "entities": [entities[0].id],
+                    }
+                ],
+            }
         ],
         "has_next": False,
     }
@@ -693,9 +715,33 @@ def test_view_concordance_search_multiple_project_names(
             {
                 "source": "abaa",
                 "target": "ccc",
-                "project_names": [project_a.name, project_b.name],
+                "tmEntries": [
+                    {
+                        "projectName": project_a.name,
+                        "projectSlug": project_a.slug,
+                        "projectDisabled": project_a.disabled,
+                        "entities": [entities[0].id],
+                    },
+                    {
+                        "projectName": project_b.name,
+                        "projectSlug": project_b.slug,
+                        "projectDisabled": project_b.disabled,
+                        "entities": [entities[0].id],
+                    },
+                ],
             },
-            {"source": "abaf", "target": "ccc", "project_names": [project_a.name]},
+            {
+                "source": "abaf",
+                "target": "ccc",
+                "tmEntries": [
+                    {
+                        "projectName": project_a.name,
+                        "projectSlug": project_a.slug,
+                        "projectDisabled": project_a.disabled,
+                        "entities": [entities[1].id],
+                    }
+                ],
+            },
         ],
         "has_next": False,
     }
@@ -752,9 +798,42 @@ def test_view_concordance_search_remove_duplicates(
     results = json.loads(response.content)
     assert results == {
         "results": [
-            {"source": "abaa", "target": "ccc", "project_names": [project_a.name]},
-            {"source": "abaf", "target": "ccc", "project_names": [project_a.name]},
-            {"source": "abaf", "target": "cccbbb", "project_names": [project_a.name]},
+            {
+                "source": "abaa",
+                "target": "ccc",
+                "tmEntries": [
+                    {
+                        "projectName": project_a.name,
+                        "projectSlug": project_a.slug,
+                        "projectDisabled": project_a.disabled,
+                        "entities": [entities[0].id],
+                    }
+                ],
+            },
+            {
+                "source": "abaf",
+                "target": "ccc",
+                "tmEntries": [
+                    {
+                        "projectName": project_a.name,
+                        "projectSlug": project_a.slug,
+                        "projectDisabled": project_a.disabled,
+                        "entities": [entities[1].id],
+                    }
+                ],
+            },
+            {
+                "source": "abaf",
+                "target": "cccbbb",
+                "tmEntries": [
+                    {
+                        "projectName": project_a.name,
+                        "projectSlug": project_a.slug,
+                        "projectDisabled": project_a.disabled,
+                        "entities": [entities[1].id],
+                    }
+                ],
+            },
         ],
         "has_next": False,
     }
@@ -815,7 +894,18 @@ def test_view_concordance_search_pagination(client, project_a, locale_a, resourc
     results = json.loads(response.content)
     assert results == {
         "results": [
-            {"source": "abaa", "target": "ccc", "project_names": [project_a.name]},
+            {
+                "source": "abaa",
+                "target": "ccc",
+                "tmEntries": [
+                    {
+                        "projectName": project_a.name,
+                        "projectSlug": project_a.slug,
+                        "projectDisabled": project_a.disabled,
+                        "entities": [entities[0].id],
+                    }
+                ],
+            },
         ],
         "has_next": True,
     }
@@ -827,7 +917,18 @@ def test_view_concordance_search_pagination(client, project_a, locale_a, resourc
     results = json.loads(response.content)
     assert results == {
         "results": [
-            {"source": "abaf", "target": "cccbbb", "project_names": [project_a.name]},
+            {
+                "source": "abaf",
+                "target": "cccbbb",
+                "tmEntries": [
+                    {
+                        "projectName": project_a.name,
+                        "projectSlug": project_a.slug,
+                        "projectDisabled": project_a.disabled,
+                        "entities": [entities[1].id],
+                    }
+                ],
+            },
         ],
         "has_next": False,
     }

--- a/pontoon/machinery/tests/test_views.py
+++ b/pontoon/machinery/tests/test_views.py
@@ -631,8 +631,8 @@ def test_view_concordance_search(client, project_a, locale_a, resource_a):
                 "target": "cCDd",
                 "projects": [
                     {
-                        "project_name": "Project A",
-                        "project_slug": "project_a",
+                        "name": "Project A",
+                        "slug": "project_a",
                     }
                 ],
                 "entities": [entities[1].id],
@@ -653,8 +653,8 @@ def test_view_concordance_search(client, project_a, locale_a, resource_a):
                 "target": "ccc",
                 "projects": [
                     {
-                        "project_name": "Project A",
-                        "project_slug": "project_a",
+                        "name": "Project A",
+                        "slug": "project_a",
                     }
                 ],
                 "entities": [entities[0].id],
@@ -665,7 +665,7 @@ def test_view_concordance_search(client, project_a, locale_a, resource_a):
 
 
 @pytest.mark.django_db
-def test_view_concordance_search_multiple_project_names(
+def test_view_concordance_search_multiple_names(
     client, project_a, project_b, locale_a, locale_b, resource_a
 ):
     """Check Concordance search doesn't produce duplicated search results."""
@@ -719,12 +719,12 @@ def test_view_concordance_search_multiple_project_names(
                 "target": "ccc",
                 "projects": [
                     {
-                        "project_name": project_a.name,
-                        "project_slug": project_a.slug,
+                        "name": project_a.name,
+                        "slug": project_a.slug,
                     },
                     {
-                        "project_name": project_b.name,
-                        "project_slug": project_b.slug,
+                        "name": project_b.name,
+                        "slug": project_b.slug,
                     },
                 ],
                 "entities": [entities[0].id],
@@ -734,8 +734,8 @@ def test_view_concordance_search_multiple_project_names(
                 "target": "ccc",
                 "projects": [
                     {
-                        "project_name": project_a.name,
-                        "project_slug": project_a.slug,
+                        "name": project_a.name,
+                        "slug": project_a.slug,
                     }
                 ],
                 "entities": [entities[1].id],
@@ -802,8 +802,8 @@ def test_view_concordance_search_remove_duplicates(
                 "target": "ccc",
                 "projects": [
                     {
-                        "project_name": project_a.name,
-                        "project_slug": project_a.slug,
+                        "name": project_a.name,
+                        "slug": project_a.slug,
                     }
                 ],
                 "entities": [entities[0].id],
@@ -813,8 +813,8 @@ def test_view_concordance_search_remove_duplicates(
                 "target": "ccc",
                 "projects": [
                     {
-                        "project_name": project_a.name,
-                        "project_slug": project_a.slug,
+                        "name": project_a.name,
+                        "slug": project_a.slug,
                     }
                 ],
                 "entities": [entities[1].id],
@@ -824,8 +824,8 @@ def test_view_concordance_search_remove_duplicates(
                 "target": "cccbbb",
                 "projects": [
                     {
-                        "project_name": project_a.name,
-                        "project_slug": project_a.slug,
+                        "name": project_a.name,
+                        "slug": project_a.slug,
                     }
                 ],
                 "entities": [entities[1].id],
@@ -897,8 +897,8 @@ def test_view_concordance_search_pagination(client, project_a, locale_a, resourc
                 "target": "ccc",
                 "projects": [
                     {
-                        "project_name": project_a.name,
-                        "project_slug": project_a.slug,
+                        "name": project_a.name,
+                        "slug": project_a.slug,
                     }
                 ],
                 "entities": [entities[0].id],
@@ -919,8 +919,8 @@ def test_view_concordance_search_pagination(client, project_a, locale_a, resourc
                 "target": "cccbbb",
                 "projects": [
                     {
-                        "project_name": project_a.name,
-                        "project_slug": project_a.slug,
+                        "name": project_a.name,
+                        "slug": project_a.slug,
                     }
                 ],
                 "entities": [entities[1].id],
@@ -983,8 +983,8 @@ def test_view_concordance_search_null_project_exclusion(
                 "target": "cccbbb",
                 "projects": [
                     {
-                        "project_name": project_a.name,
-                        "project_slug": project_a.slug,
+                        "name": project_a.name,
+                        "slug": project_a.slug,
                     }
                 ],
                 "entities": [entities[1].id],

--- a/pontoon/machinery/tests/test_views.py
+++ b/pontoon/machinery/tests/test_views.py
@@ -16,6 +16,7 @@ from pontoon.base.models import (
 )
 from pontoon.test.factories import (
     EntityFactory,
+    ProjectLocaleFactory,
     SectionFactory,
     TeamCommentFactory,
     TermFactory,
@@ -602,6 +603,7 @@ def test_view_concordance_search(client, project_a, locale_a, resource_a):
         )
         for i, x in enumerate(["abaa", "aBaf", "aaAb", "aAab"])
     ]
+    ProjectLocaleFactory.create(project=project_a, locale=locale_a)
     TranslationMemoryFactory.create(
         entity=entities[0],
         source=entities[0].string,
@@ -627,15 +629,13 @@ def test_view_concordance_search(client, project_a, locale_a, resource_a):
             {
                 "source": "aBaf",
                 "target": "cCDd",
-                "tm_entries": [
+                "projects": [
                     {
                         "project_name": "Project A",
                         "project_slug": "project_a",
-                        "project_disabled": False,
-                        "project_locale_exists": False,
-                        "entities": [entities[1].id],
                     }
                 ],
+                "entities": [entities[1].id],
             }
         ],
         "has_next": False,
@@ -651,15 +651,13 @@ def test_view_concordance_search(client, project_a, locale_a, resource_a):
             {
                 "source": "abaa",
                 "target": "ccc",
-                "tm_entries": [
+                "projects": [
                     {
                         "project_name": "Project A",
                         "project_slug": "project_a",
-                        "project_disabled": False,
-                        "project_locale_exists": False,
-                        "entities": [entities[0].id],
                     }
                 ],
+                "entities": [entities[0].id],
             }
         ],
         "has_next": False,
@@ -679,6 +677,8 @@ def test_view_concordance_search_multiple_project_names(
         )
         for i, x in enumerate(["abaa", "abaf"])
     ]
+    ProjectLocaleFactory.create(project=project_a, locale=locale_a)
+    ProjectLocaleFactory.create(project=project_b, locale=locale_a)
     TranslationMemoryFactory.create(
         entity=entities[1],
         source=entities[1].string,
@@ -717,35 +717,28 @@ def test_view_concordance_search_multiple_project_names(
             {
                 "source": "abaa",
                 "target": "ccc",
-                "tm_entries": [
+                "projects": [
                     {
                         "project_name": project_a.name,
                         "project_slug": project_a.slug,
-                        "project_disabled": project_a.disabled,
-                        "project_locale_exists": False,
-                        "entities": [entities[0].id],
                     },
                     {
                         "project_name": project_b.name,
                         "project_slug": project_b.slug,
-                        "project_disabled": project_b.disabled,
-                        "project_locale_exists": False,
-                        "entities": [entities[0].id],
                     },
                 ],
+                "entities": [entities[0].id],
             },
             {
                 "source": "abaf",
                 "target": "ccc",
-                "tm_entries": [
+                "projects": [
                     {
                         "project_name": project_a.name,
                         "project_slug": project_a.slug,
-                        "project_disabled": project_a.disabled,
-                        "project_locale_exists": False,
-                        "entities": [entities[1].id],
                     }
                 ],
+                "entities": [entities[1].id],
             },
         ],
         "has_next": False,
@@ -765,6 +758,7 @@ def test_view_concordance_search_remove_duplicates(
         )
         for i, x in enumerate(["abaa", "abaf"])
     ]
+    ProjectLocaleFactory.create(project=project_a, locale=locale_a)
     TranslationMemoryFactory.create(
         entity=entities[0],
         source=entities[0].string,
@@ -806,41 +800,35 @@ def test_view_concordance_search_remove_duplicates(
             {
                 "source": "abaa",
                 "target": "ccc",
-                "tm_entries": [
+                "projects": [
                     {
                         "project_name": project_a.name,
                         "project_slug": project_a.slug,
-                        "project_disabled": project_a.disabled,
-                        "project_locale_exists": False,
-                        "entities": [entities[0].id],
                     }
                 ],
+                "entities": [entities[0].id],
             },
             {
                 "source": "abaf",
                 "target": "ccc",
-                "tm_entries": [
+                "projects": [
                     {
                         "project_name": project_a.name,
                         "project_slug": project_a.slug,
-                        "project_disabled": project_a.disabled,
-                        "project_locale_exists": False,
-                        "entities": [entities[1].id],
                     }
                 ],
+                "entities": [entities[1].id],
             },
             {
                 "source": "abaf",
                 "target": "cccbbb",
-                "tm_entries": [
+                "projects": [
                     {
                         "project_name": project_a.name,
                         "project_slug": project_a.slug,
-                        "project_disabled": project_a.disabled,
-                        "project_locale_exists": False,
-                        "entities": [entities[1].id],
                     }
                 ],
+                "entities": [entities[1].id],
             },
         ],
         "has_next": False,
@@ -872,6 +860,8 @@ def test_view_concordance_search_pagination(client, project_a, locale_a, resourc
         EntityFactory(resource=resource_a, string=x, order=i)
         for i, x in enumerate(["abaa", "abaf"])
     ]
+    ProjectLocaleFactory.create(project=project_a, locale=locale_a)
+
     TranslationMemoryFactory.create(
         entity=entities[0],
         source=entities[0].string,
@@ -905,15 +895,13 @@ def test_view_concordance_search_pagination(client, project_a, locale_a, resourc
             {
                 "source": "abaa",
                 "target": "ccc",
-                "tm_entries": [
+                "projects": [
                     {
                         "project_name": project_a.name,
                         "project_slug": project_a.slug,
-                        "project_disabled": project_a.disabled,
-                        "project_locale_exists": False,
-                        "entities": [entities[0].id],
                     }
                 ],
+                "entities": [entities[0].id],
             },
         ],
         "has_next": True,
@@ -929,15 +917,13 @@ def test_view_concordance_search_pagination(client, project_a, locale_a, resourc
             {
                 "source": "abaf",
                 "target": "cccbbb",
-                "tm_entries": [
+                "projects": [
                     {
                         "project_name": project_a.name,
                         "project_slug": project_a.slug,
-                        "project_disabled": project_a.disabled,
-                        "project_locale_exists": False,
-                        "entities": [entities[1].id],
                     }
                 ],
+                "entities": [entities[1].id],
             },
         ],
         "has_next": False,
@@ -968,6 +954,7 @@ def test_view_concordance_search_null_project_exclusion(
         for i, x in enumerate(["abaa", "abaf"])
     ]
 
+    ProjectLocaleFactory.create(project=project_a, locale=locale_a)
     TranslationMemoryFactory.create(
         entity=entities[0],
         source=entities[0].string,
@@ -994,15 +981,13 @@ def test_view_concordance_search_null_project_exclusion(
             {
                 "source": "abaf",
                 "target": "cccbbb",
-                "tm_entries": [
+                "projects": [
                     {
                         "project_name": project_a.name,
                         "project_slug": project_a.slug,
-                        "project_disabled": project_a.disabled,
-                        "project_locale_exists": False,
-                        "entities": [entities[1].id],
                     }
                 ],
+                "entities": [entities[1].id],
             },
         ],
         "has_next": False,

--- a/pontoon/machinery/tests/test_views.py
+++ b/pontoon/machinery/tests/test_views.py
@@ -627,11 +627,11 @@ def test_view_concordance_search(client, project_a, locale_a, resource_a):
             {
                 "source": "aBaf",
                 "target": "cCDd",
-                "tmEntries": [
+                "tm_entries": [
                     {
-                        "projectName": "Project A",
-                        "projectSlug": "project_a",
-                        "projectDisabled": False,
+                        "project_name": "Project A",
+                        "project_slug": "project_a",
+                        "project_disabled": False,
                         "entities": [entities[1].id],
                     }
                 ],
@@ -650,11 +650,11 @@ def test_view_concordance_search(client, project_a, locale_a, resource_a):
             {
                 "source": "abaa",
                 "target": "ccc",
-                "tmEntries": [
+                "tm_entries": [
                     {
-                        "projectName": "Project A",
-                        "projectSlug": "project_a",
-                        "projectDisabled": False,
+                        "project_name": "Project A",
+                        "project_slug": "project_a",
+                        "project_disabled": False,
                         "entities": [entities[0].id],
                     }
                 ],
@@ -715,17 +715,17 @@ def test_view_concordance_search_multiple_project_names(
             {
                 "source": "abaa",
                 "target": "ccc",
-                "tmEntries": [
+                "tm_entries": [
                     {
-                        "projectName": project_a.name,
-                        "projectSlug": project_a.slug,
-                        "projectDisabled": project_a.disabled,
+                        "project_name": project_a.name,
+                        "project_slug": project_a.slug,
+                        "project_disabled": project_a.disabled,
                         "entities": [entities[0].id],
                     },
                     {
-                        "projectName": project_b.name,
-                        "projectSlug": project_b.slug,
-                        "projectDisabled": project_b.disabled,
+                        "project_name": project_b.name,
+                        "project_slug": project_b.slug,
+                        "project_disabled": project_b.disabled,
                         "entities": [entities[0].id],
                     },
                 ],
@@ -733,11 +733,11 @@ def test_view_concordance_search_multiple_project_names(
             {
                 "source": "abaf",
                 "target": "ccc",
-                "tmEntries": [
+                "tm_entries": [
                     {
-                        "projectName": project_a.name,
-                        "projectSlug": project_a.slug,
-                        "projectDisabled": project_a.disabled,
+                        "project_name": project_a.name,
+                        "project_slug": project_a.slug,
+                        "project_disabled": project_a.disabled,
                         "entities": [entities[1].id],
                     }
                 ],
@@ -801,11 +801,11 @@ def test_view_concordance_search_remove_duplicates(
             {
                 "source": "abaa",
                 "target": "ccc",
-                "tmEntries": [
+                "tm_entries": [
                     {
-                        "projectName": project_a.name,
-                        "projectSlug": project_a.slug,
-                        "projectDisabled": project_a.disabled,
+                        "project_name": project_a.name,
+                        "project_slug": project_a.slug,
+                        "project_disabled": project_a.disabled,
                         "entities": [entities[0].id],
                     }
                 ],
@@ -813,11 +813,11 @@ def test_view_concordance_search_remove_duplicates(
             {
                 "source": "abaf",
                 "target": "ccc",
-                "tmEntries": [
+                "tm_entries": [
                     {
-                        "projectName": project_a.name,
-                        "projectSlug": project_a.slug,
-                        "projectDisabled": project_a.disabled,
+                        "project_name": project_a.name,
+                        "project_slug": project_a.slug,
+                        "project_disabled": project_a.disabled,
                         "entities": [entities[1].id],
                     }
                 ],
@@ -825,11 +825,11 @@ def test_view_concordance_search_remove_duplicates(
             {
                 "source": "abaf",
                 "target": "cccbbb",
-                "tmEntries": [
+                "tm_entries": [
                     {
-                        "projectName": project_a.name,
-                        "projectSlug": project_a.slug,
-                        "projectDisabled": project_a.disabled,
+                        "project_name": project_a.name,
+                        "project_slug": project_a.slug,
+                        "project_disabled": project_a.disabled,
                         "entities": [entities[1].id],
                     }
                 ],
@@ -897,11 +897,11 @@ def test_view_concordance_search_pagination(client, project_a, locale_a, resourc
             {
                 "source": "abaa",
                 "target": "ccc",
-                "tmEntries": [
+                "tm_entries": [
                     {
-                        "projectName": project_a.name,
-                        "projectSlug": project_a.slug,
-                        "projectDisabled": project_a.disabled,
+                        "project_name": project_a.name,
+                        "project_slug": project_a.slug,
+                        "project_disabled": project_a.disabled,
                         "entities": [entities[0].id],
                     }
                 ],
@@ -920,11 +920,11 @@ def test_view_concordance_search_pagination(client, project_a, locale_a, resourc
             {
                 "source": "abaf",
                 "target": "cccbbb",
-                "tmEntries": [
+                "tm_entries": [
                     {
-                        "projectName": project_a.name,
-                        "projectSlug": project_a.slug,
-                        "projectDisabled": project_a.disabled,
+                        "project_name": project_a.name,
+                        "project_slug": project_a.slug,
+                        "project_disabled": project_a.disabled,
                         "entities": [entities[1].id],
                     }
                 ],
@@ -984,11 +984,11 @@ def test_view_concordance_search_null_project_exclusion(
             {
                 "source": "abaf",
                 "target": "cccbbb",
-                "tmEntries": [
+                "tm_entries": [
                     {
-                        "projectName": project_a.name,
-                        "projectSlug": project_a.slug,
-                        "projectDisabled": project_a.disabled,
+                        "project_name": project_a.name,
+                        "project_slug": project_a.slug,
+                        "project_disabled": project_a.disabled,
                         "entities": [entities[1].id],
                     }
                 ],

--- a/pontoon/machinery/utils.py
+++ b/pontoon/machinery/utils.py
@@ -21,12 +21,13 @@ from django.conf import settings
 from django.contrib.postgres.aggregates import JSONBAgg
 from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured
-from django.db.models import Q
+from django.db.models import BooleanField, Case, Q, When
 from django.db.models.functions import JSONObject
 
 import pontoon.base as base
 
 from pontoon.base.models.project import Project
+from pontoon.base.models.project_locale import ProjectLocale
 from pontoon.base.models.translation_memory import TranslationMemoryEntry
 from pontoon.base.placeables import get_placeables
 
@@ -280,6 +281,9 @@ def get_concordance_search_data(user, text, locale):
     search_query = reduce(operator.and_, search_filters)
 
     projects = Project.objects.visible_for(user)
+    pl_project_ids = ProjectLocale.objects.filter(locale=locale).values_list(
+        "project_id", flat=True
+    )
 
     search_results = (
         TranslationMemoryEntry.objects.filter(search_query, project__in=projects)
@@ -290,6 +294,11 @@ def get_concordance_search_data(user, text, locale):
                     project_name="project__name",
                     project_slug="project__slug",
                     project_disabled="project__disabled",
+                    project_locale_exists=Case(
+                        When(project__id__in=pl_project_ids, then=True),
+                        default=False,
+                        output_field=BooleanField(),
+                    ),
                     entity="entity",
                 ),
                 distinct=True,
@@ -305,6 +314,7 @@ def get_concordance_search_data(user, text, locale):
                 entry["project_name"],
                 entry["project_slug"],
                 entry["project_disabled"],
+                entry["project_locale_exists"],
             )
             if entry["project_slug"] and entry["entity"]:
                 grouped[key].append(entry["entity"])
@@ -316,6 +326,7 @@ def get_concordance_search_data(user, text, locale):
                 "project_name": k[0],
                 "project_slug": k[1],
                 "project_disabled": k[2],
+                "project_locale_exists": k[3],
                 "entities": entities,
             }
             for k, entities in grouped.items()

--- a/pontoon/machinery/utils.py
+++ b/pontoon/machinery/utils.py
@@ -18,13 +18,15 @@ from google.oauth2 import service_account
 from rapidfuzz.distance.Indel import normalized_distance
 
 from django.conf import settings
-from django.contrib.postgres.aggregates import ArrayAgg
+from django.contrib.postgres.aggregates import JSONBAgg
 from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Q
+from django.db.models.functions import JSONObject
 
 import pontoon.base as base
 
+from pontoon.base.models.translation_memory import TranslationMemoryEntry
 from pontoon.base.placeables import get_placeables
 
 
@@ -277,11 +279,39 @@ def get_concordance_search_data(text, locale):
     search_query = reduce(operator.and_, search_filters)
 
     search_results = (
-        base.models.TranslationMemoryEntry.objects.filter(search_query)
+        TranslationMemoryEntry.objects.filter(search_query)
+        .filter(
+            project__visibility="public",
+            project__disabled=False,
+            project__system_project=False,
+        )
         .values("source", "target")
-        .annotate(project_names=ArrayAgg("project__name", distinct=True))
-        .distinct()
+        .annotate(
+            tmEntries=JSONBAgg(
+                JSONObject(
+                    project_name="project__name",
+                    project_slug="project__slug",
+                    entity="entity",
+                ),
+                distinct=True,
+            )
+        )
     )
+
+    for result in search_results:
+        grouped = defaultdict(list)
+
+        for entry in result["tmEntries"]:
+            key = (entry["project_name"], entry["project_slug"])
+            if entry["project_slug"] and entry["entity"]:
+                grouped[key].append(entry["entity"])
+            elif entry["project_slug"]:
+                grouped.setdefault(key, [])
+
+        result["tmEntries"] = [
+            {"projectName": k[0], "projectSlug": k[1], "entities": entities}
+            for k, entities in grouped.items()
+        ]
 
     def sort_by_quality(entity):
         """Sort the results by their best Levenshtein distance from the search query"""
@@ -294,7 +324,7 @@ def get_concordance_search_data(text, locale):
                 levenshtein_distance(text, entity["target"]),
                 levenshtein_distance(text, entity["source"]),
             ),
-            len(entity["project_names"]),
+            len(entity["tmEntries"]),
         )
 
     return sorted(search_results, key=sort_by_quality, reverse=True)

--- a/pontoon/machinery/utils.py
+++ b/pontoon/machinery/utils.py
@@ -239,7 +239,7 @@ def get_existing_terms(url, headers):
 
 def store_new_terms(url, headers, new_terms):
     locale_codes = ["en"] + sorted(
-        base.models.Locale.objects.exclude(google_translate_code__in=["en", ""])
+        Locale.objects.exclude(google_translate_code__in=["en", ""])
         .order_by()  # Clear default ordering on the Locale model
         .values_list("google_translate_code", flat=True)
         .distinct()
@@ -266,7 +266,7 @@ def store_new_terms(url, headers, new_terms):
 
 
 def get_concordance_search_data(user, text, locale):
-    search_phrases = base.utils.get_search_phrases(text)
+    search_phrases = get_search_phrases(text)
     search_filters = (
         Q(
             Q(target__icontains_collate=(phrase, locale.db_collation))

--- a/pontoon/machinery/utils.py
+++ b/pontoon/machinery/utils.py
@@ -26,6 +26,7 @@ from django.db.models.functions import JSONObject
 
 import pontoon.base as base
 
+from pontoon.base.models.project import Project
 from pontoon.base.models.translation_memory import TranslationMemoryEntry
 from pontoon.base.placeables import get_placeables
 
@@ -266,7 +267,7 @@ def store_new_terms(url, headers, new_terms):
             log.error(f"Adding new glossary terms failed: {r.content}")
 
 
-def get_concordance_search_data(text, locale):
+def get_concordance_search_data(request, text, locale):
     search_phrases = base.utils.get_search_phrases(text)
     search_filters = (
         Q(
@@ -278,19 +279,18 @@ def get_concordance_search_data(text, locale):
     )
     search_query = reduce(operator.and_, search_filters)
 
+    projects = Project.objects.visible_for(request.user)
+
     search_results = (
-        TranslationMemoryEntry.objects.filter(search_query)
-        .filter(
-            project__visibility="public",
-            project__disabled=False,
-            project__system_project=False,
-        )
+        TranslationMemoryEntry.objects.filter(search_query, project__in=projects)
+        # TranslationMemoryEntry.objects.filter(search_query)
         .values("source", "target")
         .annotate(
             tmEntries=JSONBAgg(
                 JSONObject(
                     project_name="project__name",
                     project_slug="project__slug",
+                    project_disabled="project__disabled",
                     entity="entity",
                 ),
                 distinct=True,
@@ -302,14 +302,23 @@ def get_concordance_search_data(text, locale):
         grouped = defaultdict(list)
 
         for entry in result["tmEntries"]:
-            key = (entry["project_name"], entry["project_slug"])
+            key = (
+                entry["project_name"],
+                entry["project_slug"],
+                entry["project_disabled"],
+            )
             if entry["project_slug"] and entry["entity"]:
                 grouped[key].append(entry["entity"])
             elif entry["project_slug"]:
                 grouped.setdefault(key, [])
 
         result["tmEntries"] = [
-            {"projectName": k[0], "projectSlug": k[1], "entities": entities}
+            {
+                "projectName": k[0],
+                "projectSlug": k[1],
+                "projectDisabled": k[2],
+                "entities": entities,
+            }
             for k, entities in grouped.items()
         ]
 

--- a/pontoon/machinery/utils.py
+++ b/pontoon/machinery/utils.py
@@ -24,12 +24,9 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Q
 from django.db.models.functions import JSONObject
 
-import pontoon.base as base
-
-from pontoon.base.models.project import Project
-from pontoon.base.models.project_locale import ProjectLocale
-from pontoon.base.models.translation_memory import TranslationMemoryEntry
+from pontoon.base.models import Locale, Project, ProjectLocale, TranslationMemoryEntry
 from pontoon.base.placeables import get_placeables
+from pontoon.base.utils import get_search_phrases
 
 
 log = logging.getLogger(__name__)

--- a/pontoon/machinery/utils.py
+++ b/pontoon/machinery/utils.py
@@ -285,7 +285,7 @@ def get_concordance_search_data(user, text, locale):
         TranslationMemoryEntry.objects.filter(search_query, project__in=projects)
         .values("source", "target")
         .annotate(
-            tmEntries=JSONBAgg(
+            tm_entries=JSONBAgg(
                 JSONObject(
                     project_name="project__name",
                     project_slug="project__slug",
@@ -300,7 +300,7 @@ def get_concordance_search_data(user, text, locale):
     for result in search_results:
         grouped = defaultdict(list)
 
-        for entry in result["tmEntries"]:
+        for entry in result["tm_entries"]:
             key = (
                 entry["project_name"],
                 entry["project_slug"],
@@ -332,7 +332,7 @@ def get_concordance_search_data(user, text, locale):
                 levenshtein_distance(text, entity["target"]),
                 levenshtein_distance(text, entity["source"]),
             ),
-            len(entity["tmEntries"]),
+            len(entity["tm_entries"]),
         )
 
     return sorted(search_results, key=sort_by_quality, reverse=True)

--- a/pontoon/machinery/utils.py
+++ b/pontoon/machinery/utils.py
@@ -18,10 +18,10 @@ from google.oauth2 import service_account
 from rapidfuzz.distance.Indel import normalized_distance
 
 from django.conf import settings
-from django.contrib.postgres.aggregates import JSONBAgg
+from django.contrib.postgres.aggregates import ArrayAgg, JSONBAgg
 from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured
-from django.db.models import BooleanField, Case, Q, When
+from django.db.models import Q
 from django.db.models.functions import JSONObject
 
 import pontoon.base as base
@@ -289,48 +289,24 @@ def get_concordance_search_data(user, text, locale):
         TranslationMemoryEntry.objects.filter(search_query, project__in=projects)
         .values("source", "target")
         .annotate(
-            tm_entries=JSONBAgg(
+            projects=JSONBAgg(
                 JSONObject(
                     project_name="project__name",
                     project_slug="project__slug",
-                    project_disabled="project__disabled",
-                    project_locale_exists=Case(
-                        When(project__id__in=pl_project_ids, then=True),
-                        default=False,
-                        output_field=BooleanField(),
-                    ),
-                    entity="entity",
                 ),
                 distinct=True,
-            )
+            ),
+            entities=ArrayAgg(
+                "entity",
+                filter=Q(
+                    entity__isnull=False,
+                    project__disabled=False,
+                    project__id__in=pl_project_ids,
+                ),
+                distinct=True,
+            ),
         )
     )
-
-    for result in search_results:
-        grouped = defaultdict(list)
-
-        for entry in result["tm_entries"]:
-            key = (
-                entry["project_name"],
-                entry["project_slug"],
-                entry["project_disabled"],
-                entry["project_locale_exists"],
-            )
-            if entry["project_slug"] and entry["entity"]:
-                grouped[key].append(entry["entity"])
-            elif entry["project_slug"]:
-                grouped.setdefault(key, [])
-
-        result["tm_entries"] = [
-            {
-                "project_name": k[0],
-                "project_slug": k[1],
-                "project_disabled": k[2],
-                "project_locale_exists": k[3],
-                "entities": entities,
-            }
-            for k, entities in grouped.items()
-        ]
 
     def sort_by_quality(entity):
         """Sort the results by their best Levenshtein distance from the search query"""
@@ -343,7 +319,7 @@ def get_concordance_search_data(user, text, locale):
                 levenshtein_distance(text, entity["target"]),
                 levenshtein_distance(text, entity["source"]),
             ),
-            len(entity["tm_entries"]),
+            len(entity["projects"]),
         )
 
     return sorted(search_results, key=sort_by_quality, reverse=True)

--- a/pontoon/machinery/utils.py
+++ b/pontoon/machinery/utils.py
@@ -267,7 +267,7 @@ def store_new_terms(url, headers, new_terms):
             log.error(f"Adding new glossary terms failed: {r.content}")
 
 
-def get_concordance_search_data(request, text, locale):
+def get_concordance_search_data(user, text, locale):
     search_phrases = base.utils.get_search_phrases(text)
     search_filters = (
         Q(
@@ -279,11 +279,10 @@ def get_concordance_search_data(request, text, locale):
     )
     search_query = reduce(operator.and_, search_filters)
 
-    projects = Project.objects.visible_for(request.user)
+    projects = Project.objects.visible_for(user)
 
     search_results = (
         TranslationMemoryEntry.objects.filter(search_query, project__in=projects)
-        # TranslationMemoryEntry.objects.filter(search_query)
         .values("source", "target")
         .annotate(
             tmEntries=JSONBAgg(
@@ -312,11 +311,11 @@ def get_concordance_search_data(request, text, locale):
             elif entry["project_slug"]:
                 grouped.setdefault(key, [])
 
-        result["tmEntries"] = [
+        result["tm_entries"] = [
             {
-                "projectName": k[0],
-                "projectSlug": k[1],
-                "projectDisabled": k[2],
+                "project_name": k[0],
+                "project_slug": k[1],
+                "project_disabled": k[2],
                 "entities": entities,
             }
             for k, entities in grouped.items()
@@ -340,7 +339,7 @@ def get_concordance_search_data(request, text, locale):
 
 
 def get_translation_memory_data(text, locale, pk=None):
-    entries = base.models.TranslationMemoryEntry.objects.filter(
+    entries = TranslationMemoryEntry.objects.filter(
         locale=locale
     ).minimum_levenshtein_ratio(text)
 

--- a/pontoon/machinery/utils.py
+++ b/pontoon/machinery/utils.py
@@ -291,8 +291,8 @@ def get_concordance_search_data(user, text, locale):
         .annotate(
             projects=JSONBAgg(
                 JSONObject(
-                    project_name="project__name",
-                    project_slug="project__slug",
+                    name="project__name",
+                    slug="project__slug",
                 ),
                 distinct=True,
             ),

--- a/pontoon/machinery/views.py
+++ b/pontoon/machinery/views.py
@@ -78,7 +78,7 @@ def concordance_search(request):
         )
 
     paginator = Paginator(
-        get_concordance_search_data(request, text, locale), page_results_limit
+        get_concordance_search_data(request.user, text, locale), page_results_limit
     )
 
     try:

--- a/pontoon/machinery/views.py
+++ b/pontoon/machinery/views.py
@@ -102,8 +102,8 @@ def concordance_search(request):
     }
 
     for result in data.object_list:
-        result["tm_entries"] = sorted(
-            result["tm_entries"],
+        result["projects"] = sorted(
+            result["projects"],
             key=lambda x: project_order.get(x["project_name"], float("inf")),
         )
 

--- a/pontoon/machinery/views.py
+++ b/pontoon/machinery/views.py
@@ -77,7 +77,9 @@ def concordance_search(request):
             status=400,
         )
 
-    paginator = Paginator(get_concordance_search_data(text, locale), page_results_limit)
+    paginator = Paginator(
+        get_concordance_search_data(request, text, locale), page_results_limit
+    )
 
     try:
         data = paginator.page(page)

--- a/pontoon/machinery/views.py
+++ b/pontoon/machinery/views.py
@@ -18,6 +18,7 @@ from django.utils.html import strip_tags
 from django.views.decorators.http import require_POST
 
 from pontoon.base.models import Comment, Entity, Locale, Translation
+from pontoon.base.models.project import Project
 from pontoon.machinery.utils import (
     get_concordance_search_data,
     get_google_translate_data,
@@ -85,6 +86,26 @@ def concordance_search(request):
         data = paginator.page(page)
     except EmptyPage:
         return JsonResponse({"results": [], "has_next": False})
+
+    # JSONBAgg (used in get_concordance_search_data()) does not support using
+    # distinct=True in combination with ordering, so we need to do one of them
+    # manually - after pagination, to reduce the number of rows processed.
+    project_order = {
+        name: i
+        for i, name in enumerate(
+            list(
+                Project.objects.order_by("disabled", "-priority", "name").values_list(
+                    "name", flat=True
+                )
+            )
+        )
+    }
+
+    for result in data.object_list:
+        result["tm_entries"] = sorted(
+            result["tm_entries"],
+            key=lambda x: project_order.get(x["project_name"], float("inf")),
+        )
 
     return JsonResponse(
         {"results": data.object_list, "has_next": data.has_next()}, safe=False

--- a/pontoon/machinery/views.py
+++ b/pontoon/machinery/views.py
@@ -17,7 +17,7 @@ from django.utils.datastructures import MultiValueDictKeyError
 from django.utils.html import strip_tags
 from django.views.decorators.http import require_POST
 
-from pontoon.base.models import Comment, Entity, Locale, Project, Translation
+from pontoon.base.models import Comment, Entity, Locale, Translation
 from pontoon.machinery.utils import (
     get_concordance_search_data,
     get_google_translate_data,
@@ -83,15 +83,6 @@ def concordance_search(request):
         data = paginator.page(page)
     except EmptyPage:
         return JsonResponse({"results": [], "has_next": False})
-
-    # ArrayAgg (used in get_concordance_search_data()) does not support using
-    # distinct=True in combination with ordering, so we need to do one of them
-    # manually - after pagination, to reduce the number of rows processed.
-    projects = Project.objects.order_by("disabled", "-priority", "name").values_list(
-        "name", flat=True
-    )
-    for r in data.object_list:
-        r["project_names"] = [p for p in projects if p in r["project_names"]]
 
     return JsonResponse(
         {"results": data.object_list, "has_next": data.has_next()}, safe=False

--- a/pontoon/machinery/views.py
+++ b/pontoon/machinery/views.py
@@ -104,7 +104,7 @@ def concordance_search(request):
     for result in data.object_list:
         result["projects"] = sorted(
             result["projects"],
-            key=lambda x: project_order.get(x["project_name"], float("inf")),
+            key=lambda x: project_order.get(x["name"], float("inf")),
         )
 
     return JsonResponse(

--- a/pontoon/machinery/views.py
+++ b/pontoon/machinery/views.py
@@ -17,8 +17,7 @@ from django.utils.datastructures import MultiValueDictKeyError
 from django.utils.html import strip_tags
 from django.views.decorators.http import require_POST
 
-from pontoon.base.models import Comment, Entity, Locale, Translation
-from pontoon.base.models.project import Project
+from pontoon.base.models import Comment, Entity, Locale, Project, Translation
 from pontoon.machinery.utils import (
     get_concordance_search_data,
     get_google_translate_data,

--- a/translate/src/api/machinery.ts
+++ b/translate/src/api/machinery.ts
@@ -23,14 +23,11 @@ export type MachineryTranslation = {
   original: string;
   translation: string;
   quality?: number;
-  tmEntries?: {
+  projects?: {
     projectName: string;
     projectSlug: string;
-    projectDisabled: boolean;
-    projectLocaleExists: boolean;
-    entities: number[];
   }[];
-  projectNames?: Array<string | null>;
+  entities?: number[];
 };
 
 type ConcordanceTranslations = {
@@ -73,13 +70,11 @@ export async function fetchConcordanceResults(
     results: Array<{
       source: string;
       target: string;
-      tm_entries: {
+      projects: {
         project_name: string;
         project_slug: string;
-        project_disabled: boolean;
-        project_locale_exists: boolean;
-        entities: number[];
       }[];
+      entities: number[];
     }>;
     has_next: boolean;
   };
@@ -90,13 +85,11 @@ export async function fetchConcordanceResults(
           sources: ['concordance-search'],
           original: item.source,
           translation: item.target,
-          tmEntries: item.tm_entries.map((entry) => ({
+          projects: item.projects.map((entry) => ({
             projectName: entry.project_name,
             projectSlug: entry.project_slug,
-            projectDisabled: entry.project_disabled,
-            projectLocaleExists: entry.project_locale_exists,
-            entities: entry.entities,
           })),
+          entities: item.entities,
         })),
         hasMore: has_next,
       }

--- a/translate/src/api/machinery.ts
+++ b/translate/src/api/machinery.ts
@@ -72,10 +72,10 @@ export async function fetchConcordanceResults(
     results: Array<{
       source: string;
       target: string;
-      tmEntries: {
-        projectName: string;
-        projectSlug: string;
-        projectDisabled: boolean;
+      tm_entries: {
+        project_name: string;
+        project_slug: string;
+        project_disabled: boolean;
         entities: number[];
       }[];
     }>;
@@ -88,7 +88,12 @@ export async function fetchConcordanceResults(
           sources: ['concordance-search'],
           original: item.source,
           translation: item.target,
-          tmEntries: item.tmEntries,
+          tmEntries: item.tm_entries.map((entry) => ({
+            projectName: entry.project_name,
+            projectSlug: entry.project_slug,
+            projectDisabled: entry.project_disabled,
+            entities: entry.entities,
+          })),
         })),
         hasMore: has_next,
       }

--- a/translate/src/api/machinery.ts
+++ b/translate/src/api/machinery.ts
@@ -24,8 +24,8 @@ export type MachineryTranslation = {
   translation: string;
   quality?: number;
   projects?: {
-    projectName: string;
-    projectSlug: string;
+    name: string;
+    slug: string;
   }[];
   entities?: number[];
 };
@@ -71,8 +71,8 @@ export async function fetchConcordanceResults(
       source: string;
       target: string;
       projects: {
-        project_name: string;
-        project_slug: string;
+        name: string;
+        slug: string;
       }[];
       entities: number[];
     }>;
@@ -86,8 +86,8 @@ export async function fetchConcordanceResults(
           original: item.source,
           translation: item.target,
           projects: item.projects.map((entry) => ({
-            projectName: entry.project_name,
-            projectSlug: entry.project_slug,
+            name: entry.name,
+            slug: entry.slug,
           })),
           entities: item.entities,
         })),

--- a/translate/src/api/machinery.ts
+++ b/translate/src/api/machinery.ts
@@ -23,6 +23,11 @@ export type MachineryTranslation = {
   original: string;
   translation: string;
   quality?: number;
+  tmEntries?: {
+    projectName: string;
+    projectSlug: string;
+    entities: number[];
+  }[];
   projectNames?: Array<string | null>;
 };
 
@@ -66,7 +71,11 @@ export async function fetchConcordanceResults(
     results: Array<{
       source: string;
       target: string;
-      project_names: string[];
+      tmEntries: {
+        projectName: string;
+        projectSlug: string;
+        entities: number[];
+      }[];
     }>;
     has_next: boolean;
   };
@@ -77,7 +86,7 @@ export async function fetchConcordanceResults(
           sources: ['concordance-search'],
           original: item.source,
           translation: item.target,
-          projectNames: item.project_names,
+          tmEntries: item.tmEntries,
         })),
         hasMore: has_next,
       }

--- a/translate/src/api/machinery.ts
+++ b/translate/src/api/machinery.ts
@@ -26,6 +26,7 @@ export type MachineryTranslation = {
   tmEntries?: {
     projectName: string;
     projectSlug: string;
+    projectDisabled: boolean;
     entities: number[];
   }[];
   projectNames?: Array<string | null>;
@@ -74,6 +75,7 @@ export async function fetchConcordanceResults(
       tmEntries: {
         projectName: string;
         projectSlug: string;
+        projectDisabled: boolean;
         entities: number[];
       }[];
     }>;

--- a/translate/src/api/machinery.ts
+++ b/translate/src/api/machinery.ts
@@ -27,6 +27,7 @@ export type MachineryTranslation = {
     projectName: string;
     projectSlug: string;
     projectDisabled: boolean;
+    projectLocaleExists: boolean;
     entities: number[];
   }[];
   projectNames?: Array<string | null>;
@@ -76,6 +77,7 @@ export async function fetchConcordanceResults(
         project_name: string;
         project_slug: string;
         project_disabled: boolean;
+        project_locale_exists: boolean;
         entities: number[];
       }[];
     }>;
@@ -92,6 +94,7 @@ export async function fetchConcordanceResults(
             projectName: entry.project_name,
             projectSlug: entry.project_slug,
             projectDisabled: entry.project_disabled,
+            projectLocaleExists: entry.project_locale_exists,
             entities: entry.entities,
           })),
         })),

--- a/translate/src/modules/machinery/components/ConcordanceSearch.tsx
+++ b/translate/src/modules/machinery/components/ConcordanceSearch.tsx
@@ -11,22 +11,40 @@ type Props = {
   translation: MachineryTranslation;
 };
 
-function ProjectList({ projects }: { projects: (string | null)[] }) {
-  const notEmpty = projects.filter(Boolean) as string[];
+type tmEntry = {
+  projectName: string;
+  projectSlug: string;
+  entities: number[];
+};
 
-  if (notEmpty.length === 0) {
+function ProjectList({ tmEntries }: { tmEntries: tmEntry[] }) {
+  const { code } = useContext(Locale);
+
+  if (tmEntries.length === 0) {
     return <TranslationMemory />;
   }
 
   return (
     <>
-      {notEmpty.map((project) => (
-        <li key={project}>
-          <span className='translation-source'>
-            <span>{project.toUpperCase()}</span>
-          </span>
-        </li>
-      ))}
+      {tmEntries.map((tmEntry) =>
+        tmEntry.projectSlug ? (
+          <li key={tmEntry.projectName}>
+            {tmEntry.entities.length > 0 ? (
+              <a
+                className='translation-source'
+                href={`/${code}/${tmEntry.projectSlug}/all-resources/?list=${tmEntry.entities.join(',')}&string=${tmEntry.entities[0]}`}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <span>{tmEntry.projectName.toUpperCase()}</span>
+              </a>
+            ) : (
+              <span className='translation-source'>
+                <span>{tmEntry.projectName.toUpperCase()}</span>
+              </span>
+            )}
+          </li>
+        ) : null,
+      )}
     </>
   );
 }
@@ -36,14 +54,20 @@ export function ConcordanceSearch({
   translation,
 }: Props): React.ReactElement {
   const { code, direction, script } = useContext(Locale);
-  const projects = translation.projectNames;
-  const title = projects?.filter(Boolean).join(' • ');
+  const tmEntries = translation.tmEntries;
+
+  const title = tmEntries
+    ?.reduce((acc, entry) => {
+      acc.push(entry.projectName);
+      return acc;
+    }, [] as string[])
+    .join(' • ');
 
   return (
     <>
       <header>
         <ul className='sources projects' title={title}>
-          {projects && <ProjectList projects={projects} />}
+          {tmEntries && <ProjectList tmEntries={tmEntries} />}
         </ul>
       </header>
       <p className='original'>

--- a/translate/src/modules/machinery/components/ConcordanceSearch.tsx
+++ b/translate/src/modules/machinery/components/ConcordanceSearch.tsx
@@ -11,40 +11,23 @@ type Props = {
   translation: MachineryTranslation;
 };
 
-type tmEntry = {
+type project = {
   projectName: string;
   projectSlug: string;
-  projectDisabled: boolean;
-  projectLocaleExists: boolean;
-  entities: number[];
 };
 
-function ProjectList({ tmEntries }: { tmEntries: tmEntry[] }) {
-  const { code } = useContext(Locale);
-
-  if (tmEntries.length === 0) {
+function ProjectList({ projects }: { projects: project[] }) {
+  if (projects.length === 0) {
     return <TranslationMemory />;
   }
 
   return (
     <>
-      {tmEntries.map((tmEntry) => (
-        <li key={tmEntry.projectName}>
-          {tmEntry.entities.length > 0 &&
-          !tmEntry.projectDisabled &&
-          tmEntry.projectLocaleExists ? (
-            <a
-              className='translation-source'
-              href={`/${code}/${tmEntry.projectSlug}/all-resources/?list=${tmEntry.entities.join(',')}`}
-              onClick={(e) => e.stopPropagation()}
-            >
-              <span>{tmEntry.projectName.toUpperCase()}</span>
-            </a>
-          ) : (
-            <span className='translation-source'>
-              <span>{tmEntry.projectName.toUpperCase()}</span>
-            </span>
-          )}
+      {projects.map((project) => (
+        <li key={project.projectName}>
+          <span className='translation-source'>
+            <span>{project.projectName.toUpperCase()}</span>
+          </span>
         </li>
       ))}
     </>
@@ -56,21 +39,30 @@ export function ConcordanceSearch({
   translation,
 }: Props): React.ReactElement {
   const { code, direction, script } = useContext(Locale);
-  const tmEntries = translation.tmEntries;
+  const projects = translation.projects;
+  const entities = translation.entities;
 
-  const title = tmEntries
-    ?.reduce((acc, entry) => {
-      acc.push(entry.projectName);
-      return acc;
-    }, [] as string[])
-    .join(' • ');
+  const title = projects?.map((project) => project.projectName).join(' • ');
+
+  const projectListContainer = (
+    <ul className='sources projects' title={title}>
+      {projects && <ProjectList projects={projects} />}
+    </ul>
+  );
 
   return (
     <>
       <header>
-        <ul className='sources projects' title={title}>
-          {tmEntries && <ProjectList tmEntries={tmEntries} />}
-        </ul>
+        {entities && entities.length > 0 ? (
+          <a
+            href={`/${code}/all-projects/all-resources/?list=${entities.join(',')}`}
+            onClick={(e) => e.stopPropagation()}
+          >
+            {projectListContainer}
+          </a>
+        ) : (
+          <div>{projectListContainer}</div>
+        )}
       </header>
       <p className='original'>
         <GenericTranslation

--- a/translate/src/modules/machinery/components/ConcordanceSearch.tsx
+++ b/translate/src/modules/machinery/components/ConcordanceSearch.tsx
@@ -27,25 +27,23 @@ function ProjectList({ tmEntries }: { tmEntries: tmEntry[] }) {
 
   return (
     <>
-      {tmEntries.map((tmEntry) =>
-        tmEntry.projectSlug ? (
-          <li key={tmEntry.projectName}>
-            {tmEntry.entities.length > 0 && !tmEntry.projectDisabled ? (
-              <a
-                className='translation-source'
-                href={`/${code}/${tmEntry.projectSlug}/all-resources/?list=${tmEntry.entities.join(',')}&string=${tmEntry.entities[0]}`}
-                onClick={(e) => e.stopPropagation()}
-              >
-                <span>{tmEntry.projectName.toUpperCase()}</span>
-              </a>
-            ) : (
-              <span className='translation-source'>
-                <span>{tmEntry.projectName.toUpperCase()}</span>
-              </span>
-            )}
-          </li>
-        ) : null,
-      )}
+      {tmEntries.map((tmEntry) => (
+        <li key={tmEntry.projectName}>
+          {tmEntry.entities.length > 0 && !tmEntry.projectDisabled ? (
+            <a
+              className='translation-source'
+              href={`/${code}/${tmEntry.projectSlug}/all-resources/?list=${tmEntry.entities.join(',')}`}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <span>{tmEntry.projectName.toUpperCase()}</span>
+            </a>
+          ) : (
+            <span className='translation-source'>
+              <span>{tmEntry.projectName.toUpperCase()}</span>
+            </span>
+          )}
+        </li>
+      ))}
     </>
   );
 }

--- a/translate/src/modules/machinery/components/ConcordanceSearch.tsx
+++ b/translate/src/modules/machinery/components/ConcordanceSearch.tsx
@@ -14,6 +14,7 @@ type Props = {
 type tmEntry = {
   projectName: string;
   projectSlug: string;
+  projectDisabled: boolean;
   entities: number[];
 };
 
@@ -29,7 +30,7 @@ function ProjectList({ tmEntries }: { tmEntries: tmEntry[] }) {
       {tmEntries.map((tmEntry) =>
         tmEntry.projectSlug ? (
           <li key={tmEntry.projectName}>
-            {tmEntry.entities.length > 0 ? (
+            {tmEntry.entities.length > 0 && !tmEntry.projectDisabled ? (
               <a
                 className='translation-source'
                 href={`/${code}/${tmEntry.projectSlug}/all-resources/?list=${tmEntry.entities.join(',')}&string=${tmEntry.entities[0]}`}

--- a/translate/src/modules/machinery/components/ConcordanceSearch.tsx
+++ b/translate/src/modules/machinery/components/ConcordanceSearch.tsx
@@ -15,6 +15,7 @@ type tmEntry = {
   projectName: string;
   projectSlug: string;
   projectDisabled: boolean;
+  projectLocaleExists: boolean;
   entities: number[];
 };
 
@@ -29,7 +30,9 @@ function ProjectList({ tmEntries }: { tmEntries: tmEntry[] }) {
     <>
       {tmEntries.map((tmEntry) => (
         <li key={tmEntry.projectName}>
-          {tmEntry.entities.length > 0 && !tmEntry.projectDisabled ? (
+          {tmEntry.entities.length > 0 &&
+          !tmEntry.projectDisabled &&
+          tmEntry.projectLocaleExists ? (
             <a
               className='translation-source'
               href={`/${code}/${tmEntry.projectSlug}/all-resources/?list=${tmEntry.entities.join(',')}`}

--- a/translate/src/modules/machinery/components/ConcordanceSearch.tsx
+++ b/translate/src/modules/machinery/components/ConcordanceSearch.tsx
@@ -12,8 +12,8 @@ type Props = {
 };
 
 type project = {
-  projectName: string;
-  projectSlug: string;
+  name: string;
+  slug: string;
 };
 
 function ProjectList({ projects }: { projects: project[] }) {
@@ -24,9 +24,9 @@ function ProjectList({ projects }: { projects: project[] }) {
   return (
     <>
       {projects.map((project) => (
-        <li key={project.projectName}>
+        <li key={project.name}>
           <span className='translation-source'>
-            <span>{project.projectName.toUpperCase()}</span>
+            <span>{project.name.toUpperCase()}</span>
           </span>
         </li>
       ))}
@@ -42,7 +42,7 @@ export function ConcordanceSearch({
   const projects = translation.projects;
   const entities = translation.entities;
 
-  const title = projects?.map((project) => project.projectName).join(' • ');
+  const title = projects?.map((project) => project.name).join(' • ');
 
   const projectListContainer = (
     <ul className='sources projects' title={title}>

--- a/translate/src/modules/machinery/components/MachineryTranslation.css
+++ b/translate/src/modules/machinery/components/MachineryTranslation.css
@@ -39,9 +39,14 @@
   pointer-events: auto;
 }
 
-.machinery .translation > header > ul > li:not(:first-child)::before {
+.sources.projects > li:not(:first-child)::before {
   content: '•';
   padding-right: 3px;
+  padding-left: 3px;
+}
+
+.machinery .translation > header div {
+  cursor: default;
 }
 
 .machinery .translation > header li.google-translation {

--- a/translate/src/modules/machinery/components/MachineryTranslation.css
+++ b/translate/src/modules/machinery/components/MachineryTranslation.css
@@ -42,7 +42,6 @@
 .sources.projects > li:not(:first-child)::before {
   content: '•';
   padding-right: 3px;
-  padding-left: 3px;
 }
 
 .machinery .translation > header div {


### PR DESCRIPTION
This PR allows localizers to select certain translation memories through the Concordance Search tab via the project names list and change them via redirect. Since a project can have multiple entities with the same translation, clicking on the project name redirects the user to `/code/project/all-resources/?list=entity_1,entity_2,entity_3...&string=entity_1`.

Fixes #2276.

NOTE: currently private, disabled and system projects are excluded from the Concordance Search results, which is NOT the original behaviour of Concordance Search. A quick discussion is needed on whether to include said results and whether they count as a "security breach". For example currently, projects like ENGAGEMENT and MDN are included.

