### PR TITLE
API: Expose completed_strings in translation stats

### DIFF
--- a/pontoon/api/serializers.py
+++ b/pontoon/api/serializers.py
@@ -23,6 +23,7 @@ TRANSLATION_STATS_FIELDS = [
     "strings_with_warnings",
     "strings_with_errors",
     "missing_strings",
+    "completed_strings",
     "unreviewed_strings",
     "complete",
 ]
@@ -36,6 +37,7 @@ class TranslationStatsMixin(metaclass=serializers.SerializerMetaclass):
     strings_with_warnings = serializers.SerializerMethodField()
     strings_with_errors = serializers.SerializerMethodField()
     missing_strings = serializers.SerializerMethodField()
+    completed_strings = serializers.SerializerMethodField()
     unreviewed_strings = serializers.SerializerMethodField()
     complete = serializers.SerializerMethodField()
 
@@ -56,6 +58,9 @@ class TranslationStatsMixin(metaclass=serializers.SerializerMetaclass):
 
     def get_missing_strings(self, obj):
         return obj.missing
+
+    def get_completed_strings(self, obj):
+        return obj.completed
 
     def get_unreviewed_strings(self, obj):
         return obj.unreviewed

--- a/pontoon/api/tests/test_views.py
+++ b/pontoon/api/tests/test_views.py
@@ -146,6 +146,7 @@ def test_locale(django_assert_num_queries):
         "strings_with_warnings": 2,
         "strings_with_errors": 3,
         "missing_strings": 5,
+        "completed_strings": 17,
         "unreviewed_strings": 5,
         "complete": False,
         "projects": ["terminology"],
@@ -162,6 +163,7 @@ def test_locale(django_assert_num_queries):
         "strings_with_warnings": 2,
         "strings_with_errors": 3,
         "missing_strings": 5,
+        "completed_strings": 17,
         "unreviewed_strings": 5,
         "complete": False,
     } in localizations
@@ -227,6 +229,7 @@ def test_locales(django_assert_num_queries):
             "strings_with_warnings": loc.strings_with_warnings,
             "strings_with_errors": loc.strings_with_errors,
             "missing_strings": loc.missing_strings,
+            "completed_strings": loc.completed_strings,
             "unreviewed_strings": loc.unreviewed_strings,
             "complete": loc.complete,
         }
@@ -326,6 +329,7 @@ def test_project(django_assert_num_queries):
         "strings_with_warnings": 4,
         "strings_with_errors": 6,
         "missing_strings": 10,
+        "completed_strings": 34,
         "unreviewed_strings": 10,
         "complete": False,
         "tags": [],
@@ -453,6 +457,7 @@ def test_project(django_assert_num_queries):
         "strings_with_warnings": 2,
         "strings_with_errors": 3,
         "missing_strings": 5,
+        "completed_strings": 17,
         "unreviewed_strings": 5,
         "complete": False,
     } in localizations
@@ -468,6 +473,7 @@ def test_project(django_assert_num_queries):
         "strings_with_warnings": 2,
         "strings_with_errors": 3,
         "missing_strings": 5,
+        "completed_strings": 17,
         "unreviewed_strings": 5,
         "complete": False,
     } in localizations
@@ -565,6 +571,7 @@ def test_projects(django_assert_num_queries):
             "strings_with_warnings": p.strings_with_warnings,
             "strings_with_errors": p.strings_with_errors,
             "missing_strings": p.missing_strings,
+            "completed_strings": p.completed_strings,
             "unreviewed_strings": p.unreviewed_strings,
             "complete": p.complete,
         }
@@ -621,6 +628,7 @@ def test_system_projects(
             "strings_with_warnings": p.strings_with_warnings,
             "strings_with_errors": p.strings_with_errors,
             "missing_strings": p.missing_strings,
+            "completed_strings": p.completed_strings,
             "unreviewed_strings": p.unreviewed_strings,
             "complete": p.complete,
         }
