### PR TITLE
Notifications: show consistent exact date and time in timestamp tooltips

### DIFF
--- a/pontoon/base/notification_utils.py
+++ b/pontoon/base/notification_utils.py
@@ -59,6 +59,9 @@ def is_subscribed_to_notification(user: "User", notification: Notification) -> b
 
 def serialized_notifications(user: "User"):
     """Serialized list of notifications to display in the notifications menu."""
+    # Local import to avoid a circular import (helpers -> simple_preview -> base.models).
+    from pontoon.base.templatetags.helpers import format_datetime
+
     unread_count: int = user_notifications(user).unread().count()
     count: int = settings.NOTIFICATIONS_MAX_COUNT
     notifications = []
@@ -144,7 +147,7 @@ def serialized_notifications(user: "User"):
                     "is_comment": is_comment,
                 },
                 "verb": notification.verb,
-                "date": notification.timestamp.strftime("%b %d, %Y %H:%M"),
+                "date": format_datetime(notification.timestamp, "full"),
                 "date_iso": notification.timestamp.isoformat(),
                 "actor": actor,
                 "target": target,

--- a/pontoon/base/notification_utils.py
+++ b/pontoon/base/notification_utils.py
@@ -146,7 +146,7 @@ def serialized_notifications(user: "User"):
                     "is_comment": is_comment,
                 },
                 "verb": notification.verb,
-                "date": format_datetime(notification.timestamp, "full"),
+                "date": format_datetime(notification.timestamp),
                 "date_iso": notification.timestamp.isoformat(),
                 "actor": actor,
                 "target": target,

--- a/pontoon/base/notification_utils.py
+++ b/pontoon/base/notification_utils.py
@@ -6,6 +6,8 @@ from django.conf import settings
 from django.db.models import QuerySet
 from django.urls import reverse
 
+from pontoon.base.utils import format_datetime
+
 
 if TYPE_CHECKING:
     from pontoon.base.models import Entity, Project, User
@@ -59,9 +61,6 @@ def is_subscribed_to_notification(user: "User", notification: Notification) -> b
 
 def serialized_notifications(user: "User"):
     """Serialized list of notifications to display in the notifications menu."""
-    # Local import to avoid a circular import (helpers -> simple_preview -> base.models).
-    from pontoon.base.templatetags.helpers import format_datetime
-
     unread_count: int = user_notifications(user).unread().count()
     count: int = settings.NOTIFICATIONS_MAX_COUNT
     notifications = []

--- a/pontoon/base/templatetags/helpers.py
+++ b/pontoon/base/templatetags/helpers.py
@@ -26,6 +26,7 @@ from django.utils.safestring import mark_safe
 
 from pontoon.base.placeables import get_placeables
 from pontoon.base.simple_preview import get_simple_preview
+from pontoon.base.utils import format_datetime
 
 
 register = template.Library()
@@ -180,20 +181,7 @@ def date_status(value, complete):
     return "normal"
 
 
-@library.filter
-def format_datetime(value, format="full", default="---"):
-    if value is not None:
-        if format == "full":
-            format = "%A, %B %d, %Y at %H:%M %Z"
-        elif format == "date":
-            format = "%B %-d, %Y"
-        elif format == "short_date":
-            format = "%b %-d, %Y"
-        elif format == "time":
-            format = "%H:%M %Z"
-        return value.strftime(format)
-    else:
-        return default
+library.filter(format_datetime)
 
 
 @library.filter

--- a/pontoon/base/tests/test_notification_utils.py
+++ b/pontoon/base/tests/test_notification_utils.py
@@ -128,5 +128,5 @@ def test_serialized_notifications_date_format(user_a, project_a):
 
     notification_obj = Notification.objects.get(recipient=user_a)
     serialized = serialized_notifications(user_a)["notifications"][0]
-    assert serialized["date"] == format_datetime(notification_obj.timestamp, "full")
+    assert serialized["date"] == format_datetime(notification_obj.timestamp)
     assert serialized["date_iso"] == notification_obj.timestamp.isoformat()

