### PR TITLE
fix(bug): fix styling of notification heading

### DIFF
--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -850,6 +850,12 @@ header .right .select .menu {
   padding: 10px 0 10px 20px;
 }
 
+.notifications .menu li.notification-item .message .subject {
+  color: var(--white-1);
+  font-size: 16px;
+  font-weight: bold;
+}
+
 /* End message styling */
 
 .notifications .menu li.notification-item .timeago,

--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -850,12 +850,6 @@ header .right .select .menu {
   padding: 10px 0 10px 20px;
 }
 
-.notifications .menu li.notification-item .message .subject {
-  color: var(--white-1);
-  font-size: 16px;
-  font-weight: bold;
-}
-
 /* End message styling */
 
 .notifications .menu li.notification-item .timeago,

--- a/pontoon/messaging/views.py
+++ b/pontoon/messaging/views.py
@@ -328,7 +328,7 @@ def send_message(request):
                 recipient=recipient,
                 verb="has sent you a message",
                 target=None,
-                description=f"{subject}<br/><br/>{body}",
+                description=f'<span class="subject">{subject}</span><br/><br/>{body}',
                 identifier=identifier,
                 category="direct_message",
             )

--- a/pontoon/messaging/views.py
+++ b/pontoon/messaging/views.py
@@ -328,7 +328,7 @@ def send_message(request):
                 recipient=recipient,
                 verb="has sent you a message",
                 target=None,
-                description=f'<span class="subject">{subject}</span><br/><br/>{body}',
+                description=f'<h2 class="subject">{subject}</h2>{body}',
                 identifier=identifier,
                 category="direct_message",
             )


### PR DESCRIPTION
## Description
I update the string template of notifiy send to include a span with a class of notification subject and added correct styling to it. A better solution would we to include a separate notification template but since we are rendering just two things  and the template wont be used anywhere again. I am not sure if the effort required is worth it.

## Linked Issue
Closes #4130

## SCREENSHOTS
<img width="254" height="211" alt="Notification heading fix" src="https://github.com/user-attachments/assets/46bc4e35-3f75-4c8c-8e90-5b199512558e" />
