### PR TITLE
Send notifications for new strings only to affected locales in public projects

### DIFF
--- a/pontoon/sync/core/__init__.py
+++ b/pontoon/sync/core/__init__.py
@@ -1,10 +1,20 @@
 import logging
 
+from collections import defaultdict
 from datetime import datetime
 
+from django.db.models import Count
 from django.utils import timezone
 
-from pontoon.base.models import ChangedEntityLocale, Locale, Project, User
+from pontoon.base.models import (
+    ChangedEntityLocale,
+    Entity,
+    Locale,
+    Project,
+    TranslatedResource,
+    Translation,
+    User,
+)
 from pontoon.messaging.notifications import send_notification
 from pontoon.pretranslation.tasks import pretranslate
 from pontoon.sync.core.checkout import checkout_repos
@@ -62,7 +72,7 @@ def sync_project(
         or updated_trans_count
     )
     if added_entities_count > 0:
-        notify_users(project, added_entities_count, now)
+        notify_users(project, now)
     repo_changed = sync_translations_to_repo(
         project,
         commit,
@@ -91,17 +101,67 @@ def sync_project(
     return db_changed, repo_changed
 
 
-def notify_users(project: Project, count: int, now: datetime) -> None:
-    users = User.objects.filter(
-        translation__entity__resource__project=project,
-        profile__new_string_notifications=True,
-    ).distinct()
-    new_strings = f"{count} new {'string' if count == 1 else 'strings'}"
+def notify_users(project: Project, now: datetime) -> None:
+    # Strings added during the same sync operation have date_created == now.
+    new_by_resource = dict(
+        Entity.objects.filter(
+            resource__project=project, date_created=now, obsolete=False
+        )
+        .values_list("resource_id")
+        .annotate(count=Count("id"))
+    )
+    if not new_by_resource:
+        return
+
+    # Get accurate per-locale totals.
+    locale_counts: dict[int, int] = defaultdict(int)
+    for locale_id, resource_id in TranslatedResource.objects.filter(
+        resource_id__in=new_by_resource.keys()
+    ).values_list("locale_id", "resource_id"):
+        locale_counts[locale_id] += new_by_resource[resource_id]
+
+    # Map each translator who chose to receive notifications to the affected
+    # locales they contribute to.
+    user_locales: dict[int, set[int]] = defaultdict(set)
+    for user_id, locale_id in (
+        Translation.objects.filter(
+            entity__resource__project=project,
+            locale_id__in=locale_counts.keys(),
+            user__profile__new_string_notifications=True,
+        )
+        .values_list("user_id", "locale_id")
+        .distinct()
+    ):
+        user_locales[user_id].add(locale_id)
+    if not user_locales:
+        return
+
+    # Map locale code to internal ID. This is used to match a user's custom
+    # homepage locale.
+    locale_id_by_code = dict(
+        Locale.objects.filter(id__in=locale_counts.keys()).values_list("code", "id")
+    )
     # Stored on notification.data so both the bell menu and digest can link to
     # the exact batch via the created_time URL filter on Entity.date_created.
     created_time = now.strftime("%Y%m%d%H%M")
-    log.info(f"[{project.slug}] Notifying {len(users)} users about {new_strings}")
+    # One notification per user. The link is locale-agnostic, so it resolves to
+    # the user's homepage locale: report that locale's count when the user
+    # contributes to it, otherwise fall back to the largest count among the
+    # locales they contributed to.
+    # Private projects are only visible to superusers, so don't leak their
+    # activity to other past contributors.
+    is_public = project.visibility == Project.Visibility.PUBLIC
+    users = User.objects.filter(id__in=user_locales.keys()).select_related("profile")
     for user in users:
+        if not is_public and not user.is_superuser:
+            continue
+        locale_ids = user_locales[user.id]
+        homepage_id = locale_id_by_code.get(user.profile.custom_homepage)
+        if homepage_id in locale_ids:
+            count = locale_counts[homepage_id]
+        else:
+            count = max(locale_counts[locale_id] for locale_id in locale_ids)
+        new_strings = f"{count} new {'string' if count == 1 else 'strings'}"
         send_notification(
             project,
             recipient=user,
@@ -109,3 +169,4 @@ def notify_users(project: Project, count: int, now: datetime) -> None:
             category="new_string",
             created_time=created_time,
         )
+    log.info(f"[{project.slug}] Notifying {len(user_locales)} users about new strings")

--- a/pontoon/sync/core/__init__.py
+++ b/pontoon/sync/core/__init__.py
@@ -122,16 +122,19 @@ def notify_users(project: Project, now: datetime) -> None:
 
     # Map each translator who chose to receive notifications to the affected
     # locales they contribute to.
+    translations = Translation.objects.filter(
+        entity__resource__project=project,
+        locale_id__in=locale_counts.keys(),
+        user__profile__new_string_notifications=True,
+    )
+    # Private projects are only visible to superusers, so don't leak their
+    # activity to other past contributors.
+    if project.visibility != Project.Visibility.PUBLIC:
+        translations = translations.filter(user__is_superuser=True)
     user_locales: dict[int, set[int]] = defaultdict(set)
-    for user_id, locale_id in (
-        Translation.objects.filter(
-            entity__resource__project=project,
-            locale_id__in=locale_counts.keys(),
-            user__profile__new_string_notifications=True,
-        )
-        .values_list("user_id", "locale_id")
-        .distinct()
-    ):
+    for user_id, locale_id in translations.values_list(
+        "user_id", "locale_id"
+    ).distinct():
         user_locales[user_id].add(locale_id)
     if not user_locales:
         return
@@ -148,13 +151,8 @@ def notify_users(project: Project, now: datetime) -> None:
     # the user's homepage locale: report that locale's count when the user
     # contributes to it, otherwise fall back to the largest count among the
     # locales they contributed to.
-    # Private projects are only visible to superusers, so don't leak their
-    # activity to other past contributors.
-    is_public = project.visibility == Project.Visibility.PUBLIC
     users = User.objects.filter(id__in=user_locales.keys()).select_related("profile")
     for user in users:
-        if not is_public and not user.is_superuser:
-            continue
         locale_ids = user_locales[user.id]
         homepage_id = locale_id_by_code.get(user.profile.custom_homepage)
         if homepage_id in locale_ids:

--- a/pontoon/sync/tests/test_notify_users.py
+++ b/pontoon/sync/tests/test_notify_users.py
@@ -5,11 +5,13 @@ import pytest
 
 from notifications.models import Notification
 
+from pontoon.base.models import Project
 from pontoon.base.tests import (
     EntityFactory,
     LocaleFactory,
     ProjectFactory,
     ResourceFactory,
+    TranslatedResourceFactory,
     TranslationFactory,
     UserFactory,
 )
@@ -23,15 +25,14 @@ def test_notify_users_excludes_system_users(
 ):
     """System users that authored translations in a project must not be
     notified about new strings landing in that project."""
+    now = datetime(2026, 5, 24, 4, 44, tzinfo=timezone.utc)
     resource = ResourceFactory.create(project=project_a)
-    entity = EntityFactory.create(resource=resource)
+    entity = EntityFactory.create(resource=resource, date_created=now)
 
     TranslationFactory.create(locale=locale_a, entity=entity, user=user_a)
     TranslationFactory.create(locale=locale_a, entity=entity, user=tm_user)
 
-    notify_users(
-        project_a, count=1, now=datetime(2026, 5, 24, 4, 44, tzinfo=timezone.utc)
-    )
+    notify_users(project_a, now)
 
     recipients = {call.kwargs["recipient"] for call in mock_notify.call_args_list}
     assert user_a in recipients
@@ -45,18 +46,20 @@ def test_notify_users_stores_created_time():
     created_time (YYYYMMDDHHmm), so the bell menu and digest template can
     link to the precise batch of entities created in that sync.
     """
+    now = datetime(2026, 5, 24, 4, 44, tzinfo=timezone.utc)
     locale = LocaleFactory.create()
-    project = ProjectFactory.create(locales=[locale])
+    project = ProjectFactory.create(
+        locales=[locale], visibility=Project.Visibility.PUBLIC
+    )
     resource = ResourceFactory.create(project=project)
-    entity = EntityFactory.create(resource=resource)
+    entities = EntityFactory.create_batch(3, resource=resource, date_created=now)
 
     user = UserFactory.create()
     user.profile.new_string_notifications = True
     user.profile.save()
-    TranslationFactory.create(entity=entity, locale=locale, user=user)
+    TranslationFactory.create(entity=entities[0], locale=locale, user=user)
 
-    now = datetime(2026, 5, 24, 4, 44, tzinfo=timezone.utc)
-    notify_users(project, count=3, now=now)
+    notify_users(project, now)
 
     notifications = list(Notification.objects.filter(recipient=user))
     assert len(notifications) == 1
@@ -71,17 +74,20 @@ def test_notify_users_stores_created_time():
 @pytest.mark.django_db
 def test_notify_users_singular_verb():
     """One added string uses the singular form in the verb."""
+    now = datetime(2026, 1, 2, 3, 4, tzinfo=timezone.utc)
     locale = LocaleFactory.create()
-    project = ProjectFactory.create(locales=[locale])
+    project = ProjectFactory.create(
+        locales=[locale], visibility=Project.Visibility.PUBLIC
+    )
     resource = ResourceFactory.create(project=project)
-    entity = EntityFactory.create(resource=resource)
+    entity = EntityFactory.create(resource=resource, date_created=now)
 
     user = UserFactory.create()
     user.profile.new_string_notifications = True
     user.profile.save()
     TranslationFactory.create(entity=entity, locale=locale, user=user)
 
-    notify_users(project, count=1, now=datetime(2026, 1, 2, 3, 4, tzinfo=timezone.utc))
+    notify_users(project, now)
 
     n = Notification.objects.get(recipient=user)
     assert n.verb == "updated with 1 new string"
@@ -91,18 +97,192 @@ def test_notify_users_singular_verb():
 @pytest.mark.django_db
 def test_notify_users_skips_unsubscribed():
     """Users without new_string_notifications enabled are not notified."""
+    now = datetime(2026, 5, 24, 4, 44, tzinfo=timezone.utc)
     locale = LocaleFactory.create()
-    project = ProjectFactory.create(locales=[locale])
+    project = ProjectFactory.create(
+        locales=[locale], visibility=Project.Visibility.PUBLIC
+    )
     resource = ResourceFactory.create(project=project)
-    entity = EntityFactory.create(resource=resource)
+    entity = EntityFactory.create(resource=resource, date_created=now)
 
     user = UserFactory.create()
     user.profile.new_string_notifications = False
     user.profile.save()
     TranslationFactory.create(entity=entity, locale=locale, user=user)
 
-    notify_users(
-        project, count=2, now=datetime(2026, 5, 24, 4, 44, tzinfo=timezone.utc)
-    )
+    notify_users(project, now)
 
     assert Notification.objects.filter(recipient=user).count() == 0
+
+
+@patch("pontoon.messaging.notifications.notify.send")
+@pytest.mark.django_db
+def test_notify_users_skips_locales_without_new_strings(mock_notify):
+    """If the locale doesn't have any new strings, translator is not notified."""
+    now = datetime(2026, 5, 24, 4, 44, tzinfo=timezone.utc)
+    locale_1 = LocaleFactory.create()
+    locale_2 = LocaleFactory.create()
+    project = ProjectFactory.create(
+        locales=[locale_1, locale_2], visibility=Project.Visibility.PUBLIC
+    )
+
+    # New resource added this sync, but available only for locale_1.
+    new_resource = ResourceFactory.create(project=project)
+    new_entity = EntityFactory.create(resource=new_resource, date_created=now)
+    user_1 = UserFactory.create()
+    user_1.profile.new_string_notifications = True
+    user_1.profile.save()
+    TranslationFactory.create(entity=new_entity, locale=locale_1, user=user_1)
+
+    # Old resource available to locale_2 (no new strings this sync).
+    old_resource = ResourceFactory.create(project=project)
+    old_entity = EntityFactory.create(
+        resource=old_resource,
+        date_created=datetime(2020, 1, 1, tzinfo=timezone.utc),
+    )
+    user_2 = UserFactory.create()
+    user_2.profile.new_string_notifications = True
+    user_2.profile.save()
+    TranslationFactory.create(entity=old_entity, locale=locale_2, user=user_2)
+
+    notify_users(project, now)
+
+    recipients = {c.kwargs["recipient"] for c in mock_notify.call_args_list}
+    assert user_1 in recipients
+    assert user_2 not in recipients
+
+
+@patch("pontoon.messaging.notifications.notify.send")
+@pytest.mark.django_db
+def test_notify_users_per_locale_counts(mock_notify):
+    """Each translator's notification reports the count for their own locale,
+    not the project-wide total (accurate under syncs involving project
+    configuration and files exposed to a subset of locales)."""
+    now = datetime(2026, 5, 24, 4, 44, tzinfo=timezone.utc)
+    locale_1 = LocaleFactory.create()
+    locale_2 = LocaleFactory.create()
+    project = ProjectFactory.create(
+        locales=[locale_1, locale_2], visibility=Project.Visibility.PUBLIC
+    )
+
+    # Shared resource (5 new strings), available to both locales.
+    shared = ResourceFactory.create(project=project)
+    shared_entities = EntityFactory.create_batch(5, resource=shared, date_created=now)
+    TranslatedResourceFactory.create(resource=shared, locale=locale_1)
+    TranslatedResourceFactory.create(resource=shared, locale=locale_2)
+
+    # Resource with 3 more new strings, available to locale_1 only.
+    only_1 = ResourceFactory.create(project=project)
+    EntityFactory.create_batch(3, resource=only_1, date_created=now)
+    TranslatedResourceFactory.create(resource=only_1, locale=locale_1)
+
+    user_1 = UserFactory.create()
+    user_1.profile.new_string_notifications = True
+    user_1.profile.save()
+    TranslationFactory.create(entity=shared_entities[0], locale=locale_1, user=user_1)
+
+    user_2 = UserFactory.create()
+    user_2.profile.new_string_notifications = True
+    user_2.profile.save()
+    TranslationFactory.create(entity=shared_entities[0], locale=locale_2, user=user_2)
+
+    notify_users(project, now)
+
+    verbs = {
+        call.kwargs["recipient"]: call.kwargs["verb"]
+        for call in mock_notify.call_args_list
+    }
+    # locale_1 sees both resources (5 + 3), locale_2 only the shared one (5).
+    assert verbs[user_1] == "updated with 8 new strings"
+    assert verbs[user_2] == "updated with 5 new strings"
+
+
+@patch("pontoon.messaging.notifications.notify.send")
+@pytest.mark.django_db
+def test_notify_users_uses_homepage_count(mock_notify):
+    """A multi-locale translator gets a single notification, reporting the
+    count for the locale they selected as homepage."""
+    now = datetime(2026, 5, 24, 4, 44, tzinfo=timezone.utc)
+    locale_1 = LocaleFactory.create()
+    locale_2 = LocaleFactory.create()
+    project = ProjectFactory.create(
+        locales=[locale_1, locale_2], visibility=Project.Visibility.PUBLIC
+    )
+
+    # 8 new strings for locale_1, 5 for locale_2.
+    resource_1 = ResourceFactory.create(project=project)
+    entities_1 = EntityFactory.create_batch(8, resource=resource_1, date_created=now)
+    resource_2 = ResourceFactory.create(project=project)
+    entities_2 = EntityFactory.create_batch(5, resource=resource_2, date_created=now)
+
+    user = UserFactory.create()
+    user.profile.new_string_notifications = True
+    user.profile.custom_homepage = locale_2.code
+    user.profile.save()
+    TranslationFactory.create(entity=entities_1[0], locale=locale_1, user=user)
+    TranslationFactory.create(entity=entities_2[0], locale=locale_2, user=user)
+
+    notify_users(project, now)
+
+    assert mock_notify.call_count == 1
+    # Homepage is locale_2, so report its count (5) rather than the max (8).
+    assert mock_notify.call_args.kwargs["verb"] == "updated with 5 new strings"
+
+
+@patch("pontoon.messaging.notifications.notify.send")
+@pytest.mark.django_db
+def test_notify_users_falls_back_to_max_without_homepage(mock_notify):
+    """Without a defined homepage, a multi-locale translator will receive a
+    notification with the largest count among their locales."""
+    now = datetime(2026, 5, 24, 4, 44, tzinfo=timezone.utc)
+    locale_1 = LocaleFactory.create()
+    locale_2 = LocaleFactory.create()
+    project = ProjectFactory.create(
+        locales=[locale_1, locale_2], visibility=Project.Visibility.PUBLIC
+    )
+
+    resource_1 = ResourceFactory.create(project=project)
+    entities_1 = EntityFactory.create_batch(8, resource=resource_1, date_created=now)
+    resource_2 = ResourceFactory.create(project=project)
+    entities_2 = EntityFactory.create_batch(5, resource=resource_2, date_created=now)
+
+    user = UserFactory.create()
+    user.profile.new_string_notifications = True
+    user.profile.save()  # no custom_homepage
+    TranslationFactory.create(entity=entities_1[0], locale=locale_1, user=user)
+    TranslationFactory.create(entity=entities_2[0], locale=locale_2, user=user)
+
+    notify_users(project, now)
+
+    assert mock_notify.call_count == 1
+    assert mock_notify.call_args.kwargs["verb"] == "updated with 8 new strings"
+
+
+@patch("pontoon.messaging.notifications.notify.send")
+@pytest.mark.django_db
+def test_notify_users_private_project_only_superusers(mock_notify):
+    """A private project is only visible to superusers, so other past
+    contributors are not notified about new strings."""
+    now = datetime(2026, 5, 24, 4, 44, tzinfo=timezone.utc)
+    locale = LocaleFactory.create()
+    project = ProjectFactory.create(
+        locales=[locale], visibility=Project.Visibility.PRIVATE
+    )
+    resource = ResourceFactory.create(project=project)
+    entity = EntityFactory.create(resource=resource, date_created=now)
+
+    regular = UserFactory.create()
+    regular.profile.new_string_notifications = True
+    regular.profile.save()
+    TranslationFactory.create(entity=entity, locale=locale, user=regular)
+
+    admin = UserFactory.create(is_superuser=True)
+    admin.profile.new_string_notifications = True
+    admin.profile.save()
+    TranslationFactory.create(entity=entity, locale=locale, user=admin)
+
+    notify_users(project, now)
+
+    recipients = {c.kwargs["recipient"] for c in mock_notify.call_args_list}
+    assert admin in recipients
+    assert regular not in recipients


### PR DESCRIPTION
- Send notifications only if the locale actually received new strings
- Exclude private projects if the user is not a superuser

Fixes #2063
Fixes #2085
Fixes #4218