### PR TITLE
Pass value+properties instead of serialised string in `POST /translations/create`

### DIFF
--- a/pontoon/translations/forms.py
+++ b/pontoon/translations/forms.py
@@ -6,9 +6,7 @@ from moz.l10n.model import Message
 from django import forms
 from django.contrib.postgres.forms import SimpleArrayField
 
-from pontoon.base.models import Entity, Locale
-
-from ..base.models.resource import Resource
+from pontoon.base.models import Entity, Locale, Resource
 from .utils import JsonMessage, serialize_for_db
 
 

--- a/pontoon/translations/forms.py
+++ b/pontoon/translations/forms.py
@@ -7,6 +7,7 @@ from django import forms
 from django.contrib.postgres.forms import SimpleArrayField
 
 from pontoon.base.models import Entity, Locale, Resource
+
 from .utils import JsonMessage, serialize_for_db
 
 

--- a/pontoon/translations/forms.py
+++ b/pontoon/translations/forms.py
@@ -1,10 +1,15 @@
+from typing import Any, cast
+
+from moz.l10n.message import message_from_json
+from moz.l10n.model import Message
+
 from django import forms
 from django.contrib.postgres.forms import SimpleArrayField
 
-from pontoon.base.models import (
-    Entity,
-    Locale,
-)
+from pontoon.base.models import Entity, Locale
+
+from ..base.models.resource import Resource
+from .utils import JsonMessage, serialize_for_db
 
 
 class CreateTranslationForm(forms.Form):
@@ -14,9 +19,8 @@ class CreateTranslationForm(forms.Form):
 
     entity = forms.IntegerField()
     locale = forms.CharField()
-
-    # Some file formats allow empty translations.
-    translation = forms.CharField(required=False)
+    value = forms.JSONField(required=False)
+    properties = forms.JSONField(required=False)
 
     ignore_warnings = forms.BooleanField(required=False)
     approve = forms.BooleanField(required=False)
@@ -40,5 +44,36 @@ class CreateTranslationForm(forms.Form):
         except Locale.DoesNotExist:
             raise forms.ValidationError(f"Locale `{code}` could not be found")
 
-    def clean_translation(self):
-        return self.data.get("translation", "")
+    def clean_value(self) -> Message:
+        value = cast(JsonMessage, self.cleaned_data["value"])
+        if not value and not isinstance(value, list):
+            raise forms.ValidationError("This field is required.")
+        return message_from_json(value).normalize()
+
+    def clean_properties(self) -> dict[str, Message]:
+        properties = cast(dict[str, JsonMessage], self.cleaned_data["properties"])
+        return (
+            {k: message_from_json(v).normalize() for k, v in properties.items()}
+            if properties
+            else {}
+        )
+
+    def clean(self):
+        cleaned_data = cast(dict[str, Any], super().clean())
+        entity = cast(Entity, cleaned_data.get("entity", None))
+        value = cast(Message, cleaned_data.get("value", None))
+        properties = cast(dict[str, Message], cleaned_data.get("properties", None))
+        if entity is None or value is None or properties is None:
+            return
+        format = entity.resource.format
+
+        if properties and format != Resource.Format.FLUENT:
+            raise forms.ValidationError(f"Properties are not supported for {format}")
+
+        try:
+            cleaned_data["string"] = serialize_for_db(entity, value, properties)
+        except Exception as err:
+            value_is = "Value is" if not properties else "Value and properties are"
+            raise forms.ValidationError(
+                f"{value_is} not serializable as {format}"
+            ) from err

--- a/pontoon/translations/tests/test_forms.py
+++ b/pontoon/translations/tests/test_forms.py
@@ -1,5 +1,8 @@
 import pytest
 
+from moz.l10n.model import PatternMessage
+
+from pontoon.test.factories import EntityFactory, ResourceFactory
 from pontoon.translations.forms import CreateTranslationForm
 
 
@@ -24,7 +27,7 @@ def test_create_translation_form_clean_entity(entity_a, locale_a):
     form = CreateTranslationForm(
         {
             "entity": entity_a.pk,
-            "translation": "salut",
+            "value": ["salut"],
             "locale": locale_a.code,
         }
     )
@@ -37,7 +40,7 @@ def test_create_translation_form_clean_entity_invalid(locale_a):
     form = CreateTranslationForm(
         {
             "entity": 42,
-            "translation": "salut",
+            "value": ["salut"],
             "locale": locale_a.code,
         }
     )
