### PR TITLE
Ensure EditAccesskey state is updated before it's read

### DIFF
--- a/translate/src/modules/translationform/components/EditAccesskey.tsx
+++ b/translate/src/modules/translationform/components/EditAccesskey.tsx
@@ -71,7 +71,7 @@ export const EditAccesskey = memo(
       const setValue = useCallback(
         (value: string) => {
           setValue_(value);
-          setResultFromInput();
+          setTimeout(setResultFromInput);
         },
         [index],
       );
@@ -99,7 +99,7 @@ export const EditAccesskey = memo(
           },
           setValue,
         }),
-        [setValue],
+        [setValue, value],
       );
 
       const handleUpdate = (value: string) => {

--- a/translate/src/modules/translationform/components/TranslationForm-multiple.test.jsx
+++ b/translate/src/modules/translationform/components/TranslationForm-multiple.test.jsx
@@ -1,6 +1,8 @@
 import ftl from '@fluent/dedent';
-import React, { useContext } from 'react';
+import { fireEvent } from '@testing-library/react';
+import { useContext } from 'react';
 import { act } from 'react-dom/test-utils';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { EditorActions, EditorProvider, EditorResult } from '~/context/Editor';
 import { EntityView } from '~/context/EntityView';
@@ -14,7 +16,6 @@ import {
 import { MockLocalizationProvider } from '~/test/utils';
 
 import { TranslationForm } from './TranslationForm';
-import { expect } from 'vitest';
 
 const DEFAULT_LOCALE = {
   direction: 'ltr',
@@ -56,6 +57,8 @@ function mountForm(string) {
     ),
     store,
   );
+  vi.runAllTimers();
+
   // TODO:Replace the querySelector with testing-library-ish approaches
   const form = wrapper.container.querySelector('.translationform');
   const views = Array.from(form.querySelectorAll('.cm-content')).map(
@@ -66,6 +69,10 @@ function mountForm(string) {
 }
 
 describe('<TranslationForm> with multiple fields', () => {
+  beforeAll(() => {
+    vi.useFakeTimers();
+  });
+
   it('renders textarea for a value and each attribute', () => {
     const { views } = mountForm(ftl`
       message = Value
@@ -200,6 +207,7 @@ describe('<TranslationForm> with multiple fields', () => {
 
   it('renders access keys properly', () => {
     const {
+      getResult,
       views,
       wrapper: { container },
     } = mountForm(ftl`
@@ -224,11 +232,19 @@ describe('<TranslationForm> with multiple fields', () => {
     expect(input[0]).toHaveAttribute('maxLength', '1');
 
     expect(container.querySelectorAll('.accesskeys')).toHaveLength(1);
-    const buttonTexts = Array.from(
-      container.querySelectorAll('.accesskeys button'),
-      (button) => button.textContent,
-    );
+    const buttons = container.querySelectorAll('.accesskeys button');
+    const buttonTexts = Array.from(buttons, (button) => button.textContent);
     expect(buttonTexts).toMatchObject(['C', 'a', 'n', 'd', 'i', 't', 'e', 's']);
+
+    fireEvent.click(buttons[1]);
+    vi.runAllTimers();
+
+    expect(getResult().attributes).toEqual(
+      new Map([
+        ['label', ['Candidates']],
+        ['accesskey', ['a']],
+      ]),
+    );
   });
 
   it('does not render accesskey buttons if no candidates can be generated', () => {


### PR DESCRIPTION
Fixes #4202

We were missing a test ensuring that accesskey buttons work right, which meant that the breakage caused by [this change](https://github.com/mozilla/pontoon/pull/4178/changes#diff-960530d19de5a9f4aba7ae2da9029f9790de83d3859858e95e52258b504fb3cfR271-R279) was missed.

The implementation here is a little bit tricky, because we're needing to model the codemirror state management to keep that same API in the Editor context. Ensuring that the imperative ref is updated on `value` change helps with that, but we also need to wrap the result update in a `setTimeout()` to ensure that it happens after the `setValue()` has had an effect.