### PR TITLE
API: Expose completed_strings in translation stats

### DIFF
--- a/pontoon/api/serializers.py
+++ b/pontoon/api/serializers.py
@@ -24,6 +24,7 @@ TRANSLATION_STATS_FIELDS = [
     "strings_with_errors",
     "missing_strings",
     "unreviewed_strings",
+    "completed_strings",
     "complete",
 ]
 
@@ -37,6 +38,7 @@ class TranslationStatsMixin(metaclass=serializers.SerializerMetaclass):
     strings_with_errors = serializers.SerializerMethodField()
     missing_strings = serializers.SerializerMethodField()
     unreviewed_strings = serializers.SerializerMethodField()
+    completed_strings = serializers.SerializerMethodField()
     complete = serializers.SerializerMethodField()
 
     def get_total_strings(self, obj):
@@ -59,6 +61,9 @@ class TranslationStatsMixin(metaclass=serializers.SerializerMetaclass):
 
     def get_unreviewed_strings(self, obj):
         return obj.unreviewed
+
+    def get_completed_strings(self, obj):
+        return obj.completed
 
     def get_complete(self, obj):
         return obj.is_complete

--- a/pontoon/api/tests/test_views.py
+++ b/pontoon/api/tests/test_views.py
@@ -147,6 +147,7 @@ def test_locale(django_assert_num_queries):
         "strings_with_errors": 3,
         "missing_strings": 5,
         "unreviewed_strings": 5,
+        "completed_strings": 17,
         "complete": False,
         "projects": ["terminology"],
     }
@@ -163,6 +164,7 @@ def test_locale(django_assert_num_queries):
         "strings_with_errors": 3,
         "missing_strings": 5,
         "unreviewed_strings": 5,
+        "completed_strings": 17,
         "complete": False,
     } in localizations
 
@@ -228,6 +230,7 @@ def test_locales(django_assert_num_queries):
             "strings_with_errors": loc.strings_with_errors,
             "missing_strings": loc.missing_strings,
             "unreviewed_strings": loc.unreviewed_strings,
+            "completed_strings": loc.completed_strings,
             "complete": loc.complete,
         }
         for loc in sorted(
@@ -327,6 +330,7 @@ def test_project(django_assert_num_queries):
         "strings_with_errors": 6,
         "missing_strings": 10,
         "unreviewed_strings": 10,
+        "completed_strings": 34,
         "complete": False,
         "tags": [],
         "locales": [
@@ -454,6 +458,7 @@ def test_project(django_assert_num_queries):
         "strings_with_errors": 3,
         "missing_strings": 5,
         "unreviewed_strings": 5,
+        "completed_strings": 17,
         "complete": False,
     } in localizations
 
@@ -469,6 +474,7 @@ def test_project(django_assert_num_queries):
         "strings_with_errors": 3,
         "missing_strings": 5,
         "unreviewed_strings": 5,
+        "completed_strings": 17,
         "complete": False,
     } in localizations
 
@@ -566,6 +572,7 @@ def test_projects(django_assert_num_queries):
             "strings_with_errors": p.strings_with_errors,
             "missing_strings": p.missing_strings,
             "unreviewed_strings": p.unreviewed_strings,
+            "completed_strings": p.completed_strings,
             "complete": p.complete,
         }
         for p in sorted(Project.objects.all(), key=lambda p: p.pk)