@@ -673,6 +681,7 @@ def test_disabled_projects(
             "strings_with_warnings": p.strings_with_warnings,
             "strings_with_errors": p.strings_with_errors,
             "missing_strings": p.missing_strings,
+            "completed_strings": p.completed_strings,
             "unreviewed_strings": p.unreviewed_strings,
             "complete": p.complete,
         }
@@ -966,6 +975,7 @@ def test_project_locale(django_assert_num_queries):
             "strings_with_warnings": 2,
             "strings_with_errors": 3,
             "missing_strings": 5,
+            "completed_strings": 17,
             "unreviewed_strings": 5,
             "complete": False,
         },
@@ -975,6 +985,7 @@ def test_project_locale(django_assert_num_queries):
         "strings_with_warnings": 2,
         "strings_with_errors": 3,
         "missing_strings": 5,
+        "completed_strings": 17,
         "unreviewed_strings": 5,
         "complete": False,
         "project": {
@@ -995,6 +1006,7 @@ def test_project_locale(django_assert_num_queries):
             "strings_with_warnings": 4,
             "strings_with_errors": 6,
             "missing_strings": 10,
+            "completed_strings": 34,
             "unreviewed_strings": 10,
             "complete": False,
         },

--- a/pontoon/base/aggregated_stats.py
+++ b/pontoon/base/aggregated_stats.py
@@ -50,6 +50,14 @@ class AggregatedStats:
         )
 
     @property
+    def completed_strings(self) -> int:
+        return (
+            self.approved_strings
+            + self.pretranslated_strings
+            + self.strings_with_warnings
+        )
+
+    @property
     def complete(self) -> bool:
         return self.total_strings == self.approved_strings + self.strings_with_warnings
 

--- a/pontoon/base/models/locale.py
+++ b/pontoon/base/models/locale.py
@@ -88,6 +88,7 @@ class LocaleQuerySet(models.QuerySet):
             - F("pretranslated")
             - F("errors")
             - F("warnings"),
+            completed=F("approved") + F("pretranslated") + F("warnings"),
             is_complete=Case(
                 When(
                     total=F("approved") + F("warnings"),

--- a/pontoon/base/models/project.py
+++ b/pontoon/base/models/project.py
@@ -88,6 +88,7 @@ class ProjectQuerySet(models.QuerySet):
             - F("pretranslated")
             - F("errors")
             - F("warnings"),
+            completed=F("approved") + F("pretranslated") + F("warnings"),
             is_complete=Case(
                 When(
                     total=F("approved") + F("warnings"),

--- a/pontoon/base/models/project_locale.py
+++ b/pontoon/base/models/project_locale.py
@@ -58,6 +58,7 @@ class ProjectLocaleQuerySet(models.QuerySet):
             - F("pretranslated")
             - F("errors")
             - F("warnings"),
+            completed=F("approved") + F("pretranslated") + F("warnings"),
             is_complete=Case(
                 When(
                     total=F("approved") + F("warnings"),


### PR DESCRIPTION
Fix #3291 

Translation stats in `/api/v2/locales/, /api/v2/projects/, /api/v2/projects/<slug>/<locale>/` responses do not expose `completed_strings` (approved + pretranslated + warnings). 
`AggregatedStats` has no `completed_strings` property. `LocaleQuerySet, ProjectQuerySet, ProjectLocaleQuerySet` `stats_data()` have no completed annotation.

- Add `completed_strings` property to `AggregatedStats` for single-object access.
- Add `completed=F("approved") + F("pretranslated") + F("warnings")` annotation to `LocaleQuerySet`, `ProjectQuerySet`, `ProjectLocaleQuerySet` `stats_data()` for list queries.
- Add `completed_strings` to `TRANSLATION_STATS_FIELDS` and `TranslationStatsMixin`
- `get_completed_strings` returns `obj.completed`.
- Update tests `expected_results` dicts to include `completed_strings`.