### PR TITLE
Translate: remove google translate from concordance search results

### DIFF
--- a/translate/src/modules/machinery/components/Machinery.test.jsx
+++ b/translate/src/modules/machinery/components/Machinery.test.jsx
@@ -62,15 +62,12 @@ describe('<Machinery>', () => {
         { original: '3', sources: [] },
       ],
       {
-        results: [
-          { original: '4', sources: [] },
-          { original: '5', sources: [] },
-        ],
+        results: [],
       },
     );
 
-    expect(getAllByRole('listitem')).toHaveLength(5);
-    expect(getAllByTitle(copyListItemTitle)).toHaveLength(5);
+    expect(getAllByRole('listitem')).toHaveLength(3);
+    expect(getAllByTitle(copyListItemTitle)).toHaveLength(3);
   });
 
   it('renders a reset button if a search query is present', () => {

--- a/translate/src/modules/machinery/components/Machinery.test.jsx
+++ b/translate/src/modules/machinery/components/Machinery.test.jsx
@@ -54,7 +54,7 @@ describe('<Machinery>', () => {
     getByRole('searchbox');
   });
 
-  it('shows the correct number of translations', () => {
+  it('shows machinery translations when concordance search is not active', () => {
     const { getAllByRole, getAllByTitle } = mountMachinery(
       [
         { original: '1', sources: [] },
@@ -62,12 +62,66 @@ describe('<Machinery>', () => {
         { original: '3', sources: [] },
       ],
       {
-        results: [],
+        query: '',
+        results: [
+          {
+            original: 'concordance-only',
+            translation: 'x',
+            sources: ['concordance-search'],
+          },
+        ],
       },
     );
 
     expect(getAllByRole('listitem')).toHaveLength(3);
     expect(getAllByTitle(copyListItemTitle)).toHaveLength(3);
+  });
+
+  it('shows concordance search results only when a query is active, not machinery translations', () => {
+    const { getAllByRole, queryByText } = mountMachinery(
+      [
+        { original: 'machinery-a', sources: ['google-translate'] },
+        { original: 'machinery-b', sources: ['translation-memory'] },
+        { original: 'machinery-c', sources: ['translation-memory'] },
+      ],
+      {
+        input: 'find me',
+        query: 'find me',
+        results: [
+          {
+            original: 'one',
+            translation: 'uno',
+            sources: ['concordance-search'],
+          },
+          {
+            original: 'two',
+            translation: 'dos',
+            sources: ['concordance-search'],
+          },
+        ],
+      },
+    );
+
+    expect(getAllByRole('listitem')).toHaveLength(2);
+    expect(queryByText('machinery-a')).not.toBeInTheDocument();
+    expect(queryByText('one')).toBeInTheDocument();
+    expect(queryByText('two')).toBeInTheDocument();
+  });
+
+  it('shows no list rows when concordance search is active but has no results', () => {
+    const { queryAllByRole } = mountMachinery(
+      [
+        { original: 'machinery-a', sources: ['google-translate'] },
+        { original: 'machinery-b', sources: ['translation-memory'] },
+      ],
+      {
+        input: 'nothing',
+        query: 'nothing',
+        results: [],
+      },
+    );
+
+    expect(queryAllByRole('listitem')).toHaveLength(0);
   });
 
   it('renders a reset button if a search query is present', () => {

--- a/translate/src/modules/machinery/components/Machinery.tsx
+++ b/translate/src/modules/machinery/components/Machinery.tsx
@@ -71,27 +71,30 @@ export function Machinery(): React.ReactElement<'section'> {
         </form>
       </div>
       <div className='list-wrapper' ref={rootRef}>
-        <ul>
-          {translations.map((translation, index) => (
-            <MachineryTranslationComponent
-              index={index}
-              sourceString={source}
-              translation={translation}
-              key={index}
-            />
-          ))}
-        </ul>
+        {results.length === 0 ? (
+          <ul>
+            {translations.map((translation, index) => (
+              <MachineryTranslationComponent
+                index={index}
+                sourceString={source}
+                translation={translation}
+                key={index}
+              />
+            ))}
+          </ul>
+        ) : (
+          <ul>
+            {results.map((result, index) => (
+              <MachineryTranslationComponent
+                index={index + translations.length}
+                sourceString={query}
+                translation={result}
+                key={index + translations.length}
+              />
+            ))}
+          </ul>
+        )}
         {machineryFetching && <MachinerySkeletonLoader items={[]} />}
-        <ul>
-          {results.map((result, index) => (
-            <MachineryTranslationComponent
-              index={index + translations.length}
-              sourceString={query}
-              translation={result}
-              key={index + translations.length}
-            />
-          ))}
-        </ul>
         {(fetching || hasMore) && (
           <MachinerySkeletonLoader items={results} sentryRef={sentryRef} />
         )}

--- a/translate/src/modules/machinery/components/Machinery.tsx
+++ b/translate/src/modules/machinery/components/Machinery.tsx
@@ -23,6 +23,7 @@ export function Machinery(): React.ReactElement<'section'> {
   } = useContext(MachineryTranslations);
   const { fetching, hasMore, input, query, results, setInput, getResults } =
     useContext(SearchData);
+  const isConcordanceSearchActive = query.trim().length > 0;
 
   const [sentryRef, { rootRef }] = useInfiniteScroll({
     loading: fetching,
@@ -71,18 +72,7 @@ export function Machinery(): React.ReactElement<'section'> {
         </form>
       </div>
       <div className='list-wrapper' ref={rootRef}>
-        {results.length === 0 ? (
-          <ul>
-            {translations.map((translation, index) => (
-              <MachineryTranslationComponent
-                index={index}
-                sourceString={source}
-                translation={translation}
-                key={index}
-              />
-            ))}
-          </ul>
-        ) : (
+        {isConcordanceSearchActive ? (
           <ul>
             {results.map((result, index) => (
               <MachineryTranslationComponent
@@ -90,6 +80,17 @@ export function Machinery(): React.ReactElement<'section'> {
                 sourceString={query}
                 translation={result}
                 key={index + translations.length}
+              />
+            ))}
+          </ul>
+        ) : (
+          <ul>
+            {translations.map((translation, index) => (
+              <MachineryTranslationComponent
+                index={index}
+                sourceString={source}
+                translation={translation}
+                key={index}
               />
             ))}
           </ul>

--- a/translate/src/modules/machinery/components/Machinery.tsx
+++ b/translate/src/modules/machinery/components/Machinery.tsx
@@ -76,10 +76,10 @@ export function Machinery(): React.ReactElement<'section'> {
           <ul>
             {results.map((result, index) => (
               <MachineryTranslationComponent
-                index={index + translations.length}
+                index={index}
                 sourceString={query}
                 translation={result}
-                key={index + translations.length}
+                key={index}
               />
             ))}
           </ul>


### PR DESCRIPTION
When searching via Concordance Search, Google Translate shows up as one of the first results, which is not the intended behaviour of Concordance Search. This PR simply removes this functionality.

Fixes #4117.