@@ -622,6 +629,7 @@ def test_system_projects(
             "strings_with_errors": p.strings_with_errors,
             "missing_strings": p.missing_strings,
             "unreviewed_strings": p.unreviewed_strings,
+            "completed_strings": p.completed_strings,
             "complete": p.complete,
         }
         for p in sorted(
@@ -674,6 +682,7 @@ def test_disabled_projects(
             "strings_with_errors": p.strings_with_errors,
             "missing_strings": p.missing_strings,
             "unreviewed_strings": p.unreviewed_strings,
+            "completed_strings": p.completed_strings,
             "complete": p.complete,
         }
         for p in sorted(
@@ -967,6 +976,7 @@ def test_project_locale(django_assert_num_queries):
             "strings_with_errors": 3,
             "missing_strings": 5,
             "unreviewed_strings": 5,
+            "completed_strings": 17,
             "complete": False,
         },
         "total_strings": 25,
@@ -976,6 +986,7 @@ def test_project_locale(django_assert_num_queries):
         "strings_with_errors": 3,
         "missing_strings": 5,
         "unreviewed_strings": 5,
+        "completed_strings": 17,
         "complete": False,
         "project": {
             "slug": "terminology",
@@ -996,6 +1007,7 @@ def test_project_locale(django_assert_num_queries):
             "strings_with_errors": 6,
             "missing_strings": 10,
             "unreviewed_strings": 10,
+            "completed_strings": 34,
             "complete": False,
         },
     }

--- a/pontoon/api/tests/test_views.py
+++ b/pontoon/api/tests/test_views.py
@@ -110,8 +110,8 @@ def test_locale(django_assert_num_queries):
     )
 
     translated_resource.total_strings = 25
-    translated_resource.approved_strings = 15
-    translated_resource.pretranslated_strings = 0
+    translated_resource.approved_strings = 10
+    translated_resource.pretranslated_strings = 5
     translated_resource.strings_with_errors = 3
     translated_resource.strings_with_warnings = 2
     translated_resource.missing_strings = 5
@@ -141,13 +141,13 @@ def test_locale(django_assert_num_queries):
         "systran_translate_code": "",
         "team_description": "",
         "total_strings": 25,
-        "approved_strings": 15,
-        "pretranslated_strings": 0,
+        "approved_strings": 10,
+        "pretranslated_strings": 5,
         "strings_with_warnings": 2,
         "strings_with_errors": 3,
         "missing_strings": 5,
         "unreviewed_strings": 5,
-        "completed_strings": 17,
+        "completed_strings": 12,
         "complete": False,
         "projects": ["terminology"],
     }
@@ -158,13 +158,13 @@ def test_locale(django_assert_num_queries):
             "name": "Terminology",
         },
         "total_strings": 25,
-        "approved_strings": 15,
-        "pretranslated_strings": 0,
+        "approved_strings": 10,
+        "pretranslated_strings": 5,
         "strings_with_warnings": 2,
         "strings_with_errors": 3,
         "missing_strings": 5,
         "unreviewed_strings": 5,
-        "completed_strings": 17,
+        "completed_strings": 12,
         "complete": False,
     } in localizations
 
@@ -201,8 +201,8 @@ def test_locales(django_assert_num_queries):
 
     for translated_resource in translated_resources:
         translated_resource.total_strings = 25
-        translated_resource.approved_strings = 15
-        translated_resource.pretranslated_strings = 0
+        translated_resource.approved_strings = 10
+        translated_resource.pretranslated_strings = 5
         translated_resource.strings_with_errors = 3
         translated_resource.strings_with_warnings = 2
         translated_resource.missing_strings = 5
@@ -295,8 +295,8 @@ def test_project(django_assert_num_queries):
 
     for translated_resource in translated_resources:
         translated_resource.total_strings = 25
-        translated_resource.approved_strings = 15
-        translated_resource.pretranslated_strings = 0
+        translated_resource.approved_strings = 10
+        translated_resource.pretranslated_strings = 5
         translated_resource.strings_with_errors = 3
         translated_resource.strings_with_warnings = 2
         translated_resource.missing_strings = 5
@@ -324,13 +324,13 @@ def test_project(django_assert_num_queries):
         "sync_disabled": True,
         "pretranslation_enabled": False,
         "total_strings": 50,
-        "approved_strings": 30,
-        "pretranslated_strings": 0,
+        "approved_strings": 20,
+        "pretranslated_strings": 10,
         "strings_with_warnings": 4,
         "strings_with_errors": 6,
         "missing_strings": 10,
         "unreviewed_strings": 10,
-        "completed_strings": 34,
+        "completed_strings": 24,
         "complete": False,
         "tags": [],
         "locales": [
@@ -452,13 +452,13 @@ def test_project(django_assert_num_queries):
             "name": "Klingon",
         },
         "total_strings": 25,
