### PR TITLE
Create missing .po files if target locale folder is empty

### DIFF
--- a/documentation/docs/admin/adding-new-project.md
+++ b/documentation/docs/admin/adding-new-project.md
@@ -48,7 +48,11 @@ Incorrect pattern:
     locales/{locale_code}/path/to/file.{locale_code}.extension
 
 !!! note "Gettext .po files"
-    For Gettext files, you will need to ensure that `.po` files are included in the repository for each target locale for which they are to be translated (these files may be initially empty). For all other supported formats, Pontoon will automatically add files for each locale when it is translated.
+    When a locale's folder in the repository is empty (contains no `.po` files yet), Pontoon will create one `.po` file per source resource from the matching `.pot` template on the next sync.
+
+    When a locale's folder already contains some `.po` files, Pontoon trusts the repository and will *not* create the missing ones. This preserves projects that intentionally ship a partial subset of resources per locale (ideally declared via a TOML configuration file). For such projects, the relevant `.po` files must continue to be added to the repository before the locale starts producing translations for them.
+
+    For all other supported formats, Pontoon automatically adds files for each locale when it is translated.
 
 ## Create the project
 

--- a/pontoon/sync/core/__init__.py
+++ b/pontoon/sync/core/__init__.py
@@ -43,9 +43,12 @@ def sync_project(
         lc.code: lc for lc in project.locales.order_by("code")
     }
     paths.locales = list(locale_map.keys())
-    added_entities_count, changed_paths, removed_paths = sync_resources_from_repo(
-        project, locale_map, checkouts.source, paths, now
-    )
+    (
+        added_entities_count,
+        changed_paths,
+        removed_paths,
+        empty_gettext_locales,
+    ) = sync_resources_from_repo(project, locale_map, checkouts.source, paths, now)
 
     db_changes = ChangedEntityLocale.objects.filter(
         entity__resource__project=project, when__lte=now
@@ -72,6 +75,7 @@ def sync_project(
         changed_paths,
         removed_paths,
         now,
+        empty_gettext_locales,
     )
     if commit:
         db_changes.delete()

--- a/pontoon/sync/core/entities.py
+++ b/pontoon/sync/core/entities.py
@@ -23,6 +23,7 @@ from pontoon.base.models import (
     TranslatedResource,
 )
 from pontoon.sync.core.checkout import Checkout
+from pontoon.sync.core.gettext import find_empty_gettext_locales
 from pontoon.sync.formats import as_entity
 
 
@@ -35,10 +36,10 @@ def sync_resources_from_repo(
     checkout: Checkout,
     paths: L10nConfigPaths | L10nDiscoverPaths,
     now: datetime,
-) -> tuple[int, set[str], set[str]]:
-    """(added_entities_count, changed_source_paths, removed_source_paths"""
+) -> tuple[int, set[str], set[str], set[str]]:
+    """(added_entities_count, changed_source_paths, removed_source_paths, empty_gettext_locales)"""
     if not checkout.changed and not checkout.removed and not checkout.renamed:
-        return 0, set(), set()
+        return 0, set(), set(), set()
     log.info(f"[{project.slug}] Syncing entities from repo...")
     # db_path -> parsed_resource
     updates: dict[str, L10nResource[Message]] = {}
