### PR TITLE
Teams: fix query parameter check in bugs tab

### DIFF
--- a/pontoon/base/static/js/tabs.js
+++ b/pontoon/base/static/js/tabs.js
@@ -63,16 +63,15 @@ $(function () {
       inProgress.abort();
     }
 
-    const url = '/' + path.split('/' + urlSplit + '/')[1],
-      tab = $('#middle .links a[href="' + path.split('?')[0] + '"]');
+    const url = '/' + path.split('/' + urlSplit + '/')[1];
+    const tab = $('#middle .links a[href="' + path.split('?')[0] + '"]');
 
     // Update menu
     $('#middle .links li').removeClass('active');
     tab.parents('li').addClass('active');
 
     container.empty();
-
-    if (url !== '/bugs/') {
+    if (!url.startsWith('/bugs/')) {
       inProgress = $.ajax({
         url: '/' + urlSplit + '/ajax' + url,
         success: function (data) {

--- a/pontoon/base/static/js/tabs.js
+++ b/pontoon/base/static/js/tabs.js
@@ -71,6 +71,7 @@ $(function () {
     tab.parents('li').addClass('active');
 
     container.empty();
+
     if (!url.startsWith('/bugs/')) {
       inProgress = $.ajax({
         url: '/' + urlSplit + '/ajax' + url,


### PR DESCRIPTION
This PR fixes the issue where one accesses the bugs tab of a teams page like `/bugs/?foo` and it returns nothing instead of `Zarro Boogs.`

Fixes #2504.