### PR TITLE
Translate: fix notifications menu capping at 7 after mark-all-read

### DIFF
--- a/translate/src/api/user.ts
+++ b/translate/src/api/user.ts
@@ -4,7 +4,7 @@ import { getCSRFToken } from './utils/csrfToken';
 export type Notification = {
   id: number;
   level: string;
-  unread: string;
+  unread: boolean;
   description: {
     content: string;
     is_comment: boolean;

--- a/translate/src/modules/user/actions.ts
+++ b/translate/src/modules/user/actions.ts
@@ -17,8 +17,17 @@ import type { AppThunk } from '~/store';
 export const UPDATE = 'user/UPDATE';
 export const UPDATE_SETTINGS = 'user/UPDATE_SETTINGS';
 export const UPDATE_THEME = 'user/UPDATE_THEME';
+export const MARK_ALL_NOTIFICATIONS_READ = 'user/MARK_ALL_NOTIFICATIONS_READ';
 
-export type Action = UpdateAction | UpdateSettingsAction | UpdateThemeAction;
+export type MarkAllNotificationsReadAction = {
+  readonly type: typeof MARK_ALL_NOTIFICATIONS_READ;
+};
+
+export type Action =
+  | UpdateAction
+  | UpdateSettingsAction
+  | UpdateThemeAction
+  | MarkAllNotificationsReadAction;
 
 /**
  * Update the user data.
@@ -85,7 +94,7 @@ export function saveTheme(theme: string, username: string): AppThunk {
 
 export const markAllNotificationsAsRead_ = (): AppThunk => async (dispatch) => {
   await markAllNotificationsAsRead();
-  dispatch(getUserData());
+  dispatch({ type: MARK_ALL_NOTIFICATIONS_READ });
 };
 
 /**

--- a/translate/src/modules/user/reducer.ts
+++ b/translate/src/modules/user/reducer.ts
@@ -1,6 +1,12 @@
 import { DEFAULT_SEARCH_OPTIONS } from '~/modules/search/constants';
 
-import { Action, UPDATE, UPDATE_SETTINGS, UPDATE_THEME } from './actions';
+import {
+  Action,
+  MARK_ALL_NOTIFICATIONS_READ,
+  UPDATE,
+  UPDATE_SETTINGS,
+  UPDATE_THEME,
+} from './actions';
 
 // Name of this module.
 // Used as the key to store this module's reducer.
@@ -69,7 +75,7 @@ function settings(
 export type Notification = {
   readonly id: number;
   readonly level: string;
-  readonly unread: string;
+  readonly unread: boolean;
   readonly description: {
     readonly content: string;
     readonly is_comment: boolean;
@@ -197,6 +203,18 @@ export function reducer(state: UserState = initial, action: Action): UserState {
       return {
         ...state,
         theme: action.theme,
+      };
+    case MARK_ALL_NOTIFICATIONS_READ:
+      return {
+        ...state,
+        notifications: {
+          has_unread: false,
+          unread_count: '0',
+          notifications: state.notifications.notifications.map((n) => ({
+            ...n,
+            unread: false,
+          })),
+        },
       };
     default:
       return state;


### PR DESCRIPTION
Fix #3717 

For notification bell in translate view, `markAllNotificationsAsRead_` calls `getUserData()` after marking notifications read. Results in a collapsing list. Returns only `NOTIFICATIONS_MAX_COUNT` (7) entries.

+ Replace `getUserData()` re-fetch with `MARK_ALL_NOTIFICATIONS_READ` Redux action. 

+ Update local state directly. Set `unread` to `false` for each notification in store, clear `unread` badge.

+ Fix `Notification.unread` type `string` to `boolean`, match API response.