### PR TITLE
fix(cd): Use standard artifact-writer service account

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -65,5 +65,5 @@ jobs:
         with:
           image_tags: ${{ steps.tag.outputs.image_tags }}
           project_id: ${{ vars.GCP_PROJECT_ID }}
-          service_account_name: pontoon-gar-pusher
+          service_account_name: artifact-writer
           workload_identity_pool_project_number: ${{ vars.MOZCLOUD_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}


### PR DESCRIPTION
This PR changes the docker build workflow to use the MozCloud standard `artifact-writer` service account instead of the Pontoon-specific `pontoon-gar-pusher` service account. The permissions are equivalent between the two, this is just to align Pontoon with other tenants.

MZCLD-3166