### PR TITLE
feat: Added FXA profile image

### DIFF
--- a/pontoon/base/models/comment.py
+++ b/pontoon/base/models/comment.py
@@ -5,7 +5,7 @@ from django.db import models
 from django.utils import timezone
 
 from pontoon.base.models.user import User
-from pontoon.base.user_utils import gravatar_url, user_banner
+from pontoon.base.user_utils import avatar_url, user_banner
 
 
 if TYPE_CHECKING:
@@ -45,7 +45,7 @@ class Comment(models.Model):
             "user_banner": user_banner(author, locale, project_contact)
             if author
             else "",
-            "user_gravatar_url_small": gravatar_url(author) if author else "",
+            "user_gravatar_url_small": avatar_url(author) if author else "",
             "created_at": self.timestamp.strftime("%b %d, %Y %H:%M"),
             "date_iso": self.timestamp.isoformat(),
             "content": self.content,

--- a/pontoon/base/models/translation.py
+++ b/pontoon/base/models/translation.py
@@ -16,6 +16,7 @@ from pontoon.base.models.project import Project
 from pontoon.base.models.project_locale import ProjectLocale
 from pontoon.base.models.user import User
 from pontoon.base.simple_preview import get_simple_preview
+from pontoon.base.user_utils import avatar_url
 from pontoon.checks import DB_FORMATS
 from pontoon.checks.utils import save_failed_checks
 

--- a/pontoon/base/models/translation.py
+++ b/pontoon/base/models/translation.py
@@ -16,7 +16,6 @@ from pontoon.base.models.project import Project
 from pontoon.base.models.project_locale import ProjectLocale
 from pontoon.base.models.user import User
 from pontoon.base.simple_preview import get_simple_preview
-from pontoon.base.user_utils import avatar_url
 from pontoon.checks import DB_FORMATS
 from pontoon.checks.utils import save_failed_checks
 

--- a/pontoon/base/models/user.py
+++ b/pontoon/base/models/user.py
@@ -9,8 +9,8 @@ from pontoon.base.notification_utils import (
     unread_notifications_display,
 )
 from pontoon.base.user_utils import (
+    avatar_url,
     can_translate_locales,
-    gravatar_url,
     manager_for_locales,
     translator_for_locales,
 )
@@ -92,7 +92,7 @@ AuthUser.add_to_class("display_name", display_name)
 AuthUser.add_to_class("display_name_and_email", display_name_and_email)
 AuthUser.add_to_class("latest_action", latest_action)
 
-AuthUser.add_to_class("gravatar_url", gravatar_url)
+AuthUser.add_to_class("avatar_url", avatar_url)
 AuthUser.add_to_class("translator_for_locales", translator_for_locales)
 AuthUser.add_to_class("manager_for_locales", manager_for_locales)
 AuthUser.add_to_class("can_translate_locales", can_translate_locales)

--- a/pontoon/base/models/user.py
+++ b/pontoon/base/models/user.py
@@ -73,23 +73,6 @@ def display_name_and_email(user: User) -> str:
     return f"{name} <{user.email}>"
 
 
-def fxa_avatar(user: User) -> str | None:
-    if user.pk is None:
-        return
-
-    if hasattr(user, "_prefetched_fxa_accounts") and isinstance(
-        user._prefetched_fxa_accounts, list
-    ):
-        return (
-            user._prefetched_fxa_accounts[0].extra_data.get("avatar")
-            if user._prefetched_fxa_accounts
-            else None
-        )
-
-    fxa = user.socialaccount_set.filter(provider="fxa").first()
-    return fxa.extra_data.get("avatar") if fxa else None
-
-
 def latest_action(user: User) -> ActionLog | None:
     """
     Return the date of the latest user activity (translation submission or review).
@@ -110,7 +93,6 @@ AuthUser.add_to_class("display_name_and_email", display_name_and_email)
 AuthUser.add_to_class("latest_action", latest_action)
 
 AuthUser.add_to_class("avatar_url", avatar_url)
-AuthUser.add_to_class("fxa_avatar", fxa_avatar)
 AuthUser.add_to_class("translator_for_locales", translator_for_locales)
 AuthUser.add_to_class("manager_for_locales", manager_for_locales)
 AuthUser.add_to_class("can_translate_locales", can_translate_locales)

--- a/pontoon/base/models/user.py
+++ b/pontoon/base/models/user.py
@@ -73,6 +73,23 @@ def display_name_and_email(user: User) -> str:
     return f"{name} <{user.email}>"
 
 
+def fxa_avatar(user: User) -> str | None:
+    if user.pk is None:
+        return
+
+    if hasattr(user, "_prefetched_fxa_accounts") and isinstance(
+        user._prefetched_fxa_accounts, list
+    ):
+        return (
+            user._prefetched_fxa_accounts[0].extra_data.get("avatar")
+            if user._prefetched_fxa_accounts
+            else None
+        )
+
+    fxa = user.socialaccount_set.filter(provider="fxa").first()
+    return fxa.extra_data.get("avatar") if fxa else None
+
+
 def latest_action(user: User) -> ActionLog | None:
     """
     Return the date of the latest user activity (translation submission or review).
