### PR TITLE
#2168 make asLocaleString use locale code

### DIFF
--- a/translate/src/modules/resourceprogress/components/ResourceProgress.tsx
+++ b/translate/src/modules/resourceprogress/components/ResourceProgress.tsx
@@ -1,10 +1,11 @@
 import { Localized } from '@fluent/react';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useState, useContext } from 'react';
 import { Link } from '~/context/Location';
 import { Stats, useStats } from '~/modules/stats';
 import { asLocaleString, useOnDiscard } from '~/utils';
 import { ProgressChart } from './ProgressChart';
 import './ResourceProgress.css';
+import { Locale } from '~/context/Locale';
 
 type Props = {
   percent: number;
@@ -24,6 +25,7 @@ function ResourceProgressDialog({ percent, stats, onDiscard }: Props) {
   } = stats;
 
   const ref = React.useRef<HTMLElement>(null);
+  const { code } = useContext(Locale);
   useOnDiscard(ref, onDiscard);
 
   return (
@@ -34,13 +36,13 @@ function ResourceProgressDialog({ percent, stats, onDiscard }: Props) {
             <Localized id='resourceprogress-ResourceProgress--all-strings'>
               ALL STRINGS
             </Localized>
-            <span className='value'>{asLocaleString(total)}</span>
+            <span className='value'>{asLocaleString(total, code)}</span>
           </h2>
           <h2 className='small'>
             <Localized id='resourceprogress-ResourceProgress--unreviewed'>
               UNREVIEWED
             </Localized>
-            <span className='value'>{asLocaleString(unreviewed)}</span>
+            <span className='value'>{asLocaleString(unreviewed, code)}</span>
           </h2>
         </header>
         <ProgressChart stats={stats} size={220} />
@@ -55,7 +57,7 @@ function ResourceProgressDialog({ percent, stats, onDiscard }: Props) {
           </span>
           <p className='value' onClick={onDiscard}>
             <Link to={{ status: 'translated' }}>
-              {asLocaleString(approved)}
+              {asLocaleString(approved, code)}
             </Link>
           </p>
         </div>
@@ -67,7 +69,7 @@ function ResourceProgressDialog({ percent, stats, onDiscard }: Props) {
           </span>
           <p className='value' onClick={onDiscard}>
             <Link to={{ status: 'pretranslated' }}>
-              {asLocaleString(pretranslated)}
+              {asLocaleString(pretranslated, code)}
             </Link>
           </p>
         </div>
@@ -78,7 +80,9 @@ function ResourceProgressDialog({ percent, stats, onDiscard }: Props) {
             </Localized>
           </span>
           <p className='value' onClick={onDiscard}>
-            <Link to={{ status: 'warnings' }}>{asLocaleString(warnings)}</Link>
+            <Link to={{ status: 'warnings' }}>
+              {asLocaleString(warnings, code)}
+            </Link>
           </p>
         </div>
         <div className='errors'>
@@ -88,7 +92,9 @@ function ResourceProgressDialog({ percent, stats, onDiscard }: Props) {
             </Localized>
           </span>
           <p className='value' onClick={onDiscard}>
-            <Link to={{ status: 'errors' }}>{asLocaleString(errors)}</Link>
+            <Link to={{ status: 'errors' }}>
+              {asLocaleString(errors, code)}
+            </Link>
           </p>
         </div>
         <div className='missing'>
@@ -98,7 +104,9 @@ function ResourceProgressDialog({ percent, stats, onDiscard }: Props) {
             </Localized>
           </span>
           <p className='value' onClick={onDiscard}>
-            <Link to={{ status: 'missing' }}>{asLocaleString(missing)}</Link>
+            <Link to={{ status: 'missing' }}>
+              {asLocaleString(missing, code)}
+            </Link>
           </p>
         </div>
       </div>

--- a/translate/src/modules/search/components/FiltersPanel.tsx
+++ b/translate/src/modules/search/components/FiltersPanel.tsx
@@ -1,6 +1,12 @@
 import { Localized } from '@fluent/react';
 import classNames from 'classnames';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useContext,
+} from 'react';
 
 import type { Author } from '~/api/filter';
 import type { Tag } from '~/api/project';
@@ -12,6 +18,7 @@ import { FILTERS_EXTRA, FILTERS_STATUS } from '../constants';
 import './FiltersPanel.css';
 import type { FilterState, FilterType, TimeRangeType } from './SearchBox';
 import { TimeRangeFilter } from './TimeRangeFilter';
+import { Locale } from '~/context/Locale';
 
 type Props = {
   filters: FilterState;
@@ -56,12 +63,14 @@ const StatusFilter = ({
   selected,
   stats,
   status,
+  code,
 }: {
   onSelect: () => void;
   onToggle: () => void;
   selected: boolean;
   stats: Stats;
   status: (typeof FILTERS_STATUS)[number];
+  code: string;
 }) => (
   <li
     className={classNames(
@@ -81,7 +90,10 @@ const StatusFilter = ({
       <span className='title'>{status.name}</span>
     </Localized>
     <span className='count'>
-      {asLocaleString(stats['stat' in status ? status.stat : status.slug])}
+      {asLocaleString(
+        stats['stat' in status ? status.stat : status.slug],
+        code,
+      )}
     </span>
   </li>
 );
@@ -146,11 +158,13 @@ const AuthorFilter = ({
   onSelect,
   onToggle,
   selected,
+  code,
 }: {
   author: Author;
   onSelect: () => void;
   onToggle: () => void;
   selected: boolean;
+  code: string;
 }) => (
   <li
     className={classNames('author', selected && 'selected')}
@@ -177,7 +191,7 @@ const AuthorFilter = ({
         <p className='name'>{display_name}</p>
         <p className='role'>{role}</p>
       </figcaption>
-      <span className='count'>{asLocaleString(translation_count)}</span>
+      <span className='count'>{asLocaleString(translation_count, code)}</span>
     </figure>
   </li>
 );
@@ -244,6 +258,7 @@ export function FiltersPanelDialog({
   onDiscard,
 }: FiltersPanelProps): React.ReactElement<'div'> {
   const stats = useStats();
+  const { code } = useContext(Locale);
   const ref = React.useRef(null);
   useOnDiscard(ref, onDiscard);
 
@@ -262,6 +277,7 @@ export function FiltersPanelDialog({
             selected={statuses.includes(status.slug)}
             stats={stats}
             status={status}
+            code={code}
           />
         ))}
 
@@ -317,6 +333,7 @@ export function FiltersPanelDialog({
                 onSelect={() => onApplyFilter(author.email, 'authors')}
                 onToggle={() => onToggleFilter(author.email, 'authors')}
                 selected={authors.includes(author.email)}
+                code={code}
               />
             ))}
           </>

--- a/translate/src/utils/asLocaleString.test.js
+++ b/translate/src/utils/asLocaleString.test.js
@@ -1,0 +1,19 @@
+import { asLocaleString } from './asLocaleString';
+
+// French (and other locales) use Unicode Character 202F "NARROW NO-BREAK SPACE"
+// (U+202F) as a thousands separator. See:
+// https://github.com/unicode-org/cldr/blob/24f92afa0b467992a503c17aec466cdabebab282/common/main/fr.xml#L7165
+const NNBSP = '\u202f';
+
+describe('asLocaleString', () => {
+  it('formats numbers with language-sensitive separators', () => {
+    expect(asLocaleString(1234567, 'en-GB')).toEqual('1,234,567');
+    expect(asLocaleString(1234567, 'de')).toEqual('1.234.567');
+    expect(asLocaleString(1234567, 'fr')).toEqual(`1${NNBSP}234${NNBSP}567`);
+  });
+
+  it('always uses Latin digits regardless of locale', () => {
+    expect(asLocaleString(1234567, 'fa')).toMatch(/^[0-9,.\s${NNBSP}]+$/);
+    expect(asLocaleString(1234567, 'sat-Olck')).toMatch(/^[0-9,.\s${NNBSP}]+$/);
+  });
+});

--- a/translate/src/utils/asLocaleString.test.js
+++ b/translate/src/utils/asLocaleString.test.js
@@ -1,19 +1,16 @@
 import { asLocaleString } from './asLocaleString';
 
-// French (and other locales) use Unicode Character 202F "NARROW NO-BREAK SPACE"
-// (U+202F) as a thousands separator. See:
-// https://github.com/unicode-org/cldr/blob/24f92afa0b467992a503c17aec466cdabebab282/common/main/fr.xml#L7165
-const NNBSP = '\u202f';
+const LARGE_NUMBER = 1234567;
+const RE_LATIN_DIGITS = /^\d[\d\W]*$/;
 
 describe('asLocaleString', () => {
-  it('formats numbers with language-sensitive separators', () => {
-    expect(asLocaleString(1234567, 'en-GB')).toEqual('1,234,567');
-    expect(asLocaleString(1234567, 'de')).toEqual('1.234.567');
-    expect(asLocaleString(1234567, 'fr')).toEqual(`1${NNBSP}234${NNBSP}567`);
-  });
-
   it('always uses Latin digits regardless of locale', () => {
-    expect(asLocaleString(1234567, 'fa')).toMatch(/^[0-9,.\s${NNBSP}]+$/);
-    expect(asLocaleString(1234567, 'sat-Olck')).toMatch(/^[0-9,.\s${NNBSP}]+$/);
+    expect(asLocaleString(LARGE_NUMBER, 'fa')).toMatch(RE_LATIN_DIGITS);
+    expect(asLocaleString(LARGE_NUMBER, 'sat-Olck')).toMatch(RE_LATIN_DIGITS);
+  });
+  it('produces different output for different locale', () => {
+    expect(asLocaleString(LARGE_NUMBER, 'en-GB')).not.toEqual(
+      asLocaleString(LARGE_NUMBER, 'fr'),
+    );
   });
 });

--- a/translate/src/utils/asLocaleString.ts
+++ b/translate/src/utils/asLocaleString.ts
@@ -1,11 +1,14 @@
 /**
  * Format number as a language-sensitive representation.
- * TODO: De-hardcode en-GB locale.
- * See https://github.com/mozilla/pontoon/issues/2168 for details.
+ * Use locale's native separator style but still render Western Arabic (Latin) digits,
+ * since this is used for UI stats counts rather than translated content.
  *
  * @param {number} number The number to be formatted.
+ * @param {string} localeCode BCP 47 locale code, e.g. "de" or "nb-NO", falls back to "en-GB" if empty.
  * @returns {string} A language-sensitive representation of the number.
  */
-export function asLocaleString(number: number): string {
-  return Number(number).toLocaleString('en-GB');
+export function asLocaleString(number: number, localeCode: string): string {
+  return Number(number).toLocaleString(localeCode || 'en-GB', {
+    numberingSystem: 'latn',
+  });
 }


### PR DESCRIPTION
Now `asLocaleString` additionally gets locale code passed from context. No more hardcoded en-GB.
Force latin digits via `numberingSystem: 'latn'` to keep UI stats readable regardless of locale script (e.g. sat-Olck, fa).
Added tests for Latin digit and en-GB formatting.

See issue #2168 
