### PR TITLE
Search: compact entity view & add API

### DIFF
--- a/pontoon/search/static/css/search.css
+++ b/pontoon/search/static/css/search.css
@@ -164,7 +164,7 @@
   color: var(--translation-secondary-color);
   font-style: italic;
   line-height: 22px;
-  margin-top: 20px;
+  margin-top: 8px;
 }
 
 .entity-info-container a,
@@ -189,7 +189,6 @@
   align-items: flex-end;
   gap: 8px;
   margin-bottom: 0;
-  margin-top: 20px;
   font-size: 13px;
 }
 
@@ -203,7 +202,6 @@
   background-color: var(--dark-grey-1);
   border-radius: 6px;
   font-size: 16px;
-  margin-bottom: 20px;
   padding: 16px;
 
   .translation-info-container {
@@ -232,7 +230,7 @@
 
   .translation-container {
     border-bottom: 1px solid var(--main-border-1);
-    padding: 16px;
+    padding: 8px 16px 8px 16px;
 
     .translation-info-container {
       display: flex;
@@ -244,7 +242,6 @@
 
       .locale-container {
         font-style: italic;
-        margin-top: 20px;
 
         .translation-locale-name {
           color: var(--light-grey-7);

--- a/pontoon/search/static/css/search.css
+++ b/pontoon/search/static/css/search.css
@@ -203,6 +203,7 @@
   border-radius: 6px;
   font-size: 16px;
   padding: 16px;
+  margin-bottom: 20px;
 
   .translation-info-container {
     display: flex;
@@ -215,7 +216,7 @@
   }
 
   .button {
-    background: var(--background-1);
+    background: var(--button-background-2);
   }
 
   .button:hover {
@@ -271,6 +272,7 @@
         height: 28px;
 
         .translation-locale-code {
+          font-style: italic;
           color: var(--status-translated-alt);
           vertical-align: sub;
         }

--- a/pontoon/search/static/css/search.css
+++ b/pontoon/search/static/css/search.css
@@ -297,9 +297,7 @@
         bottom: 0;
         right: 0;
         visibility: hidden;
-        border-width: 7px 0 0 7px;
-        border-style: solid;
-        border-color: var(--black-3);
+        padding: 7px 0 0 7px;
         background-color: var(--black-3);
       }
 

--- a/pontoon/search/static/css/search.css
+++ b/pontoon/search/static/css/search.css
@@ -300,3 +300,32 @@
     }
   }
 }
+
+.footer {
+  margin: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+
+  .api-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .chip {
+    background: var(--status-translated);
+    border-radius: 3px;
+    color: var(--translation-main-button-color);
+    padding: 4px;
+  }
+
+  .api-text {
+    color: var(--light-grey-7);
+  }
+
+  a {
+    color: var(--status-translated);
+  }
+}

--- a/pontoon/search/static/css/search.css
+++ b/pontoon/search/static/css/search.css
@@ -223,10 +223,39 @@
   }
 }
 
+#translation-list-header {
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid var(--main-border-1);
+
+  span {
+    box-sizing: border-box;
+    color: var(--light-grey-7);
+    font-weight: bold;
+    min-width: 0;
+    padding: 10px 16px;
+    text-transform: uppercase;
+  }
+
+  .locale-header {
+    flex: 1;
+    padding-right: 8px;
+  }
+
+  .translation-header {
+    flex: 9;
+    padding-left: 8px;
+  }
+}
+
 #translation-list {
   color: var(--white-1);
   line-height: 1.5;
   font-size: 14px;
+
+  .translation-row {
+    display: flex;
+  }
 
   .translation-container {
     border-bottom: 1px solid var(--main-border-1);
@@ -234,32 +263,39 @@
 
     .translation-info-container {
       display: flex;
-
-      locale-container,
-      .utility-container {
-        flex: 1;
-      }
+      flex: 1;
+      min-width: 0;
 
       .locale-container {
-        font-style: italic;
-
-        .translation-locale-name {
-          color: var(--light-grey-7);
-          vertical-align: sub;
-        }
-
-        .translation-locale-name:hover {
-          color: var(--status-translated);
-        }
+        flex: 1;
+        height: 28px;
 
         .translation-locale-code {
           color: var(--status-translated-alt);
           vertical-align: sub;
         }
+      }
+    }
 
-        .divider {
-          vertical-align: sub;
-        }
+    .translation-string-container {
+      position: relative;
+      flex: 9;
+      min-width: 0;
+      padding-left: 16px;
+
+      .translation-string {
+        vertical-align: sub;
+      }
+
+      .utility-container {
+        position: absolute;
+        bottom: 0;
+        right: 0;
+        visibility: hidden;
+      }
+
+      &:hover .utility-container {
+        visibility: visible;
       }
     }
   }

--- a/pontoon/search/static/css/search.css
+++ b/pontoon/search/static/css/search.css
@@ -1,4 +1,7 @@
 #main {
+  .button {
+    user-select: none;
+  }
   .container {
     menu {
       margin-bottom: 40px;

--- a/pontoon/search/static/css/search.css
+++ b/pontoon/search/static/css/search.css
@@ -294,6 +294,10 @@
         bottom: 0;
         right: 0;
         visibility: hidden;
+        border-width: 7px 0 0 7px;
+        border-style: solid;
+        border-color: var(--black-3);
+        background-color: var(--black-3);
       }
 
       &:hover .utility-container {

--- a/pontoon/search/templates/search/entity.html
+++ b/pontoon/search/templates/search/entity.html
@@ -16,6 +16,21 @@
     <div class="container">
       {% if entity.translations %}
         {{ Translations.list_translations(entity) }}
+        <div class="footer">
+          <div class="api-row">
+            <span class="chip"> API </span>
+            <span
+              >These results are also available as an
+              <a
+                href="{{ url('entity-individual', entity.id) }}?include_translations=True"
+                >API request</a
+              >.</span
+            >
+          </div>
+          <a href="https://github.com/mozilla/pontoon/tree/main/pontoon/api"
+            >Learn more about the Pontoon API.</a
+          >
+        </div>
       {% else %}
         {{ Translations.no_translations() }}
       {% endif %}

--- a/pontoon/search/templates/search/widgets/entity_translations.html
+++ b/pontoon/search/templates/search/widgets/entity_translations.html
@@ -31,41 +31,46 @@
     </div>
   </div>
 
+  <div id="translation-list-header">
+    <span class="locale-header">LOCALE</span>
+    <span class="translation-header">Translation</span>
+  </div>
   <ul id="translation-list">
     {% for translation in entity.translations %}
       <li class="translation-container">
-        <div class="translation-string-container">
-          <span class="translation-string">{{ translation.string }}</span>
-        </div>
-
-        <div class="translation-info-container">
-          <div class="locale-container">
-            <a href="{{ url('pontoon.teams.team', translation.locale.code ) }}">
-              <span class="translation-locale-name"
-                >{{ translation.locale.name }}</span
+        <div class="translation-row">
+          <div class="translation-info-container">
+            <div class="locale-container">
+              <a
+                href="{{ url('pontoon.teams.team', translation.locale.code ) }}"
               >
-              <span class="divider">&bull;</span>
-              <span class="translation-locale-code"
-                >{{ translation.locale.code }}</span
-              >
-            </a>
+                <span
+                  class="translation-locale-code"
+                  title="{{ translation.locale.name }}"
+                  >{{ translation.locale.code }}</span
+                >
+              </a>
+            </div>
           </div>
-          <div class="utility-container controls">
-            <a
-              class="edit button"
-              href="{{ url('pontoon.translate', locale=translation.locale.code, project=entity.project.slug, resource=entity.resource.path) }}?string={{ entity.id }}"
-            >
-              <span class="fas fa-pencil-alt"></span>
-              Edit
-            </a>
-            <button
-              class="copy button"
-              type="button"
-              data-clipboard-text="{{ translation.string }}"
-            >
-              <span class="far fa-copy"></span>
-              Copy
-            </button>
+          <div class="translation-string-container">
+            <span class="translation-string">{{ translation.string }}</span>
+            <div class="utility-container controls">
+              <a
+                class="edit button"
+                href="{{ url('pontoon.translate', locale=translation.locale.code, project=entity.project.slug, resource=entity.resource.path) }}?string={{ entity.id }}"
+              >
+                <span class="fas fa-pencil-alt"></span>
+                Edit
+              </a>
+              <button
+                class="copy button"
+                type="button"
+                data-clipboard-text="{{ translation.string }}"
+              >
+                <span class="far fa-copy"></span>
+                Copy
+              </button>
+            </div>
           </div>
         </div>
       </li>


### PR DESCRIPTION
This PR addresses complaints that the entity view page at `/entities/{entity_id}` is not compact, which inhibits scrolling and quickly scanning translations in various locales. It also addresses the want of having a direct link to the REST API from the entity view.

Fixes #4069.