@@ -93,6 +110,7 @@ AuthUser.add_to_class("display_name_and_email", display_name_and_email)
 AuthUser.add_to_class("latest_action", latest_action)
 
 AuthUser.add_to_class("avatar_url", avatar_url)
+AuthUser.add_to_class("fxa_avatar", fxa_avatar)
 AuthUser.add_to_class("translator_for_locales", translator_for_locales)
 AuthUser.add_to_class("manager_for_locales", manager_for_locales)
 AuthUser.add_to_class("can_translate_locales", can_translate_locales)

--- a/pontoon/base/templates/allauth/layouts/base.html
+++ b/pontoon/base/templates/allauth/layouts/base.html
@@ -101,7 +101,7 @@
                 {% if user.is_authenticated %}
                   <img
                     class="rounded"
-                    src="{{ user.gravatar_url }}"
+                    src="{{ user.avatar_url }}"
                     width="44"
                     height="44"
                   />

--- a/pontoon/base/templates/widgets/latest_activity.html
+++ b/pontoon/base/templates/widgets/latest_activity.html
@@ -5,7 +5,7 @@
         {% set action = latest_activity.type + ' by' %}
         {% set user = latest_activity.user.name_or_email %}
         {% set link = url('pontoon.contributors.contributor.username', latest_activity.user.username) %}
-        {% set avatar = latest_activity.user.gravatar_url() %}
+        {% set avatar = latest_activity.user.avatar_url() %}
       {% else %}
         {% set action = 'imported' %}
         {% set user = '' %}

--- a/pontoon/base/templates/widgets/profile.html
+++ b/pontoon/base/templates/widgets/profile.html
@@ -3,7 +3,7 @@
     {% if user.is_authenticated %}
       <img
         class="rounded"
-        src="{{ user.gravatar_url(88) }}"
+        src="{{ user.avatar_url(88) }}"
         width="44"
         height="44"
       />
@@ -21,7 +21,7 @@
       >
         <img
           class="rounded"
-          src="{{ user.gravatar_url(176) }}"
+          src="{{ user.avatar_url(176) }}"
           width="88"
           height="88"
         />

--- a/pontoon/base/tests/models/test_comment.py
+++ b/pontoon/base/tests/models/test_comment.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pontoon.base.user_utils import gravatar_url, user_banner
+from pontoon.base.user_utils import avatar_url, user_banner
 from pontoon.test.factories import ProjectFactory
 
 
@@ -14,7 +14,7 @@ def test_serialize_comments(comment_a, team_comment_a):
         "user_banner": user_banner(
             comment_a.author, comment_a.translation.locale, project.contact
         ),
-        "user_gravatar_url_small": gravatar_url(comment_a.author),
+        "user_gravatar_url_small": avatar_url(comment_a.author),
         "created_at": comment_a.timestamp.strftime("%b %d, %Y %H:%M"),
         "date_iso": comment_a.timestamp.isoformat(),
         "content": comment_a.content,
@@ -28,7 +28,7 @@ def test_serialize_comments(comment_a, team_comment_a):
         "user_banner": user_banner(
             team_comment_a.author, team_comment_a.locale, project.contact
         ),
-        "user_gravatar_url_small": gravatar_url(team_comment_a.author),
+        "user_gravatar_url_small": avatar_url(team_comment_a.author),
         "created_at": team_comment_a.timestamp.strftime("%b %d, %Y %H:%M"),
         "date_iso": team_comment_a.timestamp.isoformat(),
         "content": team_comment_a.content,

--- a/pontoon/base/tests/test_user_utils.py
+++ b/pontoon/base/tests/test_user_utils.py
@@ -2,7 +2,7 @@ import pytest
 
 from allauth.socialaccount.models import SocialAccount
 