--- a/pontoon/base/tests/test_notification_utils.py
+++ b/pontoon/base/tests/test_notification_utils.py
@@ -109,3 +109,24 @@ def test_serialized_notifications_new_string_without_created_time(user_a, projec
     assert notification["actor"]["url"] == (
         f"/projects/{project_a.slug}/all-resources/?status=missing,pretranslated"
     )
+
+
+@pytest.mark.django_db
+def test_serialized_notifications_date_format(user_a, project_a):
+    """
+    The serialized "date" carries the exact date and time shown in the
+    timestamp tooltip, matching format_datetime("full") used by the Django
+    notifications menu.
+    """
+    from pontoon.base.templatetags.helpers import format_datetime
+
+    notify.send(
+        sender=project_a,
+        recipient=user_a,
+        verb="has reviewed suggestions",
+    )
+
+    notification_obj = Notification.objects.get(recipient=user_a)
+    serialized = serialized_notifications(user_a)["notifications"][0]
+    assert serialized["date"] == format_datetime(notification_obj.timestamp, "full")
+    assert serialized["date_iso"] == notification_obj.timestamp.isoformat()

--- a/pontoon/base/tests/test_notification_utils.py
+++ b/pontoon/base/tests/test_notification_utils.py
@@ -115,10 +115,10 @@ def test_serialized_notifications_new_string_without_created_time(user_a, projec
 def test_serialized_notifications_date_format(user_a, project_a):
     """
     The serialized "date" carries the exact date and time shown in the
-    timestamp tooltip, matching format_datetime("full") used by the Django
+    timestamp tooltip, matching format_datetime() used by the Django
     notifications menu.
     """
-    from pontoon.base.templatetags.helpers import format_datetime
+    from pontoon.base.utils import format_datetime
 
     notify.send(
         sender=project_a,

--- a/pontoon/base/utils.py
+++ b/pontoon/base/utils.py
@@ -19,6 +19,21 @@ def split_ints(s):
     return [int(part) for part in (s or "").split(",") if part]
 
 
+def format_datetime(value, format="full", default="---"):
+    if value is not None:
+        if format == "full":
+            format = "%A, %B %d, %Y at %H:%M %Z"
+        elif format == "date":
+            format = "%B %-d, %Y"
+        elif format == "short_date":
+            format = "%b %-d, %Y"
+        elif format == "time":
+            format = "%H:%M %Z"
+        return value.strftime(format)
+    else:
+        return default
+
+
 def get_ip(request):
     try:
         ip = request.META["HTTP_X_FORWARDED_FOR"]

--- a/pontoon/contributors/templates/contributors/widgets/notifications_menu.html
+++ b/pontoon/contributors/templates/contributors/widgets/notifications_menu.html
@@ -32,12 +32,20 @@
 
 {% macro notification_time(notification) %}
 
+  {% set exact_time = notification.timestamp|format_datetime("full") %}
   {% if notification|is_old_notification %}
-    <time class="old-notification" datetime="{{ notification.timestamp }}">
+    <time
+      class="old-notification"
+      datetime="{{ notification.timestamp }}"
+      title="{{ exact_time }}"
+    >
       {{ notification.timestamp|format_datetime("date") }}
     </time>
   {% else %}
-    <time class="timeago" datetime="{{ notification.timestamp }}"
+    <time
+      class="timeago"
+      datetime="{{ notification.timestamp }}"
+      title="{{ exact_time }}"
       >{{ notification.timesince() }}</time
     >
   {% endif %}

--- a/pontoon/contributors/templates/contributors/widgets/notifications_menu.html
+++ b/pontoon/contributors/templates/contributors/widgets/notifications_menu.html
@@ -32,7 +32,7 @@
 
 {% macro notification_time(notification) %}
 
-  {% set exact_time = notification.timestamp|format_datetime("full") %}
+  {% set exact_time = notification.timestamp|format_datetime() %}
   {% if notification|is_old_notification %}
     <time
       class="old-notification"

--- a/translate/src/modules/user/components/UserNotification.test.jsx
+++ b/translate/src/modules/user/components/UserNotification.test.jsx
@@ -3,9 +3,11 @@ import { UserNotification } from './UserNotification';
 import { vi } from 'vitest';
 import { render } from '@testing-library/react';
 
+const { timeAgoSpy } = vi.hoisted(() => ({ timeAgoSpy: vi.fn(() => null) }));
+
 vi.mock('react-time-ago', () => {
   return {
-    default: () => null,
+    default: timeAgoSpy,
   };
 });
 
@@ -15,7 +17,7 @@ const notificationBase = {
   unread: false,
   description: null,
   verb: 'verb',
-  date: 'Jan 31, 2000 10:20',
+  date: 'Thursday, January 31, 2019 at 10:20 UTC',
   date_iso: '2019-01-31T10:20:00+00:00',
   actor: { anchor: 'actor_anchor', url: 'actor_url' },
   target: { anchor: 'target_anchor', url: 'target_url' },
@@ -94,6 +96,34 @@ describe('<UserNotification>', () => {
 
     expect(container.querySelector('.message')).toBeNull();
     expect(container.querySelector('.verb')).toHaveTextContent('is Other');
+  });
+
+  it('shows the exact date and time in the timestamp tooltip', () => {
+    const notification = {
+      ...notificationBase,
+      description: { content: 'Unreviewed suggestions' },
+    };
+    const { container } = render(
+      <UserNotification notification={notification} />,
+    );
+
+    const time = container.querySelector('time');
+    expect(time).toHaveAttribute('title', notificationBase.date);
+    expect(time).toHaveAttribute('datetime', notificationBase.date_iso);
+    expect(time).toHaveTextContent('January 31, 2019');
+  });
+
+  it('shows the exact date and time in a recent notification tooltip', () => {
+    timeAgoSpy.mockClear();
+    const notification = {
+      ...notificationBase,
+      description: { content: 'Unreviewed suggestions' },
+      date_iso: new Date(Date.now() - 60 * 1000).toISOString(),
+    };
+    render(<UserNotification notification={notification} />);
+
+    const props = timeAgoSpy.mock.calls[0][0];
+    expect(props.formatVerboseDate()).toBe(notificationBase.date);
   });
 
   it('shows comment notification with deleted actor', () => {

--- a/translate/src/modules/user/components/UserNotification.tsx
+++ b/translate/src/modules/user/components/UserNotification.tsx
@@ -17,30 +17,32 @@ interface DateDisplayProps {
 }
 
 const DateDisplay: React.FC<DateDisplayProps> = ({ date, date_iso }) => {
-  const formattedDate: string = new Date(date).toLocaleDateString('en-US', {
-    day: 'numeric',
-    month: 'long',
-    year: 'numeric',
-  });
+  const parsed = new Date(date_iso);
   const isOld: boolean =
-    new Date(date_iso).getTime() <
-    new Date().getTime() - 7 * 24 * 60 * 60 * 1000;
+    parsed.getTime() < Date.now() - 7 * 24 * 60 * 60 * 1000;
+
+  if (isOld) {
+    const formattedDate: string = parsed.toLocaleDateString('en-US', {
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+      timeZone: 'UTC',
+    });
+    return (
+      <div className='date-display'>
+        <time dateTime={date_iso} title={date}>
+          {formattedDate}
+        </time>
+      </div>
+    );
+  }
+
   return (
-    <>
-      {isOld ? (
-        <div className='date-display'>
-          <time dateTime={date_iso} title={`${date} UTC`}>
-            {formattedDate}
-          </time>
-        </div>
-      ) : (
-        <ReactTimeAgo
-          className='timeago'
-          date={new Date(date_iso)}
-          title={`${date} UTC`}
-        />
-      )}
-    </>
+    <ReactTimeAgo
+      className='timeago'
+      date={parsed}
+      formatVerboseDate={() => date}
+    />
   );
 };
 

--- a/translate/src/modules/user/components/UserNotification.tsx
+++ b/translate/src/modules/user/components/UserNotification.tsx
@@ -17,12 +17,12 @@ interface DateDisplayProps {
 }
 
 const DateDisplay: React.FC<DateDisplayProps> = ({ date, date_iso }) => {
-  const parsed = new Date(date_iso);
+  const parsedDate = new Date(date_iso);
   const isOld: boolean =
-    parsed.getTime() < Date.now() - 7 * 24 * 60 * 60 * 1000;
+    parsedDate.getTime() < Date.now() - 7 * 24 * 60 * 60 * 1000;
 
   if (isOld) {
-    const formattedDate: string = parsed.toLocaleDateString('en-US', {
+    const formattedDate: string = parsedDate.toLocaleDateString('en-US', {
       day: 'numeric',
       month: 'long',
       year: 'numeric',
@@ -40,7 +40,7 @@ const DateDisplay: React.FC<DateDisplayProps> = ({ date, date_iso }) => {
   return (
     <ReactTimeAgo
       className='timeago'
-      date={parsed}
+      date={parsedDate}
       formatVerboseDate={() => date}
     />
   );

--- a/translate/src/modules/user/components/UserNotificationsMenu.test.jsx
+++ b/translate/src/modules/user/components/UserNotificationsMenu.test.jsx
@@ -39,7 +39,7 @@ describe('<UserNotificationsMenuDialog>', () => {
         unread: false,
         description: 'description',
         verb: 'verb',
-        date: 'Jan 31, 2000 10:20',
+        date: 'Thursday, January 31, 2019 at 10:20 UTC',
         date_iso: '2019-01-31T10:20:00+00:00',
         actor: {
           anchor: 'actor_anchor',


### PR DESCRIPTION
Fix #3809

- exact date and time via `format_datetime("full")` (Thursday, January 31, 2019 at 10:20 UTC).
- `contributors/widgets/notifications_menu.html`: add title (full timestamp) to both `timeago` and `old-notification` `<time>` in `notification_time` macro.
- `base.notification_utils.serialized_notifications`: serialize date with `format_datetime("full")` instead of `strftime`. Local import of `format_datetime` to avoid circular import.
- `UserNotification.tsx`: parse `date_iso`, render old dates in UTC, use date as tooltip. `title` for old & `formatVerboseDate` for recent.

Tests:

- test_serialized_notifications_date_format
- UserNotification.test.jsx tooltip cases (RTL) for both old and recent