### PR TITLE
Notifications: exclude system users (TM, sync, GT) from recipients

### DIFF
--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -607,6 +607,7 @@ def _send_add_comment_notifications(user, comment, entity, locale, translation):
     for recipient in User.objects.filter(
         pk__in=recipients,
         profile__comment_notifications=True,
+        profile__system_user=False,
     ).exclude(pk=user.pk):
         notify.send(
             user,
@@ -638,9 +639,10 @@ def _send_pin_comment_notifications(user, comment):
             if u:
                 recipient_data[u.pk].append(t.locale.pk)
 
-    for recipient in User.objects.filter(pk__in=recipient_data.keys()).exclude(
-        pk=user.pk
-    ):
+    for recipient in User.objects.filter(
+        pk__in=recipient_data.keys(),
+        profile__system_user=False,
+    ).exclude(pk=user.pk):
         # Send separate notification for each locale (which results in links to corresponding translate views)
         for locale in Locale.objects.filter(pk__in=recipient_data[recipient.pk]):
             notify.send(

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -6,8 +6,6 @@ from collections import defaultdict
 from datetime import datetime
 from urllib.parse import urlparse
 
-from notifications.signals import notify
-
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
@@ -50,6 +48,7 @@ from pontoon.base.services import readonly_exists
 from pontoon.base.templatetags.helpers import provider_login_url
 from pontoon.checks.libraries import run_checks
 from pontoon.checks.utils import are_blocking_checks
+from pontoon.messaging.notifications import send_notification
 
 
 log = logging.getLogger(__name__)
@@ -607,9 +606,8 @@ def _send_add_comment_notifications(user, comment, entity, locale, translation):
     for recipient in User.objects.filter(
         pk__in=recipients,
         profile__comment_notifications=True,
-        profile__system_user=False,
     ).exclude(pk=user.pk):
-        notify.send(
+        send_notification(
             user,
             recipient=recipient,
             verb="has added a comment in",
@@ -639,13 +637,12 @@ def _send_pin_comment_notifications(user, comment):
             if u:
                 recipient_data[u.pk].append(t.locale.pk)
 
-    for recipient in User.objects.filter(
-        pk__in=recipient_data.keys(),
-        profile__system_user=False,
-    ).exclude(pk=user.pk):
+    for recipient in User.objects.filter(pk__in=recipient_data.keys()).exclude(
+        pk=user.pk
+    ):
         # Send separate notification for each locale (which results in links to corresponding translate views)
         for locale in Locale.objects.filter(pk__in=recipient_data[recipient.pk]):
-            notify.send(
+            send_notification(
                 user,
                 recipient=recipient,
                 verb="has pinned a comment in",

--- a/pontoon/messaging/management/commands/send_deadline_notifications.py
+++ b/pontoon/messaging/management/commands/send_deadline_notifications.py
@@ -49,6 +49,7 @@ class Command(BaseCommand):
                     translation__entity__resource__project=project,
                     translation__locale__in=locales,
                     profile__project_deadline_notifications=True,
+                    profile__system_user=False,
                 ).distinct(),
             )
 

--- a/pontoon/messaging/management/commands/send_deadline_notifications.py
+++ b/pontoon/messaging/management/commands/send_deadline_notifications.py
@@ -1,12 +1,11 @@
 import datetime
 
-from notifications.signals import notify
-
 from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand
 
 from pontoon.base.models import Project
 from pontoon.base.models.translated_resource import TranslatedResource
+from pontoon.messaging.notifications import send_notification
 
 
 class Command(BaseCommand):
@@ -44,18 +43,15 @@ class Command(BaseCommand):
                 if pl_stats["approved"] < pl_stats["total"]:
                     locales.append(project_locale.locale)
 
-            contributors = (
-                User.objects.filter(
-                    translation__entity__resource__project=project,
-                    translation__locale__in=locales,
-                    profile__project_deadline_notifications=True,
-                    profile__system_user=False,
-                ).distinct(),
-            )
+            contributors = User.objects.filter(
+                translation__entity__resource__project=project,
+                translation__locale__in=locales,
+                profile__project_deadline_notifications=True,
+            ).distinct()
 
             for contributor in contributors:
                 if is_project_public or contributor.is_superuser:
-                    notify.send(
+                    send_notification(
                         project,
                         recipient=contributor,
                         verb=verb,

--- a/pontoon/messaging/management/commands/send_review_notifications.py
+++ b/pontoon/messaging/management/commands/send_review_notifications.py
@@ -1,14 +1,13 @@
 from collections import defaultdict
 from datetime import timedelta
 
-from notifications.signals import notify
-
 from django.core.management.base import BaseCommand
 from django.db.models import Q
 from django.template.loader import render_to_string
 from django.utils import timezone
 
 from pontoon.base.models import Translation
+from pontoon.messaging.notifications import send_notification
 
 
 class Command(BaseCommand):
@@ -30,7 +29,6 @@ class Command(BaseCommand):
         for suggestion in Translation.objects.filter(
             (Q(approved_date__gt=start) | Q(rejected_date__gt=start))
             & Q(user__profile__review_notifications=True)
-            & Q(user__profile__system_user=False)
             & Q(entity__resource__project__disabled=False)
         ):
             author = suggestion.user
@@ -72,7 +70,7 @@ class Command(BaseCommand):
                 },
             )
 
-            notify.send(
+            send_notification(
                 sender=author,
                 recipient=author,
                 verb="has reviewed suggestions",

--- a/pontoon/messaging/management/commands/send_review_notifications.py
+++ b/pontoon/messaging/management/commands/send_review_notifications.py
@@ -30,6 +30,7 @@ class Command(BaseCommand):
         for suggestion in Translation.objects.filter(
             (Q(approved_date__gt=start) | Q(rejected_date__gt=start))
             & Q(user__profile__review_notifications=True)
+            & Q(user__profile__system_user=False)
             & Q(entity__resource__project__disabled=False)
         ):
             author = suggestion.user

--- a/pontoon/messaging/management/commands/send_suggestion_notifications.py
+++ b/pontoon/messaging/management/commands/send_suggestion_notifications.py
@@ -4,8 +4,6 @@ from collections import defaultdict
 from datetime import timedelta
 from functools import cached_property
 
-from notifications.signals import notify
-
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand, CommandError
@@ -14,6 +12,7 @@ from django.template.loader import render_to_string
 from django.utils import timezone
 
 from pontoon.base.models import Comment, Locale, ProjectLocale, Translation
+from pontoon.messaging.notifications import send_notification
 
 
 class Command(BaseCommand):
@@ -115,7 +114,6 @@ class Command(BaseCommand):
         recipients = User.objects.filter(
             pk__in=pks,
             profile__unreviewed_suggestion_notifications=True,
-            profile__system_user=False,
         )
 
         for recipient in recipients:
@@ -126,7 +124,7 @@ class Command(BaseCommand):
                 {"project_locales": project_locales},
             )
 
-            notify.send(
+            send_notification(
                 recipient,
                 recipient=recipient,
                 verb="",

--- a/pontoon/messaging/management/commands/send_suggestion_notifications.py
+++ b/pontoon/messaging/management/commands/send_suggestion_notifications.py
@@ -113,7 +113,9 @@ class Command(BaseCommand):
 
         pks = [user.pk for user in data.keys()]
         recipients = User.objects.filter(
-            pk__in=pks, profile__unreviewed_suggestion_notifications=True
+            pk__in=pks,
+            profile__unreviewed_suggestion_notifications=True,
+            profile__system_user=False,
         )
 
         for recipient in recipients:

--- a/pontoon/messaging/notifications.py
+++ b/pontoon/messaging/notifications.py
@@ -4,6 +4,8 @@ from django.template.loader import render_to_string
 
 
 def send_badge_notification(user, badge, level):
+    if user.profile.system_user:
+        return
     desc = render_to_string(
         "messaging/notifications/badge_notification.html",
         {"badge": badge, "level": level, "user": user},

--- a/pontoon/messaging/notifications.py
+++ b/pontoon/messaging/notifications.py
@@ -3,15 +3,20 @@ from notifications.signals import notify
 from django.template.loader import render_to_string
 
 
-def send_badge_notification(user, badge, level):
-    if user.profile.system_user:
+def send_notification(sender, recipient, **kwargs):
+    """Send a notification, skipping system users (e.g. pontoon-sync, pontoon-gt, pontoon-tm)."""
+    if recipient.profile.system_user:
         return
+    notify.send(sender, recipient=recipient, **kwargs)
+
+
+def send_badge_notification(user, badge, level):
     desc = render_to_string(
         "messaging/notifications/badge_notification.html",
         {"badge": badge, "level": level, "user": user},
     )
-    notify.send(
-        sender=user,
+    send_notification(
+        user,
         recipient=user,
         verb="ignore",  # Triggers render of description only
         description=desc,

--- a/pontoon/messaging/tests/test_send_notifications.py
+++ b/pontoon/messaging/tests/test_send_notifications.py
@@ -1,6 +1,20 @@
+from datetime import timedelta
+from unittest.mock import patch
+
 import pytest
 
-from pontoon.messaging.management.commands.send_suggestion_notifications import Command
+from django.utils import timezone
+
+from pontoon.messaging.management.commands.send_deadline_notifications import (
+    Command as DeadlineCommand,
+)
+from pontoon.messaging.management.commands.send_review_notifications import (
+    Command as ReviewCommand,
+)
+from pontoon.messaging.management.commands.send_suggestion_notifications import (
+    Command as SuggestionCommand,
+)
+from pontoon.messaging.notifications import send_badge_notification
 from pontoon.test.factories import (
     EntityFactory,
     ProjectLocaleFactory,
@@ -39,6 +53,127 @@ def test_get_suggestions_excludes_system_projects(
         fuzzy=False,
     )
 
-    suggestions = Command().get_suggestions()
+    suggestions = SuggestionCommand().get_suggestions()
     assert regular_translation in suggestions
     assert system_translation not in suggestions
+
+
+@patch(
+    "pontoon.messaging.management.commands.send_suggestion_notifications.notify.send"
+)
+@pytest.mark.django_db
+def test_send_suggestion_notifications_excludes_system_users(
+    mock_notify,
+    locale_a,
+    project_a,
+    project_locale_a,
+    user_a,
+    tm_user,
+):
+    """System users with matching translations must not receive
+    unreviewed-suggestion notifications."""
+    resource = ResourceFactory.create(project=project_a)
+    entity = EntityFactory.create(resource=resource)
+
+    TranslationFactory.create(
+        locale=locale_a,
+        entity=entity,
+        user=user_a,
+        approved=False,
+        pretranslated=False,
+        rejected=False,
+        fuzzy=False,
+    )
+
+    TranslationFactory.create(
+        locale=locale_a,
+        entity=entity,
+        user=tm_user,
+        approved=False,
+        pretranslated=False,
+        rejected=False,
+        fuzzy=False,
+        date=timezone.now() - timedelta(days=30),
+    )
+
+    SuggestionCommand().handle(force=True)
+
+    recipients = {call.kwargs["recipient"] for call in mock_notify.call_args_list}
+    assert tm_user not in recipients
+
+
+@patch("pontoon.messaging.management.commands.send_review_notifications.notify.send")
+@pytest.mark.django_db
+def test_send_review_notifications_excludes_system_users(
+    mock_notify,
+    locale_a,
+    project_a,
+    project_locale_a,
+    user_a,
+    tm_user,
+):
+    """When a system user's suggestion is reviewed, no review recap should be
+    sent to the system user."""
+    resource = ResourceFactory.create(project=project_a)
+    entity = EntityFactory.create(resource=resource)
+
+    now = timezone.now()
+    TranslationFactory.create(
+        locale=locale_a,
+        entity=entity,
+        user=tm_user,
+        approved=True,
+        approved_user=user_a,
+        approved_date=now,
+    )
+
+    TranslationFactory.create(
+        locale=locale_a,
+        entity=entity,
+        user=user_a,
+        approved=True,
+        approved_user=user_a,
+        approved_date=now,
+    )
+
+    ReviewCommand().handle()
+
+    recipients = {call.kwargs["recipient"] for call in mock_notify.call_args_list}
+    assert tm_user not in recipients
+
+
+@patch("pontoon.messaging.management.commands.send_deadline_notifications.notify.send")
+@pytest.mark.django_db
+def test_send_deadline_notifications_excludes_system_users(
+    mock_notify,
+    locale_a,
+    project_a,
+    project_locale_a,
+    user_a,
+    tm_user,
+):
+    """System users that have contributed to a project must not receive
+    target-date notifications."""
+    project_a.deadline = (timezone.now() + timedelta(days=7)).date()
+    project_a.save()
+
+    resource = ResourceFactory.create(project=project_a)
+    entity = EntityFactory.create(resource=resource)
+
+    TranslationFactory.create(locale=locale_a, entity=entity, user=user_a)
+    TranslationFactory.create(locale=locale_a, entity=entity, user=tm_user)
+
+    DeadlineCommand().handle()
+
+    recipients = {call.kwargs["recipient"] for call in mock_notify.call_args_list}
+    assert tm_user not in recipients
+
+
+@patch("pontoon.messaging.notifications.notify.send")
+@pytest.mark.django_db
+def test_send_badge_notification_skips_system_users(mock_notify, tm_user, user_a):
+    send_badge_notification(tm_user, "Translation Champion", 1)
+    assert mock_notify.call_count == 0
+
+    send_badge_notification(user_a, "Translation Champion", 1)
+    assert mock_notify.call_count == 1

--- a/pontoon/messaging/tests/test_send_notifications.py
+++ b/pontoon/messaging/tests/test_send_notifications.py
@@ -14,7 +14,7 @@ from pontoon.messaging.management.commands.send_review_notifications import (
 from pontoon.messaging.management.commands.send_suggestion_notifications import (
     Command as SuggestionCommand,
 )
-from pontoon.messaging.notifications import send_badge_notification
+from pontoon.messaging.notifications import send_badge_notification, send_notification
 from pontoon.test.factories import (
     EntityFactory,
     ProjectLocaleFactory,
@@ -58,9 +58,19 @@ def test_get_suggestions_excludes_system_projects(
     assert system_translation not in suggestions
 
 
-@patch(
-    "pontoon.messaging.management.commands.send_suggestion_notifications.notify.send"
-)
+@patch("pontoon.messaging.notifications.notify.send")
+@pytest.mark.django_db
+def test_send_notification_skips_system_users(mock_notify, user_a, tm_user):
+    """The helper must short-circuit on system users and pass everyone else through."""
+    send_notification(user_a, recipient=tm_user, verb="x")
+    assert mock_notify.call_count == 0
+
+    send_notification(user_a, recipient=user_a, verb="x")
+    assert mock_notify.call_count == 1
+    assert mock_notify.call_args.kwargs["recipient"] == user_a
+
+
+@patch("pontoon.messaging.notifications.notify.send")
 @pytest.mark.django_db
 def test_send_suggestion_notifications_excludes_system_users(
     mock_notify,
@@ -102,7 +112,7 @@ def test_send_suggestion_notifications_excludes_system_users(
     assert tm_user not in recipients
 
 
-@patch("pontoon.messaging.management.commands.send_review_notifications.notify.send")
+@patch("pontoon.messaging.notifications.notify.send")
 @pytest.mark.django_db
 def test_send_review_notifications_excludes_system_users(
     mock_notify,
@@ -142,7 +152,7 @@ def test_send_review_notifications_excludes_system_users(
     assert tm_user not in recipients
 
 
-@patch("pontoon.messaging.management.commands.send_deadline_notifications.notify.send")
+@patch("pontoon.messaging.notifications.notify.send")
 @pytest.mark.django_db
 def test_send_deadline_notifications_excludes_system_users(
     mock_notify,

--- a/pontoon/messaging/views.py
+++ b/pontoon/messaging/views.py
@@ -268,7 +268,7 @@ def get_recipients(form):
             profile__email_communications_enabled=True
         )
 
-    return recipients
+    return recipients.filter(profile__system_user=False)
 
 
 @permission_required_or_403("base.can_manage_project")

--- a/pontoon/messaging/views.py
+++ b/pontoon/messaging/views.py
@@ -3,7 +3,6 @@ import logging
 import uuid
 
 from guardian.decorators import permission_required_or_403
-from notifications.signals import notify
 
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
@@ -20,6 +19,7 @@ from pontoon.base.utils import require_AJAX, split_ints
 from pontoon.messaging import forms
 from pontoon.messaging.emails import send_manual_emails
 from pontoon.messaging.models import Message
+from pontoon.messaging.notifications import send_notification
 
 
 log = logging.getLogger(__name__)
@@ -268,7 +268,7 @@ def get_recipients(form):
             profile__email_communications_enabled=True
         )
 
-    return recipients.filter(profile__system_user=False)
+    return recipients
 
 
 @permission_required_or_403("base.can_manage_project")
@@ -323,7 +323,7 @@ def send_message(request):
         identifier = uuid.uuid4().hex
 
         for recipient in recipients:
-            notify.send(
+            send_notification(
                 request.user,
                 recipient=recipient,
                 verb="has sent you a message",

--- a/pontoon/sync/core/__init__.py
+++ b/pontoon/sync/core/__init__.py
@@ -94,6 +94,7 @@ def notify_users(project: Project, count: int) -> None:
     users = User.objects.filter(
         translation__entity__resource__project=project,
         profile__new_string_notifications=True,
+        profile__system_user=False,
     ).distinct()
     new_strings = f"{count} new {'string' if count == 1 else 'strings'}"
     log.info(f"[{project.slug}] Notifying {len(users)} users about {new_strings}")

--- a/pontoon/sync/core/__init__.py
+++ b/pontoon/sync/core/__init__.py
@@ -1,10 +1,9 @@
 import logging
 
-from notifications.signals import notify
-
 from django.utils import timezone
 
 from pontoon.base.models import ChangedEntityLocale, Locale, Project, User
+from pontoon.messaging.notifications import send_notification
 from pontoon.pretranslation.tasks import pretranslate
 from pontoon.sync.core.checkout import checkout_repos
 from pontoon.sync.core.entities import sync_resources_from_repo
@@ -94,12 +93,11 @@ def notify_users(project: Project, count: int) -> None:
     users = User.objects.filter(
         translation__entity__resource__project=project,
         profile__new_string_notifications=True,
-        profile__system_user=False,
     ).distinct()
     new_strings = f"{count} new {'string' if count == 1 else 'strings'}"
     log.info(f"[{project.slug}] Notifying {len(users)} users about {new_strings}")
     for user in users:
-        notify.send(
+        send_notification(
             project,
             recipient=user,
             verb=f"updated with {new_strings}",

--- a/pontoon/sync/tests/test_notify_users.py
+++ b/pontoon/sync/tests/test_notify_users.py
@@ -10,7 +10,7 @@ from pontoon.base.tests import (
 from pontoon.sync.core import notify_users
 
 
-@patch("pontoon.sync.core.notify.send")
+@patch("pontoon.messaging.notifications.notify.send")
 @pytest.mark.django_db
 def test_notify_users_excludes_system_users(
     mock_notify, locale_a, project_a, project_locale_a, user_a, tm_user

--- a/pontoon/sync/tests/test_notify_users.py
+++ b/pontoon/sync/tests/test_notify_users.py
@@ -1,0 +1,30 @@
+from unittest.mock import patch
+
+import pytest
+
+from pontoon.base.tests import (
+    EntityFactory,
+    ResourceFactory,
+    TranslationFactory,
+)
+from pontoon.sync.core import notify_users
+
+
+@patch("pontoon.sync.core.notify.send")
+@pytest.mark.django_db
+def test_notify_users_excludes_system_users(
+    mock_notify, locale_a, project_a, project_locale_a, user_a, tm_user
+):
+    """System users that authored translations in a project must not be
+    notified about new strings landing in that project."""
+    resource = ResourceFactory.create(project=project_a)
+    entity = EntityFactory.create(resource=resource)
+
+    TranslationFactory.create(locale=locale_a, entity=entity, user=user_a)
+    TranslationFactory.create(locale=locale_a, entity=entity, user=tm_user)
+
+    notify_users(project_a, count=1)
+
+    recipients = {call.kwargs["recipient"] for call in mock_notify.call_args_list}
+    assert user_a in recipients
+    assert tm_user not in recipients

--- a/pontoon/translations/views.py
+++ b/pontoon/translations/views.py
@@ -168,7 +168,8 @@ def create_translation(request):
         )
 
         for manager in locale.managers_group.user_set.filter(
-            profile__new_contributor_notifications=True
+            profile__new_contributor_notifications=True,
+            profile__system_user=False,
         ):
             notify.send(
                 sender=manager,

--- a/pontoon/translations/views.py
+++ b/pontoon/translations/views.py
@@ -1,7 +1,5 @@
 from typing import cast
 
-from notifications.signals import notify
-
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.db import transaction
@@ -25,7 +23,7 @@ from pontoon.base.models import (
 from pontoon.base.services import readonly_exists
 from pontoon.checks.libraries import run_checks
 from pontoon.checks.utils import are_blocking_checks
-from pontoon.messaging.notifications import send_badge_notification
+from pontoon.messaging.notifications import send_badge_notification, send_notification
 
 from .forms import CreateTranslationForm
 from .utils import parse_db_string_to_json
@@ -169,9 +167,8 @@ def create_translation(request):
 
         for manager in locale.managers_group.user_set.filter(
             profile__new_contributor_notifications=True,
-            profile__system_user=False,
         ):
-            notify.send(
+            send_notification(
                 sender=manager,
                 recipient=manager,
                 verb="has reviewed suggestions",  # Triggers render of description only


### PR DESCRIPTION
Fix #3954 

System users (`pontoon-sync`, `pontoon-gt`, `pontoon-tm`) have translation/review activity attributed. Have `UserProfile.system_user=True` but no callsite check.

- Add `profile__system_user=False` filter to every `notify.send()` recipient queryset:
  - `sync.core.notify_users` (new strings)
  - `messaging.management.commands.send_deadline_notifications`
  - `messaging.management.commands.send_review_notifications` (filter on `user__profile__system_user`)
  - `messaging.management.commands.send_suggestion_notifications`
  - `translations.views.create_translation` (new-contributor notification to locale managers)
  - `base.views._send_add_comment_notifications` and `_send_pin_comment_notifications`
- Early-return in `messaging.notifications.send_badge_notification` when `user.profile.system_user`.
- Filter `messaging.views.get_recipients` return queryset.

Add tests (@functionzz) in `pontoon/messaging/tests/test_send_notifications.py` covering all four commands, badge notification; new `pontoon/sync/tests/test_notify_users.py` covering `sync.core.notify_users`.
