### PR TITLE
Do not flatten Fluent patterns in entries

### DIFF
--- a/translate/src/context/Editor.test.jsx
+++ b/translate/src/context/Editor.test.jsx
@@ -218,7 +218,6 @@ describe('<EditorProvider>', () => {
     expect(editor).toMatchObject({
       sourceView: false,
       initial: { id: '', value: [] },
-      placeholders: new Map([['%1$s', arg1]]),
       fields: [
         {
           id: '',
@@ -229,7 +228,6 @@ describe('<EditorProvider>', () => {
         },
       ],
     });
-    expect(editor.placeholders).toBeInstanceOf(Map);
     expect(result).toEqual({ format: 'android', id: '', value: [] });
   });
 
@@ -250,7 +248,6 @@ describe('<EditorProvider>', () => {
     expect(editor).toMatchObject({
       sourceView: false,
       initial: { id: '', value: ['Hei, ', arg1, '!'] },
-      placeholders: new Map([['%1$s', arg1]]),
       fields: [
         {
           id: '',
@@ -261,7 +258,6 @@ describe('<EditorProvider>', () => {
         },
       ],
     });
-    expect(editor.placeholders).toBeInstanceOf(Map);
     expect(result).toEqual({
       format: 'android',
       id: '',
@@ -302,7 +298,6 @@ describe('<EditorProvider>', () => {
     expect(editor).toMatchObject({
       sourceView: false,
       initial: entry,
-      placeholders: null,
       fields,
     });
     expect(result).toEqual({
@@ -547,7 +542,7 @@ describe('<EditorProvider>', () => {
     });
   });
 
-  it('reports no pending changes for empty android entry with placeholders', () => {
+  it('reports no pending changes for empty android entry', () => {
     let unsaved;
     const Spy = () => {
       unsaved = useContext(UnsavedChanges);

--- a/translate/src/context/Editor.tsx
+++ b/translate/src/context/Editor.tsx
@@ -1,4 +1,4 @@
-import { CatchallKey, Expression, Markup } from '@mozilla/l10n';
+import { CatchallKey } from '@mozilla/l10n';
 import React, {
   createContext,
   useContext,
@@ -20,6 +20,7 @@ import {
   parseEntry,
   serializeEntry,
 } from '~/utils/message';
+import { specialFormats } from '~/utils/message/specialFormats';
 import { pojoEquals } from '~/utils/pojo';
 
 import { EntityView, useActiveTranslation } from './EntityView';
@@ -28,10 +29,6 @@ import { Locale } from './Locale';
 import { MachineryTranslations } from './MachineryTranslations';
 import { UnsavedActions } from './UnsavedChanges';
 import { getMessageEntryFormat } from '../utils/message/getMessageEntryFormat';
-import {
-  getPlaceholderMap,
-  placeholderFormats,
-} from '../utils/message/placeholders';
 
 export type EditFieldHandle = {
   get value(): string;
@@ -80,8 +77,6 @@ export type EditorData = Readonly<{
   /** Used for detecting unsaved changes */
   initial: MessageEntry;
 
-  placeholders: Map<string, Expression | Markup> | null;
-
   machinery: {
     manual: boolean;
     sources: SourceType[];
@@ -113,7 +108,8 @@ export type EditorActions = {
   toggleSourceView(): void;
 };
 
-function parseEntryFromFluentSource(base: MessageEntry, source: string) {
+function parseEntryFromFluentSource(base: MessageEntry, fields: EditorField[]) {
+  const source = fields[0].handle.current.value;
   const entry = parseEntry('fluent', source);
   if (entry) {
     entry.id = base.id;
@@ -141,7 +137,6 @@ const initEditorData: EditorData = {
   base: { format: 'plain', id: '', value: [] },
   focusField: { current: null },
   initial: { format: 'plain', id: '', value: [] },
-  placeholders: null,
   machinery: null,
   fields: [],
   sourceView: false,
@@ -194,13 +189,13 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
 
       setEditorFromHelpers: (str, sources, manual) =>
         setState((prev) => {
-          const { fields, focusField, placeholders, sourceView } = prev;
+          const { fields, focusField, sourceView } = prev;
           const field = focusField.current ?? fields[0];
           field.handle.current.setValue(str);
           let next = fields.slice();
           if (sourceView) {
-            const result = buildMessageEntry(prev.base, placeholders, fields);
-            next = editSource(result);
+            const result = buildMessageEntry(prev.base, fields);
+            next = editSource(result ?? str);
             focusField.current = next[0];
             setResult(result);
           }
@@ -214,47 +209,25 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
       setEditorFromHistory: (str) =>
         setState((prev) => {
           const next = { ...prev };
-          switch (format) {
-            case 'fluent': {
-              const entry = parseEntry(format, str);
-              if (entry) {
-                next.base = entry;
-                if (!requiresSourceView(entry)) {
-                  next.fields = prev.sourceView
-                    ? editSource(entry)
-                    : editMessageEntry(entry);
-                }
-              } else {
-                next.fields = editSource(str);
-                next.sourceView = true;
+          if (specialFormats.has(format)) {
+            const entry = parseEntry(format, str);
+            if (entry) {
+              next.base = entry;
+              if (!requiresSourceView(entry)) {
+                next.fields = prev.sourceView
+                  ? editSource(entry)
+                  : editMessageEntry(entry);
               }
-              break;
+            } else {
+              next.fields = editSource(str);
+              next.sourceView = true;
             }
-            case 'android':
-            case 'gettext':
-            case 'webext':
-            case 'xcode':
-            case 'xliff': {
-              const entry = parseEntry(format, str);
-              if (entry) {
-                next.base = entry;
-                next.fields = editMessageEntry(entry);
-              } else {
-                next.fields = editSource(str);
-                next.sourceView = true;
-              }
-              break;
-            }
-            default:
-              next.fields = editMessageEntry(prev.initial);
-              next.fields[0].handle.current.setValue(str);
+          } else {
+            next.fields = editMessageEntry(prev.initial);
+            next.fields[0].handle.current.setValue(str);
           }
           next.focusField.current = next.fields[0];
-          const result = buildMessageEntry(
-            next.base,
-            next.placeholders,
-            next.fields,
-          );
+          const result = buildMessageEntry(next.base, next.fields);
           setResult(result);
           return next;
         }),
@@ -271,38 +244,36 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
       setResultFromInput: () =>
         setState((state) => {
           // Inside setState() only to access the current `state` value
-          const { base, fields, placeholders, sourceView } = state;
+          const { base, fields, sourceView } = state;
           const result = sourceView
-            ? parseEntryFromFluentSource(base, fields[0].handle.current.value)
-            : buildMessageEntry(base, placeholders, fields);
+            ? parseEntryFromFluentSource(base, fields)
+            : buildMessageEntry(base, fields);
           setResult(result);
           return state;
         }),
 
       toggleSourceView: () =>
-        setState((prev) => {
-          if (prev.sourceView) {
-            const source = prev.fields[0].handle.current.value;
-            const entry = parseEntryFromFluentSource(prev.base, source);
+        setState((state) => {
+          const { base, fields, sourceView } = state;
+          if (sourceView) {
+            const entry = parseEntryFromFluentSource(base, fields);
             if (entry && !requiresSourceView(entry)) {
               const fields = editMessageEntry(entry);
-              prev.focusField.current = fields[0];
+              state.focusField.current = fields[0];
               setResult(entry);
-              return { ...prev, base: entry, fields, sourceView: false };
+              return { ...state, base: entry, fields, sourceView: false };
             }
           } else if (format === 'fluent') {
-            const entry = buildMessageEntry(
-              prev.base,
-              prev.placeholders,
-              prev.fields,
-            );
-            const source = serializeEntry(entry);
-            const fields = editSource(source);
-            prev.focusField.current = fields[0];
-            setResult(entry);
-            return { ...prev, fields, sourceView: true };
+            const entry = buildMessageEntry(base, fields);
+            if (entry) {
+              const source = serializeEntry(entry);
+              const fields = editSource(source);
+              state.focusField.current = fields[0];
+              setResult(entry);
+              return { ...state, fields, sourceView: true };
+            }
           }
-          return prev;
+          return state;
         }),
     };
   }, [format, readonly]);
@@ -311,12 +282,7 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
     let base: MessageEntry;
     let source = activeTranslation?.string || '';
     let sourceView = false;
-    let placeholders: Map<string, Expression | Markup> | null = null;
     let orig: MessageEntry | null = null;
-    if (placeholderFormats.has(format)) {
-      orig = parseEntry(format, entity.original);
-      if (orig?.value) placeholders = getPlaceholderMap(orig.value);
-    }
     if (!source) {
       orig ??= parseEntry(format, entity.original);
       base = orig
@@ -346,7 +312,6 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
       fields,
       focusField: { current: fields[0] },
       initial: base,
-      placeholders,
       machinery: null,
       sourceView,
     }));

--- a/translate/src/context/Editor.tsx
+++ b/translate/src/context/Editor.tsx
@@ -213,11 +213,13 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
             const entry = parseEntry(format, str);
             if (entry) {
               next.base = entry;
-              if (!requiresSourceView(entry)) {
-                next.fields = prev.sourceView
-                  ? editSource(entry)
-                  : editMessageEntry(entry);
-              }
+            } else if (format !== 'fluent') {
+              return prev;
+            }
+            if (entry && !requiresSourceView(entry)) {
+              next.fields = prev.sourceView
+                ? editSource(entry)
+                : editMessageEntry(entry);
             } else {
               next.fields = editSource(str);
               next.sourceView = true;

--- a/translate/src/modules/editor/hooks/useExistingTranslationGetter.test.jsx
+++ b/translate/src/modules/editor/hooks/useExistingTranslationGetter.test.jsx
@@ -32,7 +32,7 @@ const HISTORY_FLUENT = {
 };
 
 function mountSpy(format, history, editor) {
-  const result = buildMessageEntry(editor.base, null, editor.fields);
+  const result = buildMessageEntry(editor.base, editor.fields);
 
   let res;
   const Spy = () => {

--- a/translate/src/modules/entitydetails/components/Metadata.tsx
+++ b/translate/src/modules/entitydetails/components/Metadata.tsx
@@ -1,19 +1,19 @@
 import { Localized } from '@fluent/react';
+import type { Pattern } from '@mozilla/l10n';
 import parse from 'html-react-parser';
 import React, { Fragment, useContext, useLayoutEffect } from 'react';
 // @ts-expect-error Working types are unavailable for react-linkify 0.2.2
 import Linkify from 'react-linkify';
 
 import type { Entity } from '~/api/entity';
-import type { TeamCommentState } from '~/modules/teamcomments';
-
 import { Locale } from '~/context/Locale';
+import type { TeamCommentState } from '~/modules/teamcomments';
+import { type MessageEntry, parseEntry } from '~/utils/message';
+
 import { FluentAttribute } from './FluentAttribute';
 import { Property } from './Property';
 
 import './Metadata.css';
-import { MessageEntry, parseEntry } from '~/utils/message';
-import { getPlaceholderMap } from '~/utils/message/placeholders';
 
 type Props = {
   entity: Entity;
@@ -154,19 +154,31 @@ function SourceReferences({ meta }: { meta: Entity['meta'] }) {
 }
 
 function SourceExamples({ entry }: { readonly entry: MessageEntry | null }) {
-  if (!entry?.value || Array.isArray(entry.value)) return null;
-  const phMap = getPlaceholderMap(entry.value);
-  if (!phMap) return null;
-  const placeholders = Array.from(phMap.values());
-  const examples: string[] = [];
-  for (const [name, exp] of Object.entries(entry.value.decl)) {
-    const example = exp.attr?.example;
-    if (typeof example === 'string') {
-      const ph = placeholders.find((ph) => ph.$ === name);
-      const source = ph?.attr?.source;
-      if (typeof source === 'string') {
-        examples.push(`${source}: ${example}`);
+  const msg = entry?.value;
+  if (!msg || Array.isArray(msg)) return null;
+
+  const sources = new Map<string, string>();
+  const add = (pattern: Pattern): void => {
+    for (const ph of pattern) {
+      if (typeof ph !== 'string' && ph.$) {
+        const source = ph.attr?.source;
+        if (source && typeof source === 'string') {
+          sources.set(ph.$, source);
+        }
       }
+    }
+  };
+
+  if (msg.msg) add(msg.msg);
+  else for (const v of msg.alt) add(v.pat);
+  if (!sources.size) return null;
+
+  const examples: string[] = [];
+  for (const [name, exp] of Object.entries(msg.decl)) {
+    const example = exp.attr?.example;
+    const source = sources.get(name);
+    if (typeof example === 'string' && source) {
+      examples.push(`${source}: ${example}`);
     }
   }
 

--- a/translate/src/modules/translation/components/Translation.tsx
+++ b/translate/src/modules/translation/components/Translation.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
 import { getPlainMessage } from '~/utils/message';
+import { specialFormats } from '~/utils/message/specialFormats';
 
 import { GenericTranslation } from './GenericTranslation';
-import { placeholderFormats } from '~/utils/message/placeholders';
 
 type Props = {
   content: string;
@@ -22,11 +22,7 @@ export function Translation({
     return null;
   }
 
-  if (
-    format === 'fluent' ||
-    format === 'gettext' ||
-    placeholderFormats.has(format)
-  ) {
+  if (specialFormats.has(format)) {
     content = getPlainMessage(content, format);
     diffTarget &&= getPlainMessage(diffTarget, format);
   }

--- a/translate/src/modules/translationform/utils/editFieldExtensions.ts
+++ b/translate/src/modules/translationform/utils/editFieldExtensions.ts
@@ -25,7 +25,7 @@ import { EditorActions } from '~/context/Editor';
 import { useCopyOriginalIntoEditor } from '~/modules/editor';
 import { placeholder } from '~/modules/placeable/placeholder';
 import { MessageEntry, parseEntry } from '~/utils/message';
-import { editablePattern } from '~/utils/message/placeholders';
+import { editablePattern } from '~/utils/message/editablePattern';
 import { decoratorPlugin } from './decoratorPlugin';
 import {
   useHandleCtrlShiftArrow,
@@ -181,9 +181,9 @@ function* entryPatterns(format: string, source: string) {
 }
 
 function* msgPatterns(format: MessageEntry['format'], msg: Message) {
-  if (Array.isArray(msg)) yield editablePattern(msg);
-  else if (msg.msg) yield editablePattern(msg.msg);
-  else for (const v of msg.alt) yield editablePattern(v.pat);
+  if (Array.isArray(msg)) yield editablePattern(format, msg);
+  else if (msg.msg) yield editablePattern(format, msg.msg);
+  else for (const v of msg.alt) yield editablePattern(format, v.pat);
 }
 
 function completePlaceholder(

--- a/translate/src/utils/message/buildMessageEntry.test.js
+++ b/translate/src/utils/message/buildMessageEntry.test.js
@@ -110,4 +110,12 @@ describe('buildMessageEntry', () => {
       attributes: new Map([['attr', ['trans ATTR']]]),
     });
   });
+
+  it('returns null on Fluent parse error', () => {
+    const base = parseEntry('fluent', 'msg = Hello { -world }\n');
+    const result = buildMessageEntry(base, [
+      { name: '', keys: [], handle: { current: { value: 'Hello {' } } },
+    ]);
+    expect(result).toBeNull();
+  });
 });

--- a/translate/src/utils/message/buildMessageEntry.test.js
+++ b/translate/src/utils/message/buildMessageEntry.test.js
@@ -1,63 +1,113 @@
 import { buildMessageEntry } from './buildMessageEntry';
 import { getEmptyMessageEntry } from './getEmptyMessage';
-import { getPlaceholderMap } from './placeholders';
 import { parseEntry } from './parseEntry';
-import { serializeEntry } from './serializeEntry';
-
-const LOCALE = { code: 'en-US' };
 
 describe('buildMessageEntry', () => {
-  it('matches getEmptyMessageEntry when value is empty and placeholders map is non-empty', () => {
+  it('matches getEmptyMessageEntry when value is empty', () => {
     const base = parseEntry(
       'android',
       'Hello, {$arg1 :string @source=|%1$s|}!',
     );
-    const placeholders = getPlaceholderMap(base.value);
-    expect(placeholders).not.toBeNull();
-
-    const result = buildMessageEntry(base, placeholders, [
+    const result = buildMessageEntry(base, [
       { name: '', keys: [], handle: { current: { value: '' } } },
     ]);
-    const empty = getEmptyMessageEntry(base, LOCALE);
-
+    const empty = getEmptyMessageEntry(base, { code: 'en-US' });
     expect(result).toEqual(empty);
   });
 
-  it('replaces a placeholder in a non-empty value', () => {
-    const base = parseEntry(
-      'android',
-      'Hello, {$arg1 :string @source=|%1$s|}!',
-    );
-    const placeholders = getPlaceholderMap(base.value);
-
-    const result = buildMessageEntry(base, placeholders, [
-      { name: '', keys: [], handle: { current: { value: 'Bonjour, %1$s!' } } },
-    ]);
-
-    expect(serializeEntry(result)).toEqual(
-      'Bonjour, {$arg1 :string @source=|%1$s|}!',
-    );
-  });
-
-  it('matches getEmptyMessageEntry when value is empty and placeholders map is null', () => {
-    const base = parseEntry('fluent', 'msg = Hello World\n');
-    expect(base).not.toBeNull();
-
-    const result = buildMessageEntry(base, null, [
-      { name: '', keys: [], handle: { current: { value: '' } } },
-    ]);
-    const empty = getEmptyMessageEntry(base, LOCALE);
-
-    expect(result).toEqual(empty);
-  });
-
-  it('sets a simple value without placeholders', () => {
-    const base = parseEntry('android', 'Hello World');
-
-    const result = buildMessageEntry(base, null, [
+  it('updates a plain entry', () => {
+    const base = parseEntry('gettext', 'Hello World');
+    const result = buildMessageEntry(base, [
       { name: '', keys: [], handle: { current: { value: 'Bonjour Monde' } } },
     ]);
+    expect(result).toEqual({
+      format: 'gettext',
+      id: '',
+      value: ['Bonjour Monde'],
+    });
+  });
 
-    expect(serializeEntry(result)).toEqual('Bonjour Monde');
+  it('updates an Android entry', () => {
+    const base = parseEntry(
+      'android',
+      'Hello, {$arg1 :string @source=|%1$s|}!',
+    );
+    const result = buildMessageEntry(base, [
+      { name: '', keys: [], handle: { current: { value: 'Bonjour, %1$s !' } } },
+    ]);
+    expect(result).toEqual({
+      format: 'android',
+      id: '',
+      value: [
+        'Bonjour, ',
+        { $: 'arg1', fn: 'string', attr: { source: '%1$s' } },
+        ' !',
+      ],
+    });
+  });
+
+  it('updates an Xcode entry', () => {
+    const base = parseEntry('xcode', 'Hello, {$arg @source=|%@|}!');
+    const result = buildMessageEntry(base, [
+      { name: '', keys: [], handle: { current: { value: 'Bonjour, %@ !' } } },
+    ]);
+    expect(result).toEqual({
+      format: 'xcode',
+      id: '',
+      value: ['Bonjour, ', { $: 'arg', attr: { source: '%@' } }, ' !'],
+    });
+  });
+
+  it('updates a simple Fluent entry', () => {
+    const base = parseEntry('fluent', 'msg = Hello { -world }\n');
+    const result = buildMessageEntry(base, [
+      {
+        name: '',
+        keys: [],
+        handle: { current: { value: 'Bonjour {-world}' } },
+      },
+    ]);
+    expect(result).toEqual({
+      format: 'fluent',
+      id: 'msg',
+      value: ['Bonjour ', { _: '-world', fn: 'message' }],
+    });
+  });
+
+  it('updates a complex Fluent entry', () => {
+    const base = parseEntry(
+      'fluent',
+      'msg = { $n ->\n   [one] ONE\n  *[other] OTHER\n  }\n  .attr = ATTR\n',
+    );
+    const result = buildMessageEntry(base, [
+      {
+        name: '',
+        keys: ['one'],
+        handle: { current: { value: 'trans ONE' } },
+      },
+      {
+        name: '',
+        keys: [{ '*': 'other' }],
+        handle: { current: { value: 'trans OTHER' } },
+      },
+      {
+        name: 'attr',
+        keys: [],
+        handle: { current: { value: 'trans ATTR' } },
+      },
+    ]);
+    expect(result).toEqual({
+      format: 'fluent',
+      id: 'msg',
+      value: {
+        decl: { n: { $: 'n', fn: 'number' } },
+        sel: ['n'],
+        alt: [
+          { keys: ['one'], pat: ['trans ONE'] },
+          { keys: [{ '*': 'other' }], pat: ['trans OTHER'] },
+        ],
+      },
+      attributes: new Map([['attr', ['trans ATTR']]]),
+    });
   });
 });

--- a/translate/src/utils/message/buildMessageEntry.test.js
+++ b/translate/src/utils/message/buildMessageEntry.test.js
@@ -118,4 +118,28 @@ describe('buildMessageEntry', () => {
     ]);
     expect(result).toBeNull();
   });
+
+  it('returns null on Android parse error', () => {
+    const base = parseEntry('android', 'Hello {$arg1 :string @source=|%1$s|}!');
+    const result = buildMessageEntry(base, [
+      { name: '', keys: [], handle: { current: { value: 'Hello <a>' } } },
+    ]);
+    expect(result).toBeNull();
+  });
+
+  it('returns null on webext parse error', () => {
+    const base = parseEntry('webext', 'Hello');
+    const result = buildMessageEntry(base, [
+      { name: '', keys: [], handle: { current: { value: 'Hello $x$' } } },
+    ]);
+    expect(result).toBeNull();
+  });
+
+  it('returns null on Xcode parse error', () => {
+    const base = parseEntry('xcode', 'Hello {$arg :string @source=|%@|}!');
+    const result = buildMessageEntry(base, [
+      { name: '', keys: [], handle: { current: { value: 'Hello <' } } },
+    ]);
+    expect(result).toBeNull();
+  });
 });

--- a/translate/src/utils/message/buildMessageEntry.tsx
+++ b/translate/src/utils/message/buildMessageEntry.tsx
@@ -1,41 +1,57 @@
+import {
+  isSelectMessage,
+  parsePattern,
+  type FormatKey,
+  type Message,
+} from '@mozilla/l10n';
 import type { EditorField } from '~/context/Editor';
 import type { MessageEntry } from '.';
-import {
-  Expression,
-  isSelectMessage,
-  Markup,
-  type Message,
-  type Pattern,
-} from '@mozilla/l10n';
 
-/** Get a `MessageEntry` corresponding to `edit`, based on `base`. */
+/**
+ * Get a `MessageEntry` corresponding to `fields`, based on `base`.
+ * Returns `null` on parse error.
+ */
 export function buildMessageEntry(
   base: MessageEntry,
-  placeholders: Map<string, Expression | Markup> | null,
   fields: EditorField[],
-): MessageEntry {
+): MessageEntry | null {
   const res = structuredClone(base);
-  if (res.value) setMessage(res.value, '', placeholders, fields);
-  if (res.attributes) {
-    for (const [name, msg] of res.attributes) {
-      setMessage(msg, name, placeholders, fields);
-    }
+  let format: FormatKey;
+  switch (res.format) {
+    case 'gettext':
+      format = 'plain';
+      break;
+    case 'xcode':
+      format = 'xliff';
+      break;
+    default:
+      format = res.format ?? 'plain';
   }
-  return res;
+  try {
+    if (res.value) setMessage(format, res.value, '', fields);
+    if (res.attributes) {
+      for (const [name, msg] of res.attributes) {
+        setMessage(format, msg, name, fields);
+      }
+    }
+    return res;
+  } catch {
+    return null;
+  }
 }
 
-/** Modifies `msg` according to `edit` entries which match `name`.  */
+/** Modifies `msg` according to `fields` entries which match `name`.  */
 function setMessage(
+  format: FormatKey,
   msg: Message,
   attrName: string,
-  placeholders: Map<string, Expression | Markup> | null,
   fields: EditorField[],
 ) {
   if (isSelectMessage(msg)) {
     msg.alt = [];
     for (const { name, keys, handle } of fields) {
       if (name === attrName) {
-        const pat = buildPattern(handle.current.value, placeholders);
+        const pat = parsePattern(format, handle.current.value, msg);
         msg.alt.push({ keys, pat });
       }
     }
@@ -43,41 +59,10 @@ function setMessage(
     const body = Array.isArray(msg) ? msg : msg.msg;
     for (const { name, handle } of fields) {
       if (name === attrName) {
-        const pat = buildPattern(handle.current.value, placeholders);
+        const pat = parsePattern(format, handle.current.value, msg);
         body.splice(0, body.length, ...pat);
         break;
       }
     }
   }
-}
-
-function buildPattern(
-  str: string,
-  placeholders: Map<string, Expression | Markup> | null,
-): Pattern {
-  if (!placeholders?.size) return str ? [str] : [];
-  const replacements: {
-    start: number;
-    end: number;
-    part: Expression | Markup;
-  }[] = [];
-  for (const [ph, part] of placeholders) {
-    let i = str.indexOf(ph);
-    while (i !== -1) {
-      const end = i + ph.length;
-      replacements.push({ start: i, end, part });
-      i = str.indexOf(ph, end);
-    }
-  }
-  replacements.sort((a, b) => a.start - b.start);
-  const pattern: Pattern = [];
-  let pos = 0;
-  for (const { start, end, part } of replacements) {
-    if (start < pos) continue;
-    if (start > pos) pattern.push(str.substring(pos, start));
-    pattern.push(part);
-    pos = end;
-  }
-  if (pos < str.length) pattern.push(str.substring(pos));
-  return pattern;
 }

--- a/translate/src/utils/message/editMessageEntry.tsx
+++ b/translate/src/utils/message/editMessageEntry.tsx
@@ -2,7 +2,7 @@ import { isSelectMessage, type CatchallKey, type Message } from '@mozilla/l10n';
 import type { EditorField } from '~/context/Editor';
 import type { MessageEntry } from '.';
 import { findPluralSelectors } from './findPluralSelectors';
-import { editablePattern } from './placeholders';
+import { editablePattern } from './editablePattern';
 import { serializeEntry } from './serializeEntry';
 
 const emptyHandleRef = (value: string) => ({
@@ -69,10 +69,10 @@ function* genPatterns(
         label: (typeof key === 'string' ? key : key['*']) || 'other',
         plural: plurals.has(i),
       }));
-      yield [keys, labels, editablePattern(pat)];
+      yield [keys, labels, editablePattern(format, pat)];
     }
   } else {
-    yield [[], [], editablePattern(Array.isArray(msg) ? msg : msg.msg)];
+    yield [[], [], editablePattern(format, Array.isArray(msg) ? msg : msg.msg)];
   }
 }
 

--- a/translate/src/utils/message/editablePattern.ts
+++ b/translate/src/utils/message/editablePattern.ts
@@ -4,38 +4,21 @@ import {
   mf2SerializePattern,
   Markup,
   Pattern,
-  Message,
+  fluentSerializePattern,
 } from '@mozilla/l10n';
 
-export const placeholderFormats = new Set([
-  'android',
-  'webext',
-  'xcode',
-  'xliff',
-]);
-
-export function getPlaceholderMap(
-  msg: Message,
-): Map<string, Expression | Markup> | null {
-  const placeholders = new Map<string, Expression | Markup>();
-  if (Array.isArray(msg)) addPlaceholders(msg, placeholders);
-  else if (msg.msg) addPlaceholders(msg.msg, placeholders);
-  else for (const v of msg.alt) addPlaceholders(v.pat, placeholders);
-  return placeholders.size ? placeholders : null;
-}
-
-function addPlaceholders(
-  pattern: Pattern,
-  placeholders: Map<string, Expression | Markup>,
-): void {
-  for (const part of pattern) {
-    if (typeof part !== 'string') {
-      placeholders.set(editablePlaceholder(part), part);
-    }
+/**
+ * @param format - Either a `MessageEntry['format']` or an `Entity.format`;
+ *   only the `'fluent'` value gets special consideration.
+ */
+export function editablePattern(format: string, pattern: Pattern): string {
+  if (format === 'fluent') {
+    return fluentSerializePattern(pattern, {
+      escapeSyntax: false,
+      onError: () => {},
+    });
   }
-}
 
-export function editablePattern(pattern: Pattern): string {
   let str = '';
   for (const part of pattern) {
     str += typeof part === 'string' ? part : editablePlaceholder(part);

--- a/translate/src/utils/message/getPlainMessage.ts
+++ b/translate/src/utils/message/getPlainMessage.ts
@@ -1,12 +1,7 @@
-import {
-  fluentSerializePattern,
-  Pattern,
-  serializePattern,
-  type Message,
-} from '@mozilla/l10n';
+import type { Message, Pattern } from '@mozilla/l10n';
 import type { MessageEntry } from '.';
+import { editablePattern } from './editablePattern';
 import { parseEntry } from './parseEntry';
-import { editablePattern } from './placeholders';
 
 /**
  * Return a plain string representation of a given message.
@@ -60,10 +55,5 @@ function previewMessage(format: string, message: Message): string {
     pattern = catchall.pat;
   }
 
-  return format === 'fluent'
-    ? fluentSerializePattern(pattern, {
-        escapeSyntax: false,
-        onError: () => {},
-      })
-    : editablePattern(pattern);
+  return editablePattern(format, pattern);
 }

--- a/translate/src/utils/message/index.ts
+++ b/translate/src/utils/message/index.ts
@@ -29,3 +29,4 @@ export { editMessageEntry, editSource } from './editMessageEntry';
 export { parseEntry } from './parseEntry';
 export { requiresSourceView } from './requiresSourceView';
 export { serializeEntry } from './serializeEntry';
+export { specialFormats } from './specialFormats';

--- a/translate/src/utils/message/parseEntry.test.js
+++ b/translate/src/utils/message/parseEntry.test.js
@@ -46,7 +46,7 @@ describe('parseEntry:fluent', () => {
     expect(res).toEqual({
       format: 'fluent',
       id: 'title',
-      value: ['My { $awesome } Title'],
+      value: ['My ', { $: 'awesome' }, ' Title'],
     });
   });
 
@@ -56,7 +56,9 @@ describe('parseEntry:fluent', () => {
       format: 'fluent',
       id: 'title',
       value: null,
-      attributes: new Map([['foo', ['Bar { -foo } Baz']]]),
+      attributes: new Map([
+        ['foo', ['Bar ', { _: '-foo', fn: 'message' }, ' Baz']],
+      ]),
     });
   });
 
@@ -70,10 +72,19 @@ describe('parseEntry:fluent', () => {
     expect(res).toEqual({
       format: 'fluent',
       id: 'batman',
-      value: ['The { $dark } Knight'],
+      value: ['The ', { $: 'dark' }, ' Knight'],
       attributes: new Map([
-        ['weapon', ['Brain and { -wayne-enterprise }']],
-        ['history', ['Lost { 2 } parents, has { 1 } "$alfred"']],
+        ['weapon', ['Brain and ', { _: '-wayne-enterprise', fn: 'message' }]],
+        [
+          'history',
+          [
+            'Lost ',
+            { _: '2', fn: 'number' },
+            ' parents, has ',
+            { _: '1', fn: 'number' },
+            ' "$alfred"',
+          ],
+        ],
       ]),
     });
   });
@@ -86,8 +97,8 @@ describe('parseEntry:fluent', () => {
     expect(res).toEqual({
       format: 'fluent',
       id: '-term',
-      value: ['My { $awesome } term'],
-      attributes: new Map([['attr', ['']]]),
+      value: ['My ', { $: 'awesome' }, ' term'],
+      attributes: new Map([['attr', []]]),
     });
   });
 
@@ -115,19 +126,31 @@ describe('parseEntry:fluent', () => {
         alt: [
           {
             keys: ['one', { '*': 'masculine' }],
-            pat: ['There is one email for { $awesome } him'],
+            pat: ['There is one email for ', { $: 'awesome' }, ' him'],
           },
           {
             keys: ['one', 'feminine'],
-            pat: ['There is one email for { $awesome } her'],
+            pat: ['There is one email for ', { $: 'awesome' }, ' her'],
           },
           {
             keys: [{ '*': 'other' }, { '*': 'masculine' }],
-            pat: ['There are { $num } emails for { $awesome } him'],
+            pat: [
+              'There are ',
+              { $: 'num' },
+              ' emails for ',
+              { $: 'awesome' },
+              ' him',
+            ],
           },
           {
             keys: [{ '*': 'other' }, 'feminine'],
-            pat: ['There are { $num } emails for { $awesome } her'],
+            pat: [
+              'There are ',
+              { $: 'num' },
+              ' emails for ',
+              { $: 'awesome' },
+              ' her',
+            ],
           },
         ],
       },

--- a/translate/src/utils/message/parseEntry.ts
+++ b/translate/src/utils/message/parseEntry.ts
@@ -1,17 +1,14 @@
 import {
   fluentParseEntry,
   mf2ParseMessage,
-  serializePattern,
-  type FormatKey,
+  normalizeMessage,
   type Message,
-  type Pattern,
 } from '@mozilla/l10n';
 import type { MessageEntry } from '.';
+import { specialFormats } from './specialFormats';
 
 /**
- * Parse a
- * `'fluent'`, `'android'`, `'gettext'`, `'webext'`, `'xcode'`, or `'xliff'`
- * message source as a {@link MessageEntry}.
+ * Parse a non-plain message source as a {@link MessageEntry}.
  *
  * @returns `null` on parse error or unsupported format
  */
@@ -20,46 +17,27 @@ export function parseEntry(
   source: string,
 ): MessageEntry | null {
   try {
-    switch (format) {
-      case 'fluent': {
-        const [id, entry] = fluentParseEntry(source);
-        const value = entry['='] ? flatMessage('fluent', entry['=']) : null;
-        if (entry['+']) {
-          const attributes = new Map<string, Message>();
-          for (const [name, value] of Object.entries(entry['+'])) {
-            attributes.set(name, flatMessage('fluent', value));
-          }
-          return { format, id, value, attributes };
+    if (format === 'fluent') {
+      const [id, entry] = fluentParseEntry(source);
+      const value = entry['='] ? normalizeMessage(entry['=']) : null;
+      if (entry['+']) {
+        const attributes = new Map<string, Message>();
+        for (const [name, value] of Object.entries(entry['+'])) {
+          attributes.set(name, normalizeMessage(value));
         }
-        return value ? { format, id, value } : null;
+        return { format, id, value, attributes };
       }
-
-      case 'android':
-      case 'gettext':
-      case 'webext':
-      case 'xcode':
-      case 'xliff':
-        return { format, id: '', value: mf2ParseMessage(source) };
+      return value ? { format, id, value } : null;
+    } else if (specialFormats.has(format)) {
+      return {
+        format: format as MessageEntry['format'],
+        id: '',
+        value: mf2ParseMessage(source),
+      };
     }
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     console.warn(`Parse error: ${msg}, with entry source:\n${source}`);
   }
   return null;
-}
-
-/**
- * Empty Fluent string literals `{ "" }` are dropped.
- */
-function flatMessage(format: FormatKey, msg: Message): Message {
-  const flatPattern = (pat: Pattern) => [
-    serializePattern(format, pat).replace(/{ "" }/g, ''),
-  ];
-  if (Array.isArray(msg)) return flatPattern(msg);
-  if (msg.msg) return { decl: msg.decl, msg: flatPattern(msg.msg) };
-  const flatAlt = msg.alt.map((v) => ({
-    keys: v.keys,
-    pat: flatPattern(v.pat),
-  }));
-  return { decl: msg.decl, sel: msg.sel, alt: flatAlt };
 }

--- a/translate/src/utils/message/specialFormats.ts
+++ b/translate/src/utils/message/specialFormats.ts
@@ -1,0 +1,8 @@
+export const specialFormats = new Set([
+  'android',
+  'fluent',
+  'gettext',
+  'webext',
+  'xcode',
+  'xliff',
+]);


### PR DESCRIPTION
Thus far in the Pontoon frontend we've used a kind of semi-parsed representation for Fluent entries, where the patterns within a MessageEntry are not the actual pattern data model, but a serialization thereof. This PR drops this now-unnecessary special-casing.

The parsing of translations in some other formats (Android, web extensions, Xcode) is also updated to no longer be a mechanical re-creation based on the original entry's placeholders, but an actual parse, making their handling also less bespoke.