@@ -50,7 +53,7 @@ def test_create_translation_form_clean_locale_invalid(entity_a):
     form = CreateTranslationForm(
         {
             "entity": entity_a.pk,
-            "translation": "salut",
+            "value": ["salut"],
             "locale": "invalid",
         }
     )
@@ -63,7 +66,7 @@ def test_create_translation_form_clean_locale(entity_a, locale_a):
     form = CreateTranslationForm(
         {
             "entity": entity_a.pk,
-            "translation": "salut",
+            "value": ["salut"],
             "locale": locale_a.code,
         }
     )
@@ -75,7 +78,7 @@ def test_create_translation_form_clean_locale(entity_a, locale_a):
 def test_create_translation_form_clean_stats(entity_a, locale_a):
     data = {
         "entity": entity_a.pk,
-        "translation": "salut",
+        "value": ["salut"],
         "locale": locale_a.code,
     }
     form = CreateTranslationForm(data)
@@ -97,14 +100,70 @@ def test_create_translation_form_clean_stats(entity_a, locale_a):
     assert not form.is_valid()
 
 
+@pytest.fixture
+def ftl_entity(project_a):
+    resource = ResourceFactory.create(
+        project=project_a, path="file.ftl", format="fluent"
+    )
+    return EntityFactory(
+        resource=resource, key=["key"], value=["value"], string="key = value\n"
+    )
+
+
 @pytest.mark.django_db
-def test_create_translation_form_clean_translation(entity_a, locale_a):
+def test_create_translation_form_clean_value_and_properties(ftl_entity, locale_a):
     form = CreateTranslationForm(
         {
-            "entity": entity_a.pk,
-            "translation": " salut ",
+            "entity": ftl_entity.pk,
+            "value": [" salut "],
+            "properties": {"key": ["prop"]},
             "locale": locale_a.code,
         }
     )
     assert form.is_valid()
-    assert form.cleaned_data["translation"] == " salut "
+    assert form.cleaned_data["value"] == PatternMessage([" salut "])
+    assert form.cleaned_data["properties"] == {"key": PatternMessage(["prop"])}
+    assert form.cleaned_data["string"] == 'key = { " " }salut{ " " }\n    .key = prop\n'
+
+
+@pytest.mark.django_db
+def test_create_translation_form_invalid_value(ftl_entity, locale_a):
+    form = CreateTranslationForm(
+        {
+            "entity": ftl_entity.pk,
+            "value": ["value ", {"elem": "foo"}],
+            "locale": locale_a.code,
+        }
+    )
+    assert not form.is_valid()
+    assert form.errors == {"__all__": ["Value is not serializable as fluent"]}
+
+
+@pytest.mark.django_db
+def test_create_translation_form_invalid_value_and_properties(ftl_entity, locale_a):
+    form = CreateTranslationForm(
+        {
+            "entity": ftl_entity.pk,
+            "value": ["value"],
+            "properties": {"key": [{"elem": "foo"}]},
+            "locale": locale_a.code,
+        }
+    )
+    assert not form.is_valid()
+    assert form.errors == {
+        "__all__": ["Value and properties are not serializable as fluent"]
+    }
+
+
+@pytest.mark.django_db
+def test_create_translation_form_invalid_properties(entity_a, locale_a):
+    form = CreateTranslationForm(
+        {
+            "entity": entity_a.pk,
+            "value": ["value"],
+            "properties": {"key": ["prop"]},
+            "locale": locale_a.code,
+        }
+    )
+    assert not form.is_valid()
+    assert form.errors == {"__all__": ["Properties are not supported for gettext"]}

--- a/pontoon/translations/tests/test_views.py
+++ b/pontoon/translations/tests/test_views.py
@@ -1,3 +1,4 @@
+from json import dumps
 from unittest.mock import patch
 
 import pytest
@@ -9,12 +10,10 @@ from pontoon.checks.models import FailedCheck, Warning
 from pontoon.test.factories import EntityFactory, ResourceFactory, TranslationFactory
 
 
-def request_create_translation(client, **args):
-    update_params = {"ignore_warnings": "true"}
-    update_params.update(args)
+def request_create_translation(client, value, **args):
     return client.post(
         reverse("pontoon.translations.create"),
-        update_params,
+        {"value": dumps(value), "ignore_warnings": "true", **args},
         HTTP_X_REQUESTED_WITH="XMLHttpRequest",
     )
 
