### PR TITLE
Use MessageEntry as EditorResult value

### DIFF
--- a/translate/src/context/Editor.test.jsx
+++ b/translate/src/context/Editor.test.jsx
@@ -101,7 +101,7 @@ describe('<EditorProvider>', () => {
         },
       ],
     });
-    expect(result).toMatchObject([{ name: '', keys: [], value: 'message' }]);
+    expect(result).toEqual({ format: 'plain', id: 'key', value: ['message'] });
   });
 
   it('provides a simple Fluent value', () => {
@@ -125,7 +125,11 @@ describe('<EditorProvider>', () => {
         },
       ],
     });
-    expect(result).toMatchObject([{ name: '', keys: [], value: 'message' }]);
+    expect(result).toEqual({
+      format: 'fluent',
+      id: 'key',
+      value: ['message'],
+    });
   });
 
   it('provides a rich Fluent value', () => {
@@ -151,10 +155,18 @@ describe('<EditorProvider>', () => {
       handle: { current: { value: field.handle.current.value } },
     }));
     expect(editor).toMatchObject({ sourceView: false, initial: entry, fields });
-    expect(result).toMatchObject([
-      { name: '', keys: ['one'], value: 'ONE' },
-      { name: '', keys: [{ '*': 'other' }], value: 'OTHER' },
-    ]);
+    expect(result).toEqual({
+      format: 'fluent',
+      id: 'key',
+      value: {
+        decl: { var: { $: 'var', fn: 'number' } },
+        sel: ['var'],
+        alt: [
+          { keys: ['one'], pat: ['ONE'] },
+          { keys: [{ '*': 'other' }], pat: ['OTHER'] },
+        ],
+      },
+    });
   });
 
   it('provides a forced source Fluent value', () => {
@@ -181,8 +193,12 @@ describe('<EditorProvider>', () => {
         },
       ],
     });
-    expect(result).toMatchObject([{ name: '', keys: [], value: '## comment' }]);
-    expect(warn).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({
+      format: 'fluent',
+      id: 'key',
+      value: ['## comment\n'],
+    });
+    expect(warn).toHaveBeenCalledTimes(1);
   });
 
   it('provides a simple Android value with no translation', () => {
@@ -214,7 +230,7 @@ describe('<EditorProvider>', () => {
       ],
     });
     expect(editor.placeholders).toBeInstanceOf(Map);
-    expect(result).toMatchObject([{ name: '', keys: [], value: '' }]);
+    expect(result).toEqual({ format: 'android', id: '', value: [] });
   });
 
   it('provides a simple Android value', () => {
@@ -246,7 +262,15 @@ describe('<EditorProvider>', () => {
       ],
     });
     expect(editor.placeholders).toBeInstanceOf(Map);
-    expect(result).toMatchObject([{ name: '', keys: [], value: 'Hei, %1$s!' }]);
+    expect(result).toEqual({
+      format: 'android',
+      id: '',
+      value: [
+        'Hei, ',
+        { $: 'arg1', fn: 'string', opt: undefined, attr: { source: '%1$s' } },
+        '!',
+      ],
+    });
   });
 
   it('provides a rich Android value', () => {
@@ -281,10 +305,25 @@ describe('<EditorProvider>', () => {
       placeholders: null,
       fields,
     });
-    expect(result).toMatchObject([
-      { name: '', keys: ['one'], value: 'trans:ONE' },
-      { name: '', keys: [{ '*': '' }], value: 'trans:OTHER' },
-    ]);
+    expect(result).toEqual({
+      format: 'android',
+      id: '',
+      value: {
+        decl: {
+          quantity: {
+            $: 'quantity',
+            fn: 'number',
+            opt: undefined,
+            attr: undefined,
+          },
+        },
+        sel: ['quantity'],
+        alt: [
+          { keys: ['one'], pat: ['trans:ONE'] },
+          { keys: [{ '*': '' }], pat: ['trans:OTHER'] },
+        ],
+      },
+    });
   });
 
   it('updates state on entity change', () => {
@@ -307,10 +346,18 @@ describe('<EditorProvider>', () => {
         { handle: { current: { value: 'trans other' } } },
       ],
     });
-    expect(result).toMatchObject([
-      { value: 'trans one' },
-      { value: 'trans other' },
-    ]);
+    expect(result).toEqual({
+      format: 'gettext',
+      id: '',
+      value: {
+        decl: { n: { $: 'n', attr: undefined, fn: 'number', opt: undefined } },
+        sel: ['n'],
+        alt: [
+          { keys: ['one'], pat: ['trans one'] },
+          { keys: [{ '*': '' }], pat: ['trans other'] },
+        ],
+      },
+    });
   });
 
   it('clears a rich Fluent value', () => {
@@ -426,10 +473,18 @@ describe('<EditorProvider>', () => {
         },
       ],
     });
