### PR TITLE
Profile: add is_implicit_action filter to contribution map

### DIFF
--- a/pontoon/contributors/utils.py
+++ b/pontoon/contributors/utils.py
@@ -289,7 +289,7 @@ def get_contributions_map(contributor, viewer, contribution_period=None):
     actions = ActionLog.objects.visible_for(viewer)
 
     if contribution_period is not None:
-        actions = actions.filter(contribution_period)
+        actions = actions.filter(contribution_period, is_implicit_action=False)
 
     review_action_types = [
         ActionLog.ActionType.TRANSLATION_APPROVED,


### PR DESCRIPTION
This PR adds `is_implicit_action=False` filter to the profile contribution map, which filters out users actions like auto-rejections due to a string being deleted.

Fixes #4110.

Before:
<img width="719" height="525" alt="image" src="https://github.com/user-attachments/assets/5fbd4074-7992-4679-8d10-f07c6f6a400d" />

After:
<img width="743" height="522" alt="image" src="https://github.com/user-attachments/assets/b58e0244-1349-4e28-8b83-7c721d10e19d" />