@@ -26,7 +25,7 @@ def test_create_translation_success(member, entity_a, locale_a, project_locale_a
         member.client,
         entity=entity_a.pk,
         locale=locale_a.code,
-        translation=content,
+        value=[content],
     )
     assert response.status_code == 200
     assert response.json()["status"]
@@ -48,6 +47,7 @@ def test_create_translation_success_fluent(
         entity=entity.pk,
         locale=locale_a.code,
         translation=string,
+        value=["Bonjour !"],
     )
     assert response.status_code == 200
     assert response.json()["status"]
@@ -68,6 +68,11 @@ def test_create_translation_success_mf2(member, project_a, locale_a, project_loc
         entity=entity.pk,
         locale=locale_a.code,
         translation=string,
+        value=[
+            "le ",
+            {"$": "arg", "fn": "string", "attr": {"source": "%s"}},
+            " message",
+        ],
     )
     assert response.status_code == 200
     assert response.json()["status"]
@@ -86,7 +91,7 @@ def test_create_translation_not_logged_in(client, entity_a, locale_a):
         client,
         entity=entity_a.pk,
         locale=locale_a.code,
-        translation="",
+        value=[],
     )
     assert response.status_code == 302
 
@@ -107,7 +112,7 @@ def test_create_translation_force_suggestions(
         member.client,
         entity=translation_a.entity.pk,
         locale=locale_a.code,
-        translation="approved 0",
+        value=["approved 0"],
     )
     assert response.status_code == 200
     assert Translation.objects.last().approved is True
@@ -116,7 +121,7 @@ def test_create_translation_force_suggestions(
         member.client,
         entity=translation_a.entity.pk,
         locale=locale_a.code,
-        translation="approved translation 0",
+        value=["approved translation 0"],
         force_suggestions="false",
     )
     assert response.status_code == 200
@@ -126,7 +131,7 @@ def test_create_translation_force_suggestions(
         member.client,
         entity=translation_a.entity.pk,
         locale=locale_a.code,
-        translation="unapproved translation 0",
+        value=["unapproved translation 0"],
         force_suggestions="true",
     )
     assert response.status_code == 200
@@ -171,7 +176,7 @@ def test_run_checks_during_translation_update(
         member.client,
         locale=locale_a.code,
         entity=properties_entity.pk,
-        translation="bad  suggestion",
+        value=["bad  suggestion"],
         ignore_warnings="false",
     )
 
@@ -189,7 +194,7 @@ def test_run_checks_during_translation_update(
         member.client,
         entity=properties_entity.pk,
         locale=locale_a.code,
-        translation="bad suggestion \\q %q",
+        value=["bad suggestion \\q %q"],
         ignore_warnings="true",
     )
 
@@ -207,7 +212,7 @@ def test_run_checks_during_translation_update(
         member.client,
         entity=properties_entity.pk,
         locale=locale_a.code,
-        translation="bad suggestion",
+        value=["bad suggestion"],
         ignore_warnings="true",
     )
 
@@ -258,7 +263,7 @@ def test_notify_managers_on_first_contribution(
         member.client,
         entity=translation.entity.pk,
         locale=translation.locale.code,
-        translation="First translation",
+        value=["First translation"],
     )
 
     assert response.status_code == 200
@@ -285,7 +290,7 @@ def test_notify_managers_on_first_contribution(
         member.client,
         entity=second_translation.entity.pk,
         locale=second_translation.locale.code,
-        translation="Second translation",
+        value=["Second translation"],
     )
 
     mock_notify.assert_not_called()

--- a/pontoon/translations/utils.py
+++ b/pontoon/translations/utils.py
@@ -1,11 +1,11 @@
 from typing import Any
 
-from moz.l10n.formats.fluent import fluent_parse_entry
-from moz.l10n.formats.mf2 import mf2_parse_message
-from moz.l10n.message import message_to_json
-from moz.l10n.model import CatchallKey, SelectMessage
+from moz.l10n.formats.fluent import fluent_parse_entry, fluent_serialize_entry
+from moz.l10n.formats.mf2 import mf2_parse_message, mf2_serialize_message
+from moz.l10n.message import message_to_json, serialize_message
+from moz.l10n.model import CatchallKey, Entry, Message, SelectMessage
 
