### PR TITLE
Task: upgrade postgresql to version 17

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:15
+        image: postgres:17
         env:
           POSTGRES_USER: pontoon
           POSTGRES_PASSWORD: pontoon

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
 
   # Database
   postgresql:
-    image: postgres:15
+    image: postgres:17
     environment:
       # Create the superuser account
       - POSTGRES_USER=pontoon


### PR DESCRIPTION
This PR upgrades the PostgreSQL service from version 15 to Postgres 17. 

Validation Results
Migrations: Successfully applied migrations on a fresh volume using Postgres 17.

Test Suite: 31/32 tests passed in the full suite.

Isolation Check: The failing test test_unsupported_formats was confirmed to pass in isolation. The IntegrityError (de-Test) observed during the full run is a result of pre-existing test pollution/leakage in the TestEndToEnd class and is not related to the PG17 engine.

```text
root@DESK:~/projects/pontoon# docker-compose down -v
[+] Running 4/4
 ✔ Container pontoon-server-1      Removed                                                                                    1.0s 
 ✔ Container pontoon-postgresql-1  Removed                                                                                    0.8s 
 ✔ Volume pontoon_pgdata           Removed                                                                                    0.1s 
 ✔ Network pontoon_default         Removed
 
root@DESK:~/projects/pontoon# docker volume ls | grep pontoon
root@DESKTOP-I6TQCSF:~/projects/pontoon# docker-compose up -d
[+] Running 4/4
 ✔ Network pontoon_default         Created                                                                                    0.0s 
 ✔ Volume "pontoon_pgdata"         Created                                                                                    0.0s 
 ✔ Container pontoon-postgresql-1  Started                                                                                    0.7s 
 ✔ Container pontoon-server-1      Started                                                                                    0.7s 
root@DESK:~/projects/pontoon# docker-compose exec server python manage.py migrate
System check identified some issues:

WARNINGS:
?: (staticfiles.W004) The directory '/app/documentation/site' in the STATICFILES_DIRS setting does not exist.
?: (staticfiles.W004) The directory '/app/translate/dist' in the STATICFILES_DIRS setting does not exist.
Operations to perform:
  Apply all migrations: account, actionlog, admin, api, auth, base, checks, contenttypes, guardian, homepage, insights, messaging, notifications, sessions, sites, socialaccount, sync, tags, terminology, tour, uxactionlog
Running migrations:
  No migrations to apply.
  
root@DESK:~/projects/pontoon# docker-compose exec server python manage.py test
Found 32 test(s).
Creating test database for alias 'default'...
[INFO:pontoon.base.migrations.0069_notification_categories] 2026-04-22 13:00:04,898 Notifications categorized: 0.
[INFO:pontoon.base.migrations.0069_notification_categories] 2026-04-22 13:00:04,898 Notifications left unchanged: 0.
 (0 entities) (0 translations) (0 TM entries) (0 entities) (0 translations) (0 entities) (0 xcode translations) (0 xliff translations) (0 android translations) (0 webext translations) (0 xcode translations) (0 xliff translations)[INFO:pontoon.base.migrations.0106_create_project_managers_group] 2026-04-22 13:00:06,588 Created 'project_managers' group.
[INFO:pontoon.base.migrations.0106_create_project_managers_group] 2026-04-22 13:00:06,593 Added 'can_manage_project' permission to project_managers
 (deleted 0 duplicate Xcode translations) (fixed 0 Xcode translations) (2025-01) (2025-02) (2025-03) (2025-04) (2025-05) (2025-06) (2025-07) (2025-08) (2025-09) (2025-10) (2025-11) (2025-12) (2026-01) (2026-02) (2026-03) (2026-04) (2025-09-24: 108 snapshots) (2025-09-25: 108 snapshots) (2025-09-26: 108 snapshots) (2025-09-27: 108 snapshots) (2025-09-28: 108 snapshots) (2025-09-29: 108 snapshots) (2025-09-30: 108 snapshots) (2025-10-01: 108 snapshots) (2025-10-02: 108 snapshots) (2025-10-03: 108 snapshots) (2025-10-04: 108 snapshots) (2025-10-05: 108 snapshots) (2025-10-06: 108 snapshots) (2025-10-07: 108 snapshots) (2025-10-08: 108 snapshots) (2025-10-09: 108 snapshots) (2025-10-10: 108 snapshots) (2025-10-11: 108 snapshots) (2025-10-12: 108 snapshots) (2025-10-13: 108 snapshots) (2025-10-14: 108 snapshots) (2025-10-15: 108 snapshots) (2025-10-16: 108 snapshots) (2025-10-17: 108 snapshots) (2025-10-18: 108 snapshots) (2025-10-19: 108 snapshots) (2025-10-20: 108 snapshots) (2025-10-21: 108 snapshots) (2025-10-22: 108 snapshots) (2025-10-23: 108 snapshots) (2025-10-24: 108 snapshots) (2025-10-25: 108 snapshots) (2025-10-26: 108 snapshots) (2025-10-27: 108 snapshots) (2025-10-28: 108 snapshots) (2025-10-29: 108 snapshots) (2025-10-30: 108 snapshots) (2025-10-31: 108 snapshots) (2025-11-01: 108 snapshots) (2025-11-02: 108 snapshots) (2025-11-03: 108 snapshots) (2025-11-04: 108 snapshots) (2025-11-05: 108 snapshots) (2025-11-06: 108 snapshots) (2025-11-07: 108 snapshots) (2025-11-08: 108 snapshots) (2025-11-09: 108 snapshots) (2025-11-10: 108 snapshots) (2025-11-11: 108 snapshots) (2025-11-12: 108 snapshots) (2025-11-13: 108 snapshots) (2025-11-14: 108 snapshots) (2025-11-15: 108 snapshots) (2025-11-16: 108 snapshots) (2025-11-17: 108 snapshots) (2025-11-18: 108 snapshots) (2025-11-19: 108 snapshots) (2025-11-20: 108 snapshots) (2025-11-21: 108 snapshots) (2025-11-22: 108 snapshots) (2025-11-23: 108 snapshots) (2025-11-24: 108 snapshots) (2025-11-25: 108 snapshots) (2025-11-26: 108 snapshots) (2025-11-27: 108 snapshots) (2025-11-28: 108 snapshots) (2025-11-29: 108 snapshots) (2025-11-30: 108 snapshots) (2025-12-01: 108 snapshots) (2025-12-02: 108 snapshots) (2025-12-03: 108 snapshots) (2025-12-04: 108 snapshots) (2025-12-05: 108 snapshots) (2025-12-06: 108 snapshots) (2025-12-07: 108 snapshots) (2025-12-08: 108 snapshots) (2025-12-09: 108 snapshots) (2025-12-10: 108 snapshots) (2025-12-11: 108 snapshots) (2025-12-12: 108 snapshots) (2025-12-13: 108 snapshots) (2025-12-14: 108 snapshots) (2025-12-15: 108 snapshots) (2025-12-16: 108 snapshots) (2025-12-17: 108 snapshots) (2025-12-18: 108 snapshots) (2025-12-19: 108 snapshots) (2025-12-20: 108 snapshots) (2025-12-21: 108 snapshots) (2025-12-22: 108 snapshots) (2025-12-23: 108 snapshots) (2025-12-24: 108 snapshots) (2025-12-25: 108 snapshots) (2025-12-26: 108 snapshots) (2025-12-27: 108 snapshots) (2025-12-28: 108 snapshots) (2025-12-29: 108 snapshots) (2025-12-30: 108 snapshots) (2025-12-31: 108 snapshots) (2026-01-01: 108 snapshots) (2026-01-02: 108 snapshots) (2026-01-03: 108 snapshots) (2026-01-04: 108 snapshots) (2026-01-05: 108 snapshots) (2026-01-06: 108 snapshots) (2026-01-07: 108 snapshots) (2026-01-08: 108 snapshots) (2026-01-09: 108 snapshots) (2026-01-10: 108 snapshots) (2026-01-11: 108 snapshots) (2026-01-12: 108 snapshots) (2026-01-13: 108 snapshots) (2026-01-14: 108 snapshots) (2026-01-15: 108 snapshots) (2026-01-16: 108 snapshots) (2026-01-17: 108 snapshots) (2026-01-18: 108 snapshots) (2026-01-19: 108 snapshots) (2026-01-20: 108 snapshots) (2026-01-21: 108 snapshots) (2026-01-22: 108 snapshots) (2026-01-23: 108 snapshots) (2026-01-24: 108 snapshots) (2026-01-25: 108 snapshots) (2026-01-26: 108 snapshots) (2026-01-27: 108 snapshots) (2026-01-28: 108 snapshots) (2026-01-29: 108 snapshots) (2026-01-30: 108 snapshots) (2026-01-31: 108 snapshots) (2026-02-01: 108 snapshots) (2026-02-02: 108 snapshots) (2026-02-03: 108 snapshots) (2026-02-04: 108 snapshots) (2026-02-05: 108 snapshots) (2026-02-06: 108 snapshots) (2026-02-07: 108 snapshots) (2026-02-08: 108 snapshots) (2026-02-09: 108 snapshots) (2026-02-10: 108 snapshots) (2026-02-11: 108 snapshots) (2026-02-12: 108 snapshots) (2026-02-13: 108 snapshots) (2026-02-14: 108 snapshots) (2026-02-15: 108 snapshots) (2026-02-16: 108 snapshots) (2026-02-17: 108 snapshots) (2026-02-18: 108 snapshots) (2026-02-19: 108 snapshots) (2026-02-20: 108 snapshots) (2026-02-21: 108 snapshots) (2026-02-22: 108 snapshots) (2026-02-23: 108 snapshots) (2026-02-24: 108 snapshots) (2026-02-25: 108 snapshots) (2026-02-26: 108 snapshots) (2026-02-27: 108 snapshots) (2026-02-28: 108 snapshots) (2026-03-01: 108 snapshots) (2026-03-02: 108 snapshots) (2026-03-03: 108 snapshots) (2026-03-04: 108 snapshots) (2026-03-05: 108 snapshots) (2026-03-06: 108 snapshots) (2026-03-07: 108 snapshots) (2026-03-08: 108 snapshots) (2026-03-09: 108 snapshots) (2026-03-10: 108 snapshots) (2026-03-11: 108 snapshots) (2026-03-12: 108 snapshots) (2026-03-13: 108 snapshots) (2026-03-14: 108 snapshots) (2026-03-15: 108 snapshots) (2026-03-16: 108 snapshots) (2026-03-17: 108 snapshots) (2026-03-18: 108 snapshots) (2026-03-19: 108 snapshots) (2026-03-20: 108 snapshots) (2026-03-21: 108 snapshots) (2026-03-22: 108 snapshots) (2026-03-23: 108 snapshots) (2026-03-24: 108 snapshots) (2026-03-25: 108 snapshots) (2026-03-26: 108 snapshots) (2026-03-27: 108 snapshots) (2026-03-28: 108 snapshots) (2026-03-29: 108 snapshots) (2026-03-30: 108 snapshots) (2026-03-31: 108 snapshots) (2026-04-01: 108 snapshots) (2026-04-02: 108 snapshots) (2026-04-03: 108 snapshots) (2026-04-04: 108 snapshots) (2026-04-05: 108 snapshots) (2026-04-06: 108 snapshots) (2026-04-07: 108 snapshots) (2026-04-08: 108 snapshots) (2026-04-09: 108 snapshots) (2026-04-10: 108 snapshots) (2026-04-11: 108 snapshots) (2026-04-12: 108 snapshots) (2026-04-13: 108 snapshots) (2026-04-14: 108 snapshots) (2026-04-15: 108 snapshots) (2026-04-16: 108 snapshots) (2026-04-17: 108 snapshots) (2026-04-18: 108 snapshots) (2026-04-19: 108 snapshots) (2026-04-20: 108 snapshots) (2026-04-21: 108 snapshots) (nothing to fix)[INFO:pontoon.messaging.emails] 2026-04-22 13:00:24,881 1st onboarding email sent to .
System check identified some issues:

WARNINGS:
?: (staticfiles.W004) The directory '/app/documentation/site' in the STATICFILES_DIRS setting does not exist.
?: (staticfiles.W004) The directory '/app/translate/dist' in the STATICFILES_DIRS setting does not exist.

System check identified 2 issues (0 silenced).
[DEBUG:pontoon.sync.core.checkout] 2026-04-22 13:00:24,980 [<Mock name='mock.slug' id='140098235105424'>] source root: <MagicMock name='Checkout().path' id='140098234447440'>
[DEBUG:pontoon.sync.core.checkout] 2026-04-22 13:00:24,981 [<Mock name='mock.slug' id='140096132011536'>] target root: <MagicMock name='Checkout().path' id='140098234447440'>
[DEBUG:pontoon.sync.core.checkout] 2026-04-22 13:00:24,982 [<Mock name='mock.slug' id='140096132004880'>] source root: <MagicMock name='Checkout().path' id='140098234447440'>
[DEBUG:pontoon.sync.core.checkout] 2026-04-22 13:00:24,983 [<Mock name='mock.slug' id='140096132043920'>] target root: <MagicMock name='Checkout().path' id='140098234447440'>
.[INFO:pontoon.sync.core.checkout] 2026-04-22 13:00:24,986 [SLUG] Repo at abc123
[WARNING:pontoon.sync.core.checkout] 2026-04-22 13:00:24,986 [SLUG] Considering all files as changed
.[INFO:pontoon.sync.core.checkout] 2026-04-22 13:00:24,989 [SLUG] Repo updated from def456 to abc123
[INFO:pontoon.sync.core.checkout] 2026-04-22 13:00:24,989 [SLUG] Skipping pull
[INFO:pontoon.sync.core.checkout] 2026-04-22 13:00:24,989 [SLUG] Repo updated from def456 to abc123
[INFO:pontoon.sync.core.checkout] 2026-04-22 13:00:24,989 [SLUG] Repo updated from def456 to abc123
.Scheduling sync for project Project 0.
..Scheduling sync for project Project 4.
.Scheduling sync for project Project 6.
.Scheduling sync for project Project 10.
.Scheduling sync for project Project 16.
..[ERROR:pontoon.sync.repositories.git] 2026-04-22 13:00:25,049 Error while executing command `['git', 'diff', '--name-status', '--find-renames=100%', '1..HEAD', '--', 'path']` in `path`: 
..[ERROR:pontoon.sync.repositories.hg] 2026-04-22 13:00:25,061 Error while executing command `['hg', 'status', '-a', '-m', '-r', '--rev=1', '--rev=default']` in `path`: 
..................[INFO:pontoon.messaging.emails] 2026-04-22 13:00:25,233 1st onboarding email sent to test0@example.com.
[INFO:pontoon.sync.core] 2026-04-22 13:00:25,283 [test-plain-json] Sync start
[INFO:pontoon.sync.core.checkout] 2026-04-22 13:00:25,285 [test-plain-json] Repo at abc123
[WARNING:pontoon.sync.core.checkout] 2026-04-22 13:00:25,285 [test-plain-json] Considering all files as changed
[DEBUG:pontoon.sync.core.checkout] 2026-04-22 13:00:25,285 [test-plain-json] target root: /tmp/tmpqs45xs7m/projects/test-plain-json/repo
[DEBUG:pontoon.sync.core.paths] 2026-04-22 13:00:25,286 [test-plain-json] Paths(auto): ref_root=en-US base=.
[INFO:pontoon.sync.core.translations_from_repo] 2026-04-22 13:00:25,308 [test-plain-json] Reading changes from 2 target files
[DEBUG:pontoon.sync.core.translations_from_repo] 2026-04-22 13:00:25,308 [test-plain-json] Scanning for translation updates...
[DEBUG:pontoon.sync.core.translations_from_repo] 2026-04-22 13:00:25,310 [test-plain-json] Filtering matches from translations...
[DEBUG:pontoon.sync.core.translations_from_repo] 2026-04-22 13:00:25,313 [test-plain-json] Filtering db changes from translations...
[DEBUG:pontoon.sync.core.translations_from_repo] 2026-04-22 13:00:25,315 [test-plain-json] Compiling updates...
[DEBUG:pontoon.sync.core.translations_from_repo] 2026-04-22 13:00:25,316 [test-plain-json] Compiling updates... Found 2
[DEBUG:pontoon.sync.core.translations_from_repo] 2026-04-22 13:00:25,317 [test-plain-json] Syncing translations from repo...
[INFO:pontoon.sync.core.translations_from_repo] 2026-04-22 13:00:25,324 [test-plain-json] Created 2 translations from repo changes
[INFO:pontoon.sync.core] 2026-04-22 13:00:25,338 [test-plain-json] Notifying 1 users about 3 new strings
[INFO:pontoon.sync.core.translations_to_repo] 2026-04-22 13:00:25,344 [test-plain-json] Updating 2 changed resources
[INFO:pontoon.sync.core.translations_to_repo] 2026-04-22 13:00:25,344 [test-plain-json:old-file.json] Updating all locales
[INFO:pontoon.sync.core.translations_to_repo] 2026-04-22 13:00:25,348 [test-plain-json:new-file.json] Updating all locales
[INFO:pontoon.sync.core.stats] 2026-04-22 13:00:25,362 [test-plain-json] Updated stats for 2 translated resources
[INFO:pontoon.sync.core] 2026-04-22 13:00:25,362 [test-plain-json] Sync done
.E
======================================================================
ERROR: test_unsupported_formats (pontoon.sync.tests.test_e2e.TestEndToEnd.test_unsupported_formats)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/django/db/backends/utils.py", line 89, in _execute
    return self.cursor.execute(sql, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "base_locale_code_key"
DETAIL:  Key (code)=(de-Test) already exists.


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/app/pontoon/sync/tests/test_e2e.py", line 608, in test_unsupported_formats
    with mock_setup() as (repo, locale):
  File "/usr/local/lib/python3.11/contextlib.py", line 137, in __enter__
    return next(self.gen)
           ^^^^^^^^^^^^^^
  File "/app/pontoon/sync/tests/test_e2e.py", line 51, in mock_setup
    locale = cast(Locale, LocaleFactory.create(code="de-Test", name="Test German"))
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/factory/base.py", line 539, in create
    return cls._generate(enums.CREATE_STRATEGY, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/factory/django.py", line 122, in _generate
    return super()._generate(strategy, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/factory/base.py", line 468, in _generate
    return step.build()
           ^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/factory/builder.py", line 274, in build
    instance = self.factory_meta.instantiate(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/factory/base.py", line 320, in instantiate
    return self.factory._create(model, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/factory/django.py", line 175, in _create
    return manager.create(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/models/query.py", line 660, in create
    obj.save(force_insert=True, using=self.db)
  File "/app/pontoon/base/models/locale.py", line 370, in save
    super().save(*args, **kwargs)
  File "/usr/local/lib/python3.11/site-packages/django/db/models/base.py", line 814, in save
    self.save_base(
  File "/usr/local/lib/python3.11/site-packages/django/db/models/base.py", line 877, in save_base
    updated = self._save_table(
              ^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/models/base.py", line 1020, in _save_table
    results = self._do_insert(
              ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/models/base.py", line 1061, in _do_insert
    return manager._insert(
           ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/models/manager.py", line 87, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/models/query.py", line 1810, in _insert
    return query.get_compiler(using=using).execute_sql(returning_fields)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 1822, in execute_sql
    cursor.execute(sql, params)
  File "/usr/local/lib/python3.11/site-packages/django/db/backends/utils.py", line 67, in execute
    return self._execute_with_wrappers(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/backends/utils.py", line 80, in _execute_with_wrappers
    return executor(sql, params, many, context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/backends/utils.py", line 84, in _execute
    with self.db.wrap_database_errors:
  File "/usr/local/lib/python3.11/site-packages/django/db/utils.py", line 91, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/usr/local/lib/python3.11/site-packages/django/db/backends/utils.py", line 89, in _execute
    return self.cursor.execute(sql, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
django.db.utils.IntegrityError: duplicate key value violates unique constraint "base_locale_code_key"
DETAIL:  Key (code)=(de-Test) already exists.


----------------------------------------------------------------------
Ran 32 tests in 0.416s

FAILED (errors=1)
Destroying test database for alias 'default'...


root@DESK-I6TQCSF:~/projects/pontoon# docker-compose exec server python manage.py test pontoon.sync.tests.test_e2e.TestEndToEnd.test_unsupported_formats
Found 1 test(s).
System check identified some issues:

WARNINGS:
?: (staticfiles.W004) The directory '/app/documentation/site' in the STATICFILES_DIRS setting does not exist.
?: (staticfiles.W004) The directory '/app/translate/dist' in the STATICFILES_DIRS setting does not exist.

System check identified 2 issues (0 silenced).
[INFO:pontoon.sync.core] 2026-04-22 13:01:50,724 [test-unsupported-formats] Sync start
[INFO:pontoon.sync.core.checkout] 2026-04-22 13:01:50,726 [test-unsupported-formats] Repo at abc123
[WARNING:pontoon.sync.core.checkout] 2026-04-22 13:01:50,726 [test-unsupported-formats] Considering all files as changed
[DEBUG:pontoon.sync.core.checkout] 2026-04-22 13:01:50,726 [test-unsupported-formats] target root: /tmp/tmpp0nr2p__/projects/test-unsupported-formats/repo
[DEBUG:pontoon.sync.core.paths] 2026-04-22 13:01:50,726 [test-unsupported-formats] Paths(auto): ref_root=en-US base=.
[DEBUG:pontoon.sync.core.translations_from_repo] 2026-04-22 13:01:50,739 [test-unsupported-formats] Scanning for translation updates...
[INFO:pontoon.sync.core] 2026-04-22 13:01:50,742 [test-unsupported-formats] Notifying 0 users about 1 new string
[INFO:pontoon.sync.core.translations_to_repo] 2026-04-22 13:01:50,744 [test-unsupported-formats] Updating 1 changed resource
[INFO:pontoon.sync.core.translations_to_repo] 2026-04-22 13:01:50,745 [test-unsupported-formats:file.json] Updating all locales
[INFO:pontoon.sync.core.stats] 2026-04-22 13:01:50,755 [test-unsupported-formats] Updated stats for 0 translated resources
[INFO:pontoon.sync.core] 2026-04-22 13:01:50,755 [test-unsupported-formats] Sync done.

----------------------------------------------------------------------
Ran 1 test in 0.184s

OK
```