### PR TITLE
Fix #3805: Block AI bots and crawlers via robots.txt

### DIFF
--- a/pontoon/base/templates/robots.txt
+++ b/pontoon/base/templates/robots.txt
@@ -4,3 +4,17 @@ Disallow: /admin/
 Disallow: /contributors/
 Disallow: /*insights/
 Disallow: /api/
+
+User-agent: AhrefsBot
+User-agent: AliyunSecBot
+User-agent: Amazonbot
+User-agent: Barkrowler
+User-agent: BLEXBot
+User-agent: Bytespider
+User-agent: ClaudeBot
+User-agent: GPTBot
+User-agent: meta-externalagent
+User-agent: MJ12bot
+User-agent: PetalBot
+User-agent: SemrushBot
+Disallow: /


### PR DESCRIPTION
Fixes #3805

Added a list of AI bots and crawlers to robots.txt to prevent them 
from accessing Pontoon. The list is based on what @flodolo suggested 
in the issue, along with ClaudeBot which was also mentioned.