### PR TITLE
Represent empty patterns as `[]` rather than `['']`

### DIFF
--- a/translate/src/context/Editor.test.jsx
+++ b/translate/src/context/Editor.test.jsx
@@ -198,7 +198,7 @@ describe('<EditorProvider>', () => {
     const arg1 = { $: 'arg1', fn: 'string', attr: { source: '%1$s' } };
     expect(editor).toMatchObject({
       sourceView: false,
-      initial: { id: '', value: [''] },
+      initial: { id: '', value: [] },
       placeholders: new Map([['%1$s', arg1]]),
       fields: [
         {

--- a/translate/src/utils/message/buildMessageEntry.test.js
+++ b/translate/src/utils/message/buildMessageEntry.test.js
@@ -3,7 +3,6 @@ import { getEmptyMessageEntry } from './getEmptyMessage';
 import { getPlaceholderMap } from './placeholders';
 import { parseEntry } from './parseEntry';
 import { serializeEntry } from './serializeEntry';
-import { pojoEquals } from '../pojo';
 
 const LOCALE = { code: 'en-US' };
 
@@ -21,9 +20,7 @@ describe('buildMessageEntry', () => {
     ]);
     const empty = getEmptyMessageEntry(base, LOCALE);
 
-    // serializeEntry() returns the same result for [] and [''], so using
-    // pojoEquals() in this test.
-    expect(pojoEquals(result, empty)).toBe(true);
+    expect(result).toEqual(empty);
   });
 
   it('replaces a placeholder in a non-empty value', () => {

--- a/translate/src/utils/message/buildMessageEntry.tsx
+++ b/translate/src/utils/message/buildMessageEntry.tsx
@@ -79,5 +79,5 @@ function buildPattern(
     pos = end;
   }
   if (pos < str.length) pattern.push(str.substring(pos));
-  return pattern.length > 0 ? pattern : [str];
+  return pattern;
 }

--- a/translate/src/utils/message/getEmptyMessage.ts
+++ b/translate/src/utils/message/getEmptyMessage.ts
@@ -37,10 +37,10 @@ export function getEmptyMessageEntry(
 }
 
 function getEmptyMessage(source: Message, { code }: Locale): Message {
-  if (Array.isArray(source)) return [''];
+  if (Array.isArray(source)) return [];
 
   const decl = structuredClone(source.decl);
-  if (source.msg) return { decl, msg: [''] };
+  if (source.msg) return { decl, msg: [] };
 
   const sel: string[] = [];
   const plurals = findPluralSelectors(source);
@@ -91,8 +91,8 @@ function getEmptyMessage(source: Message, { code }: Locale): Message {
     }
   }
 
-  if (sel.length === 0) return { decl, msg: [''] };
+  if (sel.length === 0) return { decl, msg: [] };
 
-  const alt = variantKeys.map((keys) => ({ keys, pat: [''] }));
+  const alt = variantKeys.map((keys) => ({ keys, pat: [] }));
   return { decl, sel: sel, alt };
 }


### PR DESCRIPTION
PR #4092 was merged a bit too eagerly, as it was applying the wrong fix -- we should prefer `[]` rather than `['']` as the canonical representation of an empty message.