-from pontoon.base.models.user import User
+from pontoon.base.models.user import User, fxa_avatar
 from pontoon.base.user_utils import avatar_url, user_banner, user_locale_role, user_role
 
 
@@ -122,3 +122,59 @@ def test_gravatar_url_falls_back_to_gravatar_when_fxa_has_no_avatar(user_a):
     )
     url = avatar_url(user_a)
     assert "gravatar.com/avatar/" in url
+
+
+@pytest.mark.django_db
+def test_fxa_avatar_returns_none_for_unsaved_user():
+    user = User(username="unsaved", email="unsaved@example.com")
+    assert fxa_avatar(user) is None
+
+
+@pytest.mark.django_db
+def test_fxa_avatar_returns_url_from_db(user_a):
+    SocialAccount.objects.create(
+        user=user_a,
+        provider="fxa",
+        uid="1234",
+        extra_data={"avatar": "https://profile.accounts.firefox.com/v1/avatar/abc"},
+    )
+    assert fxa_avatar(user_a) == "https://profile.accounts.firefox.com/v1/avatar/abc"
+
+
+@pytest.mark.django_db
+def test_fxa_avatar_returns_none_when_no_fxa_account(user_a):
+    assert fxa_avatar(user_a) is None
+
+
+@pytest.mark.django_db
+def test_fxa_avatar_returns_none_when_fxa_has_no_avatar(user_a):
+    SocialAccount.objects.create(
+        user=user_a,
+        provider="fxa",
+        uid="1234",
+        extra_data={},
+    )
+    assert fxa_avatar(user_a) is None
+
+
+@pytest.mark.django_db
+def test_fxa_avatar_uses_prefetched_accounts(user_a):
+    account = SocialAccount(
+        user=user_a,
+        provider="fxa",
+        uid="1234",
+        extra_data={
+            "avatar": "https://profile.accounts.firefox.com/v1/avatar/prefetched"
+        },
+    )
+    user_a._prefetched_fxa_accounts = [account]
+    assert (
+        fxa_avatar(user_a)
+        == "https://profile.accounts.firefox.com/v1/avatar/prefetched"
+    )
+
+
+@pytest.mark.django_db
+def test_fxa_avatar_uses_prefetched_accounts_when_empty(user_a):
+    user_a._prefetched_fxa_accounts = []
+    assert fxa_avatar(user_a) is None

--- a/pontoon/base/tests/test_user_utils.py
+++ b/pontoon/base/tests/test_user_utils.py
@@ -1,7 +1,9 @@
 import pytest
 
+from allauth.socialaccount.models import SocialAccount
+
 from pontoon.base.models.user import User
-from pontoon.base.user_utils import user_banner, user_locale_role, user_role
+from pontoon.base.user_utils import avatar_url, user_banner, user_locale_role, user_role
 
 
 @pytest.mark.django_db
@@ -91,3 +93,32 @@ def test_user_banner(user_a, user_b, user_c, user_d, gt_user, locale_a, project_
     # System user (Google Translate)
     project_contact = gt_user
     assert user_banner(gt_user, locale_a, project_contact)[1] == ""
+
+
+@pytest.mark.django_db
+def test_gravatar_url_returns_fxa_avatar_when_linked(user_a):
+    SocialAccount.objects.create(
+        user=user_a,
+        provider="fxa",
+        uid="1234",
+        extra_data={"avatar": "https://profile.accounts.firefox.com/v1/avatar/abc"},
+    )
+    assert avatar_url(user_a) == "https://profile.accounts.firefox.com/v1/avatar/abc"
+
+
+@pytest.mark.django_db
+def test_gravatar_url_falls_back_to_gravatar_when_no_fxa(user_a):
+    url = avatar_url(user_a)
+    assert "gravatar.com/avatar/" in url
+
+
+@pytest.mark.django_db
+def test_gravatar_url_falls_back_to_gravatar_when_fxa_has_no_avatar(user_a):
+    SocialAccount.objects.create(
+        user=user_a,
+        provider="fxa",
+        uid="1234",
+        extra_data={},
+    )
+    url = avatar_url(user_a)
+    assert "gravatar.com/avatar/" in url

--- a/pontoon/base/tests/test_user_utils.py
+++ b/pontoon/base/tests/test_user_utils.py
@@ -2,8 +2,14 @@ import pytest
 
 from allauth.socialaccount.models import SocialAccount
 
-from pontoon.base.models.user import User, fxa_avatar
-from pontoon.base.user_utils import avatar_url, user_banner, user_locale_role, user_role
+from pontoon.base.models.user import User
+from pontoon.base.user_utils import (
+    avatar_url,
+    fxa_avatar_url,
+    user_banner,
+    user_locale_role,
+    user_role,
+)
 
 
 @pytest.mark.django_db
@@ -127,7 +133,7 @@ def test_gravatar_url_falls_back_to_gravatar_when_fxa_has_no_avatar(user_a):
 @pytest.mark.django_db
 def test_fxa_avatar_returns_none_for_unsaved_user():
     user = User(username="unsaved", email="unsaved@example.com")
-    assert fxa_avatar(user) is None
+    assert fxa_avatar_url(user) is None
 
 
 @pytest.mark.django_db
@@ -138,12 +144,14 @@ def test_fxa_avatar_returns_url_from_db(user_a):
         uid="1234",
         extra_data={"avatar": "https://profile.accounts.firefox.com/v1/avatar/abc"},
     )
