### PR TITLE
Add locale code to submitted suggestions notification (#4139)

### DIFF
--- a/pontoon/messaging/templates/messaging/notifications/suggestions_reviewed.html
+++ b/pontoon/messaging/templates/messaging/notifications/suggestions_reviewed.html
@@ -9,9 +9,9 @@ Your suggestions have been reviewed:
       <a
         href="{{ full_url('pontoon.translate', locale.code, project.slug, 'all-resources') }}?list={{ ids }}"
       >
-        {{ project.name }} ({{ locale.code }}):</a
-      >
-      {{ msg }}
+        {{ project.name }}
+      </a>
+      · {{ locale.code }}: {{ msg }}
     </li>
   {% endfor %}
 </ul>

--- a/pontoon/messaging/templates/messaging/notifications/suggestions_submitted.html
+++ b/pontoon/messaging/templates/messaging/notifications/suggestions_submitted.html
@@ -4,8 +4,9 @@ Unreviewed suggestions have been submitted for the following projects:
     <li>
       <a
         href="{{ full_url('pontoon.translate', project_locale.locale.code, project_locale.project.slug, 'all-resources') }}?status=unreviewed"
-        >{{ project_locale.project.name }} · {{ project_locale.locale.code }}
+        >{{ project_locale.project.name }}
       </a>
+      · {{ project_locale.locale.code }}
     </li>
   {% endfor %}
 </ul>

--- a/pontoon/messaging/templates/messaging/notifications/suggestions_submitted.html
+++ b/pontoon/messaging/templates/messaging/notifications/suggestions_submitted.html
@@ -4,7 +4,7 @@ Unreviewed suggestions have been submitted for the following projects:
     <li>
       <a
         href="{{ full_url('pontoon.translate', project_locale.locale.code, project_locale.project.slug, 'all-resources') }}?status=unreviewed"
-        >{{ project_locale.project.name }}
+        >{{ project_locale.project.name }} · {{ project_locale.locale.code }}
       </a>
     </li>
   {% endfor %}


### PR DESCRIPTION
Add locale code to submitted suggestions notification template to differentiate between projects with the same name but different locales.

closes #4139