@@ -75,12 +76,15 @@ def sync_resources_from_repo(
         new_res_added_ent_count, added_paths = add_resources(
             project, updates, changed_paths, now
         )
-        update_translated_resources(project, locale_map, paths)
+        # Snapshot of locales whose gettext target folders are empty.
+        empty_gettext_locales = find_empty_gettext_locales(project, locale_map, paths)
+        update_translated_resources(project, locale_map, paths, empty_gettext_locales)
 
     return (
         old_res_added_ent_count + new_res_added_ent_count,
         renamed_paths | changed_paths | added_paths,
         removed_paths,
+        empty_gettext_locales,
     )
 
 
@@ -357,6 +361,7 @@ def update_translated_resources(
     project: Project,
     locale_map: dict[str, Locale],
     paths: L10nConfigPaths | L10nDiscoverPaths,
+    empty_gettext_locales: set[str],
 ) -> None:
     prev_tr_keys: set[tuple[int, int]] = {
         (tr["resource_id"], tr["locale_id"])
@@ -369,7 +374,7 @@ def update_translated_resources(
         _, locales = paths.target(resource.path)
         for lc in locales:
             locale = locale_map.get(lc, None)
-            if is_translated_resource(paths, resource, locale):
+            if is_translated_resource(paths, resource, locale, empty_gettext_locales):
                 assert locale is not None
                 key = (resource.pk, locale.pk)
                 if key in prev_tr_keys:
@@ -400,18 +405,21 @@ def is_translated_resource(
     paths: L10nConfigPaths | L10nDiscoverPaths,
     resource: Resource,
     locale: Locale | None,
+    empty_gettext_locales: set[str],
 ) -> bool:
     if locale is None:
         return False
 
     if resource.format == Resource.Format.GETTEXT:
-        # For gettext, only create TranslatedResource
-        # if the resource exists for the locale.
+        # Consider this a translated resource if the .po file exists on disk, or
+        # if the locale's folder is empty (the bootstrap pass will create it).
         target, _ = paths.target(resource.path)
         if target is None:
             return False
         target_path = paths.format_target_path(target, locale.code)
-        return isfile(target_path)
+        if isfile(target_path):
+            return True
+        return locale.code in empty_gettext_locales
     return True
 
 

--- a/pontoon/sync/core/gettext.py
+++ b/pontoon/sync/core/gettext.py
@@ -1,0 +1,41 @@
+from collections import defaultdict
+from os import scandir
+from os.path import dirname, isdir
+
+from moz.l10n.paths import L10nConfigPaths, L10nDiscoverPaths
+
+from pontoon.base.models import Locale, Project
+
+
+def find_empty_gettext_locales(
+    project: Project,
+    locale_map: dict[str, Locale],
+    paths: L10nConfigPaths | L10nDiscoverPaths,
+) -> set[str]:
+    # Locales with empty gettext target folders (no .po files).
+    # These locales get bootstrapped from the .pot templates, while locales
+    # that already have even a partial subset of .po files are left unchanged.
+    locale_folders: dict[str, set[str]] = defaultdict(set)
+    gettext_paths = project.resources.filter(
+        format="gettext", obsolete=False
+    ).values_list("path", flat=True)
+    for path in gettext_paths:
+        target, locale_codes = paths.target(path)
+        if target is None:
+            continue
+        for lc in locale_codes:
+            if lc in locale_map:
+                locale_folders[lc].add(dirname(paths.format_target_path(target, lc)))
+
+    return {
+        lc
+        for lc, folders in locale_folders.items()
+        if not any(_folder_has_po(f) for f in folders)
+    }
+
+
+def _folder_has_po(folder: str) -> bool:
+    if not isdir(folder):
+        return False
+    with scandir(folder) as it:
+        return any(entry.is_file() and entry.name.endswith(".po") for entry in it)

--- a/pontoon/sync/core/translations_to_repo.py
+++ b/pontoon/sync/core/translations_to_repo.py
@@ -68,11 +68,15 @@ def sync_translations_to_repo(
     changed_source_paths: set[str],
     removed_source_paths: set[str],
     now: datetime,
+    empty_gettext_locales: set[str],
 ) -> bool:
     """Returns `True` if the sync includes changes to the repo."""
     readonly_locales = project.locales.filter(project_locale__readonly=True)
     removed = delete_removed_resources(
         project, paths, locale_map, readonly_locales, removed_source_paths
+    )
+    bootstrapped, bootstrap_locales = bootstrap_missing_gettext_files(
+        project, paths, locale_map, readonly_locales, empty_gettext_locales
     )
     updated, updated_locales, translators = update_changed_resources(
         project,
@@ -83,6 +87,8 @@ def sync_translations_to_repo(
         changed_source_paths,
         now,
     )
+    updated += bootstrapped
+    updated_locales |= bootstrap_locales
     if not removed and not updated:
         return False
 
@@ -145,6 +151,66 @@ def delete_removed_resources(
         else:
             log.error(f"{log_scope} Invalid resource path")
     return count
+
+
+def bootstrap_missing_gettext_files(
+    project: Project,
+    paths: L10nConfigPaths | L10nDiscoverPaths,
+    locale_map: dict[str, Locale],
+    readonly_locales: list[Locale] | QuerySet[Locale],
+    empty_gettext_locales: set[str],
+) -> tuple[int, set[Locale]]:
+    count = 0
+    updated_locales: set[Locale] = set()
+    readonly_codes = {loc.code for loc in readonly_locales}
+    eligible_codes = (empty_gettext_locales & set(locale_map)) - readonly_codes
+    if not eligible_codes:
+        return count, updated_locales
+
+    gettext_paths = project.resources.filter(
+        format="gettext", obsolete=False
+    ).values_list("path", flat=True)
+    for path in gettext_paths:
+        log_scope = f"[{project.slug}:{path}]"
+        target, locale_codes = paths.target(path)
+        if target is None:
+            continue
+        if commonpath((paths.base or "", target)) != paths.base:
+            log.error(f"{log_scope} Invalid resource path")
+            continue
+        eligible = sorted(set(locale_codes) & eligible_codes)
+        if not eligible:
+            continue
+        ref_path = normpath(join(paths.ref_root, path))
+        if ref_path.endswith(".po"):
+            ref_path += "t"
+        if not isfile(ref_path):
+            log.error(f"{log_scope} Missing source file")
+            continue
+        for lc in eligible:
+            locale = locale_map[lc]
+            target_path = paths.format_target_path(target, lc)
+            if isfile(target_path):
+                continue
+            lc_scope = f"[{project.slug}:{path}, {lc}]"
+            try:
+                res = parse_resource(ref_path)
+                # Empty translations list still sets the gettext header block
+                # (Language, Plural-Forms, Generated-By) for this locale.
+                set_translations(locale, [], res)
+                makedirs(dirname(target_path), exist_ok=True)
+                with open(target_path, "w", encoding="utf-8") as file:
+                    for line in serialize_resource(
+                        res, gettext_plurals=locale.cldr_plurals_list()
+                    ):
+                        file.write(line)
+                updated_locales.add(locale)
+                count += 1
+                log.info(f"{lc_scope} Created empty gettext file for new locale")
+            except Exception as error:
+                log.error(f"{lc_scope} Bootstrap failed: {error}")
+                continue
+    return count, updated_locales
 
 
 def update_changed_resources(

--- a/pontoon/sync/tests/test_e2e.py
+++ b/pontoon/sync/tests/test_e2e.py
@@ -227,7 +227,10 @@ def test_add_resources():
         # Sync with no translations
         sync_project_task(project.pk)
 
-        # Test that entities are generated, translations are not, and FTL & XLIFF are localizable
+        # Test that entities are generated, translations are not, and all three
+        # formats become localizable. The empty `de-Test` folder triggers the
+        # gettext bootstrap so `file.po` is automatically created alongside
+        # FTL/XLIFF.
         assert {
             (ent.resource.path, *ent.key)
             for ent in Entity.objects.filter(resource__project=project)
@@ -242,7 +245,24 @@ def test_add_resources():
         assert {
             (tr.resource.path, tr.locale.code)
             for tr in TranslatedResource.objects.filter(resource__project=project)
-        } == {("file.ftl", "de-Test"), ("file.xliff", "de-Test")}
+        } == {
+            ("file.ftl", "de-Test"),
+            ("file.po", "de-Test"),
+            ("file.xliff", "de-Test"),
+        }
+        tgt_po_path = join(repo.checkout_path, "de-Test", "file.po")
+        with open(tgt_po_path) as file:
+            assert file.read() == dedent("""\
+                #
+                msgid ""
+                msgstr ""
+                "Language: de_Test\\n"
+                "Plural-Forms: nplurals=1; plural=0;\\n"
+                "Generated-By: Pontoon\\n"
+
+                msgid "source"
+                msgstr ""
+            """)
 
         # Add an XLIFF translation
         TranslationFactory.create(
@@ -256,10 +276,7 @@ def test_add_resources():
         )
         sync_project_task(project.pk)
 
-        # Test that gettext is not written, while XLIFF is
-        tgt_po_path = join(repo.checkout_path, "de-Test", "file.po")
         tgt_xliff_path = join(repo.checkout_path, "de-Test", "file.xliff")
-        assert not isfile(tgt_po_path)
         with open(tgt_xliff_path) as file:
             assert file.read() == dedent("""\
                 <?xml version="1.0" encoding="utf-8"?>
@@ -275,32 +292,143 @@ def test_add_resources():
                 </xliff>
             """)
 
-        # Add an empty target gettext file
-        with open(tgt_po_path, "x") as file:
-            file.write("\n")
+
+@pytest.mark.django_db
+def test_gettext_partial_locale_not_bootstrapped():
+    """When a locale folder already has some .po files, missing ones are NOT
+    automatically created."""
+    with mock_setup() as (repo, locale):
+        # Database setup
+        project = ProjectFactory.create(
+            name="partial-gettext", locales=[locale], repositories=[repo]
+        )
+
+        # Filesystem setup
+        makedirs(repo.checkout_path)
+        pot_a = dedent("""
+            #
+            msgid ""
+            msgstr ""
+
+            msgid "from-a"
+            msgstr "from-a"
+        """)
+        pot_b = dedent("""
+            #
+            msgid ""
+            msgstr ""
+
+            msgid "from-b"
+            msgstr "from-b"
+        """)
+        po_a_de = dedent("""\
+            #
+            msgid ""
+            msgstr ""
+
+            msgid "from-a"
+            msgstr ""
+        """)
+        build_file_tree(
+            repo.checkout_path,
+            {
+                "en-US": {"a.pot": pot_a, "b.pot": pot_b},
+                "de-Test": {"a.po": po_a_de},
+            },
+        )
+
         sync_project_task(project.pk)
 
-        # Test that the gettext file is now localizable
+        # Only `a.po` is localizable for de-Test; `b.po` must stay missing.
+        assert {
+            (tr.resource.path, tr.locale.code)
+            for tr in TranslatedResource.objects.filter(resource__project=project)
+        } == {("a.po", "de-Test")}
+        assert not isfile(join(repo.checkout_path, "de-Test", "b.po"))
+
+
+@pytest.mark.django_db
+def test_gettext_toml_bootstrap_respects_config():
+    """With a TOML configuration file and an empty locale folder, only the
+    gettext files the TOML lists for that locale are bootstrapped."""
+    with mock_setup() as (repo, locale_de):
+        locale_tg = cast(
+            Locale, LocaleFactory.create(code="tg-Test", name="Test Tajik")
+        )
+        project = ProjectFactory.create(
+            name="toml-gettext",
+            locales=[locale_de, locale_tg],
+            repositories=[repo],
+            configuration_file="l10n.toml",
+        )
+
+        pot_a = dedent("""\
+            #
+            msgid ""
+            msgstr ""
+
+            msgid "from-a"
+            msgstr "from-a"
+        """)
+        pot_b = dedent("""\
+            #
+            msgid ""
+            msgstr ""
+
+            msgid "from-b"
+            msgstr "from-b"
+        """)
+        po_existing = dedent("""\
+            #
+            msgid ""
+            msgstr ""
+
+            msgid "from-a"
+            msgstr ""
+        """)
+        po_b_existing = dedent("""\
+            #
+            msgid ""
+            msgstr ""
+
+            msgid "from-b"
+            msgstr ""
+        """)
+        toml = dedent("""\
+            basepath = "."
+            locales = ["de-Test", "tg-Test"]
+            [[paths]]
+                reference = "templates/a.pot"
+                l10n = "{locale}/a.po"
+            [[paths]]
+                reference = "templates/b.pot"
+                l10n = "{locale}/b.po"
+                locales = ["de-Test"]
+        """)
+        makedirs(repo.checkout_path)
+        build_file_tree(
+            repo.checkout_path,
+            {
+                "l10n.toml": toml,
+                "templates": {"a.pot": pot_a, "b.pot": pot_b},
+                "de-Test": {"a.po": po_existing, "b.po": po_b_existing},
+            },
+        )
+
+        sync_project_task(project.pk)
+
+        # tg-Test/a.po IS created (TOML configures `a.pot` for tg-Test).
+        # tg-Test/b.po is NOT created (TOML restricts `b.pot` to de-Test).
+        assert isfile(join(repo.checkout_path, "tg-Test", "a.po"))
+        assert not isfile(join(repo.checkout_path, "tg-Test", "b.po"))
         assert {
             (tr.resource.path, tr.locale.code)
             for tr in TranslatedResource.objects.filter(resource__project=project)
         } == {
-            ("file.ftl", "de-Test"),
-            ("file.po", "de-Test"),
-            ("file.xliff", "de-Test"),
+            ("templates/a.pot", "de-Test"),
+            ("templates/a.pot", "tg-Test"),
+            ("templates/b.pot", "de-Test"),
         }
-        with open(tgt_po_path) as file:
-            assert file.read() == dedent("""\
-                #
-                msgid ""
-                msgstr ""
-                "Language: de_Test\\n"
-                "Plural-Forms: nplurals=1; plural=0;\\n"
-                "Generated-By: Pontoon\\n"
-
-                msgid "source"
-                msgstr ""
-            """)
 
 
 @pytest.mark.django_db

--- a/pontoon/sync/tests/test_entities.py
+++ b/pontoon/sync/tests/test_entities.py
@@ -38,7 +38,7 @@ def test_no_changes():
         Mock(Checkout, changed=[], removed=[], renamed=[]),
         Mock(L10nDiscoverPaths),
         now,
-    ) == (0, set(), set())
+    ) == (0, set(), set(), set())
 
 
 @pytest.mark.django_db
@@ -94,9 +94,10 @@ def test_resource_obsoletion():
         paths = find_paths(project, Checkouts(mock_checkout, mock_checkout))
 
         # Test sync_resources_from_repo
-        assert sync_resources_from_repo(
+        added, changed, removed, _ = sync_resources_from_repo(
             project, locale_map, mock_checkout, paths, now
-        ) == (0, set(), {"c.ftl"})
+        )
+        assert (added, changed, removed) == (0, set(), {"c.ftl"})
         assert {res.path: res.obsolete for res in project.resources.all()} == {
             "a.ftl": False,
             "b.po": False,
@@ -174,9 +175,10 @@ def test_resource_deobsoletion():
         paths = find_paths(project, Checkouts(mock_checkout, mock_checkout))
 
         # Test
-        assert sync_resources_from_repo(
+        added, changed, removed, _ = sync_resources_from_repo(
             project, locale_map, mock_checkout, paths, now
-        ) == (3, {"c.ftl"}, set())
+        )
+        assert (added, changed, removed) == (3, {"c.ftl"}, set())
 
         res_c = project.resources.get(path="c.ftl")
 
@@ -233,9 +235,10 @@ def test_rename_resource():
         paths = find_paths(project, Checkouts(mock_checkout, mock_checkout))
 
         # Test
-        assert sync_resources_from_repo(
+        added, changed, removed, _ = sync_resources_from_repo(
             project, locale_map, mock_checkout, paths, now
-        ) == (0, {"d.ftl"}, set())
+        )
+        assert (added, changed, removed) == (0, {"d.ftl"}, set())
         assert {res.path for res in project.resources.all()} == {
             "a.ftl",
             "b.po",
@@ -287,9 +290,10 @@ def test_add_resource():
         paths = find_paths(project, Checkouts(mock_checkout, mock_checkout))
 
         # Test
-        assert sync_resources_from_repo(
+        added, changed, removed, _ = sync_resources_from_repo(
             project, locale_map, mock_checkout, paths, now
-        ) == (3, {"c.ftl"}, set())
+        )
+        assert (added, changed, removed) == (3, {"c.ftl"}, set())
         res_c = project.resources.get(path="c.ftl")
         TranslatedResource.objects.get(resource=res_c)
         assert {tuple(ent.key) for ent in Entity.objects.filter(resource=res_c)} == {
@@ -356,9 +360,10 @@ def test_update_resource():
         paths = find_paths(project, Checkouts(mock_checkout, mock_checkout))
 
         # Test sync
-        assert sync_resources_from_repo(
+        added, changed, removed, _ = sync_resources_from_repo(
             project, locale_map, mock_checkout, paths, now
-        ) == (1, {"c.ftl"}, set())
+        )
+        assert (added, changed, removed) == (1, {"c.ftl"}, set())
         assert {
             (*ent.key, ent.obsolete) for ent in Entity.objects.filter(resource=res["c"])
         } == {
@@ -434,9 +439,10 @@ def test_change_entities():
         paths = find_paths(project, Checkouts(mock_checkout, mock_checkout))
 
         # Test sync
-        assert sync_resources_from_repo(
+        added, changed, removed, _ = sync_resources_from_repo(
             project, locale_map, mock_checkout, paths, now
-        ) == (0, {"res.ftl"}, set())
+        )
+        assert (added, changed, removed) == (0, {"res.ftl"}, set())
         assert {
             tuple(ent.key): (ent.value, ent.comment)
             for ent in Entity.objects.filter(resource=res)

--- a/pontoon/sync/tests/test_translations_to_repo.py
+++ b/pontoon/sync/tests/test_translations_to_repo.py
@@ -80,6 +80,7 @@ def test_remove_resource():
             set(),
             {"c.ftl"},
             now,
+            set(),
         )
         assert exists(join(repo.checkout_path, "fr-Test", "b.po"))
         assert not exists(join(repo.checkout_path, "fr-Test", "c.ftl"))
@@ -163,6 +164,7 @@ def test_remove_entity():
             {"c.ftl"},
             set(),
             now,
+            set(),
         )
         with open(join(repo.checkout_path, "fr-Test", "c.ftl")) as file:
             assert file.read() == dedent(
@@ -281,7 +283,16 @@ def test_add_translation():
         )
         assert len(db_changes) == 4
         sync_translations_to_repo(
-            project, False, locale_map, checkouts, paths, db_changes, set(), set(), now
+            project,
+            False,
+            locale_map,
+            checkouts,
+            paths,
+            db_changes,
+            set(),
+            set(),
+            now,
+            set(),
         )
         with open(join(repo.checkout_path, "fr-Test", "c.ftl")) as file:
             assert file.read() == dedent(
@@ -359,6 +370,7 @@ def test_directory_creation_on_translation_update():
             {"nested_dir/deeper_dir/c.ftl"},
             set(),
             now,
+            set(),
         )
         target_path = join(
             repo.checkout_path, "fr-Test", "nested_dir", "deeper_dir", "c.ftl"


### PR DESCRIPTION
Not sure if there's a more elegant way to fix #3677, but this works.

Missing .po files are generated for a locale only if the folder is missing or empty. There should be no side effects, since this only affects the gettext codepath.

Tested on actual repositories here (started with fr, added it and then de).
https://github.com/flodolo/test-pontoon-issue-3677/commits/main/ (no TOML)
https://github.com/flodolo/test-pontoon-issue-3677-toml/commits/main/ (TOML file)
