### PR TITLE
Colour the MainActionButton as grayed-out when saving/suggesting is not available

### DIFF
--- a/translate/public/locale/en-US/translate.ftl
+++ b/translate/public/locale/en-US/translate.ftl
@@ -114,18 +114,22 @@ editor-EditorMenu--button-copy = COPY
     .title = Copy From Source (Ctrl + Shift + C)
 editor-EditorMenu--button-clear = CLEAR
     .title = Clear Translation (Ctrl + Shift + Backspace)
+
 editor-EditorMenu--button-approve = APPROVE
-    .title = Approve Translation (Enter)
-editor-EditorMenu--button-approving = <glyph></glyph>APPROVING
-    .title = Approving Translation…
+editor-EditorMenu--button-approving = APPROVING
 editor-EditorMenu--button-save = SAVE
-    .title = Save Translation (Enter)
-editor-EditorMenu--button-saving = <glyph></glyph>SAVING
-    .title = Saving Translation…
+editor-EditorMenu--button-saving = SAVING
 editor-EditorMenu--button-suggest = SUGGEST
-    .title = Suggest Translation (Enter)
-editor-EditorMenu--button-suggesting = <glyph></glyph>SUGGESTING
-    .title = Suggesting Translation…
+editor-EditorMenu--button-suggesting = SUGGESTING
+
+editor-EditorMenu--title-approve = Approve Translation (Enter)
+editor-EditorMenu--title-approving = Approving Translation…
+editor-EditorMenu--title-save = Save Translation (Enter)
+editor-EditorMenu--title-saving = Saving Translation…
+editor-EditorMenu--title-suggest = Suggest Translation (Enter)
+editor-EditorMenu--title-suggesting = Suggesting Translation…
+editor-EditorMenu--title-same-translation = Same translation already exists
+editor-EditorMenu--title-syntax-error = Translation with syntax error cannot be saved
 
 
 ## Editor Settings
@@ -573,6 +577,7 @@ notification--unable-to-reject-translation = Unable to reject translation
 notification--unable-to-unreject-translation = Unable to unreject translation
 notification--unable-to-delete-translation = Unable to delete translation
 notification--same-translation = Same translation already exists
+notification--syntax-error = Translation with syntax error cannot be saved
 notification--tt-checks-enabled = Translate Toolkit Checks enabled
 notification--tt-checks-disabled = Translate Toolkit Checks disabled
 notification--make-suggestions-enabled = Make Suggestions enabled

--- a/translate/public/locale/kab/translate.ftl
+++ b/translate/public/locale/kab/translate.ftl
@@ -102,18 +102,21 @@ editor-EditorMenu--button-copy = NƔEL
     .title = Nɣel seg uɣbalu (Ctrl + Shift + C)
 editor-EditorMenu--button-clear = SFEḌ
     .title = Sfeḍ tasuqilt (Ctrl + Shift + Backspace)
+
 editor-EditorMenu--button-approve = APPROVE
-    .title = Approve Translation (Enter)
-editor-EditorMenu--button-approving = <glyph></glyph>APPROVING
-    .title = Approving Translation…
+editor-EditorMenu--button-approving = APPROVING
 editor-EditorMenu--button-save = SEKLES
-    .title = Sekles tasuqilt (Kcem)
-editor-EditorMenu--button-saving = <glyph></glyph>ASEKLES
-    .title = Asekles n tsuqilt…
+editor-EditorMenu--button-saving = ASEKLES
 editor-EditorMenu--button-suggest = SUMER
-    .title = Sumer tasuqilt (Kcem)
-editor-EditorMenu--button-suggesting = <glyph></glyph>ASUMER
-    .title = Asumer n tsuqilt…
+editor-EditorMenu--button-suggesting = ASUMER
+
+editor-EditorMenu--title-approve = Approve Translation (Enter)
+editor-EditorMenu--title-approving = Approving Translation…
+editor-EditorMenu--title-save = Sekles tasuqilt (Kcem)
+editor-EditorMenu--title-saving = Asekles n tsuqilt…
+editor-EditorMenu--title-suggest = Sumer tasuqilt (Kcem)
+editor-EditorMenu--title-suggesting = Asumer n tsuqilt…
+editor-EditorMenu--title-same-translation = Tella yakan yiwet n tsuqilt am ta
 
 ## Editor Settings
 ## Shows options to update user settings regarding the editor.

--- a/translate/public/locale/sv-SE/translate.ftl
+++ b/translate/public/locale/sv-SE/translate.ftl
@@ -112,18 +112,21 @@ editor-EditorMenu--button-copy = KOPIERA
     .title = Kopiera från källa (Ctrl + Shift + C)
 editor-EditorMenu--button-clear = TÖM
     .title = Töm översättning (Ctrl + Shift + Backspace)
+
 editor-EditorMenu--button-approve = GODKÄNN