-    assert fxa_avatar(user_a) == "https://profile.accounts.firefox.com/v1/avatar/abc"
+    assert (
+        fxa_avatar_url(user_a) == "https://profile.accounts.firefox.com/v1/avatar/abc"
+    )
 
 
 @pytest.mark.django_db
 def test_fxa_avatar_returns_none_when_no_fxa_account(user_a):
-    assert fxa_avatar(user_a) is None
+    assert fxa_avatar_url(user_a) is None
 
 
 @pytest.mark.django_db
@@ -154,7 +162,7 @@ def test_fxa_avatar_returns_none_when_fxa_has_no_avatar(user_a):
         uid="1234",
         extra_data={},
     )
-    assert fxa_avatar(user_a) is None
+    assert fxa_avatar_url(user_a) is None
 
 
 @pytest.mark.django_db
@@ -169,7 +177,7 @@ def test_fxa_avatar_uses_prefetched_accounts(user_a):
     )
     user_a._prefetched_fxa_accounts = [account]
     assert (
-        fxa_avatar(user_a)
+        fxa_avatar_url(user_a)
         == "https://profile.accounts.firefox.com/v1/avatar/prefetched"
     )
 
@@ -177,4 +185,4 @@ def test_fxa_avatar_uses_prefetched_accounts(user_a):
 @pytest.mark.django_db
 def test_fxa_avatar_uses_prefetched_accounts_when_empty(user_a):
     user_a._prefetched_fxa_accounts = []
-    assert fxa_avatar(user_a) is None
+    assert fxa_avatar_url(user_a) is None

--- a/pontoon/base/user_utils.py
+++ b/pontoon/base/user_utils.py
@@ -2,6 +2,7 @@ from hashlib import md5
 from typing import TYPE_CHECKING, Any, Collection
 from urllib.parse import quote, urlencode
 
+from allauth.socialaccount.models import SocialAccount
 from dateutil.relativedelta import relativedelta
 from guardian.shortcuts import get_objects_for_user
 
@@ -20,7 +21,13 @@ def is_system_user(user: User) -> bool:
     return user.pk is None or user.profile.system_user
 
 
-def gravatar_url(user: User, size: int = 88) -> str:
+def avatar_url(user: User, size: int = 88) -> str:
+    fxa_account = SocialAccount.objects.filter(user=user, provider="fxa").first()
+    if fxa_account:
+        fxa_avatar = fxa_account.extra_data.get("avatar")
+        if fxa_avatar:
+            return fxa_avatar
+
     email = md5(user.email.lower().encode("utf-8")).hexdigest()
 
     name = quote(user.display_name)
@@ -42,7 +49,7 @@ def user_serialize(user: User):
     """Serialize Project contact"""
 
     return {
-        "avatar": gravatar_url(user),
+        "avatar": avatar_url(user),
         "name": user.name_or_email,
         "url": profile_url(user),
     }

--- a/pontoon/base/user_utils.py
+++ b/pontoon/base/user_utils.py
@@ -20,9 +20,26 @@ def is_system_user(user: User) -> bool:
     return user.pk is None or user.profile.system_user
 
 
+def fxa_avatar_url(user: User) -> str | None:
+    if user.pk is None:
+        return None
+
+    if hasattr(user, "_prefetched_fxa_accounts") and isinstance(
+        user._prefetched_fxa_accounts, list
+    ):
+        return (
+            user._prefetched_fxa_accounts[0].extra_data.get("avatar")
+            if user._prefetched_fxa_accounts
+            else None
+        )
+
+    fxa = user.socialaccount_set.filter(provider="fxa").first()
+    return fxa.extra_data.get("avatar") if fxa else None
+
+
 def avatar_url(user: User, size: int = 88) -> str:
 
