### PR TITLE
User: fake user deletion, prevent pat access with disabled/deleted user

### DIFF
--- a/pontoon/api/authentication.py
+++ b/pontoon/api/authentication.py
@@ -42,6 +42,9 @@ class PersonalAccessTokenAuthentication(BaseAuthentication):
         if pat.expires_at and pat.expires_at.astimezone() < timezone.now():
             raise AuthenticationFailed({"detail": "Token has expired."})
 
+        if not pat.user.is_active:
+            raise AuthenticationFailed({"detail": "User is disabled."})
+
         pat.last_used = timezone.now()
         pat.save(update_fields=["last_used"])
 

--- a/pontoon/base/admin.py
+++ b/pontoon/base/admin.py
@@ -1,3 +1,5 @@
+import uuid
+
 from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import UserAdmin as AuthUserAdmin
@@ -7,10 +9,43 @@ from django.forms.models import ModelForm
 from django.urls import reverse
 from django.utils.html import format_html
 
+from pontoon.actionlog.models import ActionLog
+from pontoon.api.models import PersonalAccessToken
 from pontoon.base import models
-from pontoon.base.models.user import anonymize_user
 from pontoon.base.utils import get_m2m_changes
 from pontoon.teams.utils import log_user_groups
+from pontoon.terminology.models import Term
+
+
+def anonymize_user(user):
+    random_hash = uuid.uuid4().hex
+    new_user = User.objects.create_user(
+        username="deleted-user-" + random_hash,
+        email="deleted-user-" + random_hash + "@example.com",
+        first_name="Deleted User",
+        is_active=False,
+    )
+
+    ActionLog.objects.filter(performed_by=user).update(performed_by=new_user)
+    models.PermissionChangelog.objects.filter(performed_by=user).update(
+        performed_by=new_user
+    )
+    models.PermissionChangelog.objects.filter(performed_on=user).update(
+        performed_on=new_user
+    )
+    models.Project.objects.filter(contact=user).update(contact=new_user)
+    models.Translation.objects.filter(user=user).update(user=new_user)
+    models.Translation.objects.filter(approved_user=user).update(approved_user=new_user)
+    models.Translation.objects.filter(unapproved_user=user).update(
+        unapproved_user=new_user
+    )
+    models.Translation.objects.filter(rejected_user=user).update(rejected_user=new_user)
+    models.Translation.objects.filter(unrejected_user=user).update(
+        unrejected_user=new_user
+    )
+    Term.objects.filter(created_by=user).update(created_by=new_user)
+    models.Comment.objects.filter(author=user).update(author=new_user)
+    PersonalAccessToken.objects.filter(user=user).update(revoked=True)
 
 
 AGGREGATED_STATS_FIELDS = (

--- a/pontoon/base/admin.py
+++ b/pontoon/base/admin.py
@@ -1,5 +1,3 @@
-import uuid
-
 from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import UserAdmin as AuthUserAdmin
@@ -9,10 +7,9 @@ from django.forms.models import ModelForm
 from django.urls import reverse
 from django.utils.html import format_html
 
-from pontoon.actionlog.models import ActionLog
-from pontoon.base import models, utils
+from pontoon.base import models
+from pontoon.base.utils import anonymize_user, get_m2m_changes
 from pontoon.teams.utils import log_user_groups
-from pontoon.terminology.models import Term
 
 
 AGGREGATED_STATS_FIELDS = (
@@ -57,7 +54,7 @@ class UserAdmin(AuthUserAdmin):
 
         # Users can only be moved between groups upon editing, not creation
         if "groups" in form.cleaned_data:
-            add_groups, remove_groups = utils.get_m2m_changes(
+            add_groups, remove_groups = get_m2m_changes(
                 obj.groups, form.cleaned_data["groups"]
             )
 
@@ -68,38 +65,7 @@ class UserAdmin(AuthUserAdmin):
     # move user data we care about to it and then delete the user.
     # See bug 1561663 for details.
     def delete_model(self, request, obj):
-        random_hash = uuid.uuid4().hex
-        new_user = User.objects.create_user(
-            username="deleted-user-" + random_hash,
-            email="deleted-user-" + random_hash + "@example.com",
-            first_name="Deleted User",
-            is_active=False,
-        )
-
-        ActionLog.objects.filter(performed_by=obj).update(performed_by=new_user)
-        models.PermissionChangelog.objects.filter(performed_by=obj).update(
-            performed_by=new_user
-        )
-        models.PermissionChangelog.objects.filter(performed_on=obj).update(
-            performed_on=new_user
-        )
-        models.Project.objects.filter(contact=obj).update(contact=new_user)
-        models.Translation.objects.filter(user=obj).update(user=new_user)
-        models.Translation.objects.filter(approved_user=obj).update(
-            approved_user=new_user
-        )
-        models.Translation.objects.filter(unapproved_user=obj).update(
-            unapproved_user=new_user
-        )
-        models.Translation.objects.filter(rejected_user=obj).update(
-            rejected_user=new_user
-        )
-        models.Translation.objects.filter(unrejected_user=obj).update(
-            unrejected_user=new_user
-        )
-        Term.objects.filter(created_by=obj).update(created_by=new_user)
-        models.Comment.objects.filter(author=obj).update(author=new_user)
-
+        anonymize_user(obj)
         super().delete_model(request, obj)
 
     # This method is to override bulk delete method from the user list page

--- a/pontoon/base/admin.py
+++ b/pontoon/base/admin.py
@@ -1,5 +1,3 @@
-import uuid
-
 from django.contrib import admin
 from django.contrib.auth import get_user_model
 from django.contrib.auth.admin import UserAdmin as AuthUserAdmin
@@ -9,43 +7,10 @@ from django.forms.models import ModelForm
 from django.urls import reverse
 from django.utils.html import format_html
 
-from pontoon.actionlog.models import ActionLog
-from pontoon.api.models import PersonalAccessToken
 from pontoon.base import models
+from pontoon.base.services import anonymize_user
 from pontoon.base.utils import get_m2m_changes
 from pontoon.teams.utils import log_user_groups
-from pontoon.terminology.models import Term
-
-
-def anonymize_user(user):
-    random_hash = uuid.uuid4().hex
-    new_user = User.objects.create_user(
-        username="deleted-user-" + random_hash,
-        email="deleted-user-" + random_hash + "@example.com",
-        first_name="Deleted User",
-        is_active=False,
-    )
-
-    ActionLog.objects.filter(performed_by=user).update(performed_by=new_user)
-    models.PermissionChangelog.objects.filter(performed_by=user).update(
-        performed_by=new_user
-    )
-    models.PermissionChangelog.objects.filter(performed_on=user).update(
-        performed_on=new_user
-    )
-    models.Project.objects.filter(contact=user).update(contact=new_user)
-    models.Translation.objects.filter(user=user).update(user=new_user)
-    models.Translation.objects.filter(approved_user=user).update(approved_user=new_user)
-    models.Translation.objects.filter(unapproved_user=user).update(
-        unapproved_user=new_user
-    )
-    models.Translation.objects.filter(rejected_user=user).update(rejected_user=new_user)
-    models.Translation.objects.filter(unrejected_user=user).update(
-        unrejected_user=new_user
-    )
-    Term.objects.filter(created_by=user).update(created_by=new_user)
-    models.Comment.objects.filter(author=user).update(author=new_user)
-    PersonalAccessToken.objects.filter(user=user).update(revoked=True)
 
 
 AGGREGATED_STATS_FIELDS = (

--- a/pontoon/base/admin.py
+++ b/pontoon/base/admin.py
@@ -8,7 +8,8 @@ from django.urls import reverse
 from django.utils.html import format_html
 
 from pontoon.base import models
-from pontoon.base.utils import anonymize_user, get_m2m_changes
+from pontoon.base.models.user import anonymize_user
+from pontoon.base.utils import get_m2m_changes
 from pontoon.teams.utils import log_user_groups
 
 

--- a/pontoon/base/models/user.py
+++ b/pontoon/base/models/user.py
@@ -1,3 +1,5 @@
+import uuid
+
 from datetime import timedelta
 from hashlib import md5
 from urllib.parse import quote, urlencode
@@ -13,6 +15,35 @@ from django.urls import reverse
 from django.utils import timezone
 
 from pontoon.actionlog.models import ActionLog
+from pontoon.api.models import PersonalAccessToken
+from pontoon.base.models.comment import Comment
+from pontoon.base.models.permission_changelog import PermissionChangelog
+from pontoon.base.models.project import Project
+from pontoon.base.models.translation import Translation
+from pontoon.terminology.models import Term
+
+
+def anonymize_user(user):
+    random_hash = uuid.uuid4().hex
+    new_user = User.objects.create_user(
+        username="deleted-user-" + random_hash,
+        email="deleted-user-" + random_hash + "@example.com",
+        first_name="Deleted User",
+        is_active=False,
+    )
+
+    ActionLog.objects.filter(performed_by=user).update(performed_by=new_user)
+    PermissionChangelog.objects.filter(performed_by=user).update(performed_by=new_user)
+    PermissionChangelog.objects.filter(performed_on=user).update(performed_on=new_user)
+    Project.objects.filter(contact=user).update(contact=new_user)
+    Translation.objects.filter(user=user).update(user=new_user)
+    Translation.objects.filter(approved_user=user).update(approved_user=new_user)
+    Translation.objects.filter(unapproved_user=user).update(unapproved_user=new_user)
+    Translation.objects.filter(rejected_user=user).update(rejected_user=new_user)
+    Translation.objects.filter(unrejected_user=user).update(unrejected_user=new_user)
+    Term.objects.filter(created_by=user).update(created_by=new_user)
+    Comment.objects.filter(author=user).update(author=new_user)
+    PersonalAccessToken.objects.filter(user=user).update(revoked=True)
 
 
 @property

--- a/pontoon/base/models/user.py
+++ b/pontoon/base/models/user.py
@@ -1,5 +1,3 @@
-import uuid
-
 from datetime import timedelta
 from hashlib import md5
 from urllib.parse import quote, urlencode
@@ -15,35 +13,6 @@ from django.urls import reverse
 from django.utils import timezone
 
 from pontoon.actionlog.models import ActionLog
-from pontoon.api.models import PersonalAccessToken
-from pontoon.base.models.comment import Comment
-from pontoon.base.models.permission_changelog import PermissionChangelog
-from pontoon.base.models.project import Project
-from pontoon.base.models.translation import Translation
-from pontoon.terminology.models import Term
-
-
-def anonymize_user(user):
-    random_hash = uuid.uuid4().hex
-    new_user = User.objects.create_user(
-        username="deleted-user-" + random_hash,
-        email="deleted-user-" + random_hash + "@example.com",
-        first_name="Deleted User",
-        is_active=False,
-    )
-
-    ActionLog.objects.filter(performed_by=user).update(performed_by=new_user)
-    PermissionChangelog.objects.filter(performed_by=user).update(performed_by=new_user)
-    PermissionChangelog.objects.filter(performed_on=user).update(performed_on=new_user)
-    Project.objects.filter(contact=user).update(contact=new_user)
-    Translation.objects.filter(user=user).update(user=new_user)
-    Translation.objects.filter(approved_user=user).update(approved_user=new_user)
-    Translation.objects.filter(unapproved_user=user).update(unapproved_user=new_user)
-    Translation.objects.filter(rejected_user=user).update(rejected_user=new_user)
-    Translation.objects.filter(unrejected_user=user).update(unrejected_user=new_user)
-    Term.objects.filter(created_by=user).update(created_by=new_user)
-    Comment.objects.filter(author=user).update(author=new_user)
-    PersonalAccessToken.objects.filter(user=user).update(revoked=True)
 
 
 @property

--- a/pontoon/base/services.py
+++ b/pontoon/base/services.py
@@ -1,0 +1,114 @@
+import uuid
+
+from django.contrib.auth.models import User
+from django.db.models.query import QuerySet
+from django.http import Http404
+from django.shortcuts import redirect
+from django.urls import reverse
+
+from pontoon.actionlog.models import ActionLog
+from pontoon.api.models import PersonalAccessToken
+from pontoon.base.models import Comment
+from pontoon.base.models.locale import Locale, LocaleCodeHistory
+from pontoon.base.models.permission_changelog import PermissionChangelog
+from pontoon.base.models.project import Project, ProjectSlugHistory
+from pontoon.base.models.project_locale import ProjectLocale
+from pontoon.base.models.translation import Translation
+from pontoon.terminology.models import Term
+
+
+def readonly_exists(projects, locale):
+    """
+    :arg list projects: a list of Project instances.
+    :arg Locale locale: Locale instance.
+    :returns: True if a read-only ProjectLocale instance for given Projects and
+        Locale exists.
+    """
+
+    if not isinstance(projects, (QuerySet, tuple, list)):
+        projects = [projects]
+
+    return ProjectLocale.objects.filter(
+        project__in=projects,
+        locale=locale,
+        readonly=True,
+    ).exists()
+
+
+def get_project_or_redirect(
+    slug, redirect_view_name, slug_arg_name, request_user, **kwargs
+):
+    """
+    Attempts to get a project with the given slug. If the project doesn't exist, it checks if the slug is in the
+    ProjectSlugHistory and if so, it redirects to the current project slug URL. If the old slug is not found in the
+    history, it raises an Http404 error.
+    """
+
+    try:
+        project = Project.objects.visible_for(request_user).available().get(slug=slug)
+        return project
+    except Project.DoesNotExist:
+        slug_history = (
+            ProjectSlugHistory.objects.filter(old_slug=slug)
+            .order_by("-created_at")
+            .first()
+        )
+        if slug_history is not None:
+            redirect_kwargs = {slug_arg_name: slug_history.project.slug}
+            redirect_kwargs.update(kwargs)
+            redirect_url = reverse(redirect_view_name, kwargs=redirect_kwargs)
+            return redirect(redirect_url)
+        else:
+            raise Http404
+
+
+def get_locale_or_redirect(code, redirect_view_name=None, url_arg_name=None, **kwargs):
+    """
+    Attempts to retrieve a locale using the given code. If the locale does not exist, it checks the LocaleCodeHistory
+    for a record of the old code. If an entry is found, it either redirects to the view specified by redirect_view_name
+    using the new locale code or returns the Locale object if no redirect_view_name is provided.
+    The url_arg_name parameter specifies the argument name for the locale code used in the URL pattern of the redirect view.
+    If the old code is not found in the history, it raises an Http404 error.
+    """
+
+    try:
+        return Locale.objects.get(code=code)
+    except Locale.DoesNotExist:
+        code_history = (
+            LocaleCodeHistory.objects.filter(old_code=code)
+            .order_by("-created_at")
+            .first()
+        )
+    if code_history:
+        if not redirect_view_name or not url_arg_name:
+            return code_history.locale
+
+        redirect_kwargs = {url_arg_name: code_history.locale.code}
+        redirect_kwargs.update(kwargs)
+        redirect_url = reverse(redirect_view_name, kwargs=redirect_kwargs)
+        return redirect(redirect_url)
+
+    raise Http404
+
+
+def anonymize_user(user):
+    random_hash = uuid.uuid4().hex
+    new_user = User.objects.create_user(
+        username="deleted-user-" + random_hash,
+        email="deleted-user-" + random_hash + "@example.com",
+        first_name="Deleted User",
+        is_active=False,
+    )
+
+    ActionLog.objects.filter(performed_by=user).update(performed_by=new_user)
+    PermissionChangelog.objects.filter(performed_by=user).update(performed_by=new_user)
+    PermissionChangelog.objects.filter(performed_on=user).update(performed_on=new_user)
+    Project.objects.filter(contact=user).update(contact=new_user)
+    Translation.objects.filter(user=user).update(user=new_user)
+    Translation.objects.filter(approved_user=user).update(approved_user=new_user)
+    Translation.objects.filter(unapproved_user=user).update(unapproved_user=new_user)
+    Translation.objects.filter(rejected_user=user).update(rejected_user=new_user)
+    Translation.objects.filter(unrejected_user=user).update(unrejected_user=new_user)
+    Term.objects.filter(created_by=user).update(created_by=new_user)
+    Comment.objects.filter(author=user).update(author=new_user)
+    PersonalAccessToken.objects.filter(user=user).update(revoked=True)

--- a/pontoon/base/services.py
+++ b/pontoon/base/services.py
@@ -18,13 +18,6 @@ from pontoon.terminology.models import Term
 
 
 def readonly_exists(projects, locale):
-    """
-    :arg list projects: a list of Project instances.
-    :arg Locale locale: Locale instance.
-    :returns: True if a read-only ProjectLocale instance for given Projects and
-        Locale exists.
-    """
-
     if not isinstance(projects, (QuerySet, tuple, list)):
         projects = [projects]
 

--- a/pontoon/base/services.py
+++ b/pontoon/base/services.py
@@ -8,7 +8,7 @@ from django.urls import reverse
 
 from pontoon.actionlog.models import ActionLog
 from pontoon.api.models import PersonalAccessToken
-from pontoon.base.models import Comment
+from pontoon.base.models.comment import Comment
 from pontoon.base.models.locale import Locale, LocaleCodeHistory
 from pontoon.base.models.permission_changelog import PermissionChangelog
 from pontoon.base.models.project import Project, ProjectSlugHistory

--- a/pontoon/base/utils.py
+++ b/pontoon/base/utils.py
@@ -1,12 +1,14 @@
 import functools
 import re
 import time
+import uuid
 
 from datetime import datetime, timedelta, timezone
 from xml.sax.saxutils import escape, quoteattr
 
 from guardian.decorators import permission_required as guardian_permission_required
 
+from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 from django.db.models.query import QuerySet
@@ -345,3 +347,34 @@ def get_locale_or_redirect(code, redirect_view_name=None, url_arg_name=None, **k
 
 def parse_bool(value) -> bool:
     return str(value).lower() in ("1", "true", "yes", "on")
+
+
+def anonymize_user(user):
+    from pontoon.actionlog.models import ActionLog
+    from pontoon.api.models import PersonalAccessToken
+    from pontoon.base.models.comment import Comment
+    from pontoon.base.models.permission_changelog import PermissionChangelog
+    from pontoon.base.models.project import Project
+    from pontoon.base.models.translation import Translation
+    from pontoon.terminology.models import Term
+
+    random_hash = uuid.uuid4().hex
+    new_user = User.objects.create_user(
+        username="deleted-user-" + random_hash,
+        email="deleted-user-" + random_hash + "@example.com",
+        first_name="Deleted User",
+        is_active=False,
+    )
+
+    ActionLog.objects.filter(performed_by=user).update(performed_by=new_user)
+    PermissionChangelog.objects.filter(performed_by=user).update(performed_by=new_user)
+    PermissionChangelog.objects.filter(performed_on=user).update(performed_on=new_user)
+    Project.objects.filter(contact=user).update(contact=new_user)
+    Translation.objects.filter(user=user).update(user=new_user)
+    Translation.objects.filter(approved_user=user).update(approved_user=new_user)
+    Translation.objects.filter(unapproved_user=user).update(unapproved_user=new_user)
+    Translation.objects.filter(rejected_user=user).update(rejected_user=new_user)
+    Translation.objects.filter(unrejected_user=user).update(unrejected_user=new_user)
+    Term.objects.filter(created_by=user).update(created_by=new_user)
+    Comment.objects.filter(author=user).update(author=new_user)
+    PersonalAccessToken.objects.filter(user=user).update(revoked=True)

--- a/pontoon/base/utils.py
+++ b/pontoon/base/utils.py
@@ -1,14 +1,12 @@
 import functools
 import re
 import time
-import uuid
 
 from datetime import datetime, timedelta, timezone
 from xml.sax.saxutils import escape, quoteattr
 
 from guardian.decorators import permission_required as guardian_permission_required
 
-from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 from django.db.models.query import QuerySet
@@ -347,34 +345,3 @@ def get_locale_or_redirect(code, redirect_view_name=None, url_arg_name=None, **k
 
 def parse_bool(value) -> bool:
     return str(value).lower() in ("1", "true", "yes", "on")
-
-
-def anonymize_user(user):
-    from pontoon.actionlog.models import ActionLog
-    from pontoon.api.models import PersonalAccessToken
-    from pontoon.base.models.comment import Comment
-    from pontoon.base.models.permission_changelog import PermissionChangelog
-    from pontoon.base.models.project import Project
-    from pontoon.base.models.translation import Translation
-    from pontoon.terminology.models import Term
-
-    random_hash = uuid.uuid4().hex
-    new_user = User.objects.create_user(
-        username="deleted-user-" + random_hash,
-        email="deleted-user-" + random_hash + "@example.com",
-        first_name="Deleted User",
-        is_active=False,
-    )
-
-    ActionLog.objects.filter(performed_by=user).update(performed_by=new_user)
-    PermissionChangelog.objects.filter(performed_by=user).update(performed_by=new_user)
-    PermissionChangelog.objects.filter(performed_on=user).update(performed_on=new_user)
-    Project.objects.filter(contact=user).update(contact=new_user)
-    Translation.objects.filter(user=user).update(user=new_user)
-    Translation.objects.filter(approved_user=user).update(approved_user=new_user)
-    Translation.objects.filter(unapproved_user=user).update(unapproved_user=new_user)
-    Translation.objects.filter(rejected_user=user).update(rejected_user=new_user)
-    Translation.objects.filter(unrejected_user=user).update(unrejected_user=new_user)
-    Term.objects.filter(created_by=user).update(created_by=new_user)
-    Comment.objects.filter(author=user).update(author=new_user)
-    PersonalAccessToken.objects.filter(user=user).update(revoked=True)

--- a/pontoon/base/utils.py
+++ b/pontoon/base/utils.py
@@ -9,10 +9,7 @@ from guardian.decorators import permission_required as guardian_permission_requi
 
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
-from django.db.models.query import QuerySet
-from django.http import Http404, HttpResponseBadRequest
-from django.shortcuts import redirect
-from django.urls import reverse
+from django.http import HttpResponseBadRequest
 from django.utils.text import slugify
 from django.utils.timezone import make_aware
 from django.utils.translation import trans_real
@@ -221,26 +218,6 @@ def get_m2m_changes(current_qs, new_qs):
     return list(add_items), list(remove_items)
 
 
-def readonly_exists(projects, locale):
-    """
-    :arg list projects: a list of Project instances.
-    :arg Locale locale: Locale instance.
-    :returns: True if a read-only ProjectLocale instance for given Projects and
-        Locale exists.
-    """
-    # Avoid circular import; someday we should refactor to avoid.
-    from pontoon.base.models import ProjectLocale
-
-    if not isinstance(projects, (QuerySet, tuple, list)):
-        projects = [projects]
-
-    return ProjectLocale.objects.filter(
-        project__in=projects,
-        locale=locale,
-        readonly=True,
-    ).exists()
-
-
 def get_search_phrases(search):
     """
     Split the search phrase into separate search queries.
@@ -281,66 +258,6 @@ def is_email(email):
         return True
     except ValidationError:
         return False
-
-
-def get_project_or_redirect(
-    slug, redirect_view_name, slug_arg_name, request_user, **kwargs
-):
-    """
-    Attempts to get a project with the given slug. If the project doesn't exist, it checks if the slug is in the
-    ProjectSlugHistory and if so, it redirects to the current project slug URL. If the old slug is not found in the
-    history, it raises an Http404 error.
-    """
-    # Avoid circular import; someday we should refactor to avoid.
-    from pontoon.base.models import Project, ProjectSlugHistory
-
-    try:
-        project = Project.objects.visible_for(request_user).available().get(slug=slug)
-        return project
-    except Project.DoesNotExist:
-        slug_history = (
-            ProjectSlugHistory.objects.filter(old_slug=slug)
-            .order_by("-created_at")
-            .first()
-        )
-        if slug_history is not None:
-            redirect_kwargs = {slug_arg_name: slug_history.project.slug}
-            redirect_kwargs.update(kwargs)
-            redirect_url = reverse(redirect_view_name, kwargs=redirect_kwargs)
-            return redirect(redirect_url)
-        else:
-            raise Http404
-
-
-def get_locale_or_redirect(code, redirect_view_name=None, url_arg_name=None, **kwargs):
-    """
-    Attempts to retrieve a locale using the given code. If the locale does not exist, it checks the LocaleCodeHistory
-    for a record of the old code. If an entry is found, it either redirects to the view specified by redirect_view_name
-    using the new locale code or returns the Locale object if no redirect_view_name is provided.
-    The url_arg_name parameter specifies the argument name for the locale code used in the URL pattern of the redirect view.
-    If the old code is not found in the history, it raises an Http404 error.
-    """
-    # Avoid circular import; someday we should refactor to avoid.
-    from pontoon.base.models import Locale, LocaleCodeHistory
-
-    try:
-        return Locale.objects.get(code=code)
-    except Locale.DoesNotExist:
-        code_history = (
-            LocaleCodeHistory.objects.filter(old_code=code)
-            .order_by("-created_at")
-            .first()
-        )
-    if code_history:
-        if not redirect_view_name or not url_arg_name:
-            return code_history.locale
-
-        redirect_kwargs = {url_arg_name: code_history.locale.code}
-        redirect_kwargs.update(kwargs)
-        redirect_url = reverse(redirect_view_name, kwargs=redirect_kwargs)
-        return redirect(redirect_url)
-
-    raise Http404
 
 
 def parse_bool(value) -> bool:

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -46,6 +46,7 @@ from pontoon.base.models import (
     TranslationMemoryEntry,
     UserProfile,
 )
+from pontoon.base.services import readonly_exists
 from pontoon.base.templatetags.helpers import provider_login_url
 from pontoon.checks.libraries import run_checks
 from pontoon.checks.utils import are_blocking_checks
@@ -920,7 +921,7 @@ def upload(request):
     project = get_object_or_404(Project.objects.visible_for(request.user), slug=slug)
     if not request.user.can_translate(
         project=project, locale=locale
-    ) or utils.readonly_exists(project, locale):
+    ) or readonly_exists(project, locale):
         return HttpResponseForbidden("You don't have permission to upload files.")
     get_object_or_404(Resource, project=project, path=res_path)
 

--- a/pontoon/batch/views.py
+++ b/pontoon/batch/views.py
@@ -14,10 +14,8 @@ from pontoon.base.models import (
     Translation,
     TranslationMemoryEntry,
 )
-from pontoon.base.utils import (
-    readonly_exists,
-    require_AJAX,
-)
+from pontoon.base.services import readonly_exists
+from pontoon.base.utils import require_AJAX
 from pontoon.batch import forms
 from pontoon.batch.actions import ACTIONS_FN_MAP
 

--- a/pontoon/contributors/tests/test_views.py
+++ b/pontoon/contributors/tests/test_views.py
@@ -10,12 +10,14 @@ from django.utils.timezone import make_aware, now
 
 from pontoon.api.models import PersonalAccessToken
 from pontoon.base.models import User, UserBanLog
+from pontoon.base.models.translation import Translation
 from pontoon.base.tests import (
     LocaleFactory,
     TranslationFactory,
 )
 from pontoon.base.utils import aware_datetime
 from pontoon.contributors import views
+from pontoon.test.factories import EntityFactory, ProjectFactory, ResourceFactory
 
 
 def commajoin(*items):
@@ -415,7 +417,32 @@ def test_personal_access_token_deletion_correct_permissions(member, user_b):
 
 @pytest.mark.django_db
 def test_delete_user(member):
-    """Test if user can delete their own account."""
+    """
+    Test if user can delete their own account. Check if user relationships are assigned
+    to a new placeholder user.
+    """
+    locale_a = LocaleFactory(
+        code="kg",
+        name="Klingon",
+    )
+    project_a = ProjectFactory(
+        slug="project_a",
+        name="Project A",
+    )
+    resource_a = ResourceFactory.create(
+        path="resource_a",
+        project=project_a,
+    )
+    entity_a = EntityFactory.create(string="Test String", resource=resource_a)
+
+    TranslationFactory.create(
+        string="String A",
+        locale=locale_a,
+        user=member.user,
+        entity=entity_a,
+    )
+    assert Translation.objects.filter(user=member.user).exists()
+
     url = reverse("pontoon.contributors.delete_user")
     user_pk = member.user.pk
 
@@ -425,3 +452,4 @@ def test_delete_user(member):
     assert response.json()["status"] == "success"
     assert response.json()["message"] == "User deleted successfully."
     assert not User.objects.filter(pk=user_pk).exists()
+    assert not Translation.objects.filter(user=member.user).exists()

--- a/pontoon/contributors/views.py
+++ b/pontoon/contributors/views.py
@@ -32,8 +32,8 @@ from django.views.generic import TemplateView
 
 from pontoon.api.models import PersonalAccessToken
 from pontoon.base import forms
+from pontoon.base.admin import anonymize_user
 from pontoon.base.models import Locale, Project, UserBanLog, UserProfile
-from pontoon.base.models.user import anonymize_user
 from pontoon.base.utils import get_locale_or_redirect, require_AJAX
 from pontoon.contributors import utils
 from pontoon.messaging.emails import send_verification_email

--- a/pontoon/contributors/views.py
+++ b/pontoon/contributors/views.py
@@ -32,9 +32,9 @@ from django.views.generic import TemplateView
 
 from pontoon.api.models import PersonalAccessToken
 from pontoon.base import forms
-from pontoon.base.admin import anonymize_user
 from pontoon.base.models import Locale, Project, UserBanLog, UserProfile
-from pontoon.base.utils import get_locale_or_redirect, require_AJAX
+from pontoon.base.services import anonymize_user, get_locale_or_redirect
+from pontoon.base.utils import require_AJAX
 from pontoon.contributors import utils
 from pontoon.messaging.emails import send_verification_email
 from pontoon.settings import (

--- a/pontoon/contributors/views.py
+++ b/pontoon/contributors/views.py
@@ -33,7 +33,7 @@ from django.views.generic import TemplateView
 from pontoon.api.models import PersonalAccessToken
 from pontoon.base import forms
 from pontoon.base.models import Locale, Project, UserBanLog, UserProfile
-from pontoon.base.utils import get_locale_or_redirect, require_AJAX
+from pontoon.base.utils import anonymize_user, get_locale_or_redirect, require_AJAX
 from pontoon.contributors import utils
 from pontoon.messaging.emails import send_verification_email
 from pontoon.settings import (
@@ -605,6 +605,7 @@ def delete_token(request, token_id):
 @transaction.atomic
 def delete_user(request):
     try:
+        anonymize_user(request.user)
         request.user.delete()
         logout(request)
         messages.success(request, "Your account has been deleted.")

--- a/pontoon/contributors/views.py
+++ b/pontoon/contributors/views.py
@@ -33,7 +33,8 @@ from django.views.generic import TemplateView
 from pontoon.api.models import PersonalAccessToken
 from pontoon.base import forms
 from pontoon.base.models import Locale, Project, UserBanLog, UserProfile
-from pontoon.base.utils import anonymize_user, get_locale_or_redirect, require_AJAX
+from pontoon.base.models.user import anonymize_user
+from pontoon.base.utils import get_locale_or_redirect, require_AJAX
 from pontoon.contributors import utils
 from pontoon.messaging.emails import send_verification_email
 from pontoon.settings import (

--- a/pontoon/homepage/views.py
+++ b/pontoon/homepage/views.py
@@ -4,7 +4,8 @@ from django.template import Context, Template
 from django.urls import reverse
 
 from pontoon.base.models import Locale
-from pontoon.base.utils import get_locale_or_redirect, get_project_locale_from_request
+from pontoon.base.services import get_locale_or_redirect
+from pontoon.base.utils import get_project_locale_from_request
 from pontoon.homepage.models import Homepage
 
 

--- a/pontoon/localizations/views.py
+++ b/pontoon/localizations/views.py
@@ -12,11 +12,8 @@ from pontoon.base.models import (
     ProjectLocale,
     TranslatedResource,
 )
-from pontoon.base.utils import (
-    get_locale_or_redirect,
-    get_project_or_redirect,
-    require_AJAX,
-)
+from pontoon.base.services import get_locale_or_redirect, get_project_or_redirect
+from pontoon.base.utils import require_AJAX
 from pontoon.contributors.views import ContributorsMixin
 from pontoon.insights.utils import get_insights
 from pontoon.tags.utils import Tags

--- a/pontoon/projects/views.py
+++ b/pontoon/projects/views.py
@@ -11,7 +11,8 @@ from django.views.generic.detail import DetailView
 
 from pontoon.base.aggregated_stats import get_top_instances
 from pontoon.base.models import Locale, Project, TranslatedResource, Translation
-from pontoon.base.utils import get_project_or_redirect, require_AJAX
+from pontoon.base.services import get_project_or_redirect
+from pontoon.base.utils import require_AJAX
 from pontoon.contributors.views import ContributorsMixin
 from pontoon.insights.utils import get_insights
 from pontoon.tags.utils import Tags

--- a/pontoon/teams/views.py
+++ b/pontoon/teams/views.py
@@ -46,7 +46,8 @@ from pontoon.base.models import (
 )
 from pontoon.base.models.project_locale import ProjectLocale
 from pontoon.base.models.translation import Translation
-from pontoon.base.utils import get_locale_or_redirect, require_AJAX
+from pontoon.base.services import get_locale_or_redirect
+from pontoon.base.utils import require_AJAX
 from pontoon.contributors.views import ContributorsMixin
 from pontoon.insights.utils import get_locale_insights
 from pontoon.teams.forms import LocaleRequestForm

--- a/pontoon/translate/views.py
+++ b/pontoon/translate/views.py
@@ -9,7 +9,7 @@ from django.views.decorators.csrf import (
     ensure_csrf_cookie,
 )
 
-from pontoon.base.utils import get_locale_or_redirect, get_project_or_redirect
+from pontoon.base.services import get_locale_or_redirect, get_project_or_redirect
 
 
 @csrf_exempt

--- a/pontoon/translations/views.py
+++ b/pontoon/translations/views.py
@@ -22,6 +22,7 @@ from pontoon.base.models import (
     TranslatedResource,
     Translation,
 )
+from pontoon.base.services import readonly_exists
 from pontoon.checks.libraries import run_checks
 from pontoon.checks.utils import are_blocking_checks
 from pontoon.messaging.notifications import send_badge_notification
@@ -86,7 +87,7 @@ def create_translation(request):
         )
 
     # Read-only translations cannot saved
-    if utils.readonly_exists(project, locale):
+    if readonly_exists(project, locale):
         return JsonResponse(
             {
                 "status": False,
@@ -211,7 +212,7 @@ def delete_translation(request):
     locale = translation.locale
 
     # Read-only translations cannot be deleted
-    if utils.readonly_exists(project, locale):
+    if readonly_exists(project, locale):
         return JsonResponse(
             {
                 "status": False,
@@ -267,7 +268,7 @@ def approve_translation(request):
     user = request.user
 
     # Read-only translations cannot be approved
-    if utils.readonly_exists(project, locale):
+    if readonly_exists(project, locale):
         return JsonResponse(
             {
                 "status": False,
@@ -352,7 +353,7 @@ def unapprove_translation(request):
     locale = translation.locale
 
     # Read-only translations cannot be un-approved
-    if utils.readonly_exists(project, locale):
+    if readonly_exists(project, locale):
         return JsonResponse(
             {
                 "status": False,
@@ -409,7 +410,7 @@ def reject_translation(request):
     locale = translation.locale
 
     # Read-only translations cannot be rejected
-    if utils.readonly_exists(project, locale):
+    if readonly_exists(project, locale):
         return JsonResponse(
             {
                 "status": False,
@@ -480,7 +481,7 @@ def unreject_translation(request):
     locale = translation.locale
 
     # Read-only translations cannot be un-rejected
-    if utils.readonly_exists(project, locale):
+    if readonly_exists(project, locale):
         return JsonResponse(
             {
                 "status": False,


### PR DESCRIPTION
This PR changes the user deletion behaviour found in the settings page. Instead of a simple direct deletion, the user first undertakes a process of model pruning similar to if an admin deletes a user thru the django admin portal.

In essence, a fake user is created in place of the real user, and all associated model relationships will be substituted with said fake user.

Furthermore, a check is added to PersonalAccessToken that prevents disabled users (specifically those disabled by an admin) from continuing to use a previously generated token.

With this implemented, we can close #4155 and fix the pretranslation api security issue.

Fixes #4155.