### PR TITLE
Fix missing space in 'message new' class in sent.html

### DIFF
--- a/pontoon/messaging/templates/messaging/includes/sent.html
+++ b/pontoon/messaging/templates/messaging/includes/sent.html
@@ -7,7 +7,7 @@
   {% endif %}
   <ul>
     {% for message in sent_messages %}
-      <li class="message{% if message.is_new() %}new{% endif %}">
+      <li class="message {% if message.is_new() %}new{% endif %}">
         <div class="user-avatar">
           <a
             href="{{ url('pontoon.contributors.contributor.username', message.sender.username) }}"

--- a/pontoon/messaging/templates/messaging/includes/sent.html
+++ b/pontoon/messaging/templates/messaging/includes/sent.html
@@ -7,7 +7,7 @@
   {% endif %}
   <ul>
     {% for message in sent_messages %}
-      <li class="message{% if message.is_new() %} new{% endif %}">
+      <li class="message{% if message.is_new() %}new{% endif %}">
         <div class="user-avatar">
           <a
             href="{{ url('pontoon.contributors.contributor.username', message.sender.username) }}"

--- a/pontoon/messaging/templates/messaging/includes/sent.html
+++ b/pontoon/messaging/templates/messaging/includes/sent.html
@@ -7,7 +7,7 @@
   {% endif %}
   <ul>
     {% for message in sent_messages %}
-      <li class="message{% if message.is_new() %}new{% endif %}">
+      <li class="message{% if message.is_new() %} new{% endif %}">
         <div class="user-avatar">
           <a
             href="{{ url('pontoon.contributors.contributor.username', message.sender.username) }}"


### PR DESCRIPTION
Fixes #4113

## Problem
After sending a message, the "Sent" panel displayed the newly sent 
message with an unstyled class "messagenew" instead of "message new". 
This caused the highlight styling to not apply to the new message. 
Clicking "Sent" again didn't fix it — a force-reload was required.

## Root Cause
In `sent.html`, the `new` class was missing a space before it:

```html
<!-- Before (buggy) -->
<li class="message{% if message.is_new() %}new{% endif %}">

<!-- After (fixed) -->
<li class="message{% if message.is_new() %} new{% endif %}">
```

## Fix
Added a single space before `new` inside the `{% if %}` block so the 
two CSS classes are properly separated.

