### PR TITLE
Generalise custom placeholder checks to apply to Xcode as well as Android

### DIFF
--- a/pontoon/base/simple_preview.py
+++ b/pontoon/base/simple_preview.py
@@ -15,7 +15,7 @@ from moz.l10n.model import (
 from pontoon.base.models import Resource
 
 
-def get_simple_preview(format: str, msg: str | Message | Pattern) -> str:
+def get_simple_preview(format: Resource.Format, msg: str | Message | Pattern) -> str:
     """
     Flatten a message entry as a simple string.
 

--- a/pontoon/base/tests/test_simple_preview.py
+++ b/pontoon/base/tests/test_simple_preview.py
@@ -2,6 +2,7 @@ from textwrap import dedent
 
 import pytest
 
+from pontoon.base.models import Resource
 from pontoon.base.simple_preview import get_simple_preview
 
 
@@ -101,10 +102,10 @@ GETTEXT_TRANSLATION_TESTS = {
 @pytest.mark.parametrize("name", FLUENT_TRANSLATION_TESTS)
 def test_fluent_simple_preview(name):
     string, expected = FLUENT_TRANSLATION_TESTS[name]
-    assert get_simple_preview("fluent", string) == expected
+    assert get_simple_preview(Resource.Format.FLUENT, string) == expected
 
 
 @pytest.mark.parametrize("name", GETTEXT_TRANSLATION_TESTS)
 def test_gettext_simple_preview(name):
     string, expected = GETTEXT_TRANSLATION_TESTS[name]
-    assert get_simple_preview("gettext", string) == expected
+    assert get_simple_preview(Resource.Format.GETTEXT, string) == expected

--- a/pontoon/checks/libraries/custom.py
+++ b/pontoon/checks/libraries/custom.py
@@ -1,10 +1,9 @@
 from collections.abc import Iterable, Iterator
-from html import escape
-from re import fullmatch
+from re import compile, fullmatch
+from typing import cast
 
 from fluent.syntax import FluentParser, ast
 from fluent.syntax.visitor import Visitor
-from moz.l10n.formats.android import android_parse_message
 from moz.l10n.formats.mf2 import mf2_parse_message
 from moz.l10n.formats.webext import webext_parse_message, webext_serialize_message
 from moz.l10n.model import (
@@ -59,68 +58,34 @@ def run_custom_checks(entity: Entity, string: str) -> dict[str, list[str]]:
             # Prevent empty translation submissions if not supported
             return {"pErrors": ["Empty translations are not allowed"]}
 
+    format = cast(Resource.Format, entity.resource.format)
     errors: list[str] = []
     warnings: list[str] = []
-    match entity.resource.format:
-        case Resource.Format.ANDROID:
+    match format:
+        case Resource.Format.ANDROID | Resource.Format.XCODE:
             try:
                 msg = mf2_parse_message(string)
-                patterns = get_patterns(msg)
             except ValueError as e:
                 msg = None
-                patterns = ()
                 errors.append(f"Parse error: {e}")
-
-            orig_pct_count = 0
-            orig_ph_strings: set[str] = set()
             try:
                 orig_msg = mf2_parse_message(entity.string)
-                for pattern in get_patterns(orig_msg):
-                    pattern_pct_count = 0
-                    for el in pattern:
-                        if isinstance(el, str):
-                            pattern_pct_count += el.count("%")
-                        elif not (isinstance(el, Expression) and el.arg in ("%", "\n")):
-                            orig_ph_strings.add(preview_placeholder(el))
-                    orig_pct_count = max(orig_pct_count, pattern_pct_count)
-            except ValueError:
+            except ValueError as e:
                 orig_msg = None
+                warnings.append(f"Source parse error: {e}")
 
-            if any(all(el == "" for el in pattern) for pattern in patterns):
-                errors.append("Empty translations are not allowed")
+            if msg:
+                if format == Resource.Format.ANDROID and msg.is_empty():
+                    errors.append("Empty translations are not allowed")
 
-            if isinstance(msg, SelectMessage) and not isinstance(
-                orig_msg, SelectMessage
-            ):
-                errors.append("Plural translation requires plural source")
+                if isinstance(msg, SelectMessage) and not isinstance(
+                    orig_msg, SelectMessage
+                ):
+                    errors.append("Plural translation requires plural source")
 
-            # Inlined Android checks from compare-locales to support <plurals>
-            found_ps: set[str] = set()
-            try:
-                pct_count = 0
-                for pattern in patterns:
-                    android_msg = android_parse_message(
-                        escape(get_simple_preview(Resource.Format.ANDROID, pattern))
-                    )
-                    pattern_pct_count = 0
-                    for el in android_msg.pattern:
-                        if isinstance(el, str):
-                            pattern_pct_count += el.count("%")
-                        elif not (isinstance(el, Expression) and el.arg in ("%", "\n")):
-                            ps = preview_placeholder(el)
-                            if ps in orig_ph_strings:
-                                found_ps.add(ps)
-                            else:
-                                errors.append(
-                                    f"Placeholder {ps} not found in reference"
-                                )
-                    pct_count = max(pct_count, pattern_pct_count)
-                for ps in orig_ph_strings:
-                    if ps not in found_ps:
-                        ew_list = errors if pct_count > orig_pct_count else warnings
-                        ew_list.append(f"Placeholder {ps} not found in translation")
-            except Exception as e:
-                errors.append(f"Parse error: {e}")
+                require_printf_placeholders_match(
+                    format, orig_msg, msg, errors, warnings
+                )
 
         case Resource.Format.GETTEXT:
             try:
@@ -210,6 +175,57 @@ def run_custom_checks(entity: Entity, string: str) -> dict[str, list[str]]:
     if warnings:
         checks["pndbWarnings"] = warnings
     return checks
+
+
+# Matches all HTML/XML elements and Android & Xcode printf specifiers
+ph_re = compile(
+    r"<[^>]+>|%#@\w+@|%(?:[1-9]\$|<)?[-#+ 0,(]?[0-9.]*(?:hh?|ll?|[qztjLT])?.?"
+)
+
+
+def require_printf_placeholders_match(
+    format: Resource.Format,
+    src: Message | None,
+    tgt: Message,
+    errors: list[str],
+    warnings: list[str],
+) -> None:
+    src_ph_strings: set[str] = set()
+    if src:
+        for pattern in get_patterns(src):
+            for el in pattern:
+                if isinstance(el, str):
+                    if "%" in el:
+                        # If the bare text includes a %, presumably the message is not going
+                        # to be printf-formatted, and so we can exit early.
+                        return
+                elif not (
+                    isinstance(el, Expression)
+                    and isinstance(el.arg, str)
+                    and el.function is None
+                ):
+                    src_ph_strings.add(preview_placeholder(el))
+
+    found_ph: set[str] = set()
+    for pattern in get_patterns(tgt):
+        pat_src = get_simple_preview(format, pattern)
+
+        for pm in ph_re.finditer(pat_src):
+            rest = pat_src[pm.start() :]
+            for ph in src_ph_strings:
+                if rest.startswith(ph):
+                    found_ph.add(ph)
+                    break
+            else:
+                ph = pm[0]
+                if ph not in {"%%", "%n"}:
+                    kind = "Element" if ph.startswith("<") else "Placeholder"
+                    errors.append(f"{kind} {ph} not found in reference")
+
+    for ph in src_ph_strings:
+        if ph not in found_ph:
+            kind = "Element" if ph.startswith("<") else "Placeholder"
+            warnings.append(f"{kind} {ph} not found in translation")
 
 
 def get_patterns(msg: Message) -> Iterable[Pattern]:

--- a/pontoon/checks/libraries/custom.py
+++ b/pontoon/checks/libraries/custom.py
@@ -83,9 +83,7 @@ def run_custom_checks(entity: Entity, string: str) -> dict[str, list[str]]:
                 ):
                     errors.append("Plural translation requires plural source")
 
-                require_printf_placeholders_match(
-                    format, orig_msg, msg, errors, warnings
-                )
+                require_placeholders_match(format, orig_msg, msg, errors, warnings)
 
         case Resource.Format.GETTEXT:
             try:
@@ -183,7 +181,7 @@ ph_re = compile(
 )
 
 
-def require_printf_placeholders_match(
+def require_placeholders_match(
     format: Resource.Format,
     src: Message | None,
     tgt: Message,

--- a/pontoon/checks/tests/test_custom.py
+++ b/pontoon/checks/tests/test_custom.py
@@ -10,7 +10,7 @@ def mock_entity(
     allows_empty_translations: bool = False,
 ):
     match format:
-        case "android":
+        case "android" | "xcode":
             ext = "xml"
         case "fluent":
             ext = "ftl"
@@ -197,9 +197,7 @@ def test_android_percent_signs_more():
     original = "Source string 100%"
     translation = "Translation 100%! string 100%"
     entity = mock_entity("android", string=original)
-    assert run_custom_checks(entity, translation) == {
-        "pErrors": ["Placeholder %! not found in reference"]
-    }
+    assert run_custom_checks(entity, translation) == {}
 
 
 def test_android_literal_newline():
@@ -313,8 +311,8 @@ def test_android_bad_html():
     translation = "Translation with a <a>tag mismatch{|</b>| :html}"
     entity = mock_entity("android", string=original)
     assert run_custom_checks(entity, translation) == {
-        "pErrors": ["Placeholder <a> not found in reference"],
-        "pndbWarnings": ["Placeholder <b> not found in translation"],
+        "pErrors": ["Element <a> not found in reference"],
+        "pndbWarnings": ["Element <b> not found in translation"],
     }
 
 
@@ -388,4 +386,39 @@ def test_webext_extra_named_placeholder_as_placeholder():
     entity = mock_entity("webext", string=original)
     assert run_custom_checks(entity, translation) == {
         "pErrors": ["Placeholder $FOO$ not found in reference"]
+    }
+
+
+def test_xcode_same_placeholder():
+    original = "Source string with a {$arg1 :string @source=|%1$@|}"
+    translation = "Translation with a {$arg1 :string @source=|%1$@|}"
+    entity = mock_entity("xcode", string=original)
+    assert run_custom_checks(entity, translation) == {}
+
+
+def test_xcode_missing_placeholder():
+    original = "Source string with a {$arg :string @source=|%@|}"
+    translation = "Translation"
+    entity = mock_entity("xcode", string=original)
+    assert run_custom_checks(entity, translation) == {
+        "pndbWarnings": ["Placeholder %@ not found in translation"]
+    }
+
+
+def test_xcode_mistyped_placeholder():
+    original = "Source string with a {$arg :string @source=|%@|}"
+    translation = "Translation % @"
+    entity = mock_entity("xcode", string=original)
+    assert run_custom_checks(entity, translation) == {
+        "pErrors": ["Placeholder % @ not found in reference"],
+        "pndbWarnings": ["Placeholder %@ not found in translation"],
+    }
+
+
+def test_xcode_extra_placeholder():
+    original = "Source string"
+    translation = "Translation with a {$arg :string @source=|%@|}"
+    entity = mock_entity("xcode", string=original)
+    assert run_custom_checks(entity, translation) == {
+        "pErrors": ["Placeholder %@ not found in reference"]
     }

--- a/pontoon/checks/tests/test_libraries.py
+++ b/pontoon/checks/tests/test_libraries.py
@@ -176,4 +176,7 @@ def test_tt_xcode_checks():
         "en-US",
         string="You can learn more",
         use_tt_checks=True,
-    ) == {"ttWarnings": ["Ending punctuation", "Printf format string mismatch"]}
+    ) == {
+        "pndbWarnings": ["Placeholder %@ not found in translation"],
+        "ttWarnings": ["Ending punctuation", "Printf format string mismatch"],
+    }


### PR DESCRIPTION
This is effectively a spinoff/follow-up from #4186 and #4188, as I realised that the placeholder checks could be improved, and also applied to Xcode strings.