### PR TITLE
Miscellaneous: exclude various directories from ag/rg/VSC search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .*
 !.github
+!.ignore
 
 *-all.js
 *-min.css

--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,4 @@
+# Folder exclusion for directory searches
+.git/
+node_modules/
+documentation/.cache


### PR DESCRIPTION
This PR ignores certain directories when a contributor attempts to search via `ag`, `rg` or VS code search.

Fixes #4058.

## Additional Information

For VS Code, you need to click this button to enable the functionality:

<img width="776" height="532" alt="image" src="https://github.com/user-attachments/assets/c0b3216b-ed41-4663-a1fb-aa0230f947e9" />