### PR TITLE
migrate l10n, /placeable, /project, /resource, /search, /user tests to RTL (partial)

### DIFF
--- a/translate/public/locale/en-US/translate.ftl
+++ b/translate/public/locale/en-US/translate.ftl
@@ -670,6 +670,8 @@ search-FiltersPanel--extra-name-empty = Empty
 search-FiltersPanel--extra-name-fuzzy = Fuzzy
 search-FiltersPanel--extra-name-rejected = Rejected
 search-FiltersPanel--extra-name-missing-without-unreviewed = Missing without Unreviewed
+search-FiltersPanel--toggle-filters-panel =
+    .aria-label = Toggle filters panel
 
 search-FiltersPanel--clear-selection = <glyph></glyph>CLEAR
     .title = Uncheck selected filters

--- a/translate/src/modules/l10n/components/AppLocalizationProvider.test.jsx
+++ b/translate/src/modules/l10n/components/AppLocalizationProvider.test.jsx
@@ -1,4 +1,3 @@
-import { mount } from 'enzyme';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 
@@ -6,6 +5,8 @@ import * as api from '~/api/l10n';
 
 import { AppLocalizationProvider } from './AppLocalizationProvider';
 import { vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { Localized } from '@fluent/react';
 
 describe('<AppLocalizationProvider>', () => {
   beforeAll(() => {
@@ -16,7 +17,7 @@ describe('<AppLocalizationProvider>', () => {
 
   it('fetches a locale when the component mounts', async () => {
     api.fetchL10n.mockResolvedValue('');
-    mount(
+    render(
       <AppLocalizationProvider>
         <div />
       </AppLocalizationProvider>,
@@ -27,17 +28,18 @@ describe('<AppLocalizationProvider>', () => {
   });
 
   it('renders messages and children when loaded', async () => {
-    api.fetchL10n.mockResolvedValue('key = message\n');
-    const wrapper = mount(
+    const testMessage = 'message';
+    api.fetchL10n.mockResolvedValue(`key = ${testMessage}\n`);
+    const { getByText, getByTestId } = render(
       <AppLocalizationProvider>
-        <div id='test' />
+        <Localized id='key'>
+          <div data-testid='test' />
+        </Localized>
       </AppLocalizationProvider>,
     );
     await act(() => new Promise((resolve) => setTimeout(resolve)));
-    wrapper.update();
 
-    const localization = wrapper.find('LocalizationProvider').prop('l10n');
-    expect(localization.getString('key')).toEqual('message');
-    expect(wrapper.find('#test')).toHaveLength(1);
+    getByText(testMessage);
+    getByTestId('test');
   });
 });

--- a/translate/src/modules/placeable/components/Highlight.test.jsx
+++ b/translate/src/modules/placeable/components/Highlight.test.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import { MockLocalizationProvider } from '~/test/utils';
 import { Highlight } from './Highlight';
+import { render } from '@testing-library/react';
 
 const mountMarker = (content, terms = [], search = null) =>
-  mount(
+  render(
     <MockLocalizationProvider>
       <Highlight search={search} terms={terms}>
         {content}
@@ -15,10 +15,9 @@ const mountMarker = (content, terms = [], search = null) =>
 describe('Test parser order', () => {
   it('matches webext placeholder', () => {
     const content = 'You have created $COUNT$ aliases';
-    const wrapper = mountMarker(content);
+    const { getByText } = mountMarker(content);
 
-    expect(wrapper.find('mark')).toHaveLength(1);
-    expect(wrapper.find('mark').text()).toContain('$COUNT$');
+    expect(getByText('$COUNT$').tagName).toBe('MARK');
   });
 });
 
@@ -29,11 +28,11 @@ describe('mark terms', () => {
       terms: [{ text: 'bar' }, { text: 'baz' }],
     };
 
-    const wrapper = mountMarker(string, terms);
+    const { container, getByText } = mountMarker(string, terms);
+    expect(container.querySelectorAll('mark')).toHaveLength(2);
 
-    expect(wrapper.find('mark')).toHaveLength(2);
-    expect(wrapper.find('mark').at(0).text()).toEqual('bar');
-    expect(wrapper.find('mark').at(1).text()).toEqual('baz');
+    expect(getByText('bar').tagName).toBe('MARK');
+    expect(getByText('baz').tagName).toBe('MARK');
   });
 
   it('marks entire words on partial match', () => {
@@ -42,12 +41,12 @@ describe('mark terms', () => {
       terms: [{ text: 'add-on' }],
     };
 
-    const wrapper = mountMarker(string, terms);
+    const { container, getByText } = mountMarker(string, terms);
+    expect(container.querySelectorAll('mark')).toHaveLength(1);
 
-    const mark = wrapper.find('mark');
-    expect(mark).toHaveLength(1);
-    expect(mark.text()).toEqual('Add-Ons');
-    expect(mark.prop('data-match')).toEqual('add-on');
+    const mark = getByText('Add-Ons');
+    expect(mark.tagName).toBe('MARK');
+    expect(mark).toHaveAttribute('data-match', 'add-on');
   });
 
   it('only marks terms at the beginning of the word', () => {
@@ -56,9 +55,9 @@ describe('mark terms', () => {
       terms: [{ text: 'native' }],
     };
 
-    const wrapper = mountMarker(string, terms);
+    const { container } = mountMarker(string, terms);
 
-    expect(wrapper.find('mark')).toHaveLength(0);
+    expect(container.querySelector('mark')).toBeNull();
   });
 
   it('marks longer terms first', () => {
@@ -67,10 +66,10 @@ describe('mark terms', () => {
       terms: [{ text: 'translation' }, { text: 'translation tool' }],
     };
 
-    const wrapper = mountMarker(string, terms);
+    const { getByText, container } = mountMarker(string, terms);
+    expect(container.querySelectorAll('mark')).toHaveLength(1);
 
-    expect(wrapper.find('mark')).toHaveLength(1);
-    expect(wrapper.find('mark').text()).toEqual('translation tool');
+    expect(getByText('translation tool').tagName).toBe('MARK');
   });
 
   it('does not mark terms within placeables', () => {
@@ -80,67 +79,68 @@ describe('mark terms', () => {
       terms: [{ text: 'browser' }, { text: 'version' }],
     };
 
-    const wrapper = mountMarker(string, terms);
+    const { container } = mountMarker(string, terms);
 
-    expect(wrapper.find('mark')).toHaveLength(3);
-    expect(wrapper.find('mark').at(0).text()).toEqual('browser');
-    expect(wrapper.find('mark').at(0).hasClass('term'));
-    expect(wrapper.find('mark').at(1).text()).toEqual('{ $version }');
-    expect(wrapper.find('mark').at(1).hasClass('placeable'));
-    expect(wrapper.find('mark').at(2).text()).toEqual('{ $bits }');
-    expect(wrapper.find('mark').at(2).hasClass('placeable'));
+    const marks = container.querySelectorAll('mark');
+    expect(marks).toHaveLength(3);
+    expect(marks[0]).toHaveTextContent('browser');
+    expect(marks[0]).toHaveClass('term');
+    expect(marks[1]).toHaveTextContent('{ $version }');
+    expect(marks[1]).toHaveClass('placeable');
+    expect(marks[2]).toHaveTextContent('{ $bits }');
+    expect(marks[2]).toHaveClass('placeable');
   });
 });
 
 describe('<Highlight search>', () => {
   it('does not break on regexp special characters', () => {
-    const wrapper = mountMarker('foo (bar)', [], '(bar');
-    expect(wrapper.find('mark.search').text()).toEqual('(bar');
+    const { container } = mountMarker('foo (bar)', [], '(bar');
+    expect(container.querySelector('mark.search')).toHaveTextContent('(bar');
   });
 
   it('does not mark search if empty', () => {
-    const wrapper = mountMarker('123456', [], '');
-    const marks = wrapper.find('mark');
+    const { container } = mountMarker('123456', [], '');
+    const marks = container.querySelectorAll('mark');
     expect(marks).toHaveLength(1);
-    expect(marks.at(0).hasClass('placeable'));
-    expect(marks.at(0).text()).toEqual('123456');
+    expect(marks[0]).toHaveClass('placeable');
+    expect(marks[0]).toHaveTextContent('123456');
   });
 
   it('prefers search marks over placeholders at start of mark', () => {
-    const wrapper = mountMarker('123456', [], '123');
-    const marks = wrapper.find('mark');
+    const { container } = mountMarker('123456', [], '123');
+    const marks = container.querySelectorAll('mark');
     expect(marks).toHaveLength(1);
-    expect(marks.at(0).hasClass('search'));
-    expect(marks.at(0).text()).toEqual('123');
+    expect(marks[0]).toHaveClass('search');
+    expect(marks[0]).toHaveTextContent('123');
   });
 
   it('prefers search marks over placeholders at end of mark', () => {
-    const wrapper = mountMarker('123456', [], '456');
-    const marks = wrapper.find('mark');
+    const { container } = mountMarker('123456', [], '456');
+    const marks = container.querySelectorAll('mark');
     expect(marks).toHaveLength(1);
-    expect(marks.at(0).hasClass('search'));
-    expect(marks.at(0).text()).toEqual('456');
+    expect(marks[0]).toHaveClass('search');
+    expect(marks[0]).toHaveTextContent('456');
   });
 
   it('does not break for lone " quotes', () => {
-    const wrapper = mountMarker('123456"', [], '"');
-    const marks = wrapper.find('mark');
+    const { container } = mountMarker('123456"', [], '"');
+    const marks = container.querySelectorAll('mark');
     expect(marks).toHaveLength(2);
-    expect(marks.at(1).text()).toEqual('"');
+    expect(marks[1]).toHaveTextContent('"');
   });
 
   it('does not break for doubled "" quotes', () => {
-    const wrapper = mountMarker('123456""', [], '""');
-    const marks = wrapper.find('mark');
+    const { container } = mountMarker('123456""', [], '""');
+    const marks = container.querySelectorAll('mark');
     expect(marks).toHaveLength(2);
-    expect(marks.at(1).text()).toEqual('""');
+    expect(marks[1]).toHaveTextContent('""');
   });
 
   it("does not alter source text's capitalization", () => {
-    const wrapper = mountMarker('hello world', [], 'HELLO');
-    const marks = wrapper.find('mark');
+    const { container } = mountMarker('hello world', [], 'HELLO');
+    const marks = container.querySelectorAll('mark');
     expect(marks).toHaveLength(1);
-    expect(marks.at(0).text()).toEqual('hello');
+    expect(marks[0]).toHaveTextContent('hello');
   });
 });
 
@@ -296,12 +296,12 @@ describe('specific marker', () => {
   ];
   for (const [source, ...exp] of tests) {
     test(source, () => {
-      const wrapper = mountMarker(source);
-      const marks = wrapper.find('mark');
+      const { container } = mountMarker(source);
+      const marks = container.querySelectorAll('mark');
       expect(marks).toHaveLength(exp.length);
       for (let i = 0; i < exp.length; ++i) {
-        expect(marks.at(i).hasClass('placeable'));
-        expect(marks.at(i).text()).toEqual(exp[i]);
+        expect(marks[i]).toHaveClass('placeable');
+        expect(marks[i].textContent).toEqual(exp[i]);
       }
     });
   }

--- a/translate/src/modules/project/components/ProjectItem.test.jsx
+++ b/translate/src/modules/project/components/ProjectItem.test.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { shallow } from 'enzyme';
 
 import { ProjectItem } from './ProjectItem';
+import { render } from '@testing-library/react';
 
-function createShallowProjectItem({ slug = 'slug' } = {}) {
-  return shallow(
+function renderProjectItem({ slug = 'slug' } = {}) {
+  return render(
     <ProjectItem
       location={{
         locale: 'locale',
@@ -23,28 +23,28 @@ function createShallowProjectItem({ slug = 'slug' } = {}) {
 
 describe('<ProjectItem>', () => {
   it('renders correctly', () => {
-    const wrapper = createShallowProjectItem();
-    expect(wrapper.find('li')).toHaveLength(1);
-    expect(wrapper.find('a')).toHaveLength(1);
-    expect(wrapper.find('span.project')).toHaveLength(1);
-    expect(wrapper.find('span.percent')).toHaveLength(1);
-    expect(wrapper.find('a').prop('href')).toEqual(
+    const { getByRole, container } = renderProjectItem();
+    getByRole('listitem');
+    expect(container.querySelector('span.project')).toBeInTheDocument();
+    expect(container.querySelector('span.percent')).toBeInTheDocument();
+    expect(getByRole('link')).toHaveAttribute(
+      'href',
       '/locale/slug/all-resources/',
     );
   });
 
   it('sets the className for the current project', () => {
-    const wrapper = createShallowProjectItem({ slug: 'project' });
-    expect(wrapper.find('li.current')).toHaveLength(1);
+    const { getByRole } = renderProjectItem({ slug: 'project' });
+    expect(getByRole('listitem')).toHaveClass('current');
   });
 
   it('sets the className for another project', () => {
-    const wrapper = createShallowProjectItem();
-    expect(wrapper.find('li.current')).toHaveLength(0);
+    const { getByRole } = renderProjectItem();
+    expect(getByRole('listitem')).not.toHaveClass('current');
   });
 
   it('renders completion percentage correctly', () => {
-    const wrapper = createShallowProjectItem();
-    expect(wrapper.find('.percent').text()).toEqual('50%');
+    const { getByText } = renderProjectItem();
+    getByText('50%');
   });
 });

--- a/translate/src/modules/resource/components/ResourceItem.test.jsx
+++ b/translate/src/modules/resource/components/ResourceItem.test.jsx
@@ -2,8 +2,9 @@ import React from 'react';
 
 import { ResourceItem } from './ResourceItem';
 import { render } from '@testing-library/react';
+import { expect } from 'vitest';
 
-function renderResourceItem({ path = 'path' } = {}) {
+function renderResourceItem({ path = 'path', ...otherResourceProps } = {}) {
   return render(
     <ResourceItem
       location={{
@@ -13,6 +14,7 @@ function renderResourceItem({ path = 'path' } = {}) {
       }}
       resource={{
         path: path,
+        ...otherResourceProps,
       }}
     />,
   );
@@ -20,11 +22,20 @@ function renderResourceItem({ path = 'path' } = {}) {
 
 describe('<ResourceItem>', () => {
   it('renders correctly', () => {
-    const { getByRole, container } = renderResourceItem();
+    const path = 'test-path';
+    const { getByRole, getByText } = renderResourceItem({
+      path,
+      approvedStrings: 2,
+      stringsWithWarnings: 2,
+      totalStrings: 10,
+    });
     getByRole('listitem');
-    expect(getByRole('link')).toHaveAttribute('href', '/locale/project/path/');
-    expect(container.querySelector('span.path')).toBeInTheDocument();
-    expect(container.querySelector('span.percent')).toBeInTheDocument();
+    expect(getByRole('link')).toHaveAttribute(
+      'href',
+      `/locale/project/${path}/`,
+    );
+    expect(getByText(path)).toHaveClass('path');
+    expect(getByText('40%')).toHaveClass('percent');
   });
 
   it('sets the className correctly', () => {

--- a/translate/src/modules/resource/components/ResourceItem.test.jsx
+++ b/translate/src/modules/resource/components/ResourceItem.test.jsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import { shallow } from 'enzyme';
 
 import { ResourceItem } from './ResourceItem';
-import { ResourcePercent } from './ResourcePercent';
+import { render } from '@testing-library/react';
 
-function createShallowResourceItem({ path = 'path' } = {}) {
-  return shallow(
+function renderResourceItem({ path = 'path' } = {}) {
+  return render(
     <ResourceItem
       location={{
         locale: 'locale',
@@ -21,19 +20,18 @@ function createShallowResourceItem({ path = 'path' } = {}) {
 
 describe('<ResourceItem>', () => {
   it('renders correctly', () => {
-    const wrapper = createShallowResourceItem();
-    expect(wrapper.find('li')).toHaveLength(1);
-    expect(wrapper.find('a')).toHaveLength(1);
-    expect(wrapper.find('span')).toHaveLength(1);
-    expect(wrapper.find(ResourcePercent)).toHaveLength(1);
-    expect(wrapper.find('a').prop('href')).toEqual('/locale/project/path/');
+    const { getByRole, container } = renderResourceItem();
+    getByRole('listitem');
+    expect(getByRole('link')).toHaveAttribute('href', '/locale/project/path/');
+    expect(container.querySelector('span.path')).toBeInTheDocument();
+    expect(container.querySelector('span.percent')).toBeInTheDocument();
   });
 
   it('sets the className correctly', () => {
-    let wrapper = createShallowResourceItem();
-    expect(wrapper.find('li.current')).toHaveLength(0);
+    let { container } = renderResourceItem();
+    expect(container.querySelector('li.current')).toBeNull();
 
-    wrapper = createShallowResourceItem({ path: 'resource' });
-    expect(wrapper.find('li.current')).toHaveLength(1);
+    container = renderResourceItem({ path: 'resource' }).container;
+    expect(container.querySelector('li.current')).toBeInTheDocument();
   });
 });

--- a/translate/src/modules/resource/components/ResourceMenu.test.jsx
+++ b/translate/src/modules/resource/components/ResourceMenu.test.jsx
@@ -1,4 +1,3 @@
-import { mount } from 'enzyme';
 import { createMemoryHistory } from 'history';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
@@ -11,28 +10,41 @@ import { MockLocalizationProvider } from '~/test/utils';
 
 import { ResourceItem } from './ResourceItem';
 import { ResourceMenu } from './ResourceMenu';
+import { fireEvent, render } from '@testing-library/react';
+import { expect } from 'vitest';
+
+const resources = [
+  { path: 'resourceAbc' },
+  { path: 'resourceBcd' },
+  { path: 'resourceCde' },
+];
+
+const allResourcesText = 'test-all-resource';
+const allProjectsText = 'test-all-projects';
+const resourceFile = 'to.file';
 
 function createResourceMenu({
   project = 'project',
-  resource = 'path/to.file',
+  resource = `path/${resourceFile}`,
 } = {}) {
   const store = createReduxStore({
     resource: {
       allResources: {},
-      resources: [
-        { path: 'resourceAbc' },
-        { path: 'resourceBcd' },
-        { path: 'resourceCde' },
-      ],
+      resources,
     },
   });
   const history = createMemoryHistory({
     initialEntries: [`/locale/${project}/${resource}/`],
   });
-  return mount(
+  return render(
     <Provider store={store}>
       <LocationProvider history={history}>
-        <MockLocalizationProvider>
+        <MockLocalizationProvider
+          resources={[
+            `resource-ResourceMenu--all-resources = ${allResourcesText}`,
+            `resource-ResourceMenu--all-projects = ${allProjectsText}`,
+          ]}
+        >
           <ResourceMenu />
         </MockLocalizationProvider>
       </LocationProvider>
@@ -42,68 +54,63 @@ function createResourceMenu({
 
 describe('<ResourceMenu>', () => {
   it('renders resource menu correctly', () => {
-    const wrapper = createResourceMenu();
-    wrapper.find('.selector').simulate('click');
+    const { getAllByRole, getByRole, container } = createResourceMenu();
+    fireEvent.click(getByRole('button', { name: resourceFile }));
 
-    expect(wrapper.find('.menu .search-wrapper')).toHaveLength(1);
-    expect(wrapper.find('.menu > ul')).toHaveLength(2);
-    expect(wrapper.find('.menu > ul').find(ResourceItem)).toHaveLength(3);
-    expect(wrapper.find('.menu .static-links')).toHaveLength(1);
     expect(
-      wrapper.find('.menu #resource-ResourceMenu--all-resources'),
-    ).toHaveLength(1);
-    expect(
-      wrapper.find('.menu #resource-ResourceMenu--all-projects'),
-    ).toHaveLength(1);
+      container.querySelector('.menu .search-wrapper'),
+    ).toBeInTheDocument();
+    expect(getAllByRole('list')).toHaveLength(2);
+    for (const resource of resources) {
+      getByRole('link', { name: new RegExp(resource.path) });
+    }
+    getByRole('link', { name: new RegExp(allResourcesText) });
+    getByRole('link', { name: new RegExp(allProjectsText) });
   });
 
   it('searches resource items correctly', () => {
     const SEARCH = 'bc';
-    const wrapper = createResourceMenu();
-    wrapper.find('.selector').simulate('click');
+    const { getByRole, queryByRole } = createResourceMenu();
+    fireEvent.click(getByRole('button', { name: resourceFile }));
 
-    act(() => {
-      wrapper.find('.menu .search-wrapper input').prop('onChange')({
-        currentTarget: { value: SEARCH },
-      });
+    fireEvent.change(getByRole('searchbox'), {
+      target: { value: SEARCH },
     });
-    wrapper.update();
 
-    expect(wrapper.find('.menu .search-wrapper input').prop('value')).toEqual(
-      SEARCH,
-    );
-    expect(wrapper.find('.menu > ul').find(ResourceItem)).toHaveLength(2);
+    expect(getByRole('searchbox')).toHaveValue(SEARCH);
+    getByRole('link', { name: new RegExp(resources[0].path) });
+    getByRole('link', { name: new RegExp(resources[1].path) });
+    expect(queryByRole('link', { name: new RegExp(resources[2].path) })).toBeNull();
   });
 
   it('hides resource selector for all-projects', () => {
-    const wrapper = createResourceMenu({ project: 'all-projects' });
+    const { queryByRole } = createResourceMenu({ project: 'all-projects' });
 
-    expect(wrapper.find('.resource-menu .selector')).toHaveLength(0);
+    expect(queryByRole('button')).toBeNull();
   });
 
   it('renders resource selector correctly', () => {
-    const wrapper = createResourceMenu();
+    const { getByRole } = createResourceMenu();
 
-    const selector = wrapper.find('.resource-menu .selector');
-    expect(selector).toHaveLength(1);
-    expect(selector.prop('title')).toEqual('path/to.file');
-    expect(selector.find('span:first-child').text()).toEqual('to.file');
-    expect(selector.find('.icon')).toHaveLength(1);
+    const selector = getByRole('button', { name: resourceFile });
+    expect(selector).toHaveAttribute('title', 'path/to.file');
+    expect(selector.querySelector('span:first-child')).toHaveTextContent(
+      'to.file',
+    );
+    expect(selector.querySelector('.icon')).toBeInTheDocument();
   });
 
   it('sets a localized resource name correctly for all-resources', () => {
-    const wrapper = createResourceMenu({ resource: 'all-resources' });
+    const { getByText } = createResourceMenu({ resource: 'all-resources' });
 
-    expect(wrapper.find('#resource-ResourceMenu--all-resources')).toHaveLength(
-      1,
-    );
+    getByText(allResourcesText);
   });
 
   it('renders resource menu correctly', () => {
-    const wrapper = createResourceMenu();
+    const { container, getByRole } = createResourceMenu();
 
-    expect(wrapper.find('ResourceMenuDialog')).toHaveLength(0);
-    wrapper.find('.selector').simulate('click');
-    expect(wrapper.find('ResourceMenuDialog')).toHaveLength(1);
+    expect(container.querySelector('.menu')).toBeNull();
+    fireEvent.click(getByRole('button', { name: resourceFile }));
+    expect(container.querySelector('.menu')).toBeInTheDocument();
   });
 });

--- a/translate/src/modules/resource/components/ResourceMenu.test.jsx
+++ b/translate/src/modules/resource/components/ResourceMenu.test.jsx
@@ -80,7 +80,9 @@ describe('<ResourceMenu>', () => {
     expect(getByRole('searchbox')).toHaveValue(SEARCH);
     getByRole('link', { name: new RegExp(resources[0].path) });
     getByRole('link', { name: new RegExp(resources[1].path) });
-    expect(queryByRole('link', { name: new RegExp(resources[2].path) })).toBeNull();
+    expect(
+      queryByRole('link', { name: new RegExp(resources[2].path) }),
+    ).toBeNull();
   });
 
   it('hides resource selector for all-projects', () => {

--- a/translate/src/modules/resource/components/ResourceMenu.tsx
+++ b/translate/src/modules/resource/components/ResourceMenu.tsx
@@ -232,6 +232,7 @@ export function ResourceMenu({
       <div
         className='selector unselectable'
         onClick={toggleVisible}
+        role='button'
         title={resource}
       >
         <span>{resourceName}</span>

--- a/translate/src/modules/resource/components/ResourcePercent.test.jsx
+++ b/translate/src/modules/resource/components/ResourcePercent.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-
 import { ResourcePercent } from './ResourcePercent';
+import { render } from '@testing-library/react';
 
 describe('<ResourcePercent>', () => {
   const RESOURCE = {
@@ -12,7 +11,7 @@ describe('<ResourcePercent>', () => {
   };
 
   it('renders correctly', () => {
-    const wrapper = shallow(<ResourcePercent resource={RESOURCE} />);
-    expect(wrapper.find('.percent').text()).toEqual('40%');
+    const { getByText } = render(<ResourcePercent resource={RESOURCE} />);
+    getByText('40%');
   });
 });

--- a/translate/src/modules/search/components/FiltersPanel.test.jsx
+++ b/translate/src/modules/search/components/FiltersPanel.test.jsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import { shallow } from 'enzyme';
 import { expect } from 'vitest';
 
 import { createReduxStore, mountComponentWithStore } from '~/test/store';
-
+import { MockLocalizationProvider } from '~/test/utils';
 import { FiltersPanel, FiltersPanelDialog } from './FiltersPanel';
 import { FILTERS_STATUS, FILTERS_EXTRA } from '../constants';
-import { fireEvent } from '@testing-library/react';
+import { fireEvent, render, within } from '@testing-library/react';
 
 describe('<FiltersPanelDialog>', () => {
   it('correctly sets filter as selected', () => {
@@ -192,53 +191,76 @@ describe('<FiltersPanelDialog>', () => {
 });
 
 describe('<FiltersPanel>', () => {
+  const FilterPanelDialogTitle = 'TRANSLATION STATUS';
   it('shows a panel with filters on click', () => {
-    const wrapper = shallow(
-      <FiltersPanel
-        filters={{ authors: [], extras: [], statuses: [], tags: [] }}
-        authorsData={[]}
-        tagsData={[]}
-        timeRangeData={[]}
-        parameters={{}}
-        getAuthorsAndTimeRangeData={vi.fn()}
-        updateFiltersFromURL={vi.fn()}
-      />,
+    const store = createReduxStore();
+    const { getByText, queryByText, getByRole } = mountComponentWithStore(
+      FiltersPanel,
+      store,
+      {
+        filters: { authors: [], extras: [], statuses: [], tags: [] },
+        authorsData: [],
+        tagsData: [],
+        timeRangeData: [],
+        parameters: {},
+        getAuthorsAndTimeRangeData: vi.fn(),
+        updateFiltersFromURL: vi.fn(),
+      },
     );
 
-    expect(wrapper.find('FiltersPanelDialog')).toHaveLength(0);
-    wrapper.find('.visibility-switch').simulate('click');
-    expect(wrapper.find('FiltersPanelDialog')).toHaveLength(1);
+    expect(queryByText(FilterPanelDialogTitle)).toBeNull();
+    fireEvent.click(getByRole('button'));
+    getByText(FilterPanelDialogTitle);
   });
 
   it('has the correct icon based on parameters', () => {
+    const toggleAriaLabel = 'Toggle';
     for (const { slug } of FILTERS_STATUS) {
-      const wrapper = shallow(
-        <FiltersPanel
-          filters={{ authors: [], extras: [], statuses: [slug], tags: [] }}
-          authorsData={[]}
-          tagsData={[]}
-          timeRangeData={[]}
-          parameters={{}}
-          getAuthorsAndTimeRangeData={vi.fn()}
-        />,
+      const { container } = mountComponentWithStore(
+        FiltersPanel,
+        createReduxStore(),
+        {
+          filters: { authors: [], extras: [], statuses: [slug], tags: [] },
+          authorsData: [],
+          tagsData: [],
+          timeRangeData: [],
+          parameters: {},
+          getAuthorsAndTimeRangeData: vi.fn(),
+        },
+        undefined,
+        [
+          `search-FiltersPanel--toggle-filters-panel =
+            .aria-label = ${toggleAriaLabel}`
+        ],
       );
 
-      expect(wrapper.find('.visibility-switch').hasClass(slug)).toBeTruthy();
+      const button = within(container).getByRole('button', { name: toggleAriaLabel });
+      expect(button).toHaveClass('visibility-switch');
+      expect(button).toHaveClass(slug);
     }
 
     for (const { slug } of FILTERS_EXTRA) {
-      const wrapper = shallow(
-        <FiltersPanel
-          filters={{ authors: [], extras: [slug], statuses: [], tags: [] }}
-          authorsData={[]}
-          tagsData={[]}
-          timeRangeData={[]}
-          parameters={{}}
-          getAuthorsAndTimeRangeData={vi.fn()}
-        />,
+      const { container } = mountComponentWithStore(
+        FiltersPanel,
+        createReduxStore(),
+        {
+          filters: { authors: [], extras: [slug], statuses: [], tags: [] },
+          authorsData: [],
+          tagsData: [],
+          timeRangeData: [],
+          parameters: {},
+          getAuthorsAndTimeRangeData: vi.fn(),
+        },
+        undefined,
+        [
+          `search-FiltersPanel--toggle-filters-panel =
+            .aria-label = ${toggleAriaLabel}`
+        ],
       );
-
-      expect(wrapper.find('.visibility-switch').hasClass(slug)).toBeTruthy();
+ 
+      const button = within(container).getByRole('button', { name: toggleAriaLabel });
+      expect(button).toHaveClass('visibility-switch');
+      expect(button).toHaveClass(slug);
     }
   });
 });

--- a/translate/src/modules/search/components/FiltersPanel.test.jsx
+++ b/translate/src/modules/search/components/FiltersPanel.test.jsx
@@ -230,11 +230,13 @@ describe('<FiltersPanel>', () => {
         undefined,
         [
           `search-FiltersPanel--toggle-filters-panel =
-            .aria-label = ${toggleAriaLabel}`
+            .aria-label = ${toggleAriaLabel}`,
         ],
       );
 
-      const button = within(container).getByRole('button', { name: toggleAriaLabel });
+      const button = within(container).getByRole('button', {
+        name: toggleAriaLabel,
+      });
       expect(button).toHaveClass('visibility-switch');
       expect(button).toHaveClass(slug);
     }
@@ -254,11 +256,13 @@ describe('<FiltersPanel>', () => {
         undefined,
         [
           `search-FiltersPanel--toggle-filters-panel =
-            .aria-label = ${toggleAriaLabel}`
+            .aria-label = ${toggleAriaLabel}`,
         ],
       );
- 
-      const button = within(container).getByRole('button', { name: toggleAriaLabel });
+
+      const button = within(container).getByRole('button', {
+        name: toggleAriaLabel,
+      });
       expect(button).toHaveClass('visibility-switch');
       expect(button).toHaveClass(slug);
     }

--- a/translate/src/modules/search/components/FiltersPanel.tsx
+++ b/translate/src/modules/search/components/FiltersPanel.tsx
@@ -439,12 +439,15 @@ export function FiltersPanel({
 
   return (
     <div className='filters-panel'>
-      <div
-        className={`visibility-switch ${filterIcon}`}
-        onClick={toggleVisible}
-      >
-        <span className='status fas'></span>
-      </div>
+      <Localized id='search-FiltersPanel--toggle-filters-panel' attrs={{ 'aria-label': true }}>
+        <div
+          className={`visibility-switch ${filterIcon}`}
+          role='button'
+          onClick={toggleVisible}
+        >
+          <span className='status fas'></span>
+        </div>
+      </Localized>
       {visible ? (
         <FiltersPanelDialog
           authorsData={authorsData}

--- a/translate/src/modules/search/components/FiltersPanel.tsx
+++ b/translate/src/modules/search/components/FiltersPanel.tsx
@@ -439,7 +439,10 @@ export function FiltersPanel({
 
   return (
     <div className='filters-panel'>
-      <Localized id='search-FiltersPanel--toggle-filters-panel' attrs={{ 'aria-label': true }}>
+      <Localized
+        id='search-FiltersPanel--toggle-filters-panel'
+        attrs={{ 'aria-label': true }}
+      >
         <div
           className={`visibility-switch ${filterIcon}`}
           role='button'

--- a/translate/src/modules/search/components/SearchBox.test.jsx
+++ b/translate/src/modules/search/components/SearchBox.test.jsx
@@ -5,6 +5,7 @@ import { act } from 'react-dom/test-utils';
 import { expect, vi } from 'vitest';
 
 import { createReduxStore, mountComponentWithStore } from '~/test/store';
+import { MockLocalizationProvider } from '~/test/utils';
 
 import { FILTERS_EXTRA, FILTERS_STATUS } from '../constants';
 import { SearchBox, SearchBoxBase } from './SearchBox';
@@ -18,6 +19,14 @@ const SEARCH_AND_FILTERS = {
   authors: [],
   countsPerMinute: [],
 };
+
+function WrapSearchBoxBase(props) {
+  return (
+    <MockLocalizationProvider>
+      <SearchBoxBase {...props} />
+    </MockLocalizationProvider>
+  );
+}
 
 describe('<SearchBoxBase>', () => {
   it('shows a search input', () => {
@@ -38,7 +47,7 @@ describe('<SearchBoxBase>', () => {
   it('has the correct placeholder based on parameters', () => {
     for (const { name, slug } of FILTERS_STATUS) {
       const wrapper = mount(
-        <SearchBoxBase
+        <WrapSearchBoxBase
           parameters={{ status: slug }}
           project={PROJECT}
           searchAndFilters={SEARCH_AND_FILTERS}
@@ -49,7 +58,7 @@ describe('<SearchBoxBase>', () => {
 
     for (const { name, slug } of FILTERS_EXTRA) {
       const wrapper = mount(
-        <SearchBoxBase
+        <WrapSearchBoxBase
           parameters={{ extra: slug }}
           project={PROJECT}
           searchAndFilters={SEARCH_AND_FILTERS}
@@ -61,7 +70,7 @@ describe('<SearchBoxBase>', () => {
 
   it('empties the search field after navigation parameter "search" gets removed', () => {
     const wrapper = mount(
-      <SearchBoxBase
+      <WrapSearchBoxBase
         parameters={{ search: 'search' }}
         project={PROJECT}
         searchAndFilters={SEARCH_AND_FILTERS}
@@ -78,7 +87,7 @@ describe('<SearchBoxBase>', () => {
 
   it('toggles a filter', () => {
     const wrapper = mount(
-      <SearchBoxBase
+      <WrapSearchBoxBase
         parameters={{}}
         project={PROJECT}
         searchAndFilters={SEARCH_AND_FILTERS}
@@ -99,7 +108,7 @@ describe('<SearchBoxBase>', () => {
 
   it('sets a single filter', () => {
     const wrapper = mount(
-      <SearchBoxBase
+      <WrapSearchBoxBase
         dispatch={() => {}}
         parameters={{ push() {} }}
         project={PROJECT}
@@ -124,7 +133,7 @@ describe('<SearchBoxBase>', () => {
 
   it('sets multiple & resets to initial statuses', () => {
     const wrapper = mount(
-      <SearchBoxBase
+      <WrapSearchBoxBase
         parameters={{}}
         project={PROJECT}
         searchAndFilters={SEARCH_AND_FILTERS}
@@ -163,7 +172,7 @@ describe('<SearchBoxBase>', () => {
   it('sets status to null when "all" is selected', () => {
     const push = vi.fn();
     const wrapper = mount(
-      <SearchBoxBase
+      <WrapSearchBoxBase
         dispatch={(a) => (typeof a === 'function' ? a() : {})}
         parameters={{ push }}
         project={PROJECT}
@@ -194,7 +203,7 @@ describe('<SearchBoxBase>', () => {
   it('sets correct status', () => {
     const push = vi.fn();
     const wrapper = mount(
-      <SearchBoxBase
+      <WrapSearchBoxBase
         dispatch={(a) => (typeof a === 'function' ? a() : {})}
         parameters={{ push }}
         project={PROJECT}
@@ -238,7 +247,7 @@ describe('<SearchBoxBase>', () => {
 
   it('applies profile default for search_identifiers when URL param is not provided', () => {
     const wrapper = mount(
-      <SearchBoxBase
+      <WrapSearchBoxBase
         parameters={{}}
         project={PROJECT}
         searchAndFilters={SEARCH_AND_FILTERS}
@@ -254,7 +263,7 @@ describe('<SearchBoxBase>', () => {
 
   it('URL param takes precedence over profile default for search_identifiers', () => {
     const wrapper = mount(
-      <SearchBoxBase
+      <WrapSearchBoxBase
         parameters={{ search_identifiers: false }}
         project={PROJECT}
         searchAndFilters={SEARCH_AND_FILTERS}
@@ -270,7 +279,7 @@ describe('<SearchBoxBase>', () => {
 
   it('falls back to global defaults when both URL params and profile settings are not provided', () => {
     const wrapper = mount(
-      <SearchBoxBase
+      <WrapSearchBoxBase
         parameters={{}}
         project={PROJECT}
         searchAndFilters={SEARCH_AND_FILTERS}
@@ -289,7 +298,7 @@ describe('<SearchBoxBase>', () => {
 
   it('applies profile defaults for all search options when URL params are not provided', () => {
     const wrapper = mount(
-      <SearchBoxBase
+      <WrapSearchBoxBase
         parameters={{}}
         project={PROJECT}
         searchAndFilters={SEARCH_AND_FILTERS}
@@ -317,7 +326,7 @@ describe('<SearchBoxBase>', () => {
     // search_identifiers as false in the UI, matching what the backend uses,
     // even if the profile default is true.
     const wrapper = mount(
-      <SearchBoxBase
+      <WrapSearchBoxBase
         parameters={{ search: 'foo' }}
         project={PROJECT}
         searchAndFilters={SEARCH_AND_FILTERS}
@@ -334,7 +343,7 @@ describe('<SearchBoxBase>', () => {
   it('encodes search options that differ from the global default, omits those matching it', () => {
     const push = vi.fn();
     const wrapper = mount(
-      <SearchBoxBase
+      <WrapSearchBoxBase
         dispatch={(a) => (typeof a === 'function' ? a() : {})}
         parameters={{ push, search: '' }}
         project={PROJECT}
@@ -369,7 +378,7 @@ describe('<SearchBoxBase>', () => {
   it('omits a search option from URL when user unchecks a profile-default-true option', () => {
     const push = vi.fn();
     const wrapper = mount(
-      <SearchBoxBase
+      <WrapSearchBoxBase
         dispatch={(a) => (typeof a === 'function' ? a() : {})}
         parameters={{ push, search: '', search_identifiers: true }}
         project={PROJECT}
@@ -444,7 +453,7 @@ describe('<SearchBox>', () => {
 
   it('puts focus on the search input on Ctrl + Shift + F', () => {
     const wrapper = mount(
-      <SearchBoxBase
+      <WrapSearchBoxBase
         parameters={{ search: '' }}
         project={PROJECT}
         searchAndFilters={SEARCH_AND_FILTERS}

--- a/translate/src/modules/teamcomments/components/CommentCount.test.jsx
+++ b/translate/src/modules/teamcomments/components/CommentCount.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { shallow } from 'enzyme';
 
 import { CommentCount } from './CommentCount';
+import { render } from '@testing-library/react';
 
 describe('<CommentCount>', () => {
   it('shows the correct number of pinned comments', () => {
@@ -15,31 +15,31 @@ describe('<CommentCount>', () => {
         },
       ],
     };
-    const wrapper = shallow(<CommentCount teamComments={teamComments} />);
+    const { container } = render(<CommentCount teamComments={teamComments} />);
 
     // There are only pinned results.
-    expect(wrapper.find('.count > span')).toHaveLength(1);
+    expect(container.querySelectorAll('.count > span')).toHaveLength(1);
 
     // And there are two of them.
-    expect(wrapper.find('.pinned').text()).toContain('2');
+    expect(container.querySelector('.pinned')).toHaveTextContent('2');
 
-    expect(wrapper.text()).not.toContain('+');
+    expect(container).not.toHaveTextContent('+');
   });
 
   it('shows the correct number of remaining comments', () => {
     const teamComments = {
       comments: [{}, {}, {}],
     };
-    const wrapper = shallow(<CommentCount teamComments={teamComments} />);
+    const { container } = render(<CommentCount teamComments={teamComments} />);
 
     // There are only remaining results.
-    expect(wrapper.find('.count > span')).toHaveLength(1);
-    expect(wrapper.find('.pinned')).toHaveLength(0);
+    expect(container.querySelectorAll('.count > span')).toHaveLength(1);
+    expect(container.querySelector('.pinned')).toBeNull();
 
     // And there are three of them.
-    expect(wrapper.find('.count > span').text()).toContain('3');
+    expect(container.querySelector('.count > span')).toHaveTextContent('3');
 
-    expect(wrapper.text()).not.toContain('+');
+    expect(container).not.toHaveTextContent('+');
   });
 
   it('shows the correct numbers of pinned and remaining comments', () => {
@@ -56,16 +56,17 @@ describe('<CommentCount>', () => {
         {},
       ],
     };
-    const wrapper = shallow(<CommentCount teamComments={teamComments} />);
+    const { container } = render(<CommentCount teamComments={teamComments} />);
 
+    const spans = container.querySelectorAll('.count > span');
     // There are both pinned and remaining, and the '+' sign.
-    expect(wrapper.find('.count > span')).toHaveLength(3);
+    expect(spans).toHaveLength(3);
 
     // And each count is correct.
-    expect(wrapper.find('.pinned').text()).toContain('2');
-    expect(wrapper.find('.count > span').last().text()).toContain('3');
+    expect(container.querySelector('.pinned')).toHaveTextContent('2');
+    expect(spans[spans.length - 1]).toHaveTextContent('3');
 
     // And the final display is correct as well.
-    expect(wrapper.text()).toEqual('2+3');
+    expect(container).toHaveTextContent('2+3');
   });
 });

--- a/translate/src/modules/unsavedchanges/components/UnsavedChangesPopup.test.jsx
+++ b/translate/src/modules/unsavedchanges/components/UnsavedChangesPopup.test.jsx
@@ -1,4 +1,3 @@
-import { mount } from 'enzyme';
 import React from 'react';
 
 import { UnsavedActions, UnsavedChanges } from '~/context/UnsavedChanges';
@@ -6,9 +5,15 @@ import { MockLocalizationProvider } from '~/test/utils';
 
 import { UnsavedChangesPopup } from './UnsavedChangesPopup';
 import { vi } from 'vitest';
+import { fireEvent, render } from '@testing-library/react';
+
+const closeButtonText = 'Close unsaved changes popup';
+const proceedButtonText = 'PROCEED';
+const titleText = 'YOU HAVE UNSAVED CHANGES';
+const bodyText = 'Are you sure you want to proceed?';
 
 const mountPopup = (onIgnore, resetUnsavedChanges) =>
-  mount(
+  render(
     <MockLocalizationProvider>
       <UnsavedChanges.Provider value={{ onIgnore }}>
         <UnsavedActions.Provider value={{ resetUnsavedChanges }}>
@@ -20,34 +25,34 @@ const mountPopup = (onIgnore, resetUnsavedChanges) =>
 
 describe('<UnsavedChangesPopup>', () => {
   it('renders correctly if shown', () => {
-    const wrapper = mountPopup(() => {});
+    const { container, getByRole, getByText } = mountPopup(() => {});
 
-    expect(wrapper.find('.unsaved-changes')).toHaveLength(1);
-    expect(wrapper.find('.close')).toHaveLength(1);
-    expect(wrapper.find('.title')).toHaveLength(1);
-    expect(wrapper.find('.body')).toHaveLength(1);
-    expect(wrapper.find('.proceed.anyway')).toHaveLength(1);
+    expect(container.querySelector('.unsaved-changes')).toBeInTheDocument();
+    getByRole('button', { name: closeButtonText });
+    getByText(titleText);
+    getByText(bodyText);
+    getByRole('button', { name: proceedButtonText });
   });
 
   it('does not render if not shown', () => {
-    const wrapper = mountPopup(null);
+    const { container } = mountPopup(null);
 
-    expect(wrapper.find('.unsaved-changes')).toHaveLength(0);
+    expect(container).toBeEmptyDOMElement();
   });
 
   it('closes the unsaved changes popup when the Close button is clicked', () => {
     const resetUnsavedChanges = vi.fn();
-    const wrapper = mountPopup(() => {}, resetUnsavedChanges);
+    const { getByRole } = mountPopup(() => {}, resetUnsavedChanges);
 
-    wrapper.find('.close').simulate('click');
+    fireEvent.click(getByRole('button', { name: closeButtonText }));
     expect(resetUnsavedChanges).toHaveBeenCalledWith(false);
   });
 
   it('ignores the unsaved changes popup when the Proceed button is clicked', () => {
     const resetUnsavedChanges = vi.fn();
-    const wrapper = mountPopup(() => {}, resetUnsavedChanges);
+    const { getByRole } = mountPopup(() => {}, resetUnsavedChanges);
 
-    wrapper.find('.proceed.anyway').simulate('click');
+    fireEvent.click(getByRole('button', { name: proceedButtonText }));
     expect(resetUnsavedChanges).toHaveBeenCalledWith(true);
   });
 });

--- a/translate/src/modules/user/components/UserAutoUpdater.test.jsx
+++ b/translate/src/modules/user/components/UserAutoUpdater.test.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import { mount } from 'enzyme';
 
 import { UserAutoUpdater } from './UserAutoUpdater';
 import { vi } from 'vitest';
+import { render } from '@testing-library/react';
 
 describe('<UserAutoUpdater>', () => {
   it('fetches user data on mount', () => {
     const getUserData = vi.fn();
-    mount(<UserAutoUpdater getUserData={getUserData} />);
+    render(<UserAutoUpdater getUserData={getUserData} />);
 
     expect(getUserData).toHaveBeenCalledOnce();
   });
@@ -16,7 +16,7 @@ describe('<UserAutoUpdater>', () => {
     vi.useFakeTimers();
 
     const getUserData = vi.fn();
-    mount(<UserAutoUpdater getUserData={getUserData} />);
+    render(<UserAutoUpdater getUserData={getUserData} />);
 
     vi.advanceTimersByTime(2 * 60 * 1000);
     expect(getUserData).toHaveBeenCalledTimes(2);

--- a/translate/src/modules/user/components/UserNotification.test.jsx
+++ b/translate/src/modules/user/components/UserNotification.test.jsx
@@ -1,7 +1,7 @@
-import { mount } from 'enzyme';
 import React from 'react';
 import { UserNotification } from './UserNotification';
 import { vi } from 'vitest';
+import { render } from '@testing-library/react';
 
 vi.mock('react-time-ago', () => {
   return {
@@ -27,11 +27,13 @@ describe('<UserNotification>', () => {
       ...notificationBase,
       description: { content: 'Unreviewed suggestions: <b id="foo">foo</b>' },
     };
-    const wrapper = mount(<UserNotification notification={notification} />);
+    const { container } = render(
+      <UserNotification notification={notification} />,
+    );
 
-    // https://github.com/enzymejs/enzyme/issues/419
-    const desc = wrapper.find('span.description').render();
-    expect(desc.find('b#foo')).toHaveLength(1);
+    expect(
+      container.querySelector('span.description b#foo'),
+    ).toBeInTheDocument();
   });
 
   it('shows a "has reviewed suggestions" notification', () => {
@@ -40,11 +42,13 @@ describe('<UserNotification>', () => {
       description: { content: 'Reviewed: <b id="bar">bar</b>' },
       verb: 'has reviewed suggestions',
     };
-    const wrapper = mount(<UserNotification notification={notification} />);
+    const { container } = render(
+      <UserNotification notification={notification} />,
+    );
 
-    // https://github.com/enzymejs/enzyme/issues/419
-    const desc = wrapper.find('span.description').render();
-    expect(desc.find('b#bar')).toHaveLength(1);
+    expect(
+      container.querySelector('span.description b#bar'),
+    ).toBeInTheDocument();
   });
 
   it('shows a comment notification', () => {
@@ -55,9 +59,11 @@ describe('<UserNotification>', () => {
         is_comment: true,
       },
     };
-    const wrapper = mount(<UserNotification notification={notification} />);
+    const { container } = render(
+      <UserNotification notification={notification} />,
+    );
 
-    expect(wrapper.find('.message.trim b#baz')).toHaveLength(1);
+    expect(container.querySelector('.message.trim b#baz')).toBeInTheDocument();
   });
 
   it('shows other notification with description', () => {
@@ -65,11 +71,11 @@ describe('<UserNotification>', () => {
       ...notificationBase,
       description: { content: 'Other: <b id="fuzz">fuzz</b>' },
     };
-    const wrapper = mount(<UserNotification notification={notification} />);
+    const { container } = render(
+      <UserNotification notification={notification} />,
+    );
 
-    // https://github.com/enzymejs/enzyme/issues/419
-    const desc = wrapper.find('.message').render();
-    expect(desc.find('b#fuzz')).toHaveLength(1);
+    expect(container.querySelector('.message b#fuzz')).toBeInTheDocument();
   });
 
   it('shows other notification without description', () => {
@@ -78,10 +84,12 @@ describe('<UserNotification>', () => {
       description: { content: null },
       verb: 'is Other',
     };
-    const wrapper = mount(<UserNotification notification={notification} />);
+    const { container } = render(
+      <UserNotification notification={notification} />,
+    );
 
-    expect(wrapper.find('.message')).toHaveLength(0);
-    expect(wrapper.find('.verb').text()).toBe('is Other');
+    expect(container.querySelector('.message')).toBeNull();
+    expect(container.querySelector('.verb')).toHaveTextContent('is Other');
   });
 
   it('shows comment notification with deleted actor', () => {
@@ -93,9 +101,11 @@ describe('<UserNotification>', () => {
         is_comment: true,
       },
     };
-    const wrapper = mount(<UserNotification notification={notification} />);
+    const { container } = render(
+      <UserNotification notification={notification} />,
+    );
 
-    expect(wrapper.find('.actor').text()).toBe('Deleted User');
+    expect(container.querySelector('.actor')).toHaveTextContent('Deleted User');
   });
 
   it('shows other notification with deleted actor', () => {
@@ -104,9 +114,11 @@ describe('<UserNotification>', () => {
       actor: null,
       description: { content: 'Other content' },
     };
-    const wrapper = mount(<UserNotification notification={notification} />);
+    const { container } = render(
+      <UserNotification notification={notification} />,
+    );
 
-    expect(wrapper.find('.actor').text()).toBe('Deleted User');
-    expect(wrapper.find('.actor a')).toHaveLength(0);
+    expect(container.querySelector('.actor')).toHaveTextContent('Deleted User');
+    expect(container.querySelector('.actor a')).toBeNull();
   });
 });

--- a/translate/src/modules/user/components/UserNotification.test.jsx
+++ b/translate/src/modules/user/components/UserNotification.test.jsx
@@ -27,13 +27,13 @@ describe('<UserNotification>', () => {
       ...notificationBase,
       description: { content: 'Unreviewed suggestions: <b id="foo">foo</b>' },
     };
-    const { container } = render(
+    const { getByText } = render(
       <UserNotification notification={notification} />,
     );
 
-    expect(
-      container.querySelector('span.description b#foo'),
-    ).toBeInTheDocument();
+    const element = getByText('foo');
+    expect(element).toHaveAttribute('id', 'foo');
+    expect(element.closest('span.description')).toBeInTheDocument();
   });
 
   it('shows a "has reviewed suggestions" notification', () => {
@@ -42,13 +42,13 @@ describe('<UserNotification>', () => {
       description: { content: 'Reviewed: <b id="bar">bar</b>' },
       verb: 'has reviewed suggestions',
     };
-    const { container } = render(
+    const { getByText } = render(
       <UserNotification notification={notification} />,
     );
 
-    expect(
-      container.querySelector('span.description b#bar'),
-    ).toBeInTheDocument();
+    const element = getByText('bar');
+    expect(element).toHaveAttribute('id', 'bar');
+    expect(element.closest('span.description')).toBeInTheDocument();
   });
 
   it('shows a comment notification', () => {
@@ -59,11 +59,13 @@ describe('<UserNotification>', () => {
         is_comment: true,
       },
     };
-    const { container } = render(
+    const { getByText } = render(
       <UserNotification notification={notification} />,
     );
 
-    expect(container.querySelector('.message.trim b#baz')).toBeInTheDocument();
+    const element = getByText('baz');
+    expect(element).toHaveAttribute('id', 'baz');
+    expect(element.closest('.message.trim')).toBeInTheDocument();
   });
 
   it('shows other notification with description', () => {
@@ -71,11 +73,13 @@ describe('<UserNotification>', () => {
       ...notificationBase,
       description: { content: 'Other: <b id="fuzz">fuzz</b>' },
     };
-    const { container } = render(
+    const { getByText } = render(
       <UserNotification notification={notification} />,
     );
 
-    expect(container.querySelector('.message b#fuzz')).toBeInTheDocument();
+    const element = getByText('fuzz');
+    expect(element).toHaveAttribute('id', 'fuzz');
+    expect(element.closest('.message')).toBeInTheDocument();
   });
 
   it('shows other notification without description', () => {

--- a/translate/src/modules/user/components/UserNotificationsMenu.test.jsx
+++ b/translate/src/modules/user/components/UserNotificationsMenu.test.jsx
@@ -16,7 +16,7 @@ const WrapUserNotificationsMenuDialog = (props) => {
     </MockLocalizationProvider>
   );
 };
-const NoNotificationText = 'No new notifications.';
+const noNotificationText = 'No new notifications.';
 
 describe('<UserNotificationsMenuDialog>', () => {
   it('shows empty notifications menu if user has no notifications', () => {
@@ -28,7 +28,7 @@ describe('<UserNotificationsMenuDialog>', () => {
     expect(
       container.querySelector('.notification-list .user-notification'),
     ).toBeNull();
-    getByText(NoNotificationText);
+    getByText(noNotificationText);
   });
 
   it('shows a notification in the notifications menu', () => {
@@ -56,7 +56,7 @@ describe('<UserNotificationsMenuDialog>', () => {
       <WrapUserNotificationsMenuDialog notifications={notifications} />,
     );
 
-    expect(queryByText(NoNotificationText)).toBeNull();
+    expect(queryByText(noNotificationText)).toBeNull();
     expect(
       container.querySelectorAll('.notification-list .user-notification'),
     ).toHaveLength(1);

--- a/translate/src/modules/user/components/UserNotificationsMenu.test.jsx
+++ b/translate/src/modules/user/components/UserNotificationsMenu.test.jsx
@@ -25,7 +25,9 @@ describe('<UserNotificationsMenuDialog>', () => {
       <WrapUserNotificationsMenuDialog notifications={notifications} />,
     );
 
-    expect(container.querySelector('.notification-list .user-notification')).toBeNull();
+    expect(
+      container.querySelector('.notification-list .user-notification'),
+    ).toBeNull();
     getByText(NoNotificationText);
   });
 
@@ -55,7 +57,9 @@ describe('<UserNotificationsMenuDialog>', () => {
     );
 
     expect(queryByText(NoNotificationText)).toBeNull();
-    expect(container.querySelectorAll('.notification-list .user-notification')).toHaveLength(1);
+    expect(
+      container.querySelectorAll('.notification-list .user-notification'),
+    ).toHaveLength(1);
   });
 });
 

--- a/translate/src/modules/user/components/UserNotificationsMenu.test.jsx
+++ b/translate/src/modules/user/components/UserNotificationsMenu.test.jsx
@@ -1,26 +1,32 @@
-import { mount, shallow } from 'enzyme';
 import React from 'react';
 
 import * as api from '~/api/uxaction';
-
-import { UserNotification } from './UserNotification';
 import {
   UserNotificationsMenu,
   UserNotificationsMenuDialog,
 } from './UserNotificationsMenu';
-import { vi } from 'vitest';
+import { expect, vi } from 'vitest';
+import { fireEvent, render } from '@testing-library/react';
+import { MockLocalizationProvider } from '../../../test/utils';
+
+const WrapUserNotificationsMenuDialog = (props) => {
+  return (
+    <MockLocalizationProvider>
+      <UserNotificationsMenuDialog {...props} />
+    </MockLocalizationProvider>
+  );
+};
+const NoNotificationText = 'No new notifications.';
 
 describe('<UserNotificationsMenuDialog>', () => {
   it('shows empty notifications menu if user has no notifications', () => {
     const notifications = [];
-    const wrapper = shallow(
-      <UserNotificationsMenuDialog notifications={notifications} />,
+    const { container, getByText } = render(
+      <WrapUserNotificationsMenuDialog notifications={notifications} />,
     );
 
-    expect(wrapper.find('.notification-list .user-notification')).toHaveLength(
-      0,
-    );
-    expect(wrapper.find('.notification-list .no')).toHaveLength(1);
+    expect(container.querySelector('.notification-list .user-notification')).toBeNull();
+    getByText(NoNotificationText);
   });
 
   it('shows a notification in the notifications menu', () => {
@@ -44,12 +50,12 @@ describe('<UserNotificationsMenuDialog>', () => {
       },
     ];
 
-    const wrapper = shallow(
-      <UserNotificationsMenuDialog notifications={notifications} />,
+    const { container, queryByText } = render(
+      <WrapUserNotificationsMenuDialog notifications={notifications} />,
     );
 
-    expect(wrapper.find('.notification-list .no')).toHaveLength(0);
-    expect(wrapper.find(UserNotification)).toHaveLength(1);
+    expect(queryByText(NoNotificationText)).toBeNull();
+    expect(container.querySelectorAll('.notification-list .user-notification')).toHaveLength(1);
   });
 });
 
@@ -64,9 +70,9 @@ describe('<UserNotificationsMenu>', () => {
         has_unread: false,
       },
     };
-    const wrapper = shallow(<UserNotificationsMenu user={user} />);
+    const { container } = render(<UserNotificationsMenu user={user} />);
 
-    expect(wrapper.find('.user-notifications-menu')).toHaveLength(0);
+    expect(container).toBeEmptyDOMElement();
   });
 
   it('shows the notifications icon when the user is logged in', () => {
@@ -76,9 +82,11 @@ describe('<UserNotificationsMenu>', () => {
         notifications: [],
       },
     };
-    const wrapper = shallow(<UserNotificationsMenu user={user} />);
+    const { container } = render(<UserNotificationsMenu user={user} />);
 
-    expect(wrapper.find('.user-notifications-menu')).toHaveLength(1);
+    expect(
+      container.querySelector('.user-notifications-menu'),
+    ).toBeInTheDocument();
   });
 
   it('shows the notifications badge when the user has unread notifications and call logUxAction', () => {
@@ -90,9 +98,11 @@ describe('<UserNotificationsMenu>', () => {
         unread_count: '5',
       },
     };
-    const wrapper = mount(<UserNotificationsMenu user={user} />);
+    const { container } = render(<UserNotificationsMenu user={user} />);
 
-    expect(wrapper.find('.user-notifications-menu .badge').text()).toEqual('5');
+    expect(
+      container.querySelector('.user-notifications-menu .badge'),
+    ).toHaveTextContent('5');
     expect(api.logUXAction).toHaveBeenCalled();
   });
 
@@ -105,20 +115,22 @@ describe('<UserNotificationsMenu>', () => {
         notifications: [],
       },
     };
-    const wrapper = shallow(
-      <UserNotificationsMenu
-        markAllNotificationsAsRead={markAllNotificationsAsRead}
-        user={user}
-      />,
+    const { getByRole } = render(
+      <MockLocalizationProvider>
+        <UserNotificationsMenu
+          markAllNotificationsAsRead={markAllNotificationsAsRead}
+          user={user}
+        />
+      </MockLocalizationProvider>,
     );
 
-    // shallow() does not handle useEffect()
-    expect(api.logUXAction).not.toHaveBeenCalled();
-
-    wrapper.find('.selector').simulate('click', {});
+    //useEffect calls the function once
     expect(api.logUXAction).toHaveBeenCalledOnce();
 
-    wrapper.find('.selector').simulate('click', {});
-    expect(api.logUXAction).toHaveBeenCalledOnce();
+    fireEvent.click(getByRole('button'));
+    expect(api.logUXAction).toHaveBeenCalledTimes(2);
+
+    fireEvent.click(getByRole('button'));
+    expect(api.logUXAction).toHaveBeenCalledTimes(2);
   });
 });

--- a/translate/src/modules/user/components/UserNotificationsMenu.tsx
+++ b/translate/src/modules/user/components/UserNotificationsMenu.tsx
@@ -98,7 +98,7 @@ export function UserNotificationsMenu({
 
   return user?.isAuthenticated ? (
     <div className='user-notifications-menu'>
-      <div className='selector' onClick={handleClick}>
+      <div className='selector' role='button' onClick={handleClick}>
         <i className='icon far fa-bell fa-fw'></i>
         {unread && <i className='badge'>{user.notifications.unread_count}</i>}
       </div>


### PR DESCRIPTION
Continuation of previous MR https://github.com/mozilla/pontoon/pull/4023 the migration of enzyme test to @testing-library/react under task https://github.com/mozilla/pontoon/issues/3767

Some of the tests under /project, /search, and /user have not yet been migrated due to their complexity.