-from pontoon.base.models import Resource
+from pontoon.base.models import Entity, Resource
 
 
 JsonMessage = list[Any] | dict[str, Any]
@@ -40,3 +40,22 @@ def parse_db_string_to_json(
             return message_to_json(msg), None
         case _:
             return [source] if source else [], None
+
+
+def serialize_for_db(
+    entity: Entity, value: Message, properties: dict[str, Message]
+) -> str:
+    match entity.resource.format:
+        case Resource.Format.FLUENT:
+            entry = Entry(tuple(entity.key), value, properties)
+            return fluent_serialize_entry(entry)
+        case (
+            Resource.Format.ANDROID
+            | Resource.Format.GETTEXT
+            | Resource.Format.WEBEXT
+            | Resource.Format.XCODE
+            | Resource.Format.XLIFF
+        ):
+            return mf2_serialize_message(value)
+        case _:
+            return serialize_message(None, value)

--- a/pontoon/translations/views.py
+++ b/pontoon/translations/views.py
@@ -1,8 +1,12 @@
 from typing import cast
 
+from moz.l10n.message import message_to_json
+from moz.l10n.model import Message
+
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.db import transaction
+from django.db.models import Q
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
 from django.template.loader import render_to_string
@@ -26,7 +30,6 @@ from pontoon.checks.utils import are_blocking_checks
 from pontoon.messaging.notifications import send_badge_notification, send_notification
 
 from .forms import CreateTranslationForm
-from .utils import parse_db_string_to_json
 
 
 def _add_stats(response_data, resource: Resource, locale: Locale, stats):
@@ -58,22 +61,22 @@ def create_translation(request):
     Create a new translation.
     """
     form = CreateTranslationForm(request.POST)
-
     if not form.is_valid():
-        problems = []
-        for field, errors in form.errors.items():
-            problems.append(f'Error validating field `{field}`: "{" ".join(errors)}"')
+        problems = [
+            f'Error validating field `{field}`: "{error}"'
+            for field, errors in form.errors.items()
+            for error in errors
+        ]
         return JsonResponse(
             {"status": False, "message": "\n".join(problems)}, status=400
         )
+    req_data = form.cleaned_data
 
-    entity = cast(Entity, form.cleaned_data["entity"])
-    string = form.cleaned_data["translation"]
-    locale = cast(Locale, form.cleaned_data["locale"])
-    ignore_warnings = form.cleaned_data["ignore_warnings"]
-    approve = form.cleaned_data["approve"]
-    force_suggestions = form.cleaned_data["force_suggestions"]
-    stats = form.cleaned_data["stats"]
+    entity = cast(Entity, req_data["entity"])
+    locale = cast(Locale, req_data["locale"])
+    value = cast(Message, req_data["value"])
+    properties = cast(dict[str, Message], req_data["properties"])
+    string = cast(str, req_data["string"])
 
     resource = entity.resource
     project = resource.project
@@ -94,12 +97,15 @@ def create_translation(request):
             status=403,
         )
 
-    translations = Translation.objects.filter(entity=entity, locale=locale)
-
-    same_translations = translations.filter(string=string)
+    json_value = message_to_json(value)
+    json_properties = {k: message_to_json(v) for k, v in properties.items()} or None
 
     # If same translation exists in the DB, don't save it again.
-    if same_translations:
+    if (
+        Translation.objects.filter(entity=entity, locale=locale)
+        .filter(Q(value=json_value, properties=json_properties) | Q(string=string))
+        .exists()
+    ):
         return JsonResponse({"status": False, "same": True})
 
     # Look for failed checks.
@@ -115,29 +121,27 @@ def create_translation(request):
             string,
             user.profile.quality_checks,
         )
-        if are_blocking_checks(failed_checks, ignore_warnings):
+        if are_blocking_checks(failed_checks, req_data["ignore_warnings"]):
             return JsonResponse({"status": False, "failedChecks": failed_checks})
 
-    value, properties = parse_db_string_to_json(resource.format, string)
-
     now = timezone.now()
-    can_translate = user.can_translate(project=project, locale=locale) and (
-        not force_suggestions or approve
+    approved = user.can_translate(project=project, locale=locale) and (
+        not req_data["force_suggestions"] or req_data["approve"]
     )
 
     translation = Translation(
         entity=entity,
         locale=locale,
         string=string,
-        value=value,
-        properties=properties,
+        value=json_value,
+        properties=json_properties,
         user=user,
         date=now,
-        approved=can_translate,
-        machinery_sources=form.cleaned_data["machinery_sources"],
+        approved=approved,
+        machinery_sources=req_data["machinery_sources"],
     )
 
-    if can_translate:
+    if approved:
         translation.approved_user = user
         translation.approved_date = now
 
@@ -145,8 +149,7 @@ def create_translation(request):
 
     log_action(ActionLog.ActionType.TRANSLATION_CREATED, user, translation=translation)
 
-    if translations:
-        translation = entity.reset_active_translation(locale=locale)
+    translation = entity.reset_active_translation(locale=locale)
 
     # When user makes their first contribution to the team, notify team managers
     first_contribution = (
@@ -177,7 +180,7 @@ def create_translation(request):
             )
 
     response_data = {"status": True, "translation": translation.serialize()}
-    _add_stats(response_data, resource, locale, stats)
+    _add_stats(response_data, resource, locale, req_data["stats"])
 
     # Send Translation Champion Badge notification information
     translation_count = user.badges_translation_count

--- a/translate/src/api/translation.ts
+++ b/translate/src/api/translation.ts
@@ -1,5 +1,6 @@
 import { POST } from './utils/base';
 import { getCSRFToken } from './utils/csrfToken';
+import type { MessageEntry } from '~/utils/message';
 import type { TranslationComment } from './comment';
 import type { SourceType } from './machinery';
 
@@ -80,22 +81,26 @@ type CreateTranslationResponse =
  */
 export function createTranslation(
   entityId: number,
-  translation: string,
+  entry: MessageEntry,
   localeCode: string,
   forceSuggestions: boolean,
-  resource: string,
+  allResources: boolean,
   ignoreWarnings: boolean,
   machinerySources: SourceType[],
 ): Promise<CreateTranslationResponse> {
   const payload = new URLSearchParams({
     entity: String(entityId),
-    translation,
+    value: JSON.stringify(entry.value ?? []),
     locale: localeCode,
     force_suggestions: String(forceSuggestions),
     machinery_sources: String(machinerySources),
-    stats: resource == 'all-resources' ? 'all' : 'resource',
+    stats: allResources ? 'all' : 'resource',
   });
 
+  if (entry.attributes?.size) {
+    const attrObj = Object.fromEntries(entry.attributes);
+    payload.append('properties', JSON.stringify(attrObj));
+  }
   if (ignoreWarnings) {
     payload.append('ignore_warnings', ignoreWarnings.toString());
   }

--- a/translate/src/modules/editor/hooks/useSendTranslation.ts
+++ b/translate/src/modules/editor/hooks/useSendTranslation.ts
@@ -57,18 +57,17 @@ export function useSendTranslation(): (ignoreWarnings?: boolean) => void {
     NProgress.start();
     setEditorBusy(true);
 
-    const translation = serializeEntry(entry);
-    const normalizedTranslation = getPlainMessage(translation, entity.format);
+    const allResources = location.resource == 'all-resources';
     const sources =
-      machinery && machinery.translation === normalizedTranslation
+      machinery?.translation === getPlainMessage(entry, entity.format)
         ? machinery.sources
         : [];
     const content = await createTranslation(
       entity.pk,
-      translation,
+      entry,
       locale.code,
       forceSuggestions,
-      location.resource,
+      allResources,
       ignoreWarnings,
       sources,
     );

--- a/translate/src/modules/editor/hooks/useSendTranslation.ts
+++ b/translate/src/modules/editor/hooks/useSendTranslation.ts
@@ -20,7 +20,7 @@ import {
 import { updateResource } from '~/modules/resource/actions';
 import { updateStats } from '~/modules/stats/actions';
 import { useAppDispatch, useAppSelector } from '~/hooks';
-import { serializeEntry, getPlainMessage } from '~/utils/message';
+import { getPlainMessage } from '~/utils/message';
 import { ShowBadgeTooltip } from '~/context/BadgeTooltip';
 
 /**


### PR DESCRIPTION
~Built on top of #4186 and #4187, actual diff is [here](https://github.com/eemeli/pontoon/compare/84ee83b77...eemeli:pontoon:data-api-create) -- so will probably need a rebase before merging.~ _Edit: Done._

---

This simplifies translation saving, as using the data model in the REST API avoids needing to serialize & re-parse messages just for the transit.