### PR TITLE
Fix false pending changes warning

### DIFF
--- a/translate/src/context/Editor.test.jsx
+++ b/translate/src/context/Editor.test.jsx
@@ -15,6 +15,7 @@ import {
 import { EntityView, EntityViewProvider } from './EntityView';
 import { Locale } from './Locale';
 import { Location, LocationProvider } from './Location';
+import { UnsavedChanges, UnsavedChangesProvider } from './UnsavedChanges';
 
 function mountSpy(Spy, format, translation, original) {
   const history = createMemoryHistory({
@@ -65,9 +66,11 @@ function mountSpy(Spy, format, translation, original) {
     <LocationProvider history={history}>
       <Locale.Provider value={{ code: 'sl', cldrPlurals: [1, 2, 3, 5] }}>
         <EntityViewProvider>
-          <EditorProvider>
-            <Spy />
-          </EditorProvider>
+          <UnsavedChangesProvider>
+            <EditorProvider>
+              <Spy />
+            </EditorProvider>
+          </UnsavedChangesProvider>
         </EntityViewProvider>
       </Locale.Provider>
     </LocationProvider>
@@ -465,5 +468,20 @@ describe('<EditorProvider>', () => {
       { keys: ['one'], name: '', value: 'ONE' },
       { keys: [{ '*': 'other' }], name: '', value: 'OTHER' },
     ]);
+  });
+
+  it('reports no pending changes for empty android entry with placeholders', () => {
+    let unsaved;
+    const Spy = () => {
+      unsaved = useContext(UnsavedChanges);
+      return null;
+    };
+    mountSpy(
+      Spy,
+      'android',
+      undefined,
+      'Hello, {$arg1 :string @source=|%1$s|}!',
+    );
+    expect(unsaved.check()).toBe(false);
   });
 });

--- a/translate/src/utils/message/buildMessageEntry.test.js
+++ b/translate/src/utils/message/buildMessageEntry.test.js
@@ -1,0 +1,54 @@
+import { buildMessageEntry } from './buildMessageEntry';
+import { getEmptyMessageEntry } from './getEmptyMessage';
+import { getPlaceholderMap } from './placeholders';
+import { parseEntry } from './parseEntry';
+import { serializeEntry } from './serializeEntry';
+import { pojoEquals } from '../pojo';
+
+const LOCALE = { code: 'en-US' };
+
+describe('buildMessageEntry', () => {
+  it('matches getEmptyMessageEntry when value is empty and placeholders map is non-empty', () => {
+    const base = parseEntry(
+      'android',
+      'Hello, {$arg1 :string @source=|%1$s|}!',
+    );
+    const placeholders = getPlaceholderMap(base.value);
+    expect(placeholders).not.toBeNull();
+
+    const result = buildMessageEntry(base, placeholders, [
+      { name: '', keys: [], value: '' },
+    ]);
+    const empty = getEmptyMessageEntry(base, LOCALE);
+
+    // serializeEntry() returns the same result for [] and [''], so using
+    // pojoEquals() in this test.
+    expect(pojoEquals(result, empty)).toBe(true);
+  });
+
+  it('replaces a placeholder in a non-empty value', () => {
+    const base = parseEntry(
+      'android',
+      'Hello, {$arg1 :string @source=|%1$s|}!',
+    );
+    const placeholders = getPlaceholderMap(base.value);
+
+    const result = buildMessageEntry(base, placeholders, [
+      { name: '', keys: [], value: 'Bonjour, %1$s!' },
+    ]);
+
+    expect(serializeEntry(result)).toEqual(
+      'Bonjour, {$arg1 :string @source=|%1$s|}!',
+    );
+  });
+
+  it('sets a simple value without placeholders', () => {
+    const base = parseEntry('android', 'Hello World');
+
+    const result = buildMessageEntry(base, null, [
+      { name: '', keys: [], value: 'Bonjour Monde' },
+    ]);
+
+    expect(serializeEntry(result)).toEqual('Bonjour Monde');
+  });
+});

--- a/translate/src/utils/message/buildMessageEntry.tsx
+++ b/translate/src/utils/message/buildMessageEntry.tsx
@@ -79,5 +79,5 @@ function buildPattern(
     pos = end;
   }
   if (pos < str.length) pattern.push(str.substring(pos));
-  return pattern;
+  return pattern.length > 0 ? pattern : [str];
 }


### PR DESCRIPTION
Fix #4083 

`buildPattern()` returned `[]` on an empty string with a non-empty placeholders map. `getEmptyMessageEntry()` returns `['']`, so the comparison fails.