### PR TITLE
Include value & properties for entities & translations in get-entities and get-history API calls

### DIFF
--- a/pontoon/base/map_entities.py
+++ b/pontoon/base/map_entities.py
@@ -68,32 +68,32 @@ def map_entities_to_json(
         else:
             original = entity.string
 
-        translation = (
-            entity.active_translations[0].serialize()
-            if entity.active_translations
-            else None
-        )
+        ed = {
+            "pk": entity.pk,
+            "key": entity.key,
+            "format": entity.resource.format,
+            "date_created": entity.date_created,
+            "path": entity.resource.path,
+            "project": entity.resource.project.serialize(),
+            "comment": entity.comment,
+            "original": original,
+        }
+        if entity.section_comment:
+            ed["group_comment"] = entity.section_comment
+        if entity.resource.comment:
+            ed["resource_comment"] = entity.resource.comment
+        if entity.meta:
+            ed["meta"] = entity.meta
+        if readonly:
+            ed["readonly"] = True
+        if is_sibling:
+            ed["is_sibling"] = True
+        if original != entity.string:
+            ed["machinery_original"] = entity.string
+        if entity.active_translations:
+            ed["translation"] = entity.active_translations[0].serialize()
 
-        entities_array.append(
-            {
-                "pk": entity.pk,
-                "original": original,
-                "machinery_original": entity.string,
-                "key": entity.key,
-                "path": entity.resource.path,
-                "project": entity.resource.project.serialize(),
-                "format": entity.resource.format,
-                "comment": entity.comment,
-                "group_comment": entity.section_comment or "",
-                "resource_comment": entity.resource.comment or "",
-                "meta": entity.meta,
-                "obsolete": entity.obsolete,
-                "translation": translation,
-                "readonly": readonly,
-                "is_sibling": is_sibling,
-                "date_created": entity.date_created,
-            }
-        )
+        entities_array.append(ed)
 
     return entities_array
 

--- a/pontoon/base/map_entities.py
+++ b/pontoon/base/map_entities.py
@@ -63,10 +63,11 @@ def map_entities_to_json(
             # `projectlocale` list is empty. In this case, we skip the entity.
             continue
 
-        if preferred_source_locale and entity.alternative_originals:
-            original = entity.alternative_originals[0].string
-        else:
-            original = entity.string
+        source_entity = (
+            entity.alternative_originals[0]
+            if preferred_source_locale and entity.alternative_originals
+            else entity
+        )
 
         ed = {
             "pk": entity.pk,
@@ -76,8 +77,12 @@ def map_entities_to_json(
             "path": entity.resource.path,
             "project": entity.resource.project.serialize(),
             "comment": entity.comment,
-            "original": original,
+            "original": source_entity.string,
+            "value": source_entity.value,
         }
+
+        if source_entity.properties:
+            ed["properties"] = source_entity.properties
         if entity.section_comment:
             ed["group_comment"] = entity.section_comment
         if entity.resource.comment:
@@ -88,8 +93,11 @@ def map_entities_to_json(
             ed["readonly"] = True
         if is_sibling:
             ed["is_sibling"] = True
-        if original != entity.string:
+        if source_entity != entity:
             ed["machinery_original"] = entity.string
+            ed["machinery_value"] = entity.value
+            if entity.properties:
+                ed["machinery_properties"] = entity.properties
         if entity.active_translations:
             ed["translation"] = entity.active_translations[0].serialize()
 

--- a/pontoon/base/models/translation.py
+++ b/pontoon/base/models/translation.py
@@ -478,7 +478,14 @@ class Translation(DirtyFieldsMixin, models.Model):
         self.save()
 
     def serialize(self):
-        dict = {"pk": self.pk, "status": self.status, "string": self.string}
+        dict = {
+            "pk": self.pk,
+            "status": self.status,
+            "string": self.string,
+            "value": self.value,
+        }
+        if self.properties:
+            dict["properties"] = self.properties
         if self.pk:
             if errors := [error.message for error in self.errors.all()]:
                 dict["errors"] = errors

--- a/pontoon/base/models/translation.py
+++ b/pontoon/base/models/translation.py
@@ -478,20 +478,20 @@ class Translation(DirtyFieldsMixin, models.Model):
         self.save()
 
     def serialize(self):
-        dict = {
+        data = {
             "pk": self.pk,
             "status": self.status,
             "string": self.string,
             "value": self.value,
         }
         if self.properties:
-            dict["properties"] = self.properties
+            data["properties"] = self.properties
         if self.pk:
             if errors := [error.message for error in self.errors.all()]:
-                dict["errors"] = errors
+                data["errors"] = errors
             if warnings := [warning.message for warning in self.warnings.all()]:
-                dict["warnings"] = warnings
-        return dict
+                data["warnings"] = warnings
+        return data
 
     def mark_changed(self):
         """

--- a/pontoon/base/models/translation.py
+++ b/pontoon/base/models/translation.py
@@ -9,7 +9,6 @@ from django.utils import timezone
 
 from pontoon.actionlog.models import ActionLog
 from pontoon.actionlog.utils import log_action
-from pontoon.base import utils
 from pontoon.base.models.changed_entity_locale import ChangedEntityLocale
 from pontoon.base.models.entity import Entity
 from pontoon.base.models.locale import Locale
@@ -17,7 +16,6 @@ from pontoon.base.models.project import Project
 from pontoon.base.models.project_locale import ProjectLocale
 from pontoon.base.models.user import User
 from pontoon.base.simple_preview import get_simple_preview
-from pontoon.base.user_utils import gravatar_url
 from pontoon.checks import DB_FORMATS
 from pontoon.checks.utils import save_failed_checks
 
@@ -84,43 +82,6 @@ class TranslationQuerySet(models.QuerySet["Translation"]):
         return TranslatedResource.objects.filter(
             resource__entities__translation__in=self, locale=locale
         ).distinct()
-
-    def authors(self):
-        """
-        Return a list of translation authors.
-        """
-        # *Important*
-        # pontoon.contributors.utils depends on a few models from pontoon.base.models and causes a
-        # circular dependency.
-        from pontoon.contributors.utils import users_with_translations_counts
-
-        return [
-            {
-                "email": user.email,
-                "display_name": user.name_or_email,
-                "id": user.id,
-                "gravatar_url": gravatar_url(user),
-                "translation_count": user.translations_count,
-                "role": user.user_role,
-            }
-            for user in users_with_translations_counts(None, Q(id__in=self))
-        ]
-
-    def counts_per_minute(self):
-        """
-        Return a dictionary of translation counts per minute.
-        """
-        translations = (
-            self.extra({"minute": "date_trunc('minute', date)"})
-            .order_by("minute")
-            .values("minute")
-            .annotate(count=Count("id"))
-        )
-
-        data = []
-        for period in translations:
-            data.append([utils.convert_to_unix_time(period["minute"]), period["count"]])
-        return data
 
     def for_checks(self, only_db_formats=True):
         """
@@ -259,20 +220,6 @@ class Translation(DirtyFieldsMixin, models.Model):
                 condition=Q(active=True),
             ),
         ]
-
-    @classmethod
-    def for_locale_project_paths(cls, locale, project, paths):
-        """
-        Return Translation QuerySet for given locale, project and paths.
-        """
-        translations = Translation.objects.filter(
-            entity__obsolete=False, entity__resource__project=project, locale=locale
-        )
-
-        if paths:
-            translations = translations.filter(entity__resource__path__in=paths)
-
-        return translations
 
     @property
     def latest_activity(self):

--- a/pontoon/base/models/translation.py
+++ b/pontoon/base/models/translation.py
@@ -478,17 +478,13 @@ class Translation(DirtyFieldsMixin, models.Model):
         self.save()
 
     def serialize(self):
-        return {
-            "pk": self.pk,
-            "status": self.status,
-            "string": self.string,
-            "errors": (
-                [error.message for error in self.errors.all()] if self.pk else []
-            ),
-            "warnings": (
-                [warning.message for warning in self.warnings.all()] if self.pk else []
-            ),
-        }
+        dict = {"pk": self.pk, "status": self.status, "string": self.string}
+        if self.pk:
+            if errors := [error.message for error in self.errors.all()]:
+                dict["errors"] = errors
+            if warnings := [warning.message for warning in self.warnings.all()]:
+                dict["warnings"] = warnings
+        return dict
 
     def mark_changed(self):
         """

--- a/pontoon/base/models/translation.py
+++ b/pontoon/base/models/translation.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from dirtyfields import DirtyFieldsMixin
 
@@ -260,6 +260,20 @@ class Translation(DirtyFieldsMixin, models.Model):
     def tm_target(self):
         return get_simple_preview(self.entity.resource.format, self.string)
 
+    @property
+    def status(
+        self,
+    ) -> Literal["approved", "fuzzy", "pretranslated", "rejected", "unreviewed"]:
+        if self.approved:
+            return "approved"
+        if self.rejected:
+            return "rejected"
+        if self.pretranslated:
+            return "pretranslated"
+        if self.fuzzy:
+            return "fuzzy"
+        return "unreviewed"
+
     def __str__(self):
         return self.string
 
@@ -466,11 +480,8 @@ class Translation(DirtyFieldsMixin, models.Model):
     def serialize(self):
         return {
             "pk": self.pk,
+            "status": self.status,
             "string": self.string,
-            "approved": self.approved,
-            "rejected": self.rejected,
-            "pretranslated": self.pretranslated,
-            "fuzzy": self.fuzzy,
             "errors": (
                 [error.message for error in self.errors.all()] if self.pk else []
             ),

--- a/pontoon/base/tests/models/test_entity.py
+++ b/pontoon/base/tests/models/test_entity.py
@@ -282,29 +282,19 @@ def test_entity_project_locale_no_paths(
 
     assert e0 == {
         "comment": "",
-        "group_comment": "",
-        "resource_comment": "",
         "format": "gettext",
-        "obsolete": False,
         "key": ["Entity zero"],
         "path": resource0.path,
         "project": project_a.serialize(),
         "translation": {
             "pk": tr0.pk,
-            "pretranslated": False,
-            "fuzzy": False,
+            "status": "unreviewed",
             "string": tr0.string,
-            "approved": False,
-            "rejected": False,
-            "warnings": [],
-            "errors": [],
+            "value": tr0.value,
         },
-        "meta": [],
         "pk": entity_a.pk,
         "original": entity_a.string,
-        "machinery_original": str(entity_a.string),
-        "readonly": False,
-        "is_sibling": False,
+        "value": [],
         "date_created": entity_a.date_created,
     }
     assert e1["path"] == trX.entity.resource.path
@@ -433,7 +423,7 @@ def test_entity_project_comments(admin, resource_a, locale_a):
     EntityFactory(resource=resource_a, section=None, string="e4")
 
     assert {
-        (e["original"], e["group_comment"], e["resource_comment"])
+        (e["original"], e.get("group_comment"), e.get("resource_comment"))
         for e in map_entities_to_json(
             locale_a, "", Entity.objects.filter(resource=resource_a)
         )
@@ -441,8 +431,8 @@ def test_entity_project_comments(admin, resource_a, locale_a):
         ("e0", "s0 comment", "rc"),
         ("e1", "s0 comment", "rc"),
         ("e2", "s1 comment", "rc"),
-        ("e3", "", "rc"),
-        ("e4", "", "rc"),
+        ("e3", None, "rc"),
+        ("e4", None, "rc"),
     }
 
 

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -4,6 +4,7 @@ import re
 
 from collections import defaultdict
 from datetime import datetime
+from typing import Any, cast
 from urllib.parse import urlparse
 
 from django.conf import settings
@@ -14,6 +15,7 @@ from django.db import transaction
 from django.db.models import Count, F, Prefetch, Q, QuerySet
 from django.http import (
     Http404,
+    HttpRequest,
     HttpResponse,
     HttpResponseForbidden,
     HttpResponseRedirect,
@@ -46,6 +48,7 @@ from pontoon.base.models import (
     User,
     UserProfile,
 )
+from pontoon.base.models.translation import TranslationQuerySet
 from pontoon.base.notification_utils import serialized_notifications
 from pontoon.base.services import readonly_exists
 from pontoon.base.templatetags.helpers import provider_login_url
@@ -62,6 +65,7 @@ from pontoon.base.user_utils import (
 )
 from pontoon.checks.libraries import run_checks
 from pontoon.checks.utils import are_blocking_checks
+from pontoon.contributors.utils import users_with_translations_counts
 from pontoon.messaging.notifications import send_notification
 
 
@@ -176,29 +180,53 @@ def authors_and_time_range(request, locale, slug, part):
     project = get_object_or_404(
         Project.objects.visible_for(request.user).available(), slug=slug
     )
-    paths = [part] if part != "all-resources" else None
 
-    translations = Translation.for_locale_project_paths(locale, project, paths)
+    translations = cast(TranslationQuerySet, Translation.objects).filter(
+        entity__obsolete=False, entity__resource__project=project, locale=locale
+    )
+    if part != "all-resources":
+        translations = translations.filter(entity__resource__path__in=[part])
+
+    authors = [
+        {
+            "email": user.email,
+            "display_name": user.name_or_email,
+            "id": user.id,
+            "gravatar_url": gravatar_url(user),
+            "translation_count": user.translations_count,
+            "role": user.user_role,
+        }
+        for user in users_with_translations_counts(None, Q(id__in=translations))
+    ]
+
+    counts_per_minute = [
+        (utils.convert_to_unix_time(period["minute"]), period["count"])
+        for period in translations.extra({"minute": "date_trunc('minute', date)"})
+        .order_by("minute")
+        .values("minute")
+        .annotate(count=Count("id"))
+    ]
 
     return JsonResponse(
-        {
-            "authors": translations.authors(),
-            "counts_per_minute": translations.counts_per_minute(),
-        },
+        {"authors": authors, "counts_per_minute": counts_per_minute},
         safe=False,
     )
 
 
-def _get_entities_list(locale, preferred_source_locale, project, form):
+def _get_entities_list(
+    locale: Locale,
+    preferred_source_locale: str | None,
+    project: Project,
+    cleaned_data: dict[str, Any],
+):
     """Return entities from a specified list, optionally filtered by search term.
 
     Used for batch editing and list-based entity filtering (e.g. from notifications).
     """
-    entity_ids = form.cleaned_data["entity_ids"]
+    entity_ids = cleaned_data["entity_ids"]
     entities = Entity.objects.filter(pk__in=entity_ids)
 
-    if form.cleaned_data.get("search"):
-        search_term = form.cleaned_data["search"]
+    if search_term := cleaned_data.get("search"):
         entities = entities.filter(string__icontains=search_term)
 
     entities = entities.distinct().order_by("order")
@@ -207,7 +235,7 @@ def _get_entities_list(locale, preferred_source_locale, project, form):
         {
             "entities": map_entities_to_json(locale, preferred_source_locale, entities),
             "stats": TranslatedResource.objects.query_stats(
-                project, form.cleaned_data["paths"], locale
+                project, cleaned_data["paths"], locale
             ),
         },
         safe=False,
@@ -215,36 +243,39 @@ def _get_entities_list(locale, preferred_source_locale, project, form):
 
 
 def _get_paginated_entities(
-    locale, preferred_source_locale, project, form, entities: QuerySet[Entity]
+    locale: Locale,
+    preferred_source_locale: str | None,
+    project: Project,
+    cleaned_data: dict[str, Any],
+    entities: QuerySet[Entity],
 ):
     """Return a paginated list of entities.
 
     This is used by the regular mode of the Translate page.
     """
-    paginator = Paginator(entities, form.cleaned_data["limit"])
-    page = form.cleaned_data["page"]
+    paginator = Paginator(entities, cleaned_data["limit"])
+    page_idx = cleaned_data["page"]
 
     try:
-        entities_page = paginator.page(page)
+        entities_page = paginator.page(page_idx)
     except EmptyPage:
         return JsonResponse({"has_next": False, "stats": {}})
 
-    entities_to_map = entities_page.object_list
-    requested_entity = form.cleaned_data["entity"] if page == 1 else None
-
+    requested_entity = cleaned_data["entity"] if page_idx == 1 else None
     if requested_entity and not entities.filter(pk=requested_entity).exists():
         requested_entity = None
+
     return JsonResponse(
         {
             "entities": map_entities_to_json(
                 locale,
                 preferred_source_locale,
-                entities_to_map,
+                cast(QuerySet[Entity], entities_page.object_list),
                 requested_entity=requested_entity,
             ),
             "has_next": entities_page.has_next(),
             "stats": TranslatedResource.objects.query_stats(
-                project, form.cleaned_data["paths"], locale
+                project, cleaned_data["paths"], locale
             ),
         },
         safe=False,
@@ -254,7 +285,7 @@ def _get_paginated_entities(
 @csrf_exempt
 @require_POST
 @utils.require_AJAX
-def entities(request):
+def entities(request: HttpRequest):
     """Get entities for the specified project, locale and paths."""
     form = forms.GetEntitiesForm(request.POST)
     if not form.is_valid():
@@ -265,22 +296,26 @@ def entities(request):
             },
             status=400,
         )
+    cleaned_data = form.cleaned_data
 
-    locale = get_object_or_404(Locale, code=form.cleaned_data["locale"])
+    user = cast(User, request.user)
+    locale = get_object_or_404(Locale, code=cleaned_data["locale"])
 
-    preferred_source_locale = ""
-    if request.user.is_authenticated:
-        preferred_source_locale = request.user.profile.preferred_source_locale
+    preferred_source_locale: str | None = None
+    if user.is_authenticated:
+        preferred_source_locale = user.profile.preferred_source_locale
 
-    project_slug = form.cleaned_data["project"]
+    project_slug = cleaned_data["project"]
     if project_slug == "all-projects":
         project = Project(slug=project_slug)
     else:
         project = get_object_or_404(Project, slug=project_slug)
 
     # Only return entities with provided IDs (batch editing)
-    if form.cleaned_data["entity_ids"]:
-        return _get_entities_list(locale, preferred_source_locale, project, form)
+    if cleaned_data["entity_ids"]:
+        return _get_entities_list(
+            locale, preferred_source_locale, project, cleaned_data
+        )
 
     # `get_entities_for_project_locale` only requires a subset of the fields the form contains.
     # We thus make a new dict with only the keys we want to pass to that function.
@@ -319,9 +354,7 @@ def entities(request):
             form_data[name] = UserProfile._meta.get_field(name).get_default()
 
     try:
-        entities = get_entities_for_project_locale(
-            request.user, project, locale, **form_data
-        )
+        entities = get_entities_for_project_locale(user, project, locale, **form_data)
     except ValueError as error:
         return JsonResponse({"status": False, "message": f"{error}"}, status=500)
 
@@ -331,7 +364,7 @@ def entities(request):
 
     # Out-of-context view: paginate entities
     return _get_paginated_entities(
-        locale, preferred_source_locale, project, form, entities
+        locale, preferred_source_locale, project, form.cleaned_data, entities
     )
 
 

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -519,28 +519,33 @@ def get_translation_history(request):
 
     for t in translations:
         u = t.user or User(username="Imported", first_name="Imported", email="imported")
-        translation_dict = t.serialize()
-        translation_dict.update(
+        td = t.serialize()
+        td.update(
             {
-                "user": u.name_or_email,
+                "date": t.date,
                 "uid": u.pk,
+                "user": u.name_or_email,
                 "username": u.username,
                 "user_gravatar_url_small": gravatar_url(u),
-                "user_banner": user_banner(u, locale, project_contact),
-                "date": t.date,
-                "approved_user": t.approved_user.name_or_email
-                if t.approved_user
-                else "",
-                "approved_date": t.approved_date,
-                "rejected_user": t.rejected_user.name_or_email
-                if t.rejected_user
-                else "",
-                "rejected_date": t.rejected_date,
-                "comments": [c.serialize(project_contact) for c in t.comments.all()],
-                "machinery_sources": t.machinery_sources_values,
             }
         )
-        payload.append(translation_dict)
+        banner = user_banner(u, locale, project_contact)
+        if banner != ("", ""):
+            td["user_banner"] = banner
+        if t.approved_user:
+            td["approved_user"] = t.approved_user.name_or_email
+        if t.approved_date:
+            td["approved_date"] = t.approved_date
+        if t.rejected_user:
+            td["rejected_user"] = t.rejected_user.name_or_email
+        if t.rejected_date:
+            td["rejected_date"] = t.rejected_date
+        if comments := [c.serialize(project_contact) for c in t.comments.all()]:
+            td["comments"] = comments
+        if t.machinery_sources_values:
+            td["machinery_sources"] = t.machinery_sources_values
+
+        payload.append(td)
 
     return JsonResponse(payload, safe=False)
 

--- a/pontoon/test/fixtures/base.py
+++ b/pontoon/test/fixtures/base.py
@@ -171,6 +171,7 @@ def translation_a(locale_a, project_locale_a, entity_a, user_a):
         locale=locale_a,
         user=user_a,
         string="Translation for entity_a",
+        value=["Translation for entity_a"],
     )
     translation_a.locale.refresh_from_db()
     translation_a.entity.resource.project.refresh_from_db()

--- a/translate/src/api/comment.ts
+++ b/translate/src/api/comment.ts
@@ -9,7 +9,7 @@ import { keysToCamelCase } from './utils/keysToCamelCase';
 export type TranslationComment = {
   readonly author: string;
   readonly username: string;
-  readonly userBanner: string[];
+  readonly userBanner: [string, string];
   readonly userGravatarUrlSmall: string;
   readonly createdAt: string;
   readonly dateIso: string;

--- a/translate/src/api/entity.ts
+++ b/translate/src/api/entity.ts
@@ -18,19 +18,19 @@ import type { BatchBadgeUpdate } from '../modules/batchactions/actions';
 export type Entity = {
   readonly pk: number;
   readonly key: string[];
-  readonly original: string;
-  readonly machinery_original: string;
-  readonly comment: string;
-  readonly group_comment: string;
-  readonly resource_comment: string;
-  readonly meta: Array<[key: string, value: string]>;
   readonly format: string;
+  readonly date_created: string;
   readonly path: string;
   readonly project: Record<string, any>;
-  readonly translation: EntityTranslation | undefined;
-  readonly readonly: boolean;
-  readonly isSibling: boolean;
-  readonly date_created: string;
+  readonly comment: string;
+  readonly original: string;
+  readonly group_comment?: string;
+  readonly resource_comment?: string;
+  readonly meta?: Array<[key: string, value: string]>;
+  readonly readonly?: boolean;
+  readonly isSibling?: boolean;
+  readonly machinery_original?: string;
+  readonly translation?: EntityTranslation;
 };
 
 /**

--- a/translate/src/api/entity.ts
+++ b/translate/src/api/entity.ts
@@ -10,6 +10,7 @@ import type {
   HistoryTranslation,
 } from './translation';
 import type { BatchBadgeUpdate } from '../modules/batchactions/actions';
+import { Message } from '@mozilla/l10n';
 
 /**
  * String that needs to be translated, along with its current metadata,
@@ -24,12 +25,16 @@ export type Entity = {
   readonly project: Record<string, any>;
   readonly comment: string;
   readonly original: string;
+  readonly value: Message;
+  readonly properties?: Record<string, Message>;
   readonly group_comment?: string;
   readonly resource_comment?: string;
   readonly meta?: Array<[key: string, value: string]>;
   readonly readonly?: boolean;
   readonly isSibling?: boolean;
   readonly machinery_original?: string;
+  readonly machinery_value?: Message;
+  readonly machinery_properties?: Record<string, Message>;
   readonly translation?: EntityTranslation;
 };
 

--- a/translate/src/api/translation.ts
+++ b/translate/src/api/translation.ts
@@ -17,28 +17,25 @@ export type ApiFailedChecks = {
 /**
  * Accepted Translation of an Entity, cannot exist outside of the Entity type.
  */
-export type EntityTranslation = {
+export interface EntityTranslation {
   readonly pk: number;
+  readonly status:
+    | 'approved'
+    | 'fuzzy'
+    | 'pretranslated'
+    | 'rejected'
+    | 'unreviewed';
   readonly string: string | null | undefined;
-  readonly approved: boolean;
-  readonly pretranslated: boolean;
-  readonly fuzzy: boolean;
-  readonly rejected: boolean;
   readonly errors: string[];
   readonly warnings: string[];
-};
+}
 
-export type HistoryTranslation = {
-  readonly approved: boolean;
+export interface HistoryTranslation extends EntityTranslation {
+  readonly string: string;
   readonly approvedUser: string;
   readonly approvedDate: string | null;
-  readonly pretranslated: boolean;
   readonly date: string;
-  readonly fuzzy: boolean;
-  readonly pk: number;
-  readonly rejected: boolean;
   readonly rejectedDate: string | null;
-  readonly string: string;
   readonly uid: number | null | undefined;
   readonly rejectedUser: string;
   readonly machinerySources: string;
@@ -47,7 +44,7 @@ export type HistoryTranslation = {
   readonly userGravatarUrlSmall: string;
   readonly userBanner: string[];
   readonly comments: Array<TranslationComment>;
-};
+}
 
 export type APIStats = {
   approved: number;

--- a/translate/src/api/translation.ts
+++ b/translate/src/api/translation.ts
@@ -3,6 +3,7 @@ import { getCSRFToken } from './utils/csrfToken';
 import type { MessageEntry } from '~/utils/message';
 import type { TranslationComment } from './comment';
 import type { SourceType } from './machinery';
+import { Message } from '@mozilla/l10n';
 
 export type ChangeOperation = 'approve' | 'unapprove' | 'reject' | 'unreject';
 
@@ -26,6 +27,8 @@ export interface EntityTranslation {
     | 'rejected'
     | 'unreviewed';
   readonly string: string | null | undefined;
+  readonly value: Message;
+  readonly properties?: Record<string, Message>;
   readonly errors?: string[];
   readonly warnings?: string[];
 }

--- a/translate/src/api/translation.ts
+++ b/translate/src/api/translation.ts
@@ -26,24 +26,24 @@ export interface EntityTranslation {
     | 'rejected'
     | 'unreviewed';
   readonly string: string | null | undefined;
-  readonly errors: string[];
-  readonly warnings: string[];
+  readonly errors?: string[];
+  readonly warnings?: string[];
 }
 
 export interface HistoryTranslation extends EntityTranslation {
   readonly string: string;
-  readonly approvedUser: string;
-  readonly approvedDate: string | null;
   readonly date: string;
-  readonly rejectedDate: string | null;
   readonly uid: number | null | undefined;
-  readonly rejectedUser: string;
-  readonly machinerySources: string;
   readonly user: string;
   readonly username: string;
   readonly userGravatarUrlSmall: string;
-  readonly userBanner: string[];
-  readonly comments: Array<TranslationComment>;
+  readonly userBanner?: [string, string];
+  readonly approvedUser?: string;
+  readonly approvedDate?: string;
+  readonly rejectedDate?: string;
+  readonly rejectedUser?: string;
+  readonly machinerySources?: string;
+  readonly comments?: TranslationComment[];
 }
 
 export type APIStats = {

--- a/translate/src/context/Editor.test.jsx
+++ b/translate/src/context/Editor.test.jsx
@@ -17,11 +17,47 @@ import { EntityView, EntityViewProvider } from './EntityView';
 import { Locale } from './Locale';
 import { Location, LocationProvider } from './Location';
 import { UnsavedChanges, UnsavedChangesProvider } from './UnsavedChanges';
+import { fluentParseEntry, mf2ParseMessage } from '@mozilla/l10n';
 
-function mountSpy(Spy, format, translation, original) {
+function mountSpy(Spy, format, formatTranslation, formatSource = 'key = test') {
   const history = createMemoryHistory({
     initialEntries: [`/sl/pro/all/?string=42`],
   });
+
+  let key = ['key'];
+  let value;
+  let translation = undefined;
+  switch (format) {
+    case 'fluent': {
+      const [id, entry] = fluentParseEntry(formatSource);
+      key = [id];
+      value = entry['='];
+      if (formatTranslation) {
+        const [, entry] = fluentParseEntry(formatTranslation);
+        translation = { string: formatTranslation, value: entry['='] };
+      }
+      break;
+    }
+    case 'android':
+      value = mf2ParseMessage(formatSource);
+      if (formatTranslation) {
+        translation = {
+          string: formatTranslation,
+          value: mf2ParseMessage(formatTranslation),
+        };
+      }
+      break;
+    default:
+      value = [formatSource];
+      if (formatTranslation) {
+        translation = { string: formatTranslation, value: [formatTranslation] };
+      }
+  }
+
+  const gettextSource =
+    '.input {$n :number}\n.match $n\none {{orig one}}\n* {{orig other}}';
+  const gettextTranslation =
+    '.input {$n :number}\n.match $n\none {{trans one}}\n* {{trans other}}';
 
   const initialState = {
     entities: {
@@ -29,28 +65,23 @@ function mountSpy(Spy, format, translation, original) {
         {
           pk: 42,
           format,
-          key: ['key'],
-          original: original ?? 'key = test',
-          translation: translation
-            ? { string: translation, errors: [], warnings: [] }
-            : undefined,
+          key,
+          original: formatSource,
+          value,
+          translation,
           project: { contact: '' },
-          comment: '',
         },
         {
           pk: 13,
           format: 'gettext',
           key: ['plural'],
-          original:
-            '.input {$n :number}\n.match $n\none {{orig one}}\n* {{orig other}}',
+          original: gettextSource,
+          value: mf2ParseMessage(gettextSource),
           translation: {
-            string:
-              '.input {$n :number}\n.match $n\none {{trans one}}\n* {{trans other}}',
-            errors: [],
-            warnings: [],
+            string: gettextTranslation,
+            value: mf2ParseMessage(gettextTranslation),
           },
           project: { contact: '' },
-          comment: '',
         },
       ],
     },
@@ -170,22 +201,41 @@ describe('<EditorProvider>', () => {
   });
 
   it('provides a forced source Fluent value', () => {
-    using warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     let editor, result;
     const Spy = () => {
       editor = useContext(EditorData);
       result = useContext(EditorResult);
       return null;
     };
-    const source = '## comment\n';
-    mountSpy(Spy, 'fluent', source);
+    const source = ftl`
+      key =
+          { $var ->
+              [a] A
+              [b] B
+              [c] C
+              [d] D
+              [e] E
+              [f] F
+              [g] G
+              [h] H
+              [i] I
+              [j] J
+              [k] K
+              [l] L
+              [m] M
+              [n] N
+              [o] O
+              [p] P
+             *[q] Q
+          }
+      `;
+    mountSpy(Spy, 'fluent', source, source);
 
     expect(editor).toMatchObject({
       sourceView: true,
-      initial: { id: 'key', value: ['## comment\n'] },
       fields: [
         {
-          handle: { current: { value: '## comment' } },
+          handle: { current: { value: source } },
           id: '',
           keys: [],
           labels: [],
@@ -196,9 +246,8 @@ describe('<EditorProvider>', () => {
     expect(result).toEqual({
       format: 'fluent',
       id: 'key',
-      value: ['## comment\n'],
+      value: fluentParseEntry(source)[1]['='],
     });
-    expect(warn).toHaveBeenCalledTimes(1);
   });
 
   it('provides a simple Android value with no translation', () => {
@@ -217,7 +266,7 @@ describe('<EditorProvider>', () => {
     const arg1 = { $: 'arg1', fn: 'string', attr: { source: '%1$s' } };
     expect(editor).toMatchObject({
       sourceView: false,
-      initial: { id: '', value: [] },
+      initial: { id: 'key', value: [] },
       fields: [
         {
           id: '',
@@ -228,7 +277,7 @@ describe('<EditorProvider>', () => {
         },
       ],
     });
-    expect(result).toEqual({ format: 'android', id: '', value: [] });
+    expect(result).toEqual({ format: 'android', id: 'key', value: [] });
   });
 
   it('provides a simple Android value', () => {
@@ -247,7 +296,7 @@ describe('<EditorProvider>', () => {
     const arg1 = { $: 'arg1', fn: 'string', attr: { source: '%1$s' } };
     expect(editor).toMatchObject({
       sourceView: false,
-      initial: { id: '', value: ['Hei, ', arg1, '!'] },
+      initial: { id: 'key', value: ['Hei, ', arg1, '!'] },
       fields: [
         {
           id: '',
@@ -260,7 +309,7 @@ describe('<EditorProvider>', () => {
     });
     expect(result).toEqual({
       format: 'android',
-      id: '',
+      id: 'key',
       value: [
         'Hei, ',
         { $: 'arg1', fn: 'string', opt: undefined, attr: { source: '%1$s' } },
@@ -297,12 +346,12 @@ describe('<EditorProvider>', () => {
     }));
     expect(editor).toMatchObject({
       sourceView: false,
-      initial: entry,
+      initial: { ...entry, id: 'key' },
       fields,
     });
     expect(result).toEqual({
       format: 'android',
-      id: '',
+      id: 'key',
       value: {
         decl: {
           quantity: {
@@ -330,12 +379,15 @@ describe('<EditorProvider>', () => {
       entity = useContext(EntityView).entity;
       return null;
     };
-    mountSpy(Spy, 'simple', 'translated');
+    mountSpy(Spy, 'plain', 'translated');
 
     act(() => location.push({ entity: 13 }));
 
     expect(editor).toMatchObject({
-      initial: parseEntry('gettext', entity.translation.string),
+      initial: {
+        ...parseEntry('gettext', entity.translation.string),
+        id: 'plural',
+      },
       fields: [
         { handle: { current: { value: 'trans one' } } },
         { handle: { current: { value: 'trans other' } } },
@@ -343,7 +395,7 @@ describe('<EditorProvider>', () => {
     });
     expect(result).toEqual({
       format: 'gettext',
-      id: '',
+      id: 'plural',
       value: {
         decl: { n: { $: 'n', attr: undefined, fn: 'number', opt: undefined } },
         sel: ['n'],

--- a/translate/src/context/Editor.tsx
+++ b/translate/src/context/Editor.tsx
@@ -14,12 +14,12 @@ import {
   buildMessageEntry,
   editMessageEntry,
   editSource,
-  requiresSourceView,
-  getEmptyMessageEntry,
   MessageEntry,
   parseEntry,
+  requiresSourceView,
   serializeEntry,
 } from '~/utils/message';
+import { messageEntryFromEntityTranslation } from '~/utils/message/fromEntity';
 import { specialFormats } from '~/utils/message/specialFormats';
 import { pojoEquals } from '~/utils/pojo';
 
@@ -28,7 +28,6 @@ import { FailedChecksData } from './FailedChecksData';
 import { Locale } from './Locale';
 import { MachineryTranslations } from './MachineryTranslations';
 import { UnsavedActions } from './UnsavedChanges';
-import { getMessageEntryFormat } from '../utils/message/getMessageEntryFormat';
 
 export type EditFieldHandle = {
   get value(): string;
@@ -116,20 +115,6 @@ function parseEntryFromFluentSource(base: MessageEntry, fields: EditorField[]) {
   }
   return entry;
 }
-
-/**
- * Create a new MessageEntry with a simple string pattern `value`,
- * using `id` as its identifier.
- */
-const createSimpleMessageEntry = (
-  format: string,
-  key: string[],
-  value: string,
-): MessageEntry => ({
-  format: getMessageEntryFormat(format),
-  id: key[0] ?? '',
-  value: value ? [value] : [],
-});
 
 const initEditorData: EditorData = {
   pk: 0,
@@ -281,32 +266,11 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
   }, [format, readonly]);
 
   useEffect(() => {
-    let base: MessageEntry;
-    let source = activeTranslation?.string || '';
-    let sourceView = false;
-    let orig: MessageEntry | null = null;
-    if (!source) {
-      orig ??= parseEntry(format, entity.original);
-      base = orig
-        ? getEmptyMessageEntry(orig, locale)
-        : createSimpleMessageEntry(format, entity.key, '');
-      if (requiresSourceView(base)) {
-        source = serializeEntry(base);
-        sourceView = true;
-      }
-    } else {
-      const base_ = parseEntry(format, source);
-      if (base_) {
-        base = base_;
-        sourceView = requiresSourceView(base);
-      } else {
-        base = createSimpleMessageEntry(format, entity.key, source);
-        sourceView = format === 'fluent';
-      }
-    }
-
-    const fields = sourceView ? editSource(source) : editMessageEntry(base);
-
+    const base = messageEntryFromEntityTranslation(entity, locale);
+    const sourceView = requiresSourceView(base);
+    const fields = sourceView
+      ? editSource(serializeEntry(base))
+      : editMessageEntry(base);
     setState(() => ({
       pk: entity.pk,
       busy: false,

--- a/translate/src/context/EntityView.tsx
+++ b/translate/src/context/EntityView.tsx
@@ -18,6 +18,7 @@ const emptyEntity: Entity = {
   key: [],
   format: '',
   original: '',
+  value: [],
   comment: '',
   date_created: '',
   path: '',

--- a/translate/src/context/EntityView.tsx
+++ b/translate/src/context/EntityView.tsx
@@ -68,6 +68,6 @@ export function useActiveTranslation(): EntityTranslation | null {
   const { entity } = useContext(EntityView);
   return useMemo(() => {
     const tx = entity.translation;
-    return tx && !tx.rejected ? tx : null;
+    return tx && tx.status !== 'rejected' ? tx : null;
   }, [entity]);
 }

--- a/translate/src/context/EntityView.tsx
+++ b/translate/src/context/EntityView.tsx
@@ -16,19 +16,13 @@ import { Location } from './Location';
 const emptyEntity: Entity = {
   pk: 0,
   key: [],
-  original: '',
-  machinery_original: '',
-  comment: '',
-  group_comment: '',
-  resource_comment: '',
-  meta: [],
   format: '',
+  original: '',
+  comment: '',
+  date_created: '',
   path: '',
   project: {},
-  translation: undefined,
   readonly: true,
-  isSibling: false,
-  date_created: '',
 };
 
 export type EntityView = { entity: Entity };

--- a/translate/src/context/FailedChecksData.test.jsx
+++ b/translate/src/context/FailedChecksData.test.jsx
@@ -40,7 +40,7 @@ describe('FailedChecksProvider', () => {
     EntityView.useActiveTranslation.mockReturnValue({
       errors: ['Error1'],
       warnings: ['Warning1'],
-      approved: true,
+      status: 'approved',
     });
 
     rerender(

--- a/translate/src/context/FailedChecksData.tsx
+++ b/translate/src/context/FailedChecksData.tsx
@@ -71,12 +71,17 @@ export function FailedChecksProvider({
     if (translation) {
       const { status, errors, warnings } = translation;
       if (
-        (errors.length || warnings.length) &&
+        (errors?.length || warnings?.length) &&
         (status === 'approved' ||
           status === 'pretranslated' ||
           status === 'fuzzy')
       ) {
-        setState((prev) => ({ ...prev, errors, warnings, source: 'stored' }));
+        setState((prev) => ({
+          ...prev,
+          errors: errors ?? [],
+          warnings: warnings ?? [],
+          source: 'stored',
+        }));
         return;
       }
     }

--- a/translate/src/context/FailedChecksData.tsx
+++ b/translate/src/context/FailedChecksData.tsx
@@ -69,10 +69,12 @@ export function FailedChecksProvider({
     // pretranslated or fuzzy, i.e. when their status icon is colored as
     // error/warning in the string list
     if (translation) {
-      const { approved, errors, fuzzy, pretranslated, warnings } = translation;
+      const { status, errors, warnings } = translation;
       if (
         (errors.length || warnings.length) &&
-        (approved || pretranslated || fuzzy)
+        (status === 'approved' ||
+          status === 'pretranslated' ||
+          status === 'fuzzy')
       ) {
         setState((prev) => ({ ...prev, errors, warnings, source: 'stored' }));
         return;

--- a/translate/src/context/MachineryTranslations.tsx
+++ b/translate/src/context/MachineryTranslations.tsx
@@ -54,7 +54,7 @@ export function MachineryProvider({
     pk = null;
     format = '';
   } else {
-    source = entity.machinery_original;
+    source = entity.machinery_original ?? entity.original;
     pk = entity.pk;
     format = entity.format;
   }

--- a/translate/src/context/useActiveTranslation.test.jsx
+++ b/translate/src/context/useActiveTranslation.test.jsx
@@ -28,7 +28,7 @@ describe('useActiveTranslation', () => {
 
   it('does not return rejected translations', () => {
     vi.mocked(useContext).mockReturnValue({
-      entity: { translation: { string: 'world', rejected: true } },
+      entity: { translation: { string: 'world', status: 'rejected' } },
     });
     const res = useActiveTranslation();
     expect(res).toBeNull();

--- a/translate/src/hooks/useUserBanner.ts
+++ b/translate/src/hooks/useUserBanner.ts
@@ -8,7 +8,7 @@ import { useAppSelector } from '~/hooks';
 /**
  * Return the user's status banner within the given locale, to display on the user banner
  */
-export function useUserBanner(): Array<string> {
+export function useUserBanner(): [string, string] {
   const { code } = useContext(Locale);
   const { project } = useContext(Location);
   const {

--- a/translate/src/modules/comments/components/CommentsList.tsx
+++ b/translate/src/modules/comments/components/CommentsList.tsx
@@ -29,7 +29,7 @@ export function CommentsList({
     <div className='comments-list'>
       <section className='all-comments'>
         <ul>
-          {translation.comments.map((comment) => (
+          {translation.comments?.map((comment) => (
             <Comment
               comment={comment}
               key={comment.id}

--- a/translate/src/modules/editor/components/Editor.test.jsx
+++ b/translate/src/modules/editor/components/Editor.test.jsx
@@ -17,6 +17,7 @@ import { MockLocalizationProvider } from '~/test/utils';
 
 import { Editor } from './Editor';
 import { vi } from 'vitest';
+import { fluentParseEntry } from '@mozilla/l10n';
 
 const NESTED_SELECTORS_STRING = ftl`
   my-message =
@@ -29,14 +30,14 @@ const NESTED_SELECTORS_STRING = ftl`
       }
 
   `;
+const [, nested_selectors_entry] = fluentParseEntry(NESTED_SELECTORS_STRING);
 
 const RICH_MESSAGE_STRING = ftl`
   my-message =
     Why so serious?
     .reason = Because
   `;
-
-const BROKEN_STRING = `my-message = Why so {} serious?\n`;
+const [, rich_message_entry] = fluentParseEntry(RICH_MESSAGE_STRING);
 
 const ENTITIES = [
   {
@@ -44,15 +45,20 @@ const ENTITIES = [
     format: 'fluent',
     key: ['my-message'],
     original: 'my-message = Hello',
-    translation: { string: 'my-message = Salut' },
+    value: ['Hello'],
+    translation: { string: 'my-message = Salut', value: ['Salut'] },
   },
   {
     pk: 2,
     format: 'fluent',
     key: ['my-message'],
     original: 'my-message =\n    .my-attr = Something guud',
+    value: [],
+    properties: { 'my-attr': ['Something guud'] },
     translation: {
       string: 'my-message =\n    .my-attr = Quelque chose de bien',
+      value: [],
+      properties: { 'my-attr': ['Quelque chose de bien'] },
     },
   },
   {
@@ -60,13 +66,16 @@ const ENTITIES = [
     format: 'fluent',
     key: ['my-message'],
     original: RICH_MESSAGE_STRING,
+    value: rich_message_entry['='],
+    properties: { reason: ['Because'] },
     translation: undefined,
   },
   {
     pk: 4,
     format: 'fluent',
     key: ['my-message'],
-    original: 'my-message = Hello',
+    original: 'my-message = Hello\n',
+    value: ['Hello'],
     translation: { string: '' },
   },
   {
@@ -74,14 +83,11 @@ const ENTITIES = [
     format: 'fluent',
     key: ['my-message'],
     original: NESTED_SELECTORS_STRING,
-    translation: { string: NESTED_SELECTORS_STRING },
-  },
-  {
-    pk: 6,
-    format: 'fluent',
-    key: ['my-message'],
-    original: BROKEN_STRING,
-    translation: { string: BROKEN_STRING },
+    value: nested_selectors_entry['='],
+    translation: {
+      string: NESTED_SELECTORS_STRING,
+      value: nested_selectors_entry['='],
+    },
   },
 ];
 
@@ -152,16 +158,6 @@ describe('<Editor>', () => {
     const [wrapper] = mountEditor(5);
 
     expect(wrapper.find(EditField)).toHaveLength(4);
-  });
-
-  it('renders the source form when passing a broken string', () => {
-    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const [wrapper] = mountEditor(6);
-    expect(spy).toHaveBeenCalledWith(expect.stringContaining('E0028'));
-
-    const input = wrapper.find(EditField);
-    expect(input).toHaveLength(1);
-    expect(input.prop('defaultValue')).toBe(BROKEN_STRING.trim());
   });
 
   it('converts translation when switching source mode', () => {

--- a/translate/src/modules/editor/components/EditorMainAction.tsx
+++ b/translate/src/modules/editor/components/EditorMainAction.tsx
@@ -43,7 +43,11 @@ export function EditorMainAction(): React.ReactElement<React.ElementType> {
   let onClick: (event: React.SyntheticEvent) => void;
   let error = entry ? null : 'syntax-error';
 
-  if (isTranslator && existingTranslation && !existingTranslation.approved) {
+  if (
+    isTranslator &&
+    existingTranslation &&
+    existingTranslation.status !== 'approved'
+  ) {
     action = 'approve';
     onClick = () =>
       updateTranslationStatus(existingTranslation.pk, 'approve', false);

--- a/translate/src/modules/entities/useTranslationStatus.tsx
+++ b/translate/src/modules/entities/useTranslationStatus.tsx
@@ -12,18 +12,22 @@ export function useTranslationStatus({
   translation,
 }: Entity): TranslationStatus {
   return useMemo(() => {
-    if (
-      translation &&
-      (translation.approved || translation.pretranslated || translation.fuzzy)
-    ) {
-      if (translation.errors.length) {
-        return 'errors';
-      } else if (translation.warnings.length) {
-        return 'warnings';
-      } else if (translation.approved) {
-        return 'approved';
-      } else if (translation.pretranslated) {
-        return 'pretranslated';
+    if (translation) {
+      const { status } = translation;
+      if (
+        status === 'approved' ||
+        status === 'pretranslated' ||
+        status === 'fuzzy'
+      ) {
+        if (translation.errors.length) {
+          return 'errors';
+        } else if (translation.warnings.length) {
+          return 'warnings';
+        } else if (status === 'approved') {
+          return 'approved';
+        } else if (status === 'pretranslated') {
+          return 'pretranslated';
+        }
       }
     }
     return 'missing';

--- a/translate/src/modules/entities/useTranslationStatus.tsx
+++ b/translate/src/modules/entities/useTranslationStatus.tsx
@@ -19,9 +19,9 @@ export function useTranslationStatus({
         status === 'pretranslated' ||
         status === 'fuzzy'
       ) {
-        if (translation.errors.length) {
+        if (translation.errors?.length) {
           return 'errors';
-        } else if (translation.warnings.length) {
+        } else if (translation.warnings?.length) {
           return 'warnings';
         } else if (status === 'approved') {
           return 'approved';

--- a/translate/src/modules/entitieslist/components/EntitiesList.test.js
+++ b/translate/src/modules/entitieslist/components/EntitiesList.test.js
@@ -17,8 +17,8 @@ import { fireEvent } from '@testing-library/react';
 
 // Entities shared between tests
 const ENTITIES = [
-  { pk: 1, translation: { string: '', errors: [], warnings: [] } },
-  { pk: 2, translation: { string: '', errors: [], warnings: [] } },
+  { pk: 1, key: ['k1'], translation: { string: '', value: [] } },
+  { pk: 2, key: ['k2'], translation: { string: '', value: [] } },
 ];
 
 describe('<EntitiesList>', () => {

--- a/translate/src/modules/entitieslist/components/Entity.test.jsx
+++ b/translate/src/modules/entitieslist/components/Entity.test.jsx
@@ -17,8 +17,8 @@ describe('<Entity>', () => {
   const ENTITY_A = {
     original: 'string a',
     translation: {
+      status: 'approved',
       string: 'chaine a',
-      approved: true,
       errors: [],
       warnings: [],
     },
@@ -27,8 +27,8 @@ describe('<Entity>', () => {
   const ENTITY_B = {
     original: 'string b',
     translation: {
+      status: 'pretranslated',
       string: 'chaine b',
-      pretranslated: true,
       errors: [],
       warnings: [],
     },
@@ -37,6 +37,7 @@ describe('<Entity>', () => {
   const ENTITY_C = {
     original: 'string c',
     translation: {
+      status: 'unreviewed',
       string: 'chaine c',
       errors: [],
       warnings: [],
@@ -46,8 +47,8 @@ describe('<Entity>', () => {
   const ENTITY_D = {
     original: 'string d',
     translation: {
+      status: 'approved',
       string: 'chaine d',
-      approved: true,
       errors: ['error'],
       warnings: [],
     },
@@ -56,8 +57,8 @@ describe('<Entity>', () => {
   const ENTITY_E = {
     original: 'string e',
     translation: {
+      status: 'pretranslated',
       string: 'chaine e',
-      pretranslated: true,
       errors: [],
       warnings: ['warning'],
     },

--- a/translate/src/modules/entitieslist/components/Entity.test.jsx
+++ b/translate/src/modules/entitieslist/components/Entity.test.jsx
@@ -15,51 +15,58 @@ afterAll(() => hookModule.useTranslator.mockRestore());
 
 describe('<Entity>', () => {
   const ENTITY_A = {
+    key: ['A'],
     original: 'string a',
+    value: ['string a'],
     translation: {
       status: 'approved',
       string: 'chaine a',
-      errors: [],
-      warnings: [],
+      value: ['chaine a'],
     },
   };
 
   const ENTITY_B = {
+    key: ['B'],
     original: 'string b',
+    value: ['string b'],
     translation: {
       status: 'pretranslated',
       string: 'chaine b',
-      errors: [],
-      warnings: [],
+      value: ['chaine b'],
     },
   };
 
   const ENTITY_C = {
+    key: ['C'],
     original: 'string c',
+    value: ['string c'],
     translation: {
       status: 'unreviewed',
       string: 'chaine c',
-      errors: [],
-      warnings: [],
+      value: ['chaine c'],
     },
   };
 
   const ENTITY_D = {
+    key: ['D'],
     original: 'string d',
+    value: ['string d'],
     translation: {
       status: 'approved',
       string: 'chaine d',
+      value: ['chaine d'],
       errors: ['error'],
-      warnings: [],
     },
   };
 
   const ENTITY_E = {
+    key: ['E'],
     original: 'string e',
+    value: ['string e'],
     translation: {
       status: 'pretranslated',
       string: 'chaine e',
-      errors: [],
+      value: ['chaine e'],
       warnings: ['warning'],
     },
   };

--- a/translate/src/modules/entitieslist/components/Entity.tsx
+++ b/translate/src/modules/entitieslist/components/Entity.tsx
@@ -9,6 +9,10 @@ import type { Location } from '~/context/Location';
 import { useTranslationStatus } from '~/modules/entities/useTranslationStatus';
 import { Translation } from '~/modules/translation';
 import { useTranslator } from '~/hooks/useTranslator';
+import {
+  messageEntryFromEntity,
+  messageEntryFromEntityTranslation,
+} from '~/utils/message/fromEntity';
 
 import './Entity.css';
 
@@ -143,8 +147,7 @@ export function Entity({
         <div>
           <p className='source-string'>
             <Translation
-              content={entity.original}
-              format={entity.format}
+              content={messageEntryFromEntity(entity)}
               search={
                 parameters.search_exclude_source_strings
                   ? null
@@ -159,8 +162,7 @@ export function Entity({
             data-script={script}
           >
             <Translation
-              content={entity.translation?.string ?? ''}
-              format={entity.format}
+              content={messageEntryFromEntityTranslation(entity)}
               search={parameters.search}
             />
           </p>

--- a/translate/src/modules/entitydetails/components/EntityDetails.test.jsx
+++ b/translate/src/modules/entitydetails/components/EntityDetails.test.jsx
@@ -16,7 +16,6 @@ const ENTITY = (pk) => ({
   translation: { string: 'test', errors: [], warnings: [] },
   project: { contact: '' },
   comment: '',
-  meta: [],
   date_created: new Date().toISOString(),
 });
 
@@ -55,6 +54,7 @@ describe('<EntityDetails>', () => {
     urls = [];
     const { container, getAllByRole } = mockEntityDetails(42);
     expect(urls).toMatchObject([
+      'http://localhost/terminology/get-terms/?source_string=le+test&locale=kg',
       'http://localhost/other-locales/?entity=42&locale=kg',
       'http://localhost/get-team-comments/?entity=42&locale=kg',
     ]);
@@ -65,10 +65,12 @@ describe('<EntityDetails>', () => {
     expect(getAllByRole('tablist')).toHaveLength(2);
   });
 
-  it('does not load anything for entity 0', () => {
+  it('loads only terminology for entity 0', () => {
     urls = [];
     const { container, queryByRole } = mockEntityDetails(0);
-    expect(urls).toMatchObject([]);
+    expect(urls).toMatchObject([
+      'http://localhost/terminology/get-terms/?source_string=le+test&locale=kg',
+    ]);
 
     expect(
       container.querySelector('.entity-navigation'),

--- a/translate/src/modules/entitydetails/components/EntityDetails.tsx
+++ b/translate/src/modules/entitydetails/components/EntityDetails.tsx
@@ -63,8 +63,8 @@ export function EntityDetails(): React.ReactElement<'section'> | null {
   const { entity, locale: lc, project } = location;
 
   useEffect(() => {
-    const { format, machinery_original, pk } = selectedEntity;
-    const source = getPlainMessage(machinery_original, format);
+    const { format, machinery_original, original, pk } = selectedEntity;
+    const source = getPlainMessage(machinery_original ?? original, format);
 
     if (source !== terms.sourceString && project !== 'terminology') {
       dispatch(getTerms(source, lc));

--- a/translate/src/modules/entitydetails/components/Metadata.tsx
+++ b/translate/src/modules/entitydetails/components/Metadata.tsx
@@ -70,8 +70,8 @@ function EntityComment({ comment }: { comment: string }) {
   );
 }
 
-function GroupComment({ comment }: { comment: string }) {
-  return (
+function GroupComment({ comment }: { comment: string | undefined }) {
+  return !comment ? null : (
     <Datum id='group-comment' title='GROUP COMMENT'>
       {comment}
     </Datum>
@@ -108,7 +108,7 @@ function EntityCreatedDate({ dateCreated }: { dateCreated: string }) {
   );
 }
 
-function ResourceComment({ comment }: { comment: string }) {
+function ResourceComment({ comment }: { comment: string | undefined }) {
   const ref = React.useRef<HTMLDivElement>(null);
   const [overflow, setOverflow] = React.useState(false);
   const [expand, setExpand] = React.useState(false);
@@ -139,6 +139,7 @@ function ResourceComment({ comment }: { comment: string }) {
 }
 
 function SourceReferences({ meta }: { meta: Entity['meta'] }) {
+  if (!meta) return null;
   const refs = [];
   for (let [key, value] of meta) {
     if (key === 'reference') {

--- a/translate/src/modules/history/components/HistoryTranslation.test.jsx
+++ b/translate/src/modules/history/components/HistoryTranslation.test.jsx
@@ -24,13 +24,10 @@ afterAll(() => {
 
 describe('<HistoryTranslationComponent>', () => {
   const DEFAULT_TRANSLATION = {
-    approved: false,
+    status: 'unreviewed',
     approvedUser: '',
-    pretranslated: false,
     date: '',
-    fuzzy: false,
     pk: 1,
-    rejected: false,
     string: 'The storm approaches. We speak no more.',
     uid: 0,
     rejectedUser: '',
@@ -57,10 +54,7 @@ describe('<HistoryTranslationComponent>', () => {
 
   describe('getStatus', () => {
     it('returns the correct status for approved translations', () => {
-      const translation = {
-        ...DEFAULT_TRANSLATION,
-        ...{ approved: true },
-      };
+      const translation = { ...DEFAULT_TRANSLATION, status: 'approved' };
       const { container } = render(
         <WrapHistoryTranslationBase
           translation={translation}
@@ -73,10 +67,7 @@ describe('<HistoryTranslationComponent>', () => {
     });
 
     it('returns the correct status for rejected translations', () => {
-      const translation = {
-        ...DEFAULT_TRANSLATION,
-        ...{ rejected: true },
-      };
+      const translation = { ...DEFAULT_TRANSLATION, status: 'rejected' };
       const { container } = render(
         <WrapHistoryTranslationBase
           translation={translation}
@@ -89,10 +80,7 @@ describe('<HistoryTranslationComponent>', () => {
     });
 
     it('returns the correct status for pretranslated translations', () => {
-      const translation = {
-        ...DEFAULT_TRANSLATION,
-        ...{ pretranslated: true },
-      };
+      const translation = { ...DEFAULT_TRANSLATION, status: 'pretranslated' };
       const { container } = render(
         <WrapHistoryTranslationBase
           translation={translation}
@@ -105,10 +93,7 @@ describe('<HistoryTranslationComponent>', () => {
     });
 
     it('returns the correct status for fuzzy translations', () => {
-      const translation = {
-        ...DEFAULT_TRANSLATION,
-        ...{ fuzzy: true },
-      };
+      const translation = { ...DEFAULT_TRANSLATION, status: 'fuzzy' };
       const { container } = render(
         <WrapHistoryTranslationBase
           translation={translation}
@@ -138,7 +123,8 @@ describe('<HistoryTranslationComponent>', () => {
       const approvedTitle = 'test-approved';
       const translation = {
         ...DEFAULT_TRANSLATION,
-        ...{ approved: true, approvedUser: 'Cespenar' },
+        status: 'approved',
+        approvedUser: 'Cespenar',
       };
 
       const { getAllByTitle } = render(
@@ -161,10 +147,7 @@ describe('<HistoryTranslationComponent>', () => {
 
     it('returns the correct review title when approved and approved user is not available', () => {
       const approvedAnonymousTitle = 'test-approved-anonymous';
-      const translation = {
-        ...DEFAULT_TRANSLATION,
-        ...{ approved: true },
-      };
+      const translation = { ...DEFAULT_TRANSLATION, status: 'approved' };
       const { getAllByTitle } = render(
         <MockLocalizationProvider
           resources={[
@@ -187,7 +170,8 @@ describe('<HistoryTranslationComponent>', () => {
       const rejectedTitle = 'test-rejected';
       const translation = {
         ...DEFAULT_TRANSLATION,
-        ...{ rejected: true, rejectedUser: 'Bhaal' },
+        status: 'rejected',
+        rejectedUser: 'Bhaal',
       };
       const { getAllByTitle } = render(
         <MockLocalizationProvider
@@ -209,10 +193,7 @@ describe('<HistoryTranslationComponent>', () => {
 
     it('returns the correct review title when rejected and rejected user is not available', () => {
       const rejectedAnonymousTitle = 'test-rejected-anonymous';
-      const translation = {
-        ...DEFAULT_TRANSLATION,
-        ...{ rejected: true },
-      };
+      const translation = { ...DEFAULT_TRANSLATION, status: 'rejected' };
       const { getAllByTitle } = render(
         <MockLocalizationProvider
           resources={[
@@ -255,7 +236,9 @@ describe('<HistoryTranslationComponent>', () => {
     it('returns a link when the author is known', () => {
       const translation = {
         ...DEFAULT_TRANSLATION,
-        ...{ uid: 1, username: 'id_Sarevok', user: 'Sarevok' },
+        uid: 1,
+        username: 'id_Sarevok',
+        user: 'Sarevok',
       };
       const { getByRole } = render(
         <WrapHistoryTranslationBase
@@ -273,10 +256,7 @@ describe('<HistoryTranslationComponent>', () => {
     });
 
     it('returns no link when the author is not known', () => {
-      const translation = {
-        ...DEFAULT_TRANSLATION,
-        ...{ user: 'Sarevok' },
-      };
+      const translation = { ...DEFAULT_TRANSLATION, user: 'Sarevok' };
       const { queryByRole, getByText } = render(
         <WrapHistoryTranslationBase
           translation={translation}
@@ -300,10 +280,7 @@ describe('<HistoryTranslationComponent>', () => {
     const notRejected = 'Not rejected';
 
     it('shows the correct buttons for approved translations', () => {
-      const translation = {
-        ...DEFAULT_TRANSLATION,
-        ...{ approved: true },
-      };
+      const translation = { ...DEFAULT_TRANSLATION, status: 'approved' };
       const { getByRole, queryByRole } = render(
         <WrapHistoryTranslationBase
           translation={translation}
@@ -319,10 +296,7 @@ describe('<HistoryTranslationComponent>', () => {
     });
 
     it('shows the correct buttons for rejected translations', () => {
-      const translation = {
-        ...DEFAULT_TRANSLATION,
-        ...{ rejected: true },
-      };
+      const translation = { ...DEFAULT_TRANSLATION, status: 'rejected' };
       const { getByRole, queryByRole } = render(
         <WrapHistoryTranslationBase
           translation={translation}
@@ -371,7 +345,7 @@ describe('<HistoryTranslationComponent>', () => {
     });
 
     it('forbids the user to reject their own approved translation', () => {
-      const translation = { ...DEFAULT_TRANSLATION, approved: true };
+      const translation = { ...DEFAULT_TRANSLATION, status: 'approved' };
       const { queryByRole } = render(
         <WrapHistoryTranslationBase
           translation={translation}
@@ -400,7 +374,7 @@ describe('<HistoryTranslationComponent>', () => {
 
     it('allows translators to delete the rejected translation', () => {
       hookModule.useTranslator.mockReturnValue(true);
-      const translation = { ...DEFAULT_TRANSLATION, rejected: true };
+      const translation = { ...DEFAULT_TRANSLATION, status: 'rejected' };
       const { getByRole } = render(
         <WrapHistoryTranslationBase
           translation={translation}
@@ -414,10 +388,9 @@ describe('<HistoryTranslationComponent>', () => {
 
     it('forbids translators to delete non-rejected translation', () => {
       hookModule.useTranslator.mockReturnValue(true);
-      const translation = { ...DEFAULT_TRANSLATION, rejected: false };
       const { queryByRole } = render(
         <WrapHistoryTranslationBase
-          translation={translation}
+          translation={DEFAULT_TRANSLATION}
           entity={DEFAULT_ENTITY}
           user={DEFAULT_USER}
         />,
@@ -427,7 +400,7 @@ describe('<HistoryTranslationComponent>', () => {
     });
 
     it('allows the user to delete their own rejected translation', () => {
-      const translation = { ...DEFAULT_TRANSLATION, rejected: true };
+      const translation = { ...DEFAULT_TRANSLATION, status: 'rejected' };
       const { getByRole } = render(
         <WrapHistoryTranslationBase
           translation={translation}
@@ -440,7 +413,7 @@ describe('<HistoryTranslationComponent>', () => {
     });
 
     it('forbids the user to delete rejected translation of another user', () => {
-      const translation = { ...DEFAULT_TRANSLATION, rejected: true };
+      const translation = { ...DEFAULT_TRANSLATION, status: 'rejected' };
       const { queryByRole } = render(
         <WrapHistoryTranslationBase
           translation={translation}

--- a/translate/src/modules/history/components/HistoryTranslation.test.jsx
+++ b/translate/src/modules/history/components/HistoryTranslation.test.jsx
@@ -23,12 +23,15 @@ afterAll(() => {
 });
 
 describe('<HistoryTranslationComponent>', () => {
+  const string = 'The storm approaches. We speak no more.';
   const DEFAULT_TRANSLATION = {
     status: 'unreviewed',
     approvedUser: '',
     date: '',
     pk: 1,
-    string: 'The storm approaches. We speak no more.',
+    key: ['key'],
+    string,
+    value: [string],
     uid: 0,
     rejectedUser: '',
     user: '',
@@ -43,6 +46,8 @@ describe('<HistoryTranslationComponent>', () => {
 
   const DEFAULT_ENTITY = {
     format: 'gettext',
+    key: ['key'],
+    value: [],
   };
   const WrapHistoryTranslationBase = (props) => {
     return (

--- a/translate/src/modules/history/components/HistoryTranslation.tsx
+++ b/translate/src/modules/history/components/HistoryTranslation.tsx
@@ -14,6 +14,7 @@ import { withActionsDisabled } from '~/utils';
 import { useTranslator } from '~/hooks/useTranslator';
 
 import './HistoryTranslation.css';
+import { messageEntryFromTranslation } from '~/utils/message/fromTranslation';
 
 type Props = {
   entity: Entity;
@@ -439,11 +440,10 @@ export function HistoryTranslationBase({
               data-script={script}
             >
               <Translation
-                content={translation.string}
+                content={messageEntryFromTranslation(translation, entity)}
                 diffTarget={
                   isDiffVisible ? activeTranslation.string : undefined
                 }
-                format={entity.format}
               />
             </p>
           </div>

--- a/translate/src/modules/history/components/HistoryTranslation.tsx
+++ b/translate/src/modules/history/components/HistoryTranslation.tsx
@@ -199,26 +199,29 @@ export function HistoryTranslationBase({
     vars: { user: '', reviewedDate: new Date() },
     attrs: { title: true },
   };
-  if (translation.approved) {
-    if (translation.approvedDate) {
-      review.vars.reviewedDate = new Date(translation.approvedDate);
-    }
-    if (translation.approvedUser) {
-      review.vars.user = translation.approvedUser;
-      review.id = 'history-translation--approved';
-    } else {
-      review.id = 'history-translation--approved-anonymous';
-    }
-  } else if (translation.rejected) {
-    if (translation.rejectedDate) {
-      review.vars.reviewedDate = new Date(translation.rejectedDate);
-    }
-    if (translation.rejectedUser) {
-      review.vars.user = translation.rejectedUser;
-      review.id = 'history-translation--rejected';
-    } else {
-      review.id = 'history-translation--rejected-anonymous';
-    }
+  const { status } = translation;
+  switch (status) {
+    case 'approved':
+      if (translation.approvedDate) {
+        review.vars.reviewedDate = new Date(translation.approvedDate);
+      }
+      if (translation.approvedUser) {
+        review.vars.user = translation.approvedUser;
+        review.id = 'history-translation--approved';
+      } else {
+        review.id = 'history-translation--approved-anonymous';
+      }
+      break;
+    case 'rejected':
+      if (translation.rejectedDate) {
+        review.vars.reviewedDate = new Date(translation.rejectedDate);
+      }
+      if (translation.rejectedUser) {
+        review.vars.user = translation.rejectedUser;
+        review.id = 'history-translation--rejected';
+      } else {
+        review.id = 'history-translation--rejected-anonymous';
+      }
   }
 
   const commentCount = translation.comments?.length ?? 0;
@@ -229,7 +232,7 @@ export function HistoryTranslationBase({
 
   let canDelete = (isTranslator || ownTranslation) && !isReadOnlyEditor;
   let canReject =
-    (isTranslator || (ownTranslation && !translation.approved)) &&
+    (isTranslator || (ownTranslation && status !== 'approved')) &&
     !isReadOnlyEditor;
   let canComment = user.isAuthenticated;
 
@@ -242,15 +245,7 @@ export function HistoryTranslationBase({
 
   const className = classNames(
     'translation',
-    translation.approved
-      ? 'approved'
-      : translation.pretranslated
-        ? 'pretranslated'
-        : translation.fuzzy
-          ? 'fuzzy'
-          : translation.rejected
-            ? 'rejected'
-            : 'unreviewed',
+    status,
     isReadOnlyEditor
       ? 'cannot-copy'
       : { 'can-approve': isTranslator, 'can-reject': canReject },
@@ -315,7 +310,7 @@ export function HistoryTranslationBase({
                   />
                 ) : null}
 
-                {translation.rejected && canDelete ? (
+                {status === 'rejected' && canDelete ? (
                   // Delete Button
                   <Localized
                     id='history-Translation--button-delete'
@@ -329,7 +324,7 @@ export function HistoryTranslationBase({
                     />
                   </Localized>
                 ) : null}
-                {translation.approved ? (
+                {status === 'approved' ? (
                   // Unapprove Button
                   isTranslator && !isReadOnlyEditor ? (
                     <Localized
@@ -382,7 +377,7 @@ export function HistoryTranslationBase({
                     />
                   </Localized>
                 )}
-                {translation.rejected ? (
+                {status === 'rejected' ? (
                   // Unreject Button
                   canReject ? (
                     <Localized

--- a/translate/src/modules/translation/components/Translation.tsx
+++ b/translate/src/modules/translation/components/Translation.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
-import { getPlainMessage } from '~/utils/message';
+import { getPlainMessage, MessageEntry } from '~/utils/message';
 import { specialFormats } from '~/utils/message/specialFormats';
 
 import { GenericTranslation } from './GenericTranslation';
 
 type Props = {
-  content: string;
-  format: string;
+  content: string | MessageEntry | null;
+  format?: string;
   diffTarget?: string;
   search?: string | null;
 };
@@ -22,14 +22,12 @@ export function Translation({
     return null;
   }
 
-  if (specialFormats.has(format)) {
-    content = getPlainMessage(content, format);
-    diffTarget &&= getPlainMessage(diffTarget, format);
-  }
+  const plain = getPlainMessage(content, format);
+  diffTarget &&= getPlainMessage(diffTarget, format);
 
   return (
     <GenericTranslation
-      content={content}
+      content={plain}
       diffTarget={diffTarget}
       search={search}
     />

--- a/translate/src/modules/translationform/components/TranslationForm-multiple.test.jsx
+++ b/translate/src/modules/translationform/components/TranslationForm-multiple.test.jsx
@@ -1,4 +1,5 @@
 import ftl from '@fluent/dedent';
+import { fluentParseEntry } from '@mozilla/l10n';
 import { fireEvent } from '@testing-library/react';
 import { useContext } from 'react';
 import { act } from 'react-dom/test-utils';
@@ -28,11 +29,14 @@ function mountForm(string) {
   const store = createReduxStore();
   createDefaultUser(store);
 
+  const [id, entry] = fluentParseEntry(string);
   const entity = {
     pk: 0,
     format: 'fluent',
-    original: 'my-message = Hello',
-    translation: { string },
+    key: [id],
+    original: 'my-message = Hello\n',
+    value: ['Hello'],
+    translation: { string, value: entry['='] ?? [], properties: entry['+'] },
   };
 
   let actions, result;

--- a/translate/src/modules/translationform/components/TranslationForm-single.test.jsx
+++ b/translate/src/modules/translationform/components/TranslationForm-single.test.jsx
@@ -29,7 +29,8 @@ function mountForm(string) {
     pk: 0,
     key: ['key'],
     original: 'Hello',
-    translation: { string },
+    value: ['Hello'],
+    translation: { string, value: [string] },
   };
 
   let actions, result;

--- a/translate/src/modules/translationform/utils/editFieldShortcuts.ts
+++ b/translate/src/modules/translationform/utils/editFieldShortcuts.ts
@@ -42,7 +42,7 @@ export function useHandleEnter(): () => true {
       updateTranslationStatus(source, 'approve', ignoreWarnings);
     } else {
       const existingTranslation = getExistingTranslation();
-      if (existingTranslation && !existingTranslation.approved) {
+      if (existingTranslation && existingTranslation.status !== 'approved') {
         updateTranslationStatus(
           existingTranslation.pk,
           'approve',

--- a/translate/src/modules/user/components/UserAvatar.tsx
+++ b/translate/src/modules/user/components/UserAvatar.tsx
@@ -7,12 +7,12 @@ type Props = {
   username: string;
   title?: string;
   imageUrl: string;
-  userBanner: string[];
+  userBanner?: [string, string];
 };
 
 export function UserAvatar(props: Props): React.ReactElement<'div'> {
   const { username, title, imageUrl, userBanner } = props;
-  const [status, tooltip] = userBanner;
+  const [status, tooltip] = userBanner ?? [];
 
   return (
     <div className='user-avatar'>

--- a/translate/src/utils/message/fromEntity.test.ts
+++ b/translate/src/utils/message/fromEntity.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import type { Entity } from '~/api/entity';
+import type { Locale } from '~/context/Locale';
+import {
+  messageEntryFromEntity,
+  messageEntryFromEntityTranslation,
+} from './fromEntity';
+
+describe('messageEntryFromEntity', () => {
+  it('android entry', () => {
+    const entity = {
+      format: 'android',
+      key: ['id'],
+      value: ['VALUE ', { $: 'x' }],
+      translation: { value: ['TRANS ', { $: 'x' }] },
+    } as Entity;
+    expect(messageEntryFromEntity(entity)).toEqual({
+      format: 'android',
+      id: 'id',
+      value: ['VALUE ', { $: 'x' }],
+    });
+  });
+
+  it('fluent entry with attributes', () => {
+    const entity = {
+      format: 'fluent',
+      key: ['id'],
+      value: ['VALUE ', { $: 'x' }],
+      properties: { a: ['ATTR A'], b: ['ATTR B'] },
+    } as unknown as Entity;
+    expect(messageEntryFromEntity(entity)).toEqual({
+      format: 'fluent',
+      id: 'id',
+      value: ['VALUE ', { $: 'x' }],
+      attributes: new Map([
+        ['a', ['ATTR A']],
+        ['b', ['ATTR B']],
+      ]),
+    });
+  });
+});
+
+describe('messageEntryFromEntityTranslation', () => {
+  it('android entry with translation', () => {
+    const entity = {
+      format: 'android',
+      key: ['id'],
+      value: ['VALUE ', { $: 'x' }],
+      translation: { status: 'approved', value: ['TRANS ', { $: 'x' }] },
+    };
+    const locale = { code: 'sl' } as Locale;
+
+    expect(messageEntryFromEntityTranslation(entity as Entity)).toEqual({
+      format: 'android',
+      id: 'id',
+      value: ['TRANS ', { $: 'x' }],
+    });
+
+    entity.translation.status = 'rejected';
+    expect(messageEntryFromEntityTranslation(entity as Entity, locale)).toEqual(
+      { format: 'android', id: 'id', value: [] },
+    );
+  });
+
+  it('fluent entry with attributes and no translation', () => {
+    const entity = {
+      format: 'fluent',
+      key: ['id'],
+      value: ['VALUE ', { $: 'x' }],
+      properties: { a: ['ATTR A'], b: ['ATTR B'] },
+    } as unknown as Entity;
+    const locale = { code: 'sl' } as Locale;
+    expect(messageEntryFromEntityTranslation(entity)).toBeNull();
+    expect(messageEntryFromEntityTranslation(entity, locale)).toEqual({
+      format: 'fluent',
+      id: 'id',
+      value: [],
+      attributes: new Map([
+        ['a', []],
+        ['b', []],
+      ]),
+    });
+  });
+});

--- a/translate/src/utils/message/fromEntity.ts
+++ b/translate/src/utils/message/fromEntity.ts
@@ -1,0 +1,41 @@
+import type { Entity } from '~/api/entity';
+import type { Locale } from '~/context/Locale';
+import type { MessageEntry } from '.';
+import { getEmptyMessageEntry } from './getEmptyMessage';
+import { getMessageEntryFormat } from './getMessageEntryFormat';
+import { messageEntryFromTranslation } from './fromTranslation';
+
+export function messageEntryFromEntity(entity: Entity): MessageEntry {
+  const format = getMessageEntryFormat(entity.format);
+  const id = entity.key[0] ?? '';
+  const { value, properties } = entity;
+  if (format === 'fluent' && properties) {
+    const attributes = new Map(Object.entries(properties));
+    const value_ = Array.isArray(value) && value.length === 0 ? null : value;
+    return { format, id, value: value_, attributes };
+  } else {
+    return { format, id, value };
+  }
+}
+
+export function messageEntryFromEntityTranslation(
+  entity: Entity,
+): MessageEntry | null;
+export function messageEntryFromEntityTranslation(
+  entity: Entity,
+  locale: Locale,
+): MessageEntry;
+export function messageEntryFromEntityTranslation(
+  entity: Entity,
+  locale?: Locale,
+): MessageEntry | null {
+  const { translation } = entity;
+
+  if (!translation || translation.status === 'rejected') {
+    if (!locale) return null;
+    const orig = messageEntryFromEntity(entity);
+    return getEmptyMessageEntry(orig, locale);
+  }
+
+  return messageEntryFromTranslation(translation, entity);
+}

--- a/translate/src/utils/message/fromTranslation.test.ts
+++ b/translate/src/utils/message/fromTranslation.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import type { Entity } from '~/api/entity';
+import type { EntityTranslation } from '~/api/translation';
+import { messageEntryFromTranslation } from './fromTranslation';
+
+describe('messageEntryFromTranslation', () => {
+  it('android entry', () => {
+    const translation = { value: ['TRANS ', { $: 'x' }] } as EntityTranslation;
+    expect(messageEntryFromTranslation(translation, 'android')).toEqual({
+      format: 'android',
+      id: '',
+      value: ['TRANS ', { $: 'x' }],
+    });
+  });
+
+  it('fluent translation with attributes', () => {
+    const translation = {
+      value: ['VALUE ', { $: 'x' }],
+      properties: {
+        a: ['ATTR A'],
+        b: ['ATTR B'],
+      },
+    } as unknown as EntityTranslation;
+    const exp = {
+      format: 'fluent',
+      id: '',
+      value: ['VALUE ', { $: 'x' }],
+      attributes: new Map([
+        ['a', ['ATTR A']],
+        ['b', ['ATTR B']],
+      ]),
+    };
+    expect(messageEntryFromTranslation(translation, 'fluent')).toEqual(exp);
+    expect(
+      messageEntryFromTranslation(translation, {
+        format: 'fluent',
+        key: ['id'],
+      } as Entity),
+    ).toEqual({ ...exp, id: 'id' });
+  });
+});

--- a/translate/src/utils/message/fromTranslation.ts
+++ b/translate/src/utils/message/fromTranslation.ts
@@ -1,0 +1,35 @@
+import type { EntityTranslation } from '~/api/translation';
+import type { MessageEntry } from '.';
+import { getMessageEntryFormat } from './getMessageEntryFormat';
+import type { Entity } from '~/api/entity';
+
+export function messageEntryFromTranslation(
+  translation: EntityTranslation,
+  entity: Entity,
+): MessageEntry;
+export function messageEntryFromTranslation(
+  translation: EntityTranslation,
+  format: string,
+  id?: string,
+): MessageEntry;
+export function messageEntryFromTranslation(
+  { value, properties }: EntityTranslation,
+  entityOrFormat: string | Entity,
+  id: string = '',
+): MessageEntry {
+  let format;
+  if (typeof entityOrFormat === 'string') {
+    format = getMessageEntryFormat(entityOrFormat);
+  } else {
+    format = getMessageEntryFormat(entityOrFormat.format);
+    id ||= entityOrFormat.key[0] ?? '';
+  }
+
+  if (format === 'fluent' && properties) {
+    const attributes = new Map(Object.entries(properties));
+    const value_ = Array.isArray(value) && value.length === 0 ? null : value;
+    return { format, id, value: value_, attributes };
+  }
+
+  return { format, id, value };
+}

--- a/translate/src/utils/message/getPlainMessage.test.js
+++ b/translate/src/utils/message/getPlainMessage.test.js
@@ -176,6 +176,15 @@ describe('getPlainMessage', () => {
       const res = getPlainMessage(message, 'fluent');
       expect(res).toEqual('{ 22 }');
     });
+
+    it('work with a message entry value', () => {
+      const entry = {
+        format: 'fluent',
+        value: ['a = ', { $: 'b' }],
+      };
+      const res = getPlainMessage(entry);
+      expect(res).toEqual('a = { $b }');
+    });
   });
 
   describe('Unicode MessageFormat', () => {
@@ -202,6 +211,15 @@ describe('getPlainMessage', () => {
         '{$vendor :xliff:g id=vendor example=Xiaomi @translate=no @source=|%1$s|} additional settings';
       const res = getPlainMessage(message, 'android');
       expect(res).toEqual('%1$s additional settings');
+    });
+
+    it('work with a message entry value', () => {
+      const entry = {
+        format: 'android',
+        value: ['a = ', { $: 'b' }],
+      };
+      const res = getPlainMessage(entry);
+      expect(res).toEqual('a = {$b}');
     });
   });
 });

--- a/translate/src/utils/message/getPlainMessage.ts
+++ b/translate/src/utils/message/getPlainMessage.ts
@@ -12,7 +12,7 @@ import { parseEntry } from './parseEntry';
  */
 export function getPlainMessage(
   message: string | MessageEntry,
-  format: string,
+  format: string | undefined,
 ): string {
   if (!message) {
     return '';
@@ -20,7 +20,7 @@ export function getPlainMessage(
 
   let entry: MessageEntry | null;
   if (typeof message === 'string') {
-    entry = parseEntry(format, message);
+    entry = parseEntry(format!, message);
     if (!entry) {
       return message;
     }
@@ -29,12 +29,15 @@ export function getPlainMessage(
   }
 
   if (entry.value) {
-    return previewMessage(format, entry.value);
+    const preview = previewMessage(entry.format, entry.value);
+    if (preview) {
+      return preview;
+    }
   }
 
   if (entry.attributes) {
     for (const attr of entry.attributes.values()) {
-      const preview = previewMessage(format, attr);
+      const preview = previewMessage(entry.format, attr);
       if (preview) {
         return preview;
       }


### PR DESCRIPTION
The headline change here is including the `.value` and `.properties` fields in the `POST /get-entities` and `POST /get-history` response data, and starting to use those for some of the frontend operations.

The changes here also include some related cleanup, as well as a slight minification of those endpoints' included data, as empty fields are now left out of the payload, and a single `.status` enum replaces the previously used multiple booleans.