-    if fxa_avatar := user.fxa_avatar():
+    if fxa_avatar := fxa_avatar_url(user):
         return fxa_avatar
 
     email = md5(user.email.lower().encode("utf-8")).hexdigest()

--- a/pontoon/base/user_utils.py
+++ b/pontoon/base/user_utils.py
@@ -2,7 +2,6 @@ from hashlib import md5
 from typing import TYPE_CHECKING, Any, Collection
 from urllib.parse import quote, urlencode
 
-from allauth.socialaccount.models import SocialAccount
 from dateutil.relativedelta import relativedelta
 from guardian.shortcuts import get_objects_for_user
 
@@ -22,14 +21,11 @@ def is_system_user(user: User) -> bool:
 
 
 def avatar_url(user: User, size: int = 88) -> str:
-    fxa_account = SocialAccount.objects.filter(user=user, provider="fxa").first()
-    if fxa_account:
-        fxa_avatar = fxa_account.extra_data.get("avatar")
-        if fxa_avatar:
-            return fxa_avatar
+
+    if fxa_avatar := user.fxa_avatar():
+        return fxa_avatar
 
     email = md5(user.email.lower().encode("utf-8")).hexdigest()
-
     name = quote(user.display_name)
     background = "333941"
     color = "FFFFFF"

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -53,10 +53,10 @@ from pontoon.base.notification_utils import serialized_notifications
 from pontoon.base.services import readonly_exists
 from pontoon.base.templatetags.helpers import provider_login_url
 from pontoon.base.user_utils import (
+    avatar_url,
     can_manage_locales,
     can_translate,
     can_translate_locales,
-    gravatar_url,
     manager_for_locales,
     profile_url,
     translated_projects,
@@ -192,7 +192,7 @@ def authors_and_time_range(request, locale, slug, part):
             "email": user.email,
             "display_name": user.name_or_email,
             "id": user.id,
-            "gravatar_url": gravatar_url(user),
+            "gravatar_url": avatar_url(user),
             "translation_count": user.translations_count,
             "role": user.user_role,
         }
@@ -526,7 +526,7 @@ def get_translation_history(request):
                 "uid": u.pk,
                 "user": u.name_or_email,
                 "username": u.username,
-                "user_gravatar_url_small": gravatar_url(u),
+                "user_gravatar_url_small": avatar_url(u),
             }
         )
         banner = user_banner(u, locale, project_contact)
@@ -894,7 +894,7 @@ def get_users(request):
     for u in users:
         payload.append(
             {
-                "gravatar": gravatar_url(u, 44),
+                "gravatar": avatar_url(u, 44),
                 "name": u.name_or_email,
                 "url": profile_url(u),
                 "username": u.profile.username,
@@ -1109,8 +1109,8 @@ def user_data(request):
             "tour_status": user.profile.tour_status,
             "has_dismissed_addon_promotion": user.profile.has_dismissed_addon_promotion,
             "logout_url": logout_url,
-            "gravatar_url_small": gravatar_url(user, 88),
-            "gravatar_url_big": gravatar_url(user, 176),
+            "gravatar_url_small": avatar_url(user, 88),
+            "gravatar_url_big": avatar_url(user, 176),
             "notifications": serialized_notifications(user),
             "theme": user.profile.theme,
             "editor_theme": user.profile.editor_theme,

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -7,6 +7,8 @@ from datetime import datetime
 from typing import Any, cast
 from urllib.parse import urlparse
 
+from allauth.socialaccount.models import SocialAccount
+
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
@@ -505,7 +507,16 @@ def get_translation_history(request):
                     "timestamp"
                 ),
             ),
-            "user",
+            Prefetch(
+                "user",
+                queryset=User.objects.prefetch_related(
+                    Prefetch(
+                        "socialaccount_set",
+                        queryset=SocialAccount.objects.filter(provider="fxa"),
+                        to_attr="_prefetched_fxa_accounts",
+                    )
+                ),
+            ),
             "approved_user",
             "rejected_user",
             "errors",
@@ -572,6 +583,13 @@ def get_team_comments(request):
     comments = (
         Comment.objects.filter(entity=entity)
         .filter(Q(locale=locale) | Q(pinned=True))
+        .prefetch_related(
+            Prefetch(
+                "author__socialaccount_set",
+                queryset=SocialAccount.objects.filter(provider="fxa"),
+                to_attr="_prefetched_fxa_accounts",
+            )
+        )
         .order_by("timestamp")
     )
 
