### PR TITLE
Link notifications for new strings only to actual strings added

### DIFF
--- a/documentation/docs/localizer/notifications.md
+++ b/documentation/docs/localizer/notifications.md
@@ -24,7 +24,7 @@ Pontoon includes several types of notifications and most of them can be [manuall
 
 ### New strings
 
-This notification informs users when new strings are added to a project. The notification is sent to all users who contributed translations to that project, as soon as new strings are available.
+This notification informs users when new strings are added to a project. The notification is sent to all users who contributed translations to that project, as soon as new strings are available. Clicking the notification opens the list of strings added in that sync cycle, including strings already translated (e.g. as part of a Fluent migration).
 
 ### Project target dates
 

--- a/pontoon/base/forms.py
+++ b/pontoon/base/forms.py
@@ -351,6 +351,7 @@ class GetEntitiesForm(forms.Form):
     search_match_whole_word = forms.BooleanField(required=False)
     tag = forms.CharField(required=False)
     time = forms.CharField(required=False)
+    created_time = forms.CharField(required=False)
     author = forms.CharField(required=False)
     review_time = forms.CharField(required=False)
     reviewer = forms.CharField(required=False)

--- a/pontoon/base/models/entity.py
+++ b/pontoon/base/models/entity.py
@@ -193,6 +193,9 @@ class EntityQuerySet(models.QuerySet["Entity"]):
     def between_time_interval(self, locale, start, end):
         return Q(translation__locale=locale, translation__date__range=(start, end))
 
+    def between_created_time_interval(self, start, end):
+        return Q(date_created__range=(start, end))
+
     def between_review_time_interval(self, locale, start, end):
         return Q(
             Q(translation__locale=locale)
@@ -359,6 +362,7 @@ class Entity(DirtyFieldsMixin, models.Model):
         search_match_case=None,
         search_match_whole_word=None,
         time=None,
+        created_time=None,
         author=None,
         review_time=None,
         reviewer=None,
@@ -377,6 +381,13 @@ class Entity(DirtyFieldsMixin, models.Model):
                 start, end = utils.parse_time_interval(time)
                 pre_filters.append(
                     Entity.objects.between_time_interval(locale, start, end)
+                )
+
+        if created_time:
+            if match("^[0-9]{12}-[0-9]{12}$", created_time):
+                start, end = utils.parse_time_interval(created_time)
+                pre_filters.append(
+                    Entity.objects.between_created_time_interval(start, end)
                 )
 
         if review_time:

--- a/pontoon/base/models/user.py
+++ b/pontoon/base/models/user.py
@@ -397,16 +397,26 @@ def serialized_notifications(self):
 
         if hasattr(notification.actor, "slug"):
             if "new string" in notification.verb:
+                new_strings_url = reverse(
+                    "pontoon.translate.locale.agnostic",
+                    kwargs={
+                        "slug": notification.actor.slug,
+                        "part": "all-resources",
+                    },
+                )
+                # Link to the exact batch of added strings via the created_time
+                # URL filter on Entity.date_created, falling back to all
+                # missing/pretranslated strings for older notifications.
+                created_time = (
+                    notification.data.get("created_time") if notification.data else None
+                )
+                if created_time:
+                    new_strings_url += f"?created_time={created_time}-{created_time}"
+                else:
+                    new_strings_url += "?status=missing,pretranslated"
                 actor = {
                     "anchor": notification.actor.name,
-                    "url": reverse(
-                        "pontoon.translate.locale.agnostic",
-                        kwargs={
-                            "slug": notification.actor.slug,
-                            "part": "all-resources",
-                        },
-                    )
-                    + "?status=missing,pretranslated",
+                    "url": new_strings_url,
                 }
             else:
                 actor = {

--- a/pontoon/base/tests/forms/test_entity.py
+++ b/pontoon/base/tests/forms/test_entity.py
@@ -8,3 +8,16 @@ def test_form_search_with_whitespace():
     form = GetEntitiesForm({"project": "firefox", "locale": "kl", "search": " z"})
     assert form.is_valid()
     assert form.cleaned_data["search"] == " z"
+
+
+@pytest.mark.django_db
+def test_form_accepts_created_time():
+    form = GetEntitiesForm(
+        {
+            "project": "firefox",
+            "locale": "kl",
+            "created_time": "202605240444-202605240444",
+        }
+    )
+    assert form.is_valid()
+    assert form.cleaned_data["created_time"] == "202605240444-202605240444"

--- a/pontoon/base/tests/managers/test_entity.py
+++ b/pontoon/base/tests/managers/test_entity.py
@@ -990,3 +990,57 @@ def test_lookup_collation(resource_a, locale_a):
     assert set(Translation.objects.filter(string__icontains="string")) == {
         translations[n] for n in [0, 2, 3, 4]
     }
+
+
+@pytest.mark.django_db
+def test_mgr_entity_filter_created_time(admin, resource_a, locale_a):
+    """
+    created_time filters Entity.for_project_locale by Entity.date_created,
+    which is how the new-string notification link points to the exact
+    batch of strings added in a single sync.
+    """
+    from datetime import datetime, timezone
+
+    TranslatedResourceFactory.create(locale=locale_a, resource=resource_a)
+
+    older = EntityFactory.create(resource=resource_a, string="older")
+    newer_a = EntityFactory.create(resource=resource_a, string="newer a")
+    newer_b = EntityFactory.create(resource=resource_a, string="newer b")
+
+    # Two distinct bulk batches: 2026-05-22 12:48 (newer) and 2026-05-22 05:20 (older).
+    Entity.objects.filter(pk=older.pk).update(
+        date_created=datetime(2026, 5, 22, 5, 20, 8, 146586, tzinfo=timezone.utc),
+    )
+    Entity.objects.filter(pk__in=[newer_a.pk, newer_b.pk]).update(
+        date_created=datetime(2026, 5, 22, 12, 48, 35, 638056, tzinfo=timezone.utc),
+    )
+
+    # created_time=202605221248-202605221248 matches the 12:48 batch only.
+    assert set(
+        Entity.for_project_locale(
+            admin,
+            resource_a.project,
+            locale_a,
+            created_time="202605221248-202605221248",
+        )
+    ) == {newer_a, newer_b}
+
+    # created_time=202605220520-202605220520 matches the 05:20 batch only.
+    assert list(
+        Entity.for_project_locale(
+            admin,
+            resource_a.project,
+            locale_a,
+            created_time="202605220520-202605220520",
+        )
+    ) == [older]
+
+    # A malformed value is ignored (mirrors the existing `time` filter pattern).
+    assert set(
+        Entity.for_project_locale(
+            admin,
+            resource_a.project,
+            locale_a,
+            created_time="not-a-range",
+        )
+    ) == {older, newer_a, newer_b}

--- a/pontoon/base/tests/models/test_user.py
+++ b/pontoon/base/tests/models/test_user.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 import pytest
 
 from notifications.models import Notification
+from notifications.signals import notify
 
 from django.contrib.auth.models import User
 
@@ -158,3 +159,43 @@ def test_is_subscribed_to_notification_no_category(user_with_subscriptions):
 
     # Call the function and assert the result
     assert user_with_subscriptions.is_subscribed_to_notification(notification) is False
+
+
+@pytest.mark.django_db
+def test_serialized_notifications_new_string_created_time(user_a, project_a):
+    """
+    New string notifications carrying a created_time on their data link to the
+    exact batch of added strings via the created_time URL filter.
+    """
+    notify.send(
+        sender=project_a,
+        recipient=user_a,
+        verb="updated with 3 new strings",
+        category="new_string",
+        created_time="202605240444",
+    )
+
+    notification = user_a.serialized_notifications["notifications"][0]
+    assert notification["actor"]["url"] == (
+        f"/projects/{project_a.slug}/all-resources/"
+        "?created_time=202605240444-202605240444"
+    )
+
+
+@pytest.mark.django_db
+def test_serialized_notifications_new_string_without_created_time(user_a, project_a):
+    """
+    Older new string notifications without a created_time fall back to linking
+    to all missing and pretranslated strings.
+    """
+    notify.send(
+        sender=project_a,
+        recipient=user_a,
+        verb="updated with 3 new strings",
+        category="new_string",
+    )
+
+    notification = user_a.serialized_notifications["notifications"][0]
+    assert notification["actor"]["url"] == (
+        f"/projects/{project_a.slug}/all-resources/?status=missing,pretranslated"
+    )

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -279,6 +279,7 @@ def entities(request):
         "search_match_case",
         "search_match_whole_word",
         "time",
+        "created_time",
         "author",
         "review_time",
         "reviewer",

--- a/pontoon/contributors/templates/contributors/widgets/notifications_menu.html
+++ b/pontoon/contributors/templates/contributors/widgets/notifications_menu.html
@@ -60,7 +60,13 @@
           {% if notification.actor.slug %}
             {% set actor_anchor = notification.actor %}
             {% if "new string" in notification.verb %}
-              {% set actor_url = full_url('pontoon.translate.locale.agnostic', notification.actor.slug, "all-resources") + '?status=missing,pretranslated' %}
+              {% set new_strings_base = full_url('pontoon.translate.locale.agnostic', notification.actor.slug, "all-resources") %}
+              {% if notification.data and notification.data.created_time %}
+                {% set created_time = notification.data.created_time %}
+                {% set actor_url = new_strings_base + '?created_time=' + created_time + '-' + created_time %}
+              {% else %}
+                {% set actor_url = new_strings_base + '?status=missing,pretranslated' %}
+              {% endif %}
             {% else %}
               {% set actor_url = full_url('pontoon.projects.project', notification.actor.slug) %}
             {% endif %}

--- a/pontoon/sync/core/__init__.py
+++ b/pontoon/sync/core/__init__.py
@@ -1,5 +1,7 @@
 import logging
 
+from datetime import datetime
+
 from django.utils import timezone
 
 from pontoon.base.models import ChangedEntityLocale, Locale, Project, User
@@ -60,7 +62,7 @@ def sync_project(
         or updated_trans_count
     )
     if added_entities_count > 0:
-        notify_users(project, added_entities_count)
+        notify_users(project, added_entities_count, now)
     repo_changed = sync_translations_to_repo(
         project,
         commit,
@@ -89,12 +91,15 @@ def sync_project(
     return db_changed, repo_changed
 
 
-def notify_users(project: Project, count: int) -> None:
+def notify_users(project: Project, count: int, now: datetime) -> None:
     users = User.objects.filter(
         translation__entity__resource__project=project,
         profile__new_string_notifications=True,
     ).distinct()
     new_strings = f"{count} new {'string' if count == 1 else 'strings'}"
+    # Stored on notification.data so both the bell menu and digest can link to
+    # the exact batch via the created_time URL filter on Entity.date_created.
+    created_time = now.strftime("%Y%m%d%H%M")
     log.info(f"[{project.slug}] Notifying {len(users)} users about {new_strings}")
     for user in users:
         send_notification(
@@ -102,4 +107,5 @@ def notify_users(project: Project, count: int) -> None:
             recipient=user,
             verb=f"updated with {new_strings}",
             category="new_string",
+            created_time=created_time,
         )

--- a/pontoon/sync/tests/test_notify_users.py
+++ b/pontoon/sync/tests/test_notify_users.py
@@ -1,11 +1,17 @@
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import pytest
 
+from notifications.models import Notification
+
 from pontoon.base.tests import (
     EntityFactory,
+    LocaleFactory,
+    ProjectFactory,
     ResourceFactory,
     TranslationFactory,
+    UserFactory,
 )
 from pontoon.sync.core import notify_users
 
@@ -23,8 +29,80 @@ def test_notify_users_excludes_system_users(
     TranslationFactory.create(locale=locale_a, entity=entity, user=user_a)
     TranslationFactory.create(locale=locale_a, entity=entity, user=tm_user)
 
-    notify_users(project_a, count=1)
+    notify_users(
+        project_a, count=1, now=datetime(2026, 5, 24, 4, 44, tzinfo=timezone.utc)
+    )
 
     recipients = {call.kwargs["recipient"] for call in mock_notify.call_args_list}
     assert user_a in recipients
     assert tm_user not in recipients
+
+
+@pytest.mark.django_db
+def test_notify_users_stores_created_time():
+    """
+    notify_users() records the sync timestamp on notification.data as
+    created_time (YYYYMMDDHHmm), so the bell menu and digest template can
+    link to the precise batch of entities created in that sync.
+    """
+    locale = LocaleFactory.create()
+    project = ProjectFactory.create(locales=[locale])
+    resource = ResourceFactory.create(project=project)
+    entity = EntityFactory.create(resource=resource)
+
+    user = UserFactory.create()
+    user.profile.new_string_notifications = True
+    user.profile.save()
+    TranslationFactory.create(entity=entity, locale=locale, user=user)
+
+    now = datetime(2026, 5, 24, 4, 44, tzinfo=timezone.utc)
+    notify_users(project, count=3, now=now)
+
+    notifications = list(Notification.objects.filter(recipient=user))
+    assert len(notifications) == 1
+    n = notifications[0]
+    assert n.verb == "updated with 3 new strings"
+    assert n.data == {
+        "category": "new_string",
+        "created_time": "202605240444",
+    }
+
+
+@pytest.mark.django_db
+def test_notify_users_singular_verb():
+    """One added string uses the singular form in the verb."""
+    locale = LocaleFactory.create()
+    project = ProjectFactory.create(locales=[locale])
+    resource = ResourceFactory.create(project=project)
+    entity = EntityFactory.create(resource=resource)
+
+    user = UserFactory.create()
+    user.profile.new_string_notifications = True
+    user.profile.save()
+    TranslationFactory.create(entity=entity, locale=locale, user=user)
+
+    notify_users(project, count=1, now=datetime(2026, 1, 2, 3, 4, tzinfo=timezone.utc))
+
+    n = Notification.objects.get(recipient=user)
+    assert n.verb == "updated with 1 new string"
+    assert n.data["created_time"] == "202601020304"
+
+
+@pytest.mark.django_db
+def test_notify_users_skips_unsubscribed():
+    """Users without new_string_notifications enabled are not notified."""
+    locale = LocaleFactory.create()
+    project = ProjectFactory.create(locales=[locale])
+    resource = ResourceFactory.create(project=project)
+    entity = EntityFactory.create(resource=resource)
+
+    user = UserFactory.create()
+    user.profile.new_string_notifications = False
+    user.profile.save()
+    TranslationFactory.create(entity=entity, locale=locale, user=user)
+
+    notify_users(
+        project, count=2, now=datetime(2026, 5, 24, 4, 44, tzinfo=timezone.utc)
+    )
+
+    assert Notification.objects.filter(recipient=user).count() == 0

--- a/translate/src/api/entity.ts
+++ b/translate/src/api/entity.ts
@@ -140,6 +140,7 @@ function buildFetchPayload(
     'tag',
     'author',
     'time',
+    'created_time',
     'reviewer',
     'review_time',
     'exclude_self_reviewed',

--- a/translate/src/context/Location.test.jsx
+++ b/translate/src/context/Location.test.jsx
@@ -60,6 +60,32 @@ describe('LocationProvider', () => {
     });
   });
 
+  it('correctly parses the created_time query parameter', () => {
+    let view;
+    const Spy = () => {
+      view = useContext(Location);
+      return null;
+    };
+    const history = {
+      location: {
+        pathname: '/kg/waterwolf/all-resources/',
+        search: '?created_time=202605240444-202605240444',
+      },
+      listen: vi.fn(),
+    };
+    render(
+      <LocationProvider history={history}>
+        <Spy />
+      </LocationProvider>,
+    );
+    expect(view).toMatchObject({
+      locale: 'kg',
+      project: 'waterwolf',
+      resource: 'all-resources',
+      created_time: '202605240444-202605240444',
+    });
+  });
+
   it('correctly parses a query string with a list', () => {
     let view;
     const Spy = () => {

--- a/translate/src/context/Location.tsx
+++ b/translate/src/context/Location.tsx
@@ -31,6 +31,7 @@ export type Location = {
   tag: string | null;
   author: string | null;
   time: string | null;
+  created_time: string | null;
   reviewer: string | null;
   review_time: string | null;
   exclude_self_reviewed: boolean;
@@ -49,6 +50,7 @@ const emptyParams = {
   tag: null,
   author: null,
   time: null,
+  created_time: null,
   reviewer: null,
   review_time: null,
   exclude_self_reviewed: false,
@@ -135,6 +137,7 @@ function parse(
         tag: params.get('tag'),
         author: params.get('author'),
         time: params.get('time'),
+        created_time: params.get('created_time'),
         reviewer: params.get('reviewer'),
         review_time: params.get('review_time'),
         exclude_self_reviewed: params.has('exclude_self_reviewed'),
@@ -173,6 +176,7 @@ function stringify(prev: Location, next: string | Partial<Location>) {
     'tag',
     'author',
     'time',
+    'created_time',
     'reviewer',
     'review_time',
     'exclude_self_reviewed',

--- a/translate/src/modules/entitieslist/components/Entity.tsx
+++ b/translate/src/modules/entitieslist/components/Entity.tsx
@@ -89,13 +89,15 @@ export function Entity({
   );
 
   const showSiblingEntitiesButton = () => {
-    const { search, status, extra, tag, time, author } = parameters;
+    const { search, status, extra, tag, time, created_time, author } =
+      parameters;
     return (
       search ||
       status != null ||
       extra != null ||
       tag != null ||
       time != null ||
+      created_time != null ||
       author != null
     );
   };


### PR DESCRIPTION
Fixes #2403 

Now the notification link points to the batch of strings added in a sync, not all unreviewed+pretranslated in the project. That's going to help reviewing strings imported as translated (e.g. for Fluent migrations), but also help locales that are behind.

This PR adds an internal filter for creation date, which is on purpose not exposed in the UI and only reachable via URL. 
In case, that would be a conversation for #3511, since the menu is already crowded, and the time picker is the buggiest part.