### PR TITLE
Clear URL-only filters when selecting a different filter in the UI

### DIFF
--- a/translate/src/modules/search/components/SearchBox.test.jsx
+++ b/translate/src/modules/search/components/SearchBox.test.jsx
@@ -196,8 +196,46 @@ describe('<SearchBoxBase>', () => {
       status: null,
       tag: '',
       time: null,
+      created_time: null,
+      reviewer: null,
+      review_time: null,
+      exclude_self_reviewed: false,
       entity: 0,
     });
+  });
+
+  it('clears URL-only filters (e.g. created_time) when a filter is applied', () => {
+    const push = vi.fn();
+    const wrapper = mount(
+      <WrapSearchBoxBase
+        dispatch={(a) => (typeof a === 'function' ? a() : {})}
+        parameters={{
+          push,
+          // URL-only filters with no representation in the panel, e.g. coming
+          // from a new-string notification link.
+          created_time: '202606120818-202606120818',
+          reviewer: 'user@example.com',
+          review_time: '202606120818-202606120818',
+          exclude_self_reviewed: true,
+        }}
+        project={PROJECT}
+        searchAndFilters={SEARCH_AND_FILTERS}
+        store={{ getState: () => ({ unsavedchanges: {} }) }}
+      />,
+    );
+
+    act(() => {
+      const apply = wrapper.find('FiltersPanel').prop('applySingleFilter');
+      apply('all', 'statuses');
+    });
+    wrapper.update();
+
+    expect(push).toHaveBeenCalledTimes(1);
+    const pushed = push.mock.calls[0][0];
+    expect(pushed.created_time).toBeNull();
+    expect(pushed.reviewer).toBeNull();
+    expect(pushed.review_time).toBeNull();
+    expect(pushed.exclude_self_reviewed).toBe(false);
   });
 
   it('sets correct status', () => {
@@ -240,6 +278,10 @@ describe('<SearchBoxBase>', () => {
       status: 'missing,warnings',
       tag: 'browser',
       time: '111111111111-111111111111',
+      created_time: null,
+      reviewer: null,
+      review_time: null,
+      exclude_self_reviewed: false,
       entity: 0,
       list: null,
     });

--- a/translate/src/modules/search/components/SearchBox.tsx
+++ b/translate/src/modules/search/components/SearchBox.tsx
@@ -303,6 +303,8 @@ export function SearchBoxBase({
           // Clear URL-only filters that have no representation in the panel, so
           // applying a filter from the UI doesn't silently keep them active
           // (e.g. the created_time filter from new-string notification links).
+          //
+          // TODO: Remove once search/filter state is redesigned (#3511).
           created_time: null,
           reviewer: null,
           review_time: null,

--- a/translate/src/modules/search/components/SearchBox.tsx
+++ b/translate/src/modules/search/components/SearchBox.tsx
@@ -300,6 +300,13 @@ export function SearchBoxBase({
           status,
           tag: tags.join(','),
           time: timeRange ? `${timeRange.from}-${timeRange.to}` : null,
+          // Clear URL-only filters that have no representation in the panel, so
+          // applying a filter from the UI doesn't silently keep them active
+          // (e.g. the created_time filter from new-string notification links).
+          created_time: null,
+          reviewer: null,
+          review_time: null,
+          exclude_self_reviewed: false,
           entity: 0, // With the new results, the current entity might not be available anymore.
           list: parameters.list ?? null,
           ...getSearchUpdates(searchOptions),


### PR DESCRIPTION
This is a bit of a compromise, but I think it's a better experience than having to manually edit the URL to remove the filter.
Further improvements should probably be part of the redesign of the filter UI.

Fixes #4217