@@ -878,6 +896,13 @@ def get_users(request):
         .exclude(email__regex=r"^deleted-user-(\w+)@example.com$")
         # Prefetch profile for retrieving username
         .prefetch_related("profile")
+        .prefetch_related(
+            Prefetch(
+                "socialaccount_set",
+                queryset=SocialAccount.objects.filter(provider="fxa"),
+                to_attr="_prefetched_fxa_accounts",
+            )
+        )
         .annotate(
             in_locale=Count(
                 "translation", filter=Q(translation__locale__code=locale_code)

--- a/pontoon/contributors/templates/contributors/contributors.html
+++ b/pontoon/contributors/templates/contributors/contributors.html
@@ -60,7 +60,7 @@
           >
             <img
               class="rounded"
-              src="{{ top_contributor.gravatar_url(252) }}"
+              src="{{ top_contributor.avatar_url(252) }}"
               height="126"
               width="126"
             />

--- a/pontoon/contributors/templates/contributors/profile.html
+++ b/pontoon/contributors/templates/contributors/profile.html
@@ -48,7 +48,7 @@
           {% endif %}
           <img
             class="rounded"
-            src="{{ contributor.gravatar_url(512) }}"
+            src="{{ contributor.avatar_url(512) }}"
             width="256"
             height="256"
           />

--- a/pontoon/contributors/templates/contributors/settings.html
+++ b/pontoon/contributors/templates/contributors/settings.html
@@ -14,7 +14,7 @@
       <div class="desc">Update profile picture</div>
       <img
         class="rounded"
-        src="{{ user.gravatar_url(400) }}"
+        src="{{ user.avatar_url(400) }}"
         width="200"
         height="200"
       />

--- a/pontoon/contributors/templates/contributors/widgets/contributor_list.html
+++ b/pontoon/contributors/templates/contributors/widgets/contributor_list.html
@@ -29,7 +29,7 @@
             >
               <img
                 class="rounded"
-                src="{{ contributor.gravatar_url() }}"
+                src="{{ contributor.avatar_url() }}"
                 width="44"
                 height="44"
               />

--- a/pontoon/contributors/utils.py
+++ b/pontoon/contributors/utils.py
@@ -6,6 +6,7 @@ from urllib.parse import urlencode
 
 import jwt
 
+from allauth.socialaccount.models import SocialAccount
 from dateutil.relativedelta import relativedelta
 
 from django.conf import settings
@@ -103,10 +104,20 @@ def users_with_translations_counts(
         for user in loc.translators_group.fetched_translators:
             translators[user].add(loc.code)
 
-    contributors = User.objects.filter(
-        pk__in=user_stats.keys(),
-        is_active=True,
-    ).prefetch_related("profile")
+    contributors = (
+        User.objects.filter(
+            pk__in=user_stats.keys(),
+            is_active=True,
+        )
+        .prefetch_related("profile")
+        .prefetch_related(
+            Prefetch(
+                "socialaccount_set",
+                queryset=SocialAccount.objects.filter(provider="fxa"),
+                to_attr="_prefetched_fxa_accounts",
+            )
+        )
+    )
 
     if None in user_stats.keys():
         contributors = list(contributors)

--- a/pontoon/messaging/templates/messaging/includes/sent.html
+++ b/pontoon/messaging/templates/messaging/includes/sent.html
@@ -15,7 +15,7 @@
             rel="noopener noreferrer"
           >
             <img
-              src="{{ message.sender.gravatar_url() }}"
+              src="{{ message.sender.avatar_url() }}"
               height="44"
               width="44"
               class="rounded"


### PR DESCRIPTION
## Description
Added FXA avatar scope and the avatar will be loaded on runtime using the user_gravatar_url if available. Also changed the property of UserModel from gravatar_url to avatar_url

## Linked Issue
Closes #4017

## Screenshot
<img width="1189" height="124" alt="Profle Image" src="https://github.com/user-attachments/assets/7289b064-44c3-46bb-b11b-dacc3a70480d" />


## Caveats
There several caveats with this implementation
- Users using the Gravatar Image with FXA accounts will have there avatars replaced with FXA one since we prioritize FXA ones. The reason is because we are sending the Gravatar image url back to the template. To prioritize it we will first have to send a http request to the url and if it fails default to FXA.
- The class rounded on img tag does make the FXA image look a bit boxy, see screenshot.