-    .title = Godkänn översättning (Enter)
-editor-EditorMenu--button-approving = <glyph></glyph>GODKÄNNER
-    .title = Godkänner översättning…
+editor-EditorMenu--button-approving = GODKÄNNER
 editor-EditorMenu--button-save = SPARA
-    .title = Spara översättning (Enter)
-editor-EditorMenu--button-saving = <glyph></glyph>SPARAR
-    .title = Sparar översättning…
+editor-EditorMenu--button-saving = SPARAR
 editor-EditorMenu--button-suggest = FÖRESLÅ
-    .title = Föreslå översättning (Enter)
-editor-EditorMenu--button-suggesting = <glyph></glyph>FÖRESLÅR
-    .title = Föreslår översättning…
+editor-EditorMenu--button-suggesting = FÖRESLÅR
+
+editor-EditorMenu--title-approve = Godkänn översättning (Enter)
+editor-EditorMenu--title-approving = Godkänner översättning…
+editor-EditorMenu--title-save = Spara översättning (Enter)
+editor-EditorMenu--title-saving = Sparar översättning…
+editor-EditorMenu--title-suggest = Föreslå översättning (Enter)
+editor-EditorMenu--title-suggesting = Föreslår översättning…
+editor-EditorMenu--title-same-translation = Samma översättning finns redan
 
 
 ## Editor Settings

--- a/translate/src/modules/editor/components/EditorMainAction.test.jsx
+++ b/translate/src/modules/editor/components/EditorMainAction.test.jsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 
+import { EditorData, EditorResult } from '~/context/Editor';
 import * as Hooks from '~/hooks';
 import * as Translator from '~/hooks/useTranslator';
 
@@ -121,5 +122,24 @@ describe('<EditorMainAction>', () => {
     expect(button.querySelector('.fa-spin')).toBeInTheDocument();
     fireEvent.click(button);
     expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('does not show a spinner on syntax error', () => {
+    const spy = vi.fn();
+    SendTranslation.useSendTranslation.mockReturnValue(spy);
+    Hooks.useAppSelector.mockReturnValue(true); // user.settings.forceSuggestions
+    vi.mocked(useContext).mockImplementation((context) => {
+      if (context === EditorData) return { busy: true };
+      if (context === EditorResult) return null;
+      return {};
+    });
+
+    const { getByRole } = render(<EditorMainAction />);
+    const button = getByRole('button');
+
+    expect(button.querySelector('.fa-spin')).not.toBeInTheDocument();
+
+    fireEvent.click(button);
+    expect(spy).toHaveBeenCalled();
   });
 });

--- a/translate/src/modules/editor/components/EditorMainAction.test.jsx
+++ b/translate/src/modules/editor/components/EditorMainAction.test.jsx
@@ -24,7 +24,7 @@ beforeAll(() => {
     const actual = await importOriginal();
     return {
       ...actual,
-      Localized: ({ children }) => children,
+      useLocalization: () => ({ l10n: { getString: (id) => id } }),
     };
   });
 

