### PR TITLE
Admin: sandbox jinja2 templates in emails

### DIFF
--- a/pontoon/administration/tests/test_views.py
+++ b/pontoon/administration/tests/test_views.py
@@ -382,7 +382,7 @@ def test_manage_project_strings_download_csv(client_superuser):
 
 @pytest.mark.django_db
 def test_manage_project_translate_link_excludes_obsolete_resources(client_superuser):
-    """Test that translate_locale is only set when non-obsolete resources exist."""
+    """Test that Translate link is only shown when non-obsolete resources exist."""
     locale_kl = LocaleFactory.create(code="tlh", name="Klingon")
     project = ProjectFactory.create(
         data_source=Project.DataSource.DATABASE,
@@ -390,20 +390,24 @@ def test_manage_project_translate_link_excludes_obsolete_resources(client_superu
         repositories=[],
     )
 
+    url = reverse("pontoon.admin.project", args=(project.slug,))
+    translate_url = reverse(
+        "pontoon.localizations.localization", args=(locale_kl.code, project.slug)
+    )
+
     # add obsolete resource
     ResourceFactory.create(project=project, obsolete=True)
 
-    url = reverse("pontoon.admin.project", args=(project.slug,))
     response = client_superuser.get(url)
     assert response.status_code == 200
-    assert "translate_locale" not in response.context
+    assert translate_url.encode() not in response.content
 
     # add non-obsolete resource
     ResourceFactory.create(project=project, obsolete=False)
 
     response = client_superuser.get(url)
     assert response.status_code == 200
-    assert response.context["translate_locale"] == "tlh"
+    assert translate_url.encode() in response.content
 
 
 @pytest.mark.django_db

--- a/pontoon/administration/tests/test_views.py
+++ b/pontoon/administration/tests/test_views.py
@@ -396,14 +396,14 @@ def test_manage_project_translate_link_excludes_obsolete_resources(client_superu
     url = reverse("pontoon.admin.project", args=(project.slug,))
     response = client_superuser.get(url)
     assert response.status_code == 200
-    assert "translate_locale" not in response.context
+    assert "Translate" not in response.content.decode()
 
     # add non-obsolete resource
     ResourceFactory.create(project=project, obsolete=False)
 
     response = client_superuser.get(url)
     assert response.status_code == 200
-    assert response.context["translate_locale"] == "tlh"
+    assert "Translate" in response.content.decode()
 
 
 @pytest.mark.django_db

--- a/pontoon/administration/tests/test_views.py
+++ b/pontoon/administration/tests/test_views.py
@@ -396,14 +396,14 @@ def test_manage_project_translate_link_excludes_obsolete_resources(client_superu
     url = reverse("pontoon.admin.project", args=(project.slug,))
     response = client_superuser.get(url)
     assert response.status_code == 200
-    assert "Translate" not in response.content.decode()
+    assert "translate_locale" not in response.context
 
     # add non-obsolete resource
     ResourceFactory.create(project=project, obsolete=False)
 
     response = client_superuser.get(url)
     assert response.status_code == 200
-    assert "Translate" in response.content.decode()
+    assert response.context["translate_locale"] == "tlh"
 
 
 @pytest.mark.django_db

--- a/pontoon/messaging/emails.py
+++ b/pontoon/messaging/emails.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 
 from celery import shared_task
 from dateutil.relativedelta import relativedelta
-from django_jinja.backend import Jinja2
+from jinja2.sandbox import SandboxedEnvironment
 from notifications.models import Notification
 
 from django.conf import settings
@@ -18,13 +18,21 @@ from django.utils import timezone
 
 from pontoon.actionlog.models import ActionLog
 from pontoon.base.models import Locale, UserProfile
+from pontoon.base.templatetags.helpers import full_url
 from pontoon.insights.models import LocaleInsightsSnapshot
 from pontoon.messaging.models import EmailContent
 from pontoon.messaging.utils import html_to_plain_text_with_links
+from pontoon.settings.base import (
+    INACTIVE_CONTRIBUTOR_PERIOD,
+    INACTIVE_MANAGER_PERIOD,
+    INACTIVE_TRANSLATOR_PERIOD,
+)
 
 
-jinja_env = Jinja2.get_default().env
+jinja_env = SandboxedEnvironment()
 log = logging.getLogger(__name__)
+
+jinja_env.globals["full_url"] = full_url
 
 
 def _get_monthly_user_actions(users, months_ago):
@@ -334,7 +342,9 @@ def send_onboarding_email_1(user):
     Sends 1st onboarding email to a new user.
     """
     email_content = EmailContent.objects.get(email="onboarding_1")
-    content = jinja_env.from_string(email_content.body).render()
+    content = jinja_env.from_string(email_content.body).render(
+        {"INACTIVE_CONTRIBUTOR_PERIOD": INACTIVE_CONTRIBUTOR_PERIOD}
+    )
 
     subject = email_content.subject
     template = get_template("messaging/emails/transactional.html")
@@ -442,7 +452,9 @@ def send_inactive_contributor_emails(users):
     log.info("Start sending inactive contributor emails.")
 
     email_content = EmailContent.objects.get(email="inactive_contributor")
-    content = jinja_env.from_string(email_content.body).render()
+    content = jinja_env.from_string(email_content.body).render(
+        {"INACTIVE_CONTRIBUTOR_PERIOD": INACTIVE_CONTRIBUTOR_PERIOD}
+    )
 
     subject = email_content.subject
     template = get_template("messaging/emails/transactional.html")
@@ -490,7 +502,9 @@ def send_inactive_translator_emails(users, translator_map):
             log.error(f"User {user} is not a translator of any locale.")
             continue
 
-        content = jinja_env.from_string(email_content.body).render({"locale": locale})
+        content = jinja_env.from_string(email_content.body).render(
+            {"locale": locale, "INACTIVE_TRANSLATOR_PERIOD": INACTIVE_TRANSLATOR_PERIOD}
+        )
         body_html = template.render(
             {
                 "content": content,
@@ -533,7 +547,9 @@ def send_inactive_manager_emails(users, manager_map):
             log.error(f"User {user} is not a manager of any locale.")
             continue
 
-        content = jinja_env.from_string(email_content.body).render({"locale": locale})
+        content = jinja_env.from_string(email_content.body).render(
+            {"locale": locale, "INACTIVE_MANAGER_PERIOD": INACTIVE_MANAGER_PERIOD}
+        )
         body_html = template.render(
             {
                 "content": content,

--- a/pontoon/messaging/emails.py
+++ b/pontoon/messaging/emails.py
@@ -341,7 +341,6 @@ def send_onboarding_email_1(user):
     content = email_content.body.format_map(
         SafeDict(
             {
-                "INACTIVE_CONTRIBUTOR_PERIOD": settings.INACTIVE_CONTRIBUTOR_PERIOD,
                 "translate_url": full_url(
                     "pontoon.translate", "projects", "tutorial", "playground"
                 ),
@@ -432,6 +431,7 @@ def send_onboarding_emails_3(users):
     content = email_content.body.format_map(
         SafeDict(
             {
+                "docs_url": full_url("pontoon.docs", "localizer"),
                 "settings_url": full_url("pontoon.contributors.settings"),
             }
         )

--- a/pontoon/messaging/emails.py
+++ b/pontoon/messaging/emails.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 
 from celery import shared_task
 from dateutil.relativedelta import relativedelta
-from jinja2.sandbox import SandboxedEnvironment
 from notifications.models import Notification
 
 from django.conf import settings
@@ -22,17 +21,9 @@ from pontoon.base.templatetags.helpers import full_url
 from pontoon.insights.models import LocaleInsightsSnapshot
 from pontoon.messaging.models import EmailContent
 from pontoon.messaging.utils import html_to_plain_text_with_links
-from pontoon.settings.base import (
-    INACTIVE_CONTRIBUTOR_PERIOD,
-    INACTIVE_MANAGER_PERIOD,
-    INACTIVE_TRANSLATOR_PERIOD,
-)
 
 
-jinja_env = SandboxedEnvironment()
 log = logging.getLogger(__name__)
-
-jinja_env.globals["full_url"] = full_url
 
 
 def _get_monthly_user_actions(users, months_ago):
@@ -342,8 +333,15 @@ def send_onboarding_email_1(user):
     Sends 1st onboarding email to a new user.
     """
     email_content = EmailContent.objects.get(email="onboarding_1")
-    content = jinja_env.from_string(email_content.body).render(
-        {"INACTIVE_CONTRIBUTOR_PERIOD": INACTIVE_CONTRIBUTOR_PERIOD}
+    content = email_content.body.format_map(
+        {
+            "INACTIVE_CONTRIBUTOR_PERIOD": settings.INACTIVE_CONTRIBUTOR_PERIOD,
+            "translate_url": full_url(
+                "pontoon.translate", "projects", "tutorial", "playground"
+            ),
+            "settings_url": full_url("pontoon.contributors.settings"),
+            "teams_url": full_url("pontoon.teams"),
+        }
     )
 
     subject = email_content.subject
@@ -380,7 +378,13 @@ def send_onboarding_emails_2(users):
     log.info("Start sending 2nd onboarding emails.")
 
     email_content = EmailContent.objects.get(email="onboarding_2")
-    content = jinja_env.from_string(email_content.body).render()
+    content = email_content.body.format_map(
+        {
+            "homepage_url": full_url("pontoon.homepage"),
+            "projects_url": full_url("pontoon.projects"),
+            "teams_url": full_url("pontoon.teams"),
+        }
+    )
 
     subject = email_content.subject
     template = get_template("messaging/emails/transactional.html")
@@ -416,7 +420,11 @@ def send_onboarding_emails_3(users):
     log.info("Start sending 3rd onboarding emails.")
 
     email_content = EmailContent.objects.get(email="onboarding_3")
-    content = jinja_env.from_string(email_content.body).render()
+    content = email_content.body.format_map(
+        {
+            "settings_url": full_url("pontoon.contributors.settings"),
+        }
+    )
 
     subject = email_content.subject
     template = get_template("messaging/emails/transactional.html")
@@ -452,8 +460,11 @@ def send_inactive_contributor_emails(users):
     log.info("Start sending inactive contributor emails.")
 
     email_content = EmailContent.objects.get(email="inactive_contributor")
-    content = jinja_env.from_string(email_content.body).render(
-        {"INACTIVE_CONTRIBUTOR_PERIOD": INACTIVE_CONTRIBUTOR_PERIOD}
+    content = email_content.body.format_map(
+        {
+            "INACTIVE_CONTRIBUTOR_PERIOD": settings.INACTIVE_CONTRIBUTOR_PERIOD,
+            "homepage_url": full_url("pontoon.homepage"),
+        }
     )
 
     subject = email_content.subject
@@ -502,8 +513,12 @@ def send_inactive_translator_emails(users, translator_map):
             log.error(f"User {user} is not a translator of any locale.")
             continue
 
-        content = jinja_env.from_string(email_content.body).render(
-            {"locale": locale, "INACTIVE_TRANSLATOR_PERIOD": INACTIVE_TRANSLATOR_PERIOD}
+        content = email_content.body.format_map(
+            {
+                "locale": locale,
+                "INACTIVE_TRANSLATOR_PERIOD": settings.INACTIVE_TRANSLATOR_PERIOD,
+                "team_url": full_url("pontoon.teams.team", locale.code),
+            }
         )
         body_html = template.render(
             {
@@ -546,9 +561,13 @@ def send_inactive_manager_emails(users, manager_map):
         except IndexError:
             log.error(f"User {user} is not a manager of any locale.")
             continue
-
-        content = jinja_env.from_string(email_content.body).render(
-            {"locale": locale, "INACTIVE_MANAGER_PERIOD": INACTIVE_MANAGER_PERIOD}
+        content = email_content.body.format_map(
+            {
+                "locale": locale,
+                "INACTIVE_MANAGER_PERIOD": settings.INACTIVE_MANAGER_PERIOD,
+                "contributors_url": full_url("pontoon.teams.contributors", locale.code),
+                "team_url": full_url("pontoon.teams.team", locale.code),
+            }
         )
         body_html = template.render(
             {

--- a/pontoon/messaging/emails.py
+++ b/pontoon/messaging/emails.py
@@ -431,7 +431,7 @@ def send_onboarding_emails_3(users):
     content = email_content.body.format_map(
         SafeDict(
             {
-                "docs_url": full_url("pontoon.docs", "localizer"),
+                "docs_url": full_url("pontoon.docs"),
                 "settings_url": full_url("pontoon.contributors.settings"),
             }
         )

--- a/pontoon/messaging/emails.py
+++ b/pontoon/messaging/emails.py
@@ -341,7 +341,7 @@ def send_onboarding_email_1(user):
     content = email_content.body.format_map(
         SafeDict(
             {
-                "translate_url": full_url(
+                "tutorial_url": full_url(
                     "pontoon.translate", "projects", "tutorial", "playground"
                 ),
                 "settings_url": full_url("pontoon.contributors.settings"),

--- a/pontoon/messaging/emails.py
+++ b/pontoon/messaging/emails.py
@@ -26,6 +26,11 @@ from pontoon.messaging.utils import html_to_plain_text_with_links
 log = logging.getLogger(__name__)
 
 
+class SafeDict(dict):
+    def __missing__(self, key):
+        return "{" + key + "}"
+
+
 def _get_monthly_user_actions(users, months_ago):
     month_date = timezone.now() - relativedelta(months=months_ago)
 
@@ -334,14 +339,16 @@ def send_onboarding_email_1(user):
     """
     email_content = EmailContent.objects.get(email="onboarding_1")
     content = email_content.body.format_map(
-        {
-            "INACTIVE_CONTRIBUTOR_PERIOD": settings.INACTIVE_CONTRIBUTOR_PERIOD,
-            "translate_url": full_url(
-                "pontoon.translate", "projects", "tutorial", "playground"
-            ),
-            "settings_url": full_url("pontoon.contributors.settings"),
-            "teams_url": full_url("pontoon.teams"),
-        }
+        SafeDict(
+            {
+                "INACTIVE_CONTRIBUTOR_PERIOD": settings.INACTIVE_CONTRIBUTOR_PERIOD,
+                "translate_url": full_url(
+                    "pontoon.translate", "projects", "tutorial", "playground"
+                ),
+                "settings_url": full_url("pontoon.contributors.settings"),
+                "teams_url": full_url("pontoon.teams"),
+            }
+        )
     )
 
     subject = email_content.subject
@@ -379,11 +386,13 @@ def send_onboarding_emails_2(users):
 
     email_content = EmailContent.objects.get(email="onboarding_2")
     content = email_content.body.format_map(
-        {
-            "homepage_url": full_url("pontoon.homepage"),
-            "projects_url": full_url("pontoon.projects"),
-            "teams_url": full_url("pontoon.teams"),
-        }
+        SafeDict(
+            {
+                "homepage_url": full_url("pontoon.homepage"),
+                "projects_url": full_url("pontoon.projects"),
+                "teams_url": full_url("pontoon.teams"),
+            }
+        )
     )
 
     subject = email_content.subject
@@ -421,9 +430,11 @@ def send_onboarding_emails_3(users):
 
     email_content = EmailContent.objects.get(email="onboarding_3")
     content = email_content.body.format_map(
-        {
-            "settings_url": full_url("pontoon.contributors.settings"),
-        }
+        SafeDict(
+            {
+                "settings_url": full_url("pontoon.contributors.settings"),
+            }
+        )
     )
 
     subject = email_content.subject
@@ -461,10 +472,12 @@ def send_inactive_contributor_emails(users):
 
     email_content = EmailContent.objects.get(email="inactive_contributor")
     content = email_content.body.format_map(
-        {
-            "INACTIVE_CONTRIBUTOR_PERIOD": settings.INACTIVE_CONTRIBUTOR_PERIOD,
-            "homepage_url": full_url("pontoon.homepage"),
-        }
+        SafeDict(
+            {
+                "INACTIVE_CONTRIBUTOR_PERIOD": settings.INACTIVE_CONTRIBUTOR_PERIOD,
+                "homepage_url": full_url("pontoon.homepage"),
+            }
+        )
     )
 
     subject = email_content.subject
@@ -514,11 +527,12 @@ def send_inactive_translator_emails(users, translator_map):
             continue
 
         content = email_content.body.format_map(
-            {
-                "locale": locale,
-                "INACTIVE_TRANSLATOR_PERIOD": settings.INACTIVE_TRANSLATOR_PERIOD,
-                "team_url": full_url("pontoon.teams.team", locale.code),
-            }
+            SafeDict(
+                {
+                    "INACTIVE_TRANSLATOR_PERIOD": settings.INACTIVE_TRANSLATOR_PERIOD,
+                    "team_url": full_url("pontoon.teams.team", locale.code),
+                }
+            )
         )
         body_html = template.render(
             {
@@ -562,12 +576,15 @@ def send_inactive_manager_emails(users, manager_map):
             log.error(f"User {user} is not a manager of any locale.")
             continue
         content = email_content.body.format_map(
-            {
-                "locale": locale,
-                "INACTIVE_MANAGER_PERIOD": settings.INACTIVE_MANAGER_PERIOD,
-                "contributors_url": full_url("pontoon.teams.contributors", locale.code),
-                "team_url": full_url("pontoon.teams.team", locale.code),
-            }
+            SafeDict(
+                {
+                    "INACTIVE_MANAGER_PERIOD": settings.INACTIVE_MANAGER_PERIOD,
+                    "contributors_url": full_url(
+                        "pontoon.teams.contributors", locale.code
+                    ),
+                    "team_url": full_url("pontoon.teams.team", locale.code),
+                }
+            )
         )
         body_html = template.render(
             {

--- a/pontoon/messaging/templates/messaging/emails/content/inactive_contributor.html
+++ b/pontoon/messaging/templates/messaging/emails/content/inactive_contributor.html
@@ -1,9 +1,7 @@
 <p>
   It's been a while since we’ve last seen you, but we wanted to thank you for
   contributing to localization efforts at
-  <a href="{{ full_url('pontoon.homepage') }}"
-    >{{ full_url('pontoon.homepage') }}</a
-  >.
+  <a href="{homepage_url}">{homepage_url}</a>.
 </p>
 
 <p>
@@ -15,18 +13,16 @@
 <p>
   As part of our efforts to keep our localization community active and engaged,
   we periodically review account activity. We’ve noticed you haven’t signed in
-  to your Pontoon account in the past {{ settings.INACTIVE_CONTRIBUTOR_PERIOD }}
-  months. While we completely understand that circumstances change, we wanted to
-  inform you that we may deactivate dormant accounts in the future to ensure the
+  to your Pontoon account in the past {INACTIVE_CONTRIBUTOR_PERIOD} months.
+  While we completely understand that circumstances change, we wanted to inform
+  you that we may deactivate dormant accounts in the future to ensure the
   security and efficiency of our platform.
 </p>
 
 <p>
   If you’d like to keep your Pontoon account active (we hope you will!) please
   sign in to Pontoon by visiting
-  <a href="{{ full_url('pontoon.homepage') }}"
-    >{{ full_url('pontoon.homepage') }}</a
-  >
+  <a href="{homepage_url}">{homepage_url}</a>
   and click the “Sign in” button in the top right corner.
 </p>
 

--- a/pontoon/messaging/templates/messaging/emails/content/inactive_manager.html
+++ b/pontoon/messaging/templates/messaging/emails/content/inactive_manager.html
@@ -10,10 +10,10 @@
 <p>
   As part of our efforts to keep our localization community active and engaged,
   we periodically review account activity. We’ve noticed that in the past
-  {{ settings.INACTIVE_MANAGER_PERIOD }} months you have not submitted any
-  translations or reviewed any translation submissions for your locale. We
-  understand that life can get busy, and finding time to contribute to projects
-  isn't always easy. We get it.
+  {INACTIVE_MANAGER_PERIOD} months you have not submitted any translations or
+  reviewed any translation submissions for your locale. We understand that life
+  can get busy, and finding time to contribute to projects isn't always easy. We
+  get it.
 </p>
 
 <p>
@@ -40,18 +40,14 @@
 <p>
   In addition, another Team Manager responsibility is to evaluate candidates for
   advanced roles within their community. Please review the
-  <a href="{{ full_url('pontoon.teams.contributors', locale.code) }}"
-    >contributors page</a
-  >
+  <a href="{contributors_url}">contributors page</a>
   for your team and see if there are any motivated and active community members
   that may be interested in taking on additional responsibilities within your
   team.
 </p>
 
 <p>
-  <a href="{{ full_url('pontoon.teams.team', locale.code) }}"
-    >{{ full_url('pontoon.teams.team', locale.code) }}</a
-  >
+  <a href="{team_url}">{team_url}</a>
 </p>
 
 <p>

--- a/pontoon/messaging/templates/messaging/emails/content/inactive_translator.html
+++ b/pontoon/messaging/templates/messaging/emails/content/inactive_translator.html
@@ -9,10 +9,10 @@
 <p>
   As part of our efforts to keep our localization community active and engaged,
   we periodically review account activity. We’ve noticed that in the past
-  {{ settings.INACTIVE_TRANSLATOR_PERIOD }} months you have not submitted any
-  translations or reviewed any translation submissions for your locale. We
-  understand that life can get busy, and finding time to contribute to projects
-  isn't always easy. We get it.
+  {INACTIVE_TRANSLATOR_PERIOD} months you have not submitted any translations or
+  reviewed any translation submissions for your locale. We understand that life
+  can get busy, and finding time to contribute to projects isn't always easy. We
+  get it.
 </p>
 
 <p>
@@ -37,9 +37,7 @@
 </ul>
 
 <p>
-  <a href="{{ full_url('pontoon.teams.team', locale.code) }}"
-    >{{ full_url('pontoon.teams.team', locale.code) }}</a
-  >
+  <a href="{team_url}">{team_url}</a>
 </p>
 
 <p>

--- a/pontoon/messaging/templates/messaging/emails/content/onboarding_1.html
+++ b/pontoon/messaging/templates/messaging/emails/content/onboarding_1.html
@@ -10,22 +10,19 @@
 <ol>
   <li>
     Take a
-    <a
-      href="{{ full_url('pontoon.translate', 'projects', 'tutorial', 'playground') }}"
-      >tour</a
-    >
+    <a href="{translate_url}">tour</a>
     of Pontoon to get familiar with its workflow and features, then play around
     in the sandbox to try it out for yourself.
   </li>
   <li>
     Update your
-    <a href="{{ full_url('pontoon.contributors.settings') }}">settings</a> to
-    personalize your Pontoon profile by adding an avatar and username, select
-    between a dark and light theme, and choose your default locale.
+    <a href="{settings_url}">settings</a> to personalize your Pontoon profile by
+    adding an avatar and username, select between a dark and light theme, and
+    choose your default locale.
   </li>
   <li>
-    Check out your <a href="{{ full_url('pontoon.teams') }}">team</a> page to
-    find more information and resources about your locale.
+    Check out your <a href="{teams_url}">team</a> page to find more information
+    and resources about your locale.
     <ul>
       <li>
         On the contributors tab you can find your locale’s team managers. If you
@@ -41,10 +38,10 @@
   <li>
     Start translating. One of the best ways to get used to translating is to
     dive right in! Check the
-    <a href="{{ full_url('pontoon.teams') }}">team</a> page for your locale and
-    find a project to work on: look for a project with progress under 100% and
-    click the “Missing” number that appears when you hover over it - this will
-    show you anything that still needs a translation.
+    <a href="{teams_url}">team</a> page for your locale and find a project to
+    work on: look for a project with progress under 100% and click the “Missing”
+    number that appears when you hover over it - this will show you anything
+    that still needs a translation.
   </li>
 </ol>
 

--- a/pontoon/messaging/templates/messaging/emails/content/onboarding_1.html
+++ b/pontoon/messaging/templates/messaging/emails/content/onboarding_1.html
@@ -10,7 +10,7 @@
 <ol>
   <li>
     Take a
-    <a href="{translate_url}">tour</a>
+    <a href="{tutorial_url}">tour</a>
     of Pontoon to get familiar with its workflow and features, then play around
     in the sandbox to try it out for yourself.
   </li>

--- a/pontoon/messaging/templates/messaging/emails/content/onboarding_2.html
+++ b/pontoon/messaging/templates/messaging/emails/content/onboarding_2.html
@@ -1,9 +1,7 @@
 <p>
   Thank you again for joining translation community on Pontoon. As always, you
   can continue contributing translations at
-  <a href="{{ full_url('pontoon.homepage') }}"
-    >{{ full_url('pontoon.homepage') }}</a
-  >.
+  <a href="{homepage_url}">{homepage_url}</a>.
 </p>
 
 <p>
@@ -39,15 +37,14 @@
     included into the product. The timing depends on the project, but often
     strings will be implemented at the time of the next build and ready to check
     in product. Be sure to check the deadlines in the
-    <a href="{{ full_url('pontoon.projects') }}">project page</a> to understand
-    which strings need translations soon.
+    <a href="{projects_url}">project page</a> to understand which strings need
+    translations soon.
   </li>
 </ol>
 
 <p>
   Each localization community has its own specific workflows, so do reach out to
-  your <a href="{{ full_url('pontoon.teams') }}">Team Managers</a> to learn
-  more.
+  your <a href="{teams_url}">Team Managers</a> to learn more.
 </p>
 
 <h2>Team roles</h2>

--- a/pontoon/messaging/templates/messaging/emails/content/onboarding_3.html
+++ b/pontoon/messaging/templates/messaging/emails/content/onboarding_3.html
@@ -13,7 +13,7 @@
 
 <p>
   For in-depth documentation on Pontoon, see our
-  <a href="{docs_url}">Documentation for localizers</a>.
+  <a href="{docs_url}localizer/">Documentation for localizers</a>.
 </p>
 
 <h2>Pontoon Add-on</h2>

--- a/pontoon/messaging/templates/messaging/emails/content/onboarding_3.html
+++ b/pontoon/messaging/templates/messaging/emails/content/onboarding_3.html
@@ -13,9 +13,7 @@
 
 <p>
   For in-depth documentation on Pontoon, see our
-  <a href="{{ full_url('pontoon.docs') }}localizer/"
-    >Documentation for localizers</a
-  >.
+  <a href="{docs_url}">Documentation for localizers</a>.
 </p>
 
 <h2>Pontoon Add-on</h2>
@@ -38,8 +36,7 @@
 <p>
   Finally, if you’re interested in the latest updates, announcements about new
   Pontoon features and more, be sure to enable “News and updates“ in your
-  <a href="{{ full_url('pontoon.contributors.settings') }}">settings</a> so you
-  can be the first to get notified.
+  <a href="{settings_url}">settings</a> so you can be the first to get notified.
 </p>
 
 <p>

--- a/pontoon/messaging/tests/test_emails.py
+++ b/pontoon/messaging/tests/test_emails.py
@@ -1,15 +1,26 @@
+from collections import defaultdict
 from datetime import date, datetime, timezone
 from unittest.mock import patch
 
 import pytest
 
+from django.template import TemplateSyntaxError
 from django.test.client import RequestFactory
+from django.urls import NoReverseMatch
 
+from pontoon.base.models import User
 from pontoon.insights.models import LocaleInsightsSnapshot
 from pontoon.messaging.emails import (
     _get_monthly_locale_stats,
+    send_inactive_contributor_emails,
+    send_inactive_manager_emails,
+    send_inactive_translator_emails,
+    send_onboarding_email_1,
+    send_onboarding_emails_2,
+    send_onboarding_emails_3,
     send_verification_email,
 )
+from pontoon.messaging.models import EmailContent
 from pontoon.test.factories import LocaleFactory
 
 
@@ -60,3 +71,105 @@ def test_get_monthly_locale_stats_uses_end_of_month_snapshot():
     assert result[locale.pk].pk == snapshot_nov_1.pk
     assert result[locale.pk].approved_strings == 100
     assert result[locale.pk].completion == 100.0
+
+
+@pytest.mark.django_db
+def test_send_onboarding_email_1(user_a):
+    try:
+        send_onboarding_email_1(user_a)
+    except EmailContent.DoesNotExist:
+        pytest.fail("EmailContent for 'onboarding_1' is missing from the DB.")
+    except NoReverseMatch as e:
+        pytest.fail(f"URL resolution failed: check URL config: {e}")
+    except TemplateSyntaxError as e:
+        pytest.fail(f"Template is broken: {e}")
+    except Exception as e:
+        pytest.fail(f"An unexpected error occurred: {e}")
+
+
+@pytest.mark.django_db
+def test_send_onboarding_emails_2(user_a):
+
+    users = User.objects.filter(pk=user_a.pk)
+
+    try:
+        send_onboarding_emails_2(users)
+    except EmailContent.DoesNotExist:
+        pytest.fail("EmailContent for 'onboarding_2' is missing from the DB.")
+    except NoReverseMatch as e:
+        pytest.fail(f"URL resolution failed: check URL config: {e}")
+    except TemplateSyntaxError as e:
+        pytest.fail(f"Template is broken: {e}")
+    except Exception as e:
+        pytest.fail(f"An unexpected error occurred: {e}")
+
+
+@pytest.mark.django_db
+def test_send_onboarding_emails_3(user_a):
+
+    users = User.objects.filter(pk=user_a.pk)
+
+    try:
+        send_onboarding_emails_3(users)
+    except EmailContent.DoesNotExist:
+        pytest.fail("EmailContent for 'onboarding_3' is missing from the DB.")
+    except NoReverseMatch as e:
+        pytest.fail(f"URL resolution failed: check URL config: {e}")
+    except TemplateSyntaxError as e:
+        pytest.fail(f"Template is broken: {e}")
+    except Exception as e:
+        pytest.fail(f"An unexpected error occurred: {e}")
+
+
+@pytest.mark.django_db
+def test_send_inactive_contributor_emails(user_a):
+
+    users = User.objects.filter(pk=user_a.pk)
+
+    try:
+        send_inactive_contributor_emails(users)
+    except EmailContent.DoesNotExist:
+        pytest.fail("EmailContent for 'inactive_contributor' is missing from the DB.")
+    except NoReverseMatch as e:
+        pytest.fail(f"URL resolution failed: check URL config: {e}")
+    except TemplateSyntaxError as e:
+        pytest.fail(f"Template is broken: {e}")
+    except Exception as e:
+        pytest.fail(f"An unexpected error occurred: {e}")
+
+
+@pytest.mark.django_db
+def test_send_inactive_translator_emails(user_a, locale_a):
+    translators = defaultdict(set)
+
+    users = User.objects.filter(pk=user_a.pk)
+    translators[user_a.pk].add(locale_a)
+    try:
+        send_inactive_translator_emails(users, translators)
+    except EmailContent.DoesNotExist:
+        pytest.fail("EmailContent for 'inactive_translator' is missing from the DB.")
+    except NoReverseMatch as e:
+        pytest.fail(f"URL resolution failed: check URL config: {e}")
+    except TemplateSyntaxError as e:
+        pytest.fail(f"Template is broken: {e}")
+    except Exception as e:
+        pytest.fail(f"An unexpected error occurred: {e}")
+
+
+@pytest.mark.django_db
+def test_send_inactive_manager_emails(user_a, locale_a):
+    managers = defaultdict(set)
+
+    users = User.objects.filter(pk=user_a.pk)
+    managers[user_a.pk].add(locale_a)
+
+    try:
+        send_inactive_manager_emails(users, managers)
+    except EmailContent.DoesNotExist:
+        pytest.fail("EmailContent for 'inactive_manager' is missing from the DB.")
+    except NoReverseMatch as e:
+        pytest.fail(f"URL resolution failed: check URL config: {e}")
+    except TemplateSyntaxError as e:
+        pytest.fail(f"Template is broken: {e}")
+    except Exception as e:
+        pytest.fail(f"An unexpected error occurred: {e}")

--- a/pontoon/messaging/tests/test_emails.py
+++ b/pontoon/messaging/tests/test_emails.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
+from django.core import mail
 from django.template import TemplateSyntaxError
 from django.test.client import RequestFactory
 from django.urls import NoReverseMatch
@@ -86,6 +87,9 @@ def test_send_onboarding_email_1(user_a):
     except Exception as e:
         pytest.fail(f"An unexpected error occurred: {e}")
 
+    assert len(mail.outbox) == 2
+    assert mail.outbox[0].to == [user_a.contact_email]
+
 
 @pytest.mark.django_db
 def test_send_onboarding_emails_2(user_a):
@@ -102,6 +106,9 @@ def test_send_onboarding_emails_2(user_a):
         pytest.fail(f"Template is broken: {e}")
     except Exception as e:
         pytest.fail(f"An unexpected error occurred: {e}")
+
+    assert len(mail.outbox) == 2
+    assert mail.outbox[0].to == [user_a.contact_email]
 
 
 @pytest.mark.django_db
@@ -120,6 +127,9 @@ def test_send_onboarding_emails_3(user_a):
     except Exception as e:
         pytest.fail(f"An unexpected error occurred: {e}")
 
+    assert len(mail.outbox) == 2
+    assert mail.outbox[0].to == [user_a.contact_email]
+
 
 @pytest.mark.django_db
 def test_send_inactive_contributor_emails(user_a):
@@ -136,6 +146,9 @@ def test_send_inactive_contributor_emails(user_a):
         pytest.fail(f"Template is broken: {e}")
     except Exception as e:
         pytest.fail(f"An unexpected error occurred: {e}")
+
+    assert len(mail.outbox) == 2
+    assert mail.outbox[0].to == [user_a.contact_email]
 
 
 @pytest.mark.django_db
@@ -155,6 +168,9 @@ def test_send_inactive_translator_emails(user_a, locale_a):
     except Exception as e:
         pytest.fail(f"An unexpected error occurred: {e}")
 
+    assert len(mail.outbox) == 2
+    assert mail.outbox[0].to == [user_a.contact_email]
+
 
 @pytest.mark.django_db
 def test_send_inactive_manager_emails(user_a, locale_a):
@@ -173,3 +189,6 @@ def test_send_inactive_manager_emails(user_a, locale_a):
         pytest.fail(f"Template is broken: {e}")
     except Exception as e:
         pytest.fail(f"An unexpected error occurred: {e}")
+
+    assert len(mail.outbox) == 2
+    assert mail.outbox[0].to == [user_a.contact_email]


### PR DESCRIPTION
This PR removes the ability for users with admin access to conduct RCE via jinja2 templates within Pontoon onboarding and user inactivity emails. It uses `SandboxedEnvironment` to prevent access to dangerous commands.

Fixes #3985.

Note: access to `settings` has been restricted to `INACTIVE_CONTRIBUTOR_PERIOD`, `INACTIVE_TRANSLATOR_PERIOD` and `INACTIVE_MANAGER_PERIOD`. Therefore, we must subsequently edit the onboarding and inactivity emails in the PROD and DEV dbs to reflect that, or else we risk crashing Pontoon.

Note 2: The above note expanded: all template tags in PROD and DEV must be of the format `{placeholder}`. `full_url` is no longer used within email templates, and jinja templating brackets (`{{}}`) are replaced with single brackets (`{}`).