-        "approved_strings": 15,
-        "pretranslated_strings": 0,
+        "approved_strings": 10,
+        "pretranslated_strings": 5,
         "strings_with_warnings": 2,
         "strings_with_errors": 3,
         "missing_strings": 5,
         "unreviewed_strings": 5,
-        "completed_strings": 17,
+        "completed_strings": 12,
         "complete": False,
     } in localizations
 
@@ -468,13 +468,13 @@ def test_project(django_assert_num_queries):
             "name": "Afrikaans",
         },
         "total_strings": 25,
-        "approved_strings": 15,
-        "pretranslated_strings": 0,
+        "approved_strings": 10,
+        "pretranslated_strings": 5,
         "strings_with_warnings": 2,
         "strings_with_errors": 3,
         "missing_strings": 5,
         "unreviewed_strings": 5,
-        "completed_strings": 17,
+        "completed_strings": 12,
         "complete": False,
     } in localizations
 
@@ -544,8 +544,8 @@ def test_projects(django_assert_num_queries):
 
     for translated_resource in translated_resources:
         translated_resource.total_strings = 25
-        translated_resource.approved_strings = 15
-        translated_resource.pretranslated_strings = 0
+        translated_resource.approved_strings = 10
+        translated_resource.pretranslated_strings = 5
         translated_resource.strings_with_errors = 3
         translated_resource.strings_with_warnings = 2
         translated_resource.missing_strings = 5
@@ -941,8 +941,8 @@ def test_project_locale(django_assert_num_queries):
 
     for translated_resource in translated_resources:
         translated_resource.total_strings = 25
-        translated_resource.approved_strings = 15
-        translated_resource.pretranslated_strings = 0
+        translated_resource.approved_strings = 10
+        translated_resource.pretranslated_strings = 5
         translated_resource.strings_with_errors = 3
         translated_resource.strings_with_warnings = 2
         translated_resource.missing_strings = 5
@@ -970,23 +970,23 @@ def test_project_locale(django_assert_num_queries):
             "systran_translate_code": "",
             "team_description": "",
             "total_strings": 25,
-            "approved_strings": 15,
-            "pretranslated_strings": 0,
+            "approved_strings": 10,
+            "pretranslated_strings": 5,
             "strings_with_warnings": 2,
             "strings_with_errors": 3,
             "missing_strings": 5,
             "unreviewed_strings": 5,
-            "completed_strings": 17,
+            "completed_strings": 12,
             "complete": False,
         },
         "total_strings": 25,
-        "approved_strings": 15,
-        "pretranslated_strings": 0,
+        "approved_strings": 10,
+        "pretranslated_strings": 5,
         "strings_with_warnings": 2,
         "strings_with_errors": 3,
         "missing_strings": 5,
         "unreviewed_strings": 5,
-        "completed_strings": 17,
+        "completed_strings": 12,
         "complete": False,
         "project": {
             "slug": "terminology",
@@ -1001,13 +1001,13 @@ def test_project_locale(django_assert_num_queries):
             "sync_disabled": True,
             "pretranslation_enabled": False,
             "total_strings": 50,
-            "approved_strings": 30,
-            "pretranslated_strings": 0,
+            "approved_strings": 20,
+            "pretranslated_strings": 10,
             "strings_with_warnings": 4,
             "strings_with_errors": 6,
             "missing_strings": 10,
             "unreviewed_strings": 10,
-            "completed_strings": 34,
+            "completed_strings": 24,
             "complete": False,
         },
     }

--- a/pontoon/base/aggregated_stats.py
+++ b/pontoon/base/aggregated_stats.py
@@ -50,6 +50,14 @@ class AggregatedStats:
         )
 
     @property
+    def completed_strings(self) -> int:
+        return (
+            self.approved_strings
+            + self.pretranslated_strings
+            + self.strings_with_warnings
+        )
+
+    @property
     def complete(self) -> bool:
         return self.total_strings == self.approved_strings + self.strings_with_warnings
 