-    expect(result).toMatchObject([
-      { keys: ['one'], name: '', value: 'ONE' },
-      { keys: [{ '*': 'other' }], name: '', value: 'OTHER' },
-    ]);
+    expect(result).toEqual({
+      format: 'fluent',
+      id: 'key',
+      value: {
+        decl: { var: { $: 'var', fn: 'number' } },
+        sel: ['var'],
+        alt: [
+          { keys: ['one'], pat: ['ONE'] },
+          { keys: [{ '*': 'other' }], pat: ['OTHER'] },
+        ],
+      },
+    });
   });
 
   it('toggles Fluent source view', () => {
@@ -462,15 +517,34 @@ describe('<EditorProvider>', () => {
         },
       ],
     });
-    expect(result).toMatchObject([{ keys: [], name: '', value: source }]);
+    expect(result).toEqual({
+      format: 'fluent',
+      id: 'key',
+      value: {
+        decl: { var: { $: 'var', fn: 'number' } },
+        sel: ['var'],
+        alt: [
+          { keys: ['one'], pat: ['ONE'] },
+          { keys: [{ '*': 'other' }], pat: ['OTHER'] },
+        ],
+      },
+    });
 
     act(() => actions.toggleSourceView());
 
     expect(editor).toMatchObject({ fields: [{}, {}], sourceView: false });
