### PR TITLE
Extend PAT authentication to all /api/v2/ endpoints

### DIFF
--- a/pontoon/api/authentication.py
+++ b/pontoon/api/authentication.py
@@ -18,6 +18,8 @@ class PersonalAccessTokenAuthentication(BaseAuthentication):
         auth_header = request.headers.get("Authorization")
 
         if not auth_header or not auth_header.startswith("Bearer "):
+            # Return None to let DRF try the next authenticator (e.g. session auth).
+            # Raising AuthenticationFailed here would block all non-Bearer requests.
             return None
 
         try:

--- a/pontoon/api/authentication.py
+++ b/pontoon/api/authentication.py
@@ -18,9 +18,7 @@ class PersonalAccessTokenAuthentication(BaseAuthentication):
         auth_header = request.headers.get("Authorization")
 
         if not auth_header or not auth_header.startswith("Bearer "):
-            raise AuthenticationFailed(
-                {"detail": "Missing or invalid Authorization header."}
-            )
+            return None
 
         try:
             token_id, unhashed_token = auth_header.split(" ")[1].split("_")

--- a/pontoon/api/tests/test_authentication.py
+++ b/pontoon/api/tests/test_authentication.py
@@ -38,9 +38,17 @@ def test_authenticate_missing_authorization_header():
     auth = PersonalAccessTokenAuthentication()
     request = type("Request", (), {"headers": {}})
 
-    with pytest.raises(AuthenticationFailed) as excinfo:
-        auth.authenticate(request)
-    assert excinfo.value.detail["detail"] == "Missing or invalid Authorization header."
+    result = auth.authenticate(request)
+    assert result is None
+
+
+@pytest.mark.django_db
+def test_authenticate_non_bearer_authorization_header():
+    auth = PersonalAccessTokenAuthentication()
+    request = type("Request", (), {"headers": {"Authorization": "Basic dXNlcjpwYXNz"}})
+
+    result = auth.authenticate(request)
+    assert result is None
 
 
 @pytest.mark.django_db

--- a/pontoon/api/tests/test_views.py
+++ b/pontoon/api/tests/test_views.py
@@ -1835,3 +1835,66 @@ def test_pretranslation_tm(member):
     )
 
     assert response.status_code == 400
+
+
+@pytest.mark.django_db
+def test_pat_auth_on_locales_endpoint(member):
+    """PAT authentication works on non-pretranslation endpoints."""
+    token = PersonalAccessToken.objects.create(
+        user=member.user,
+        name="Test Token PAT Locales",
+        token_hash="hashed_token",
+        expires_at=now() + timedelta(days=1),
+    )
+    token_id = token.id
+    token_unhashed = "unhashed-token"
+    token.token_hash = make_password(token_unhashed)
+    token.save()
+
+    response = APIClient().get(
+        "/api/v2/locales/",
+        HTTP_ACCEPT="application/json",
+        headers={"Authorization": f"Bearer {token_id}_{token_unhashed}"},
+    )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_session_auth_still_works_on_user_actions(member):
+    """Session authentication continues to work after PAT auth is added to defaults."""
+    client = APIClient()
+    client.force_authenticate(user=member.user)
+
+    project = ProjectFactory(slug="test-session-project")
+    date = now().strftime("%Y-%m-%d")
+
+    response = client.get(
+        f"/api/v2/user-actions/{date}/project/{project.slug}/",
+        HTTP_ACCEPT="application/json",
+    )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_expired_pat_rejected_on_non_pretranslation_endpoint(member):
+    """Expired PAT returns 403 on non-pretranslation endpoints."""
+    token = PersonalAccessToken.objects.create(
+        user=member.user,
+        name="Test Token Expired",
+        token_hash="hashed_token",
+        expires_at=now() - timedelta(days=1),
+    )
+    token_id = token.id
+    token_unhashed = "unhashed-token"
+    token.token_hash = make_password(token_unhashed)
+    token.save()
+
+    response = APIClient().get(
+        "/api/v2/locales/",
+        HTTP_ACCEPT="application/json",
+        headers={"Authorization": f"Bearer {token_id}_{token_unhashed}"},
+    )
+
+    assert response.status_code == 403

--- a/pontoon/settings/base.py
+++ b/pontoon/settings/base.py
@@ -1270,6 +1270,10 @@ TBX_TITLE = os.environ.get("TBX_TITLE", "Pontoon Terminology")
 TBX_DESCRIPTION = os.environ.get("TBX_DESCRIPTION", "Terms localized in Pontoon")
 
 REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "pontoon.api.authentication.PersonalAccessTokenAuthentication",
+        "rest_framework.authentication.SessionAuthentication",
+    ],
     "DEFAULT_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"],
     "DEFAULT_PAGINATION_CLASS": "pontoon.api.pagination.DynamicPageNumberPagination",
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",


### PR DESCRIPTION
## Summary

- Fix `PersonalAccessTokenAuthentication` to return `None` (instead of raising `AuthenticationFailed`) when no Bearer header is present, per [DRF convention](https://www.django-rest-framework.org/api-guide/authentication/#custom-authentication). This allows PAT auth to coexist with session auth on any view.
- Add `DEFAULT_AUTHENTICATION_CLASSES` to `REST_FRAMEWORK` settings, putting PAT auth first and session auth second. All `/api/v2/` endpoints now accept `Authorization: Bearer <token>` in addition to session cookies.
- `PretranslationView` retains its explicit `authentication_classes = [PersonalAccessTokenAuthentication]` and remains token-only.

## Motivation

Thunderbird's [Bitergia/GrimoireLab](https://github.com/chaoss/grimoirelab) deployment collects translation metrics from Pontoon using the `sessionid` cookie, which expires every 14 days and requires a human to log in, copy the cookie from DevTools, and restart the collection pipeline. When nobody renews it, Pontoon data collection silently stops.

Pontoon already has Personal Access Tokens (PATs) with 365-day expiry (added in #3729, spec [0122](https://github.com/mozilla/pontoon/blob/main/specs/0122-rest-api-authentication.md)), but they only work on the `/api/v2/pretranslate/` endpoint. This PR extends PAT support to all API endpoints so GrimoireLab can use a long-lived token instead of a session cookie, eliminating the 14-day manual renewal cycle.

## Changes

| File | Change |
|------|--------|
| `pontoon/api/authentication.py` | Return `None` instead of raising when no Bearer header |
| `pontoon/settings/base.py` | Add `DEFAULT_AUTHENTICATION_CLASSES` to `REST_FRAMEWORK` |
| `pontoon/api/tests/test_authentication.py` | Update missing-header test; add non-Bearer header test |
| `pontoon/api/tests/test_views.py` | Add tests: PAT on locales, session auth still works, expired PAT rejected |

## Test plan

- [x] All 33 API tests pass (`make pytest opts="pontoon/api/tests/"`)
- [x] Verify browser-based session auth still works end-to-end on a dev instance
- [x] Generate a PAT and test `curl -H "Authorization: Bearer <token>" /api/v2/locales/`