--- a/pontoon/base/aggregated_stats.py
+++ b/pontoon/base/aggregated_stats.py
@@ -51,11 +51,7 @@ class AggregatedStats:
 
     @property
     def completed_strings(self) -> int:
-        return (
-            self.approved_strings
-            + self.pretranslated_strings
-            + self.strings_with_warnings
-        )
+        return self.approved_strings + self.strings_with_warnings
 
     @property
     def complete(self) -> bool:

--- a/pontoon/base/models/locale.py
+++ b/pontoon/base/models/locale.py
@@ -88,7 +88,7 @@ class LocaleQuerySet(models.QuerySet):
             - F("pretranslated")
             - F("errors")
             - F("warnings"),
-            completed=F("approved") + F("pretranslated") + F("warnings"),
+            completed=F("approved") + F("warnings"),
             is_complete=Case(
                 When(
                     total=F("approved") + F("warnings"),

--- a/pontoon/base/models/locale.py
+++ b/pontoon/base/models/locale.py
@@ -88,6 +88,7 @@ class LocaleQuerySet(models.QuerySet):
             - F("pretranslated")
             - F("errors")
             - F("warnings"),
+            completed=F("approved") + F("pretranslated") + F("warnings"),
             is_complete=Case(
                 When(
                     total=F("approved") + F("warnings"),

--- a/pontoon/base/models/project.py
+++ b/pontoon/base/models/project.py
@@ -88,7 +88,7 @@ class ProjectQuerySet(models.QuerySet):
             - F("pretranslated")
             - F("errors")
             - F("warnings"),
-            completed=F("approved") + F("pretranslated") + F("warnings"),
+            completed=F("approved") + F("warnings"),
             is_complete=Case(
                 When(
                     total=F("approved") + F("warnings"),

--- a/pontoon/base/models/project.py
+++ b/pontoon/base/models/project.py
@@ -88,6 +88,7 @@ class ProjectQuerySet(models.QuerySet):
             - F("pretranslated")
             - F("errors")
             - F("warnings"),
+            completed=F("approved") + F("pretranslated") + F("warnings"),
             is_complete=Case(
                 When(
                     total=F("approved") + F("warnings"),

--- a/pontoon/base/models/project_locale.py
+++ b/pontoon/base/models/project_locale.py
@@ -58,6 +58,7 @@ class ProjectLocaleQuerySet(models.QuerySet):
             - F("pretranslated")
             - F("errors")
             - F("warnings"),
+            completed=F("approved") + F("pretranslated") + F("warnings"),
             is_complete=Case(
                 When(
                     total=F("approved") + F("warnings"),

--- a/pontoon/base/models/project_locale.py
+++ b/pontoon/base/models/project_locale.py
@@ -58,7 +58,7 @@ class ProjectLocaleQuerySet(models.QuerySet):
             - F("pretranslated")
             - F("errors")
             - F("warnings"),
-            completed=F("approved") + F("pretranslated") + F("warnings"),
+            completed=F("approved") + F("warnings"),
             is_complete=Case(
                 When(
                     total=F("approved") + F("warnings"),


### PR DESCRIPTION
Fix #3291 

Translation stats in `/api/v2/locales/, /api/v2/projects/, /api/v2/projects/<slug>/<locale>/` responses do not expose `completed_strings` (approved + pretranslated + warnings). 
`AggregatedStats` has no `completed_strings` property. `LocaleQuerySet, ProjectQuerySet, ProjectLocaleQuerySet` `stats_data()` have no completed annotation.

- Add `completed_strings` property to `AggregatedStats` for single-object access.
- Add `completed=F("approved") + F("pretranslated") + F("warnings")` annotation to `LocaleQuerySet`, `ProjectQuerySet`, `ProjectLocaleQuerySet` `stats_data()` for list queries.
- Add `completed_strings` to `TRANSLATION_STATS_FIELDS` and `TranslationStatsMixin`
- `get_completed_strings` returns `obj.completed`.
- Update tests `expected_results` dicts to include `completed_strings`.