### PR TITLE
Use correct syntax in standalone-login template

### DIFF
--- a/pontoon/base/templates/allauth/layouts/base.html
+++ b/pontoon/base/templates/allauth/layouts/base.html
@@ -100,7 +100,7 @@
                 {% if user.is_authenticated %}
                   <img
                     class="rounded"
-                    src="{{ request.user.gravatar_url() }}"
+                    src="{{ user.gravatar_url }}"
                     width="44"
                     height="44"
                   />


### PR DESCRIPTION
Fixes a regression from #4197.