### PR TITLE
Fix default activity view on contributor profiles

### DIFF
--- a/pontoon/contributors/views.py
+++ b/pontoon/contributors/views.py
@@ -83,11 +83,15 @@ def contributor_username(request, username):
 
 def contributor(request, user):
     """Contributor profile."""
+    is_own_profile = request.user.is_authenticated and request.user == user
+    default_contribution_type = (
+        "all_contributions" if is_own_profile else "all_user_contributions"
+    )
     graph_data, graph_title = utils.get_contribution_graph_data(
-        user, request.user, "all_contributions"
+        user, request.user, default_contribution_type
     )
     timeline_data = utils.get_contribution_timeline_data(
-        user, request.user, False, "all_contributions"
+        user, request.user, False, default_contribution_type
     )
 
     context = {


### PR DESCRIPTION
## Bug
When viewing another contributor's profile, the activity shown by default 
is "All contributions" which includes actions from other contributors 
(such as reviews received), instead of only showing that contributor's 
own actions.

## Fix
In `contributors/views.py`, the `contributor()` function was hardcoded 
to use `"all_contributions"` for all profiles.

Changed the default contribution type based on whose profile is being viewed:
- Own profile → `"all_contributions"` (includes reviews received)
- Another contributor's profile → `"all_user_contributions"` (only their own actions)

Fixes #4121