--- a/translate/src/modules/editor/components/EditorMainAction.tsx
+++ b/translate/src/modules/editor/components/EditorMainAction.tsx
@@ -55,7 +55,7 @@ export function EditorMainAction(): React.ReactElement<React.ElementType> {
 
   const className = classNames(`action-${action}`, error && 'has-error');
 
-  if (busy) {
+  if (busy && !error) {
     if (action === 'approve') {
       action = 'approving';
     } else if (action === 'save') {
@@ -75,7 +75,7 @@ export function EditorMainAction(): React.ReactElement<React.ElementType> {
     ' ',
   );
 
-  if (busy) {
+  if (busy && !error) {
     const glyph = <i className='fas fa-circle-notch fa-spin' />;
     return (
       <button className={className} disabled title={title}>

--- a/translate/src/modules/editor/components/EditorMainAction.tsx
+++ b/translate/src/modules/editor/components/EditorMainAction.tsx
@@ -1,7 +1,8 @@
-import { Localized } from '@fluent/react';
+import { useLocalization } from '@fluent/react';
+import classNames from 'classnames';
 import React, { useContext } from 'react';
-import { EditorData } from '~/context/Editor';
 
+import { EditorData, EditorResult } from '~/context/Editor';
 import { useAppSelector } from '~/hooks';
 import { useTranslator } from '~/hooks/useTranslator';
 
@@ -24,11 +25,13 @@ export function EditorMainAction(): React.ReactElement<React.ElementType> {
   const forceSuggestions = useAppSelector(
     (state) => state.user.settings.forceSuggestions,
   );
+  const { l10n } = useLocalization();
   const isTranslator = useTranslator();
   const existingTranslation = useExistingTranslationGetter()();
   const sendTranslation = useSendTranslation();
   const updateTranslationStatus = useUpdateTranslationStatus();
   const { busy } = useContext(EditorData);
+  const entry = useContext(EditorResult);
 
   let action:
     | 'approve'
@@ -38,27 +41,19 @@ export function EditorMainAction(): React.ReactElement<React.ElementType> {
     | 'save'
     | 'saving';
   let onClick: (event: React.SyntheticEvent) => void;
-  let title: string;
+  let error = entry ? null : 'syntax-error';
 
   if (isTranslator && existingTranslation && !existingTranslation.approved) {
-    // Button to approve the translation
     action = 'approve';
     onClick = () =>
       updateTranslationStatus(existingTranslation.pk, 'approve', false);
-    title = 'Approve Translation (Enter)';
-  } else if (forceSuggestions || !isTranslator) {
-    // Button to send an unreviewed translation
-    action = 'suggest';
-    onClick = () => sendTranslation();
-    title = 'Suggest Translation (Enter)';
   } else {
-    // Button to send an approved translation
-    action = 'save';
+    action = forceSuggestions || !isTranslator ? 'suggest' : 'save';
     onClick = () => sendTranslation();
-    title = 'Save Translation (Enter)';
+    error ??= existingTranslation ? 'same-translation' : null;
   }
 
-  const className = `action-${action}`;
+  const className = classNames(`action-${action}`, error && 'has-error');
 
   if (busy) {
     if (action === 'approve') {
@@ -69,26 +64,30 @@ export function EditorMainAction(): React.ReactElement<React.ElementType> {
       action = 'suggesting';
     }
   }
-  const id = `editor-EditorMenu--button-${action}`;
-  const label = action.toUpperCase();
+  const label = l10n.getString(
+    `editor-EditorMenu--button-${action}`,
+    null,
+    action.toUpperCase(),
+  );
+  const title = l10n.getString(
+    `editor-EditorMenu--title-${error ?? action}`,
+    null,
+    ' ',
+  );
 
   if (busy) {
     const glyph = <i className='fas fa-circle-notch fa-spin' />;
     return (
-      <Localized id={id} attrs={{ title: true }} elems={{ glyph }}>
-        <button className={className} disabled title={title}>
-          {glyph}
-          {label}
-        </button>
-      </Localized>
+      <button className={className} disabled title={title}>
+        {glyph}
+        {label}
+      </button>
     );
   } else {
     return (
-      <Localized id={id} attrs={{ title: true }}>
-        <button className={className} onClick={onClick} title={title}>
-          {label}
-        </button>
-      </Localized>
+      <button className={className} onClick={onClick} title={title}>
+        {label}
+      </button>
     );
   }
 }

--- a/translate/src/modules/editor/components/EditorMenu.css
+++ b/translate/src/modules/editor/components/EditorMenu.css
@@ -22,7 +22,7 @@
   padding: 10px 3px;
 }
 
-.editor-menu .actions button:hover {
+.editor-menu .actions button:not(.has-error):hover {
   color: var(--status-translated);
 }
 
@@ -45,9 +45,13 @@
   background: var(--status-unreviewed);
 }
 
+.editor-menu .actions .has-error {
+  background: var(--status-missing);
+}
+
 .editor-menu .actions .action-approve:hover,
-.editor-menu .actions .action-save:hover,
-.editor-menu .actions .action-suggest:hover {
+.editor-menu .actions .action-save:not(.has-error):hover,
+.editor-menu .actions .action-suggest:not(.has-error):hover {
   color: var(--white-1);
 }
 

--- a/translate/src/modules/editor/hooks/useSendTranslation.ts
+++ b/translate/src/modules/editor/hooks/useSendTranslation.ts
@@ -13,6 +13,7 @@ import { updateEntityTranslation } from '~/modules/entities/actions';
 import { usePushNextTranslatable } from '~/modules/entities/hooks';
 import {
   SAME_TRANSLATION,
+  SYNTAX_ERROR,
   TRANSLATION_SAVED,
   UNABLE_TO_SAVE_TRANSLATION,
 } from '~/modules/notification/messages';
@@ -45,6 +46,11 @@ export function useSendTranslation(): (ignoreWarnings?: boolean) => void {
 
   return async (ignoreWarnings = false) => {
     if (busy || entity.pk === 0) {
+      return;
+    }
+
+    if (!entry) {
+      showNotification(SYNTAX_ERROR);
       return;
     }
 

--- a/translate/src/modules/notification/messages.tsx
+++ b/translate/src/modules/notification/messages.tsx
@@ -120,6 +120,15 @@ export const SAME_TRANSLATION: NotificationMessage = {
   type: 'error',
 };
 
+export const SYNTAX_ERROR: NotificationMessage = {
+  content: (
+    <Localized id='notification--syntax-error'>
+      Translation with syntax error cannot be saved
+    </Localized>
+  ),
+  type: 'error',
+};
+
 export const CHECKS_ENABLED: NotificationMessage = {
   content: (
     <Localized id='notification--tt-checks-enabled'>


### PR DESCRIPTION
When saving or suggesting a translation would produce an error that we can detect in the frontend, i.e. when:
- the same translation already exists, or
- the translation has a syntax error,

the main action button should not advertise itself as being available, but instead be dimmed out.