### PR TITLE
Translate: support dark theme in editor

### DIFF
--- a/pontoon/base/static/css/dark-theme.css
+++ b/pontoon/base/static/css/dark-theme.css
@@ -61,13 +61,13 @@
   --translation-secondary-color: #aaaaaa;
   --translation-main-button-color: #272a2f;
   --translation-subtitle-color: #888888;
-  --editor-background: #ffffff;
-  --editor-color: #444444;
+  --editor-background: #333941;
+  --editor-color: #ffffff;
   --editor-form-background: #272a2f;
   --editor-menu-background: #272a2f;
   --editor-menu-color: #aaaaaa;
   --editor-menu-action-button-color: #ffffff;
-  --editor-readonly-background: #c7cacf;
+  --editor-readonly-background: #272a2f;
   --time-range-handles: #272a2f;
 
   /* Highlights */
@@ -77,13 +77,13 @@
   --diff-ins-color: #9cd699;
   --search-color: #ffa10f;
   --search-background: #676054;
-  --tags-brace-color: #872bff;
-  --tags-bracket-color: #3e9682;
-  --tags-keyword-color: #872bff;
-  --tags-literal-color: #3e9682;
-  --tags-name-color: #872bff;
-  --tags-quote-color: #3e9682;
-  --tags-tag-name-color: #3e9682;
+  --tags-brace-color: #b36aff;
+  --tags-bracket-color: #5dbfaa;
+  --tags-keyword-color: #b36aff;
+  --tags-literal-color: #5dbfaa;
+  --tags-name-color: #b36aff;
+  --tags-quote-color: #5dbfaa;
+  --tags-tag-name-color: #5dbfaa;
 
   /* Chart colors */
   --green-blue: #4fc4f666;

--- a/pontoon/base/static/css/dark-theme.css
+++ b/pontoon/base/static/css/dark-theme.css
@@ -56,18 +56,18 @@
 
   /* Translation workspace */
   --translation-background: #3f4752;
-  --translation-border: #5e6475;
+  --translation-border: #7a8898;
   --translation-color: #ffffff;
   --translation-secondary-color: #aaaaaa;
   --translation-main-button-color: #272a2f;
   --translation-subtitle-color: #888888;
-  --editor-background: #333941;
+  --editor-background: #272a2f;
   --editor-color: #ffffff;
-  --editor-form-background: #272a2f;
+  --editor-form-background: #4d5967;
   --editor-menu-background: #272a2f;
   --editor-menu-color: #aaaaaa;
   --editor-menu-action-button-color: #ffffff;
-  --editor-readonly-background: #272a2f;
+  --editor-readonly-background: #333941;
   --time-range-handles: #272a2f;
 
   /* Highlights */

--- a/translate/src/modules/translationform/components/TranslationForm.css
+++ b/translate/src/modules/translationform/components/TranslationForm.css
@@ -92,6 +92,10 @@
   outline: none;
 }
 
+.cm-editor .cm-content {
+  caret-color: var(--editor-color);
+}
+
 .cm-editor .cm-scroller {
   font-family: inherit;
   line-height: 22px;

--- a/translate/src/modules/translationform/components/TranslationForm.css
+++ b/translate/src/modules/translationform/components/TranslationForm.css
@@ -38,8 +38,10 @@
 }
 
 .translationform .accesskey-input {
+  background: var(--editor-background);
   border: none;
   box-sizing: border-box;
+  color: var(--editor-color);
   float: left;
   font-size: 14px;
   height: 24px;
@@ -59,7 +61,7 @@
 }
 
 .translationform .accesskeys .key {
-  border: 1px solid var(--light-grey-1);
+  border: 1px solid var(--grey-3);
   background: var(--grey-3);
   color: var(--white-1);
   cursor: pointer;


### PR DESCRIPTION
Fixes #4001 

Update `--editor-background`, `--editor-color`, and `--editor-readonly-background` 
in `dark-theme.css` to use the same dark values as other inputs. Also brighten 
`--tags-*` colors for readability against the dark background.

Fix cursor visibility by setting `caret-color` on `.cm-content` to match `--editor-color`.