-    expect(result).toMatchObject([
-      { keys: ['one'], name: '', value: 'ONE' },
-      { keys: [{ '*': 'other' }], name: '', value: 'OTHER' },
-    ]);
+    expect(result).toEqual({
+      format: 'fluent',
+      id: 'key',
+      value: {
+        decl: { var: { $: 'var', fn: 'number' } },
+        sel: ['var'],
+        alt: [
+          { keys: ['one'], pat: ['ONE'] },
+          { keys: [{ '*': 'other' }], pat: ['OTHER'] },
+        ],
+      },
+    });
   });
 
   it('reports no pending changes for empty android entry with placeholders', () => {

--- a/translate/src/context/Editor.tsx
+++ b/translate/src/context/Editor.tsx
@@ -66,7 +66,7 @@ export type EditorData = Readonly<{
   busy: boolean;
 
   /** Used to reconstruct edited messages */
-  entry: MessageEntry;
+  base: MessageEntry;
 
   /** Input fields for the value being edited */
   fields: EditorField[];
@@ -153,7 +153,7 @@ const createSimpleMessageEntry = (
 const initEditorData: EditorData = {
   pk: 0,
   busy: false,
-  entry: { format: 'plain', id: '', value: [] },
+  base: { format: 'plain', id: '', value: [] },
   focusField: { current: null },
   initial: { format: 'plain', id: '', value: [] },
   placeholders: null,
@@ -222,7 +222,7 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
           if (sourceView) {
             const result = buildResult(next);
             next = editSource(
-              buildMessageEntry(prev.entry, placeholders, result),
+              buildMessageEntry(prev.base, placeholders, result),
             );
             focusField.current = next[0];
             setResult(result);
@@ -241,7 +241,7 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
             case 'fluent': {
               const entry = parseEntry(format, str);
               if (entry) {
-                next.entry = entry;
+                next.base = entry;
                 if (!requiresSourceView(entry)) {
                   next.fields = prev.sourceView
                     ? editSource(entry)
@@ -260,7 +260,7 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
             case 'xliff': {
               const entry = parseEntry(format, str);
               if (entry) {
-                next.entry = entry;
+                next.base = entry;
                 next.fields = editMessageEntry(entry);
               } else {
                 next.fields = editSource(str);
@@ -300,16 +300,16 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
         setState((prev) => {
           if (prev.sourceView) {
             const source = prev.fields[0].handle.current.value;
-            const entry = parseEntryFromFluentSource(prev.entry, source);
+            const entry = parseEntryFromFluentSource(prev.base, source);
             if (entry && !requiresSourceView(entry)) {
               const fields = editMessageEntry(entry);
               prev.focusField.current = fields[0];
               setResult(buildResult(fields));
-              return { ...prev, entry, fields, sourceView: false };
+              return { ...prev, base: entry, fields, sourceView: false };
             }
           } else if (format === 'fluent') {
             const entry = buildMessageEntry(
-              prev.entry,
+              prev.base,
               prev.placeholders,
               buildResult(prev.fields),
             );
@@ -325,7 +325,7 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
   }, [format, readonly]);
 
   useEffect(() => {
-    let entry: MessageEntry;
+    let base: MessageEntry;
     let source = activeTranslation?.string || '';
     let sourceView = false;
     let placeholders: Map<string, Expression | Markup> | null = null;
@@ -336,33 +336,33 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
     }
     if (!source) {
       orig ??= parseEntry(format, entity.original);
-      entry = orig
+      base = orig
         ? getEmptyMessageEntry(orig, locale)
         : createSimpleMessageEntry(format, entity.key, '');
-      if (requiresSourceView(entry)) {
-        source = serializeEntry(entry);
+      if (requiresSourceView(base)) {
+        source = serializeEntry(base);
         sourceView = true;
       }
     } else {
-      const entry_ = parseEntry(format, source);
-      if (entry_) {
-        entry = entry_;
-        sourceView = requiresSourceView(entry);
+      const base_ = parseEntry(format, source);
+      if (base_) {
+        base = base_;
+        sourceView = requiresSourceView(base);
       } else {
-        entry = createSimpleMessageEntry(format, entity.key, source);
+        base = createSimpleMessageEntry(format, entity.key, source);
         sourceView = format === 'fluent';
       }
     }
 
-    const fields = sourceView ? editSource(source) : editMessageEntry(entry);
+    const fields = sourceView ? editSource(source) : editMessageEntry(base);
 
     setState(() => ({
       pk: entity.pk,
       busy: false,
-      entry,
+      base,
       fields,
       focusField: { current: fields[0] },
-      initial: entry,
+      initial: base,
       placeholders,
       machinery: null,
       sourceView,
@@ -397,10 +397,10 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
     // but the latter needs to be defined at a higher level to make it
     // available in `EntitiesList`. Therefore, that state is managed here.
     // Let's also avoid the calculation, unless it's actually required.
-    const { entry, initial, placeholders, sourceView } = state;
+    const { base, initial, placeholders, sourceView } = state;
     const next = sourceView
-      ? parseEntryFromFluentSource(entry, result[0].value)
-      : buildMessageEntry(entry, placeholders, result);
+      ? parseEntryFromFluentSource(base, result[0].value)
+      : buildMessageEntry(base, placeholders, result);
     const hasChanges = !pojoEquals(initial, next);
 
     if (hasChanges) {
@@ -422,9 +422,9 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
 }
 
 export function useEditorMessageEntry() {
-  const { entry, placeholders, sourceView } = useContext(EditorData);
+  const { base, placeholders, sourceView } = useContext(EditorData);
   const message = useContext(EditorResult);
   return sourceView
-    ? parseEntryFromFluentSource(entry, message[0].value)
-    : buildMessageEntry(entry, placeholders, message);
+    ? parseEntryFromFluentSource(base, message[0].value)
+    : buildMessageEntry(base, placeholders, message);
 }

--- a/translate/src/context/Editor.tsx
+++ b/translate/src/context/Editor.tsx
@@ -91,20 +91,6 @@ export type EditorData = Readonly<{
   sourceView: boolean;
 }>;
 
-export type EditorResult = Array<{
-  /** Attribute name, or empty for the value */
-  name: string;
-
-  /** Selector keys, or empty array for single-pattern messages */
-  keys: (string | CatchallKey)[];
-
-  /**
-   * A flattened representation of a single message pattern,
-   * which may contain syntactic representations of placeholders.
-   */
-  value: string;
-}>;
-
 export type EditorActions = {
   clearEditor(): void;
 
@@ -122,8 +108,7 @@ export type EditorActions = {
 
   setEditorSelection(content: string): void;
 
-  /** Set the result value of the active input */
-  setResultFromInput(idx: number, value: string): void;
+  setResultFromInput(): void;
 
   toggleSourceView(): void;
 };
@@ -173,15 +158,8 @@ const initEditorActions: EditorActions = {
 };
 
 export const EditorData = createContext(initEditorData);
-export const EditorResult = createContext<EditorResult>([]);
+export const EditorResult = createContext<MessageEntry | null>(null);
 export const EditorActions = createContext(initEditorActions);
-
-const buildResult = (message: EditorField[]): EditorResult =>
-  message.map(({ handle, keys, name }) => ({
-    name,
-    keys,
-    value: handle.current.value,
-  }));
 
 export function EditorProvider({ children }: { children: React.ReactElement }) {
   const locale = useContext(Locale);
@@ -194,7 +172,7 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
   const { resetFailedChecks } = useContext(FailedChecksData);
 
   const [state, setState] = useState(initEditorData);
-  const [result, setResult] = useState<EditorResult>([]);
+  const [result, setResult] = useState<MessageEntry | null>(null);
 
   const actions = useMemo<EditorActions>(() => {
     if (readonly) {
@@ -203,6 +181,7 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
     return {
       clearEditor() {
         setState((state) => {
+          // Inside setState() only to access the current `state` value
           for (const field of state.fields) {
             field.handle.current.setValue('');
           }
@@ -220,10 +199,8 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
           field.handle.current.setValue(str);
           let next = fields.slice();
           if (sourceView) {
-            const result = buildResult(next);
-            next = editSource(
-              buildMessageEntry(prev.base, placeholders, result),
-            );
+            const result = buildMessageEntry(prev.base, placeholders, fields);
+            next = editSource(result);
             focusField.current = next[0];
             setResult(result);
           }
@@ -273,27 +250,33 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
               next.fields[0].handle.current.setValue(str);
           }
           next.focusField.current = next.fields[0];
-          setResult(buildResult(next.fields));
+          const result = buildMessageEntry(
+            next.base,
+            next.placeholders,
+            next.fields,
+          );
+          setResult(result);
           return next;
         }),
 
       setEditorSelection: (content) =>
         setState((state) => {
+          // Inside setState() only to access the current `state` value
           const { fields, focusField } = state;
           const field = focusField.current ?? fields[0];
           field.handle.current.setSelection(content);
           return state;
         }),
 
-      setResultFromInput: (idx, value) =>
-        setResult((prev) => {
-          if (prev.length > idx) {
-            const res = prev.slice();
-            res[idx] = { ...res[idx], value };
-            return res;
-          } else {
-            return prev;
-          }
+      setResultFromInput: () =>
+        setState((state) => {
+          // Inside setState() only to access the current `state` value
+          const { base, fields, placeholders, sourceView } = state;
+          const result = sourceView
+            ? parseEntryFromFluentSource(base, fields[0].handle.current.value)
+            : buildMessageEntry(base, placeholders, fields);
+          setResult(result);
+          return state;
         }),
 
       toggleSourceView: () =>
@@ -304,19 +287,19 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
             if (entry && !requiresSourceView(entry)) {
               const fields = editMessageEntry(entry);
               prev.focusField.current = fields[0];
-              setResult(buildResult(fields));
+              setResult(entry);
               return { ...prev, base: entry, fields, sourceView: false };
             }
           } else if (format === 'fluent') {
             const entry = buildMessageEntry(
               prev.base,
               prev.placeholders,
-              buildResult(prev.fields),
+              prev.fields,
             );
             const source = serializeEntry(entry);
             const fields = editSource(source);
             prev.focusField.current = fields[0];
-            setResult(buildResult(fields));
+            setResult(entry);
             return { ...prev, fields, sourceView: true };
           }
           return prev;
@@ -367,7 +350,7 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
       machinery: null,
       sourceView,
     }));
-    setResult(buildResult(fields));
+    setResult(base);
   }, [locale, entity, activeTranslation]);
 
   // For missing entries, fill editor initially with a perfect match from
@@ -397,16 +380,10 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
     // but the latter needs to be defined at a higher level to make it
     // available in `EntitiesList`. Therefore, that state is managed here.
     // Let's also avoid the calculation, unless it's actually required.
-    const { base, initial, placeholders, sourceView } = state;
-    const next = sourceView
-      ? parseEntryFromFluentSource(base, result[0].value)
-      : buildMessageEntry(base, placeholders, result);
-    const hasChanges = !pojoEquals(initial, next);
-
+    const hasChanges = !pojoEquals(state.initial, result);
     if (hasChanges) {
       resetFailedChecks();
     }
-
     setUnsavedChanges(() => hasChanges);
   }, [result]);
 
@@ -419,12 +396,4 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
       </EditorResult.Provider>
     </EditorData.Provider>
   );
-}
-
-export function useEditorMessageEntry() {
-  const { base, placeholders, sourceView } = useContext(EditorData);
-  const message = useContext(EditorResult);
-  return sourceView
-    ? parseEntryFromFluentSource(base, message[0].value)
-    : buildMessageEntry(base, placeholders, message);
 }

--- a/translate/src/modules/editor/components/Editor.test.jsx
+++ b/translate/src/modules/editor/components/Editor.test.jsx
@@ -211,21 +211,4 @@ describe('<Editor>', () => {
     // The translation has been updated to a simplified preview.
     expect(wrapper.find(EditField).text()).toEqual('Coucou');
   });
-
-  it('passes a reconstructed translation to sendTranslation', async () => {
-    using createSpy = vi
-      .spyOn(TranslationAPI, 'createTranslation')
-      .mockReturnValue({});
-
-    const [wrapper, actions] = mountEditor(1);
-
-    // Update the content with new input
-    act(() => actions.setResultFromInput(0, 'Coucou'));
-    wrapper.update();
-    await act(() => wrapper.find('.action-suggest').prop('onClick')());
-
-    expect(createSpy.mock.calls.length).toBe(1);
-    const args = createSpy.mock.calls[0];
-    expect(args[1]).toBe('my-message = Coucou\n');
-  });
 });

--- a/translate/src/modules/editor/components/FtlSwitch.tsx
+++ b/translate/src/modules/editor/components/FtlSwitch.tsx
@@ -29,19 +29,16 @@ export function FtlSwitch() {
   );
   const { toggleSourceView } = useContext(EditorActions);
   const { sourceView } = useContext(EditorData);
-  const edit = useContext(EditorResult);
+  const result = useContext(EditorResult);
   const { entity } = useContext(EntityView);
 
   const hasError = useMemo(() => {
     if (sourceView && entity.format === 'fluent') {
-      const source = edit[0].value;
-      if (!source) return true;
-      const entry = parseEntry('fluent', source);
-      return entry && requiresSourceView(entry);
+      return result ? requiresSourceView(result) : true;
     } else {
       return false;
     }
-  }, [sourceView, edit, entity.format]);
+  }, [sourceView, result, entity.format]);
 
   const handleClick = useCallback(() => {
     if (hasError) {

--- a/translate/src/modules/editor/components/FtlSwitch.tsx
+++ b/translate/src/modules/editor/components/FtlSwitch.tsx
@@ -6,7 +6,7 @@ import { EditorActions, EditorData, EditorResult } from '~/context/Editor';
 import { ShowNotification } from '~/context/Notification';
 import { FTL_NOT_SUPPORTED_RICH_EDITOR } from '~/modules/notification/messages';
 import { USER } from '~/modules/user';
-import { requiresSourceView, parseEntry } from '~/utils/message';
+import { requiresSourceView } from '~/utils/message';
 import { useAppSelector } from '~/hooks';
 import { useReadonlyEditor } from '~/hooks/useReadonlyEditor';
 

--- a/translate/src/modules/editor/components/MachinerySourceIndicator.tsx
+++ b/translate/src/modules/editor/components/MachinerySourceIndicator.tsx
@@ -6,15 +6,16 @@ import { EditorData, EditorResult } from '~/context/Editor';
 import './MachinerySourceIndicator.css';
 
 export function MachinerySourceIndicator() {
-  const { machinery, sourceView } = useContext(EditorData);
-  const edit = useContext(EditorResult);
+  const { fields, machinery, sourceView } = useContext(EditorData);
+  // Included to re-render on input changes
+  useContext(EditorResult);
 
   if (
     !machinery ||
     machinery.manual ||
     sourceView ||
-    edit.length !== 1 ||
-    machinery.translation !== edit[0].value
+    fields.length !== 1 ||
+    machinery.translation !== fields[0].handle.current.value
   ) {
     return null;
   }

--- a/translate/src/modules/editor/components/TranslationLength.test.jsx
+++ b/translate/src/modules/editor/components/TranslationLength.test.jsx
@@ -24,8 +24,8 @@ describe('<TranslationLength>', () => {
 
   function mountTranslationLength(format, original, value, comment) {
     const context = new Map([
-      [EditorData, { sourceView: false }],
-      [EditorResult, [{ value }]],
+      [EditorData, { sourceView: false, fields: [{}] }],
+      [EditorResult, { value: [value] }],
       [EntityView, { entity: { comment, format, original } }],
     ]);
     vi.mocked(useContext).mockImplementation((key) => context.get(key));

--- a/translate/src/modules/editor/components/TranslationLength.tsx
+++ b/translate/src/modules/editor/components/TranslationLength.tsx
@@ -8,14 +8,15 @@ import './TranslationLength.css';
 /** Shows translation length vs. original string length.  */
 export function TranslationLength(): React.ReactElement<'div'> | null {
   const { entity } = useContext(EntityView);
-  const { sourceView } = useContext(EditorData);
-  const edit = useContext(EditorResult);
+  const { fields, sourceView } = useContext(EditorData);
+  // Included to re-render on input changes
+  const result = useContext(EditorResult);
 
-  if (sourceView || edit.length !== 1) {
+  if (sourceView || fields.length !== 1) {
     return null;
   }
 
-  const text = edit[0].value;
+  const text = result ? getPlainMessage(result, entity.format) : '';
   const srcText = getPlainMessage(entity.original, entity.format);
 
   return (

--- a/translate/src/modules/editor/hooks/useExistingTranslationGetter.test.jsx
+++ b/translate/src/modules/editor/hooks/useExistingTranslationGetter.test.jsx
@@ -5,7 +5,11 @@ import { render } from '@testing-library/react';
 import { EditorData, EditorResult } from '~/context/Editor';
 import * as Entity from '~/context/EntityView';
 import { HistoryData } from '~/context/HistoryData';
-import { editMessageEntry, parseEntry } from '~/utils/message';
+import {
+  buildMessageEntry,
+  editMessageEntry,
+  parseEntry,
+} from '~/utils/message';
 
 import { useExistingTranslationGetter } from './useExistingTranslationGetter';
 
@@ -28,11 +32,7 @@ const HISTORY_FLUENT = {
 };
 
 function mountSpy(format, history, editor) {
-  const result = editor.fields.map(({ handle, keys, name }) => ({
-    name,
-    keys,
-    value: handle.current.value,
-  }));
+  const result = buildMessageEntry(editor.base, null, editor.fields);
 
   let res;
   const Spy = () => {

--- a/translate/src/modules/editor/hooks/useExistingTranslationGetter.test.jsx
+++ b/translate/src/modules/editor/hooks/useExistingTranslationGetter.test.jsx
@@ -86,7 +86,7 @@ describe('useExistingTranslation', () => {
   it('finds identical initial/active translation', () => {
     const entry = mockMessageEntry('something');
     const res = mountSpy('simple', HISTORY_STRING, {
-      entry,
+      base: entry,
       fields: editMessageEntry(entry),
       initial: entry,
     });
@@ -97,7 +97,7 @@ describe('useExistingTranslation', () => {
   it('finds identical Fluent initial/active translation', () => {
     const entry = parseEntry('fluent', 'msg = something');
     const res = mountSpy('fluent', HISTORY_FLUENT, {
-      entry,
+      base: entry,
       fields: editMessageEntry(entry),
       initial: entry,
     });
@@ -108,7 +108,7 @@ describe('useExistingTranslation', () => {
   it('finds empty initial/active translation', () => {
     const entry = mockMessageEntry('');
     const res = mountSpy('simple', HISTORY_STRING, {
-      entry,
+      base: entry,
       fields: editMessageEntry(entry),
       initial: entry,
     });
@@ -120,7 +120,7 @@ describe('useExistingTranslation', () => {
     const entry = mockMessageEntry('');
     const prev0 = HISTORY_STRING.translations[0];
     const res0 = mountSpy('simple', HISTORY_STRING, {
-      entry,
+      base: entry,
       fields: mockEditorMessage(prev0.string),
       initial: entry,
     });
@@ -129,7 +129,7 @@ describe('useExistingTranslation', () => {
 
     const prev1 = HISTORY_STRING.translations[1];
     const res1 = mountSpy('simple', HISTORY_STRING, {
-      entry,
+      base: entry,
       fields: mockEditorMessage(prev1.string),
       initial: entry,
     });
@@ -141,7 +141,7 @@ describe('useExistingTranslation', () => {
     const entry = parseEntry('fluent', 'msg = something');
     const prev0 = HISTORY_FLUENT.translations[0];
     const res0 = mountSpy('fluent', HISTORY_FLUENT, {
-      entry,
+      base: entry,
       fields: editMessageEntry(parseEntry('fluent', prev0.string)),
       initial: entry,
     });
@@ -150,7 +150,7 @@ describe('useExistingTranslation', () => {
 
     const prev1 = HISTORY_FLUENT.translations[1];
     const res1 = mountSpy('fluent', HISTORY_FLUENT, {
-      entry,
+      base: entry,
       fields: editMessageEntry(parseEntry('fluent', prev1.string)),
       initial: entry,
     });
@@ -161,7 +161,7 @@ describe('useExistingTranslation', () => {
   it('finds empty translation in history', () => {
     const entry = mockMessageEntry('x');
     const res = mountSpy('simple', HISTORY_STRING, {
-      entry,
+      base: entry,
       fields: mockEditorMessage(''),
       initial: entry,
     });
@@ -172,7 +172,7 @@ describe('useExistingTranslation', () => {
   it('finds a Fluent translation in history', () => {
     const entry = parseEntry('fluent', 'msg = something');
     const res = mountSpy('fluent', HISTORY_FLUENT, {
-      entry,
+      base: entry,
       fields: mockEditorMessage('Come on Morty!'),
       initial: entry,
     });

--- a/translate/src/modules/editor/hooks/useExistingTranslationGetter.ts
+++ b/translate/src/modules/editor/hooks/useExistingTranslationGetter.ts
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
 import type { HistoryTranslation } from '~/api/translation';
-import { EditorData, useEditorMessageEntry } from '~/context/Editor';
+import { EditorData, EditorResult } from '~/context/Editor';
 import { EntityView, useActiveTranslation } from '~/context/EntityView';
 import { HistoryData } from '~/context/HistoryData';
 import { parseEntry, serializeEntry } from '~/utils/message';
@@ -18,7 +18,7 @@ export function useExistingTranslationGetter() {
   const { translations } = useContext(HistoryData);
   const { format } = useContext(EntityView).entity;
   const { initial } = useContext(EditorData);
-  const entry = useEditorMessageEntry();
+  const entry = useContext(EditorResult);
 
   return () => {
     if (activeTranslation?.pk && pojoEquals(initial, entry)) {

--- a/translate/src/modules/editor/hooks/useSendTranslation.ts
+++ b/translate/src/modules/editor/hooks/useSendTranslation.ts
@@ -2,11 +2,7 @@ import NProgress from 'nprogress';
 import { useContext } from 'react';
 
 import { createTranslation } from '~/api/translation';
-import {
-  EditorActions,
-  EditorData,
-  useEditorMessageEntry,
-} from '~/context/Editor';
+import { EditorActions, EditorData, EditorResult } from '~/context/Editor';
 import { EntityView } from '~/context/EntityView';
 import { FailedChecksData } from '~/context/FailedChecksData';
 import { Locale } from '~/context/Locale';
@@ -45,7 +41,7 @@ export function useSendTranslation(): (ignoreWarnings?: boolean) => void {
   const { setFailedChecks } = useContext(FailedChecksData);
   const { setEditorBusy } = useContext(EditorActions);
   const { busy, machinery } = useContext(EditorData);
-  const entry = useEditorMessageEntry();
+  const entry = useContext(EditorResult);
 
   return async (ignoreWarnings = false) => {
     if (busy || entity.pk === 0) {

--- a/translate/src/modules/translationform/components/EditAccesskey.tsx
+++ b/translate/src/modules/translationform/components/EditAccesskey.tsx
@@ -71,7 +71,7 @@ export const EditAccesskey = memo(
       const setValue = useCallback(
         (value: string) => {
           setValue_(value);
-          setResultFromInput(index, value);
+          setResultFromInput();
         },
         [index],
       );

--- a/translate/src/modules/translationform/components/EditField.test.tsx
+++ b/translate/src/modules/translationform/components/EditField.test.tsx
@@ -93,22 +93,22 @@ describe('<EditField>', () => {
   });
 
   it('sets the result on user input', async () => {
-    const spy = vi.fn();
+    const res: string[] = [];
+    const spy = vi.fn(() => {
+      res.push(ref.current!.value);
+    });
+    const ref = React.createRef<EditFieldHandle>();
     const { container } = render(
       <MockEditField
         defaultValue='foo'
         format='fluent'
+        fieldRef={ref}
         setResultFromInput={spy}
       />,
     );
     await userEvent.click(container.querySelector('.cm-line')!);
     await userEvent.keyboard('x{ArrowRight}{ArrowRight}{ArrowRight}  y');
-    expect(spy.mock.calls).toMatchObject([
-      [0, 'xfoo'],
-      [0, 'xfoo '],
-      [0, 'xfoo  '],
-      [0, 'xfoo  y'],
-    ]);
+    expect(res).toEqual(['xfoo', 'xfoo ', 'xfoo  ', 'xfoo  y']);
   });
 
   it('ignores user input when readonly', async () => {
@@ -127,7 +127,10 @@ describe('<EditField>', () => {
   });
 
   it('sets the result via ref', async () => {
-    const spy = vi.fn();
+    const res: string[] = [];
+    const spy = vi.fn(() => {
+      res.push(ref.current!.value);
+    });
     const ref = React.createRef<EditFieldHandle>();
     render(
       <MockEditField
@@ -141,7 +144,7 @@ describe('<EditField>', () => {
       ref.current!.focus();
       ref.current!.setSelection('bar');
     });
-    expect(spy.mock.calls).toMatchObject([[0, 'foobar']]);
+    expect(res).toEqual(['foobar']);
   });
 
   it('does not highlight `% d` as code (#2988)', () => {

--- a/translate/src/modules/translationform/components/EditField.tsx
+++ b/translate/src/modules/translationform/components/EditField.tsx
@@ -68,7 +68,7 @@ export const EditField = memo(
                     onFocus();
                   }
                   if (update.docChanged) {
-                    setResultFromInput(index, update.state.doc.toString());
+                    setResultFromInput();
                   }
                 }),
               );

--- a/translate/src/modules/translationform/components/TranslationForm-multiple.test.jsx
+++ b/translate/src/modules/translationform/components/TranslationForm-multiple.test.jsx
@@ -263,7 +263,11 @@ describe('<TranslationForm> with multiple fields', () => {
     act(() => actions.setEditorSelection('Add'));
 
     const result = getResult();
-    expect(result[0].value).toEqual('ValueAdd');
-    expect(result[1].value).toEqual('Something');
+    expect(result).toMatchObject({
+      format: 'fluent',
+      id: 'title',
+      value: ['ValueAdd'],
+      attributes: new Map([['label', ['Something']]]),
+    });
   });
 });

--- a/translate/src/modules/translationform/components/TranslationForm-single.test.jsx
+++ b/translate/src/modules/translationform/components/TranslationForm-single.test.jsx
@@ -73,14 +73,22 @@ describe('<TranslationForm> with one field', () => {
         changes: { from: 0, to: view.state.doc.length, insert: 'good bye' },
       }),
     );
-    expect(getResult()[0].value).toBe('good bye');
+    expect(getResult()).toEqual({
+      format: 'plain',
+      id: 'key',
+      value: ['good bye'],
+    });
   });
 
   it('updates the translation when setEditorSelection is passed without focus', async () => {
     const { actions, getResult } = mountForm('Foo');
     act(() => actions.setEditorSelection(', Bar'));
 
-    expect(getResult()[0].value).toBe('Foo, Bar');
+    expect(getResult()).toEqual({
+      format: 'plain',
+      id: 'key',
+      value: ['Foo, Bar'],
+    });
   });
 
   it('updates the translation when setEditorSelection is passed with focus', async () => {
@@ -91,6 +99,10 @@ describe('<TranslationForm> with one field', () => {
       actions.setEditorSelection(', World');
     });
 
-    expect(getResult()[0].value).toBe('Hello, World');
+    expect(getResult()).toEqual({
+      format: 'plain',
+      id: 'key',
+      value: ['Hello, World'],
+    });
   });
 });

--- a/translate/src/utils/message/buildMessageEntry.test.js
+++ b/translate/src/utils/message/buildMessageEntry.test.js
@@ -16,7 +16,7 @@ describe('buildMessageEntry', () => {
     expect(placeholders).not.toBeNull();
 
     const result = buildMessageEntry(base, placeholders, [
-      { name: '', keys: [], value: '' },
+      { name: '', keys: [], handle: { current: { value: '' } } },
     ]);
     const empty = getEmptyMessageEntry(base, LOCALE);
 
@@ -31,7 +31,7 @@ describe('buildMessageEntry', () => {
     const placeholders = getPlaceholderMap(base.value);
 
     const result = buildMessageEntry(base, placeholders, [
-      { name: '', keys: [], value: 'Bonjour, %1$s!' },
+      { name: '', keys: [], handle: { current: { value: 'Bonjour, %1$s!' } } },
     ]);
 
     expect(serializeEntry(result)).toEqual(
@@ -44,7 +44,7 @@ describe('buildMessageEntry', () => {
     expect(base).not.toBeNull();
 
     const result = buildMessageEntry(base, null, [
-      { name: '', keys: [], value: '' },
+      { name: '', keys: [], handle: { current: { value: '' } } },
     ]);
     const empty = getEmptyMessageEntry(base, LOCALE);
 
@@ -55,7 +55,7 @@ describe('buildMessageEntry', () => {
     const base = parseEntry('android', 'Hello World');
 
     const result = buildMessageEntry(base, null, [
-      { name: '', keys: [], value: 'Bonjour Monde' },
+      { name: '', keys: [], handle: { current: { value: 'Bonjour Monde' } } },
     ]);
 
     expect(serializeEntry(result)).toEqual('Bonjour Monde');

--- a/translate/src/utils/message/buildMessageEntry.tsx
+++ b/translate/src/utils/message/buildMessageEntry.tsx
@@ -1,4 +1,4 @@
-import type { EditorResult } from '~/context/Editor';
+import type { EditorField } from '~/context/Editor';
 import type { MessageEntry } from '.';
 import {
   Expression,
@@ -12,13 +12,13 @@ import {
 export function buildMessageEntry(
   base: MessageEntry,
   placeholders: Map<string, Expression | Markup> | null,
-  next: EditorResult,
+  fields: EditorField[],
 ): MessageEntry {
   const res = structuredClone(base);
-  if (res.value) setMessage(res.value, '', placeholders, next);
+  if (res.value) setMessage(res.value, '', placeholders, fields);
   if (res.attributes) {
     for (const [name, msg] of res.attributes) {
-      setMessage(msg, name, placeholders, next);
+      setMessage(msg, name, placeholders, fields);
     }
   }
   return res;
@@ -29,21 +29,21 @@ function setMessage(
   msg: Message,
   attrName: string,
   placeholders: Map<string, Expression | Markup> | null,
-  next: EditorResult,
+  fields: EditorField[],
 ) {
   if (isSelectMessage(msg)) {
     msg.alt = [];
-    for (const { name, keys, value } of next) {
+    for (const { name, keys, handle } of fields) {
       if (name === attrName) {
-        const pat = buildPattern(value, placeholders);
+        const pat = buildPattern(handle.current.value, placeholders);
         msg.alt.push({ keys, pat });
       }
     }
   } else {
     const body = Array.isArray(msg) ? msg : msg.msg;
-    for (const { name, value } of next) {
+    for (const { name, handle } of fields) {
       if (name === attrName) {
-        const pat = buildPattern(value, placeholders);
+        const pat = buildPattern(handle.current.value, placeholders);
         body.splice(0, body.length, ...pat);
         break;
       }


### PR DESCRIPTION
The changes here should be externally invisible, as they're only modifying how we handle and store intermediate results from the translation editor. Previously, changes in the editor were reflected in an `EditorResult` array that closely mirrored `EditorField[]`, and an actual `MessageEntry` was only reconstructed from that result value when necessary.

But it turns out that "when necessary" is all the time, and so we were re-reconstructing it multiple times every time the result changed.

So let's just do it once, and store the `MessageEntry` (or `null` if it's invalid) as the `EditorResult` context value.

To clarify things a bit, the `EditorData.entry` is renamed as `EditorData.base`, as it is _not_ the current editor's entry value, but the base value used in the reconstruction, as it contains the right pattern slots that we need.