### PR TITLE
Fix #4155: Handle null author in Comment.serialize()

### DIFF
--- a/pontoon/base/models/comment.py
+++ b/pontoon/base/models/comment.py
@@ -28,11 +28,21 @@ class Comment(models.Model):
 
     def serialize(self, project_contact):
         locale = self.locale or self.translation.locale
+        if self.author is None:
+            author = "Deleted"
+            username = None
+            user_banner = ("", "")
+            user_gravatar_url_small = None
+        else:
+            author = self.author.name_or_email
+            username = self.author.username
+            user_banner = self.author.banner(locale, project_contact)
+            user_gravatar_url_small = self.author.gravatar_url(88)
         return {
-            "author": self.author.name_or_email,
-            "username": self.author.username,
-            "user_banner": self.author.banner(locale, project_contact),
-            "user_gravatar_url_small": self.author.gravatar_url(88),
+            "author": author,
+            "username": username,
+            "user_banner": user_banner,
+            "user_gravatar_url_small": user_gravatar_url_small,
             "created_at": self.timestamp.strftime("%b %d, %Y %H:%M"),
             "date_iso": self.timestamp.isoformat(),
             "content": self.content,

--- a/translate/src/api/comment.ts
+++ b/translate/src/api/comment.ts
@@ -8,9 +8,9 @@ import { keysToCamelCase } from './utils/keysToCamelCase';
  */
 export type TranslationComment = {
   readonly author: string;
-  readonly username: string;
-  readonly userBanner: string[];
-  readonly userGravatarUrlSmall: string;
+  readonly username: string | null;
+  readonly userBanner: string[] | null;
+  readonly userGravatarUrlSmall: string | null;
   readonly createdAt: string;
   readonly dateIso: string;
   readonly content: string;

--- a/translate/src/modules/comments/components/Comment.tsx
+++ b/translate/src/modules/comments/components/Comment.tsx
@@ -88,15 +88,21 @@ export function Comment(props: Props): null | React.ReactElement<'li'> {
         ) : (
           <div className='content'>
             <div>
-              <a
-                className='comment-author'
-                href={`/contributors/${comment.username}`}
-                target='_blank'
-                rel='noopener noreferrer'
-                onClick={(e: React.MouseEvent) => e.stopPropagation()}
-              >
-                {comment.author}
-              </a>
+              {comment.username ? (
+                <a
+                  className='comment-author'
+                  href={`/contributors/${comment.username}`}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                >
+                  {comment.author}
+                </a>
+              ) : (
+                <span className='comment-author deleted-user'>
+                  {comment.author}
+                </span>
+              )}
               <Linkify
                 properties={{
                   target: '_blank',

--- a/translate/src/modules/comments/components/CommentsList.tsx
+++ b/translate/src/modules/comments/components/CommentsList.tsx
@@ -35,8 +35,13 @@ export function CommentsList({
               key={comment.id}
               onDeleteComment={onDeleteComment}
               onEditComment={onEditComment}
-              canEdit={user.username === comment.username}
-              canDelete={user.username === comment.username || user.isPM}
+              canEdit={
+                comment.username !== null && user.username === comment.username
+              }
+              canDelete={
+                comment.username !== null &&
+                (user.username === comment.username || user.isPM)
+              }
               user={user}
             />
           ))}

--- a/translate/src/modules/teamcomments/components/TeamComments.tsx
+++ b/translate/src/modules/teamcomments/components/TeamComments.tsx
@@ -56,8 +56,11 @@ export function TeamComments({
       canPin={user.isPM}
       key={comment.id}
       togglePinnedStatus={togglePinnedStatus}
-      canEdit={user.username === comment.username}
-      canDelete={user.username === comment.username || user.isPM}
+      canEdit={comment.username !== null && user.username === comment.username}
+      canDelete={
+        comment.username !== null &&
+        (user.username === comment.username || user.isPM)
+      }
       onEditComment={onEditComment}
       onDeleteComment={onDeleteComment}
       user={user}

--- a/translate/src/modules/user/components/UserAvatar.tsx
+++ b/translate/src/modules/user/components/UserAvatar.tsx
@@ -4,36 +4,58 @@ import { Localized } from '@fluent/react';
 import './UserAvatar.css';
 
 type Props = {
-  username: string;
+  username: string | null;
   title?: string;
-  imageUrl: string;
-  userBanner: string[];
+  imageUrl: string | null;
+  userBanner: string[] | null;
 };
+
+const DELETED_USER_AVATAR =
+  'data:image/svg+xml,' +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" width="44" height="44" viewBox="0 0 44 44">' +
+      '<rect width="44" height="44" rx="4" fill="#aaa"/>' +
+      '<text x="22" y="30" font-size="24" text-anchor="middle" fill="#fff">?</text>' +
+      '</svg>',
+  );
 
 export function UserAvatar(props: Props): React.ReactElement<'div'> {
   const { username, title, imageUrl, userBanner } = props;
-  const [status, tooltip] = userBanner;
+  const [status, tooltip] = userBanner ?? ['', ''];
+
+  const avatarImage = (
+    <div className='avatar-container'>
+      <Localized id='user-UserAvatar--alt-text' attrs={{ alt: true }}>
+        <img
+          src={imageUrl ?? DELETED_USER_AVATAR}
+          alt='User Profile'
+          height='44'
+          width='44'
+        />
+      </Localized>
+      {status && (
+        <span className={`user-banner ${status}`} title={tooltip}>
+          {status}
+        </span>
+      )}
+    </div>
+  );
 
   return (
     <div className='user-avatar'>
-      <a
-        href={`/contributors/${username}`}
-        title={title}
-        target='_blank'
-        rel='noopener noreferrer'
-        onClick={(e: React.MouseEvent) => e.stopPropagation()}
-      >
-        <div className='avatar-container'>
-          <Localized id='user-UserAvatar--alt-text' attrs={{ alt: true }}>
-            <img src={imageUrl} alt='User Profile' height='44' width='44' />
-          </Localized>
-          {status && (
-            <span className={`user-banner ${status}`} title={tooltip}>
-              {status}
-            </span>
-          )}
-        </div>
-      </a>
+      {username ? (
+        <a
+          href={`/contributors/${username}`}
+          title={title}
+          target='_blank'
+          rel='noopener noreferrer'
+          onClick={(e: React.MouseEvent) => e.stopPropagation()}
+        >
+          {avatarImage}
+        </a>
+      ) : (
+        avatarImage
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Fixes #4155

When a user deletes their account, the author field is set to NULL. 
The serialize() method was trying to access author properties without 
checking if author is None first, causing the comment API to crash.

Added null checks for all author properties in Comment.serialize() 
so deleted user comments are handled gracefully.