### PR TITLE
Improve pytest performance

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -101,7 +101,7 @@ jobs:
           done
 
       - name: Run tests
-        run: pytest --cov-report=xml:pontoon/coverage.xml --cov=.
+        run: pytest -n auto --cov-report=xml:pontoon/coverage.xml --cov=.
       - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           flags: backend

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -101,6 +101,8 @@ jobs:
           done
 
       - name: Run tests
+        env:
+          COVERAGE_CORE: sysmon
         run: pytest -n auto --cov-report=xml:pontoon/coverage.xml --cov=.
       - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ vitest:
 
 test-server: pytest
 pytest:
-	"${DC}" run ${run_opts} --rm server pytest --cov-report=xml:pontoon/coverage.xml --cov=. $(opts)
+	"${DC}" run ${run_opts} --rm server pytest $(opts)
 
 format: prettier ruff
 

--- a/Makefile
+++ b/Makefile
@@ -108,8 +108,10 @@ vitest:
 	npm test -w translate
 
 test-server: pytest
+# Parallelize across CPUs by default; override with e.g. `num_procs=0` for targeted runs.
+num_procs ?= auto
 pytest:
-	"${DC}" run ${run_opts} --rm server pytest $(opts)
+	"${DC}" run ${run_opts} --rm server pytest -n $(num_procs) $(opts)
 
 format: prettier ruff
 

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -982,9 +982,7 @@ markupsafe==2.0.1 \
 moz-l10n[xml]==0.11.3 \
     --hash=sha256:30b2d81aac683fe1c6c8ce17131c177fb10f8bed38f426872da3f52ffa4c1bdf \
     --hash=sha256:f6e65ee6249b104161dcaf43f8a6b65da6c93d88206fcbdce4986993a03bd77a
-    # via
-    #   -r default.in
-    #   moz-l10n
+    # via -r default.in
 newrelic==9.6.0 \
     --hash=sha256:01c0eb630bb18261241a37aa0a70cb6f706079a1f58f59f2bb64f26fda54ffc5 \
     --hash=sha256:09dad0db993402e166e37d99302c2ad5588b4ff1e5b814819540ca5ec2bd3cea \
@@ -1966,3 +1964,6 @@ zensical==0.0.34 \
     --hash=sha256:eb9d880ccb25edba332e1f310b40e65afb0e1072c69530ec02afc6179b33c5ec \
     --hash=sha256:f77cb1152b51ccc5bf0c1055ac06802a6eeeff9cb8b4293919300c0becbd26bd
     # via -r default.in
+
+# The following packages were excluded from the output:
+# setuptools

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -25,4 +25,5 @@ factory-boy==3.3.1
 pytest==9.0.3
 pytest-cov==5.0.0
 pytest-django==4.9.0
+pytest-xdist==3.8.0
 requests-mock==1.12.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -215,6 +215,10 @@ coverage[toml]==7.6.1 \
     # via
     #   -r test.in
     #   pytest-cov
+execnet==2.1.2 \
+    --hash=sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd \
+    --hash=sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec
+    # via pytest-xdist
 factory-boy==3.3.1 \
     --hash=sha256:7b1113c49736e1e9995bc2a18f4dbf2c52cf0f841103517010b1d825712ce3ca \
     --hash=sha256:8317aa5289cdfc45f9cae570feb07a6177316c82e34d14df3c2e1f22f26abef0
@@ -256,6 +260,7 @@ pytest==9.0.3 \
     #   -r test.in
     #   pytest-cov
     #   pytest-django
+    #   pytest-xdist
 pytest-cov==5.0.0 \
     --hash=sha256:4f0764a1219df53214206bf1feea4633c3b558a2925c8b59f144f682861ce652 \
     --hash=sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857
@@ -263,6 +268,10 @@ pytest-cov==5.0.0 \
 pytest-django==4.9.0 \
     --hash=sha256:1d83692cb39188682dbb419ff0393867e9904094a549a7d38a3154d5731b2b99 \
     --hash=sha256:8bf7bc358c9ae6f6fc51b6cebb190fe20212196e6807121f11bd6a3b03428314
+    # via -r test.in
+pytest-xdist==3.8.0 \
+    --hash=sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88 \
+    --hash=sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1
     # via -r test.in
 python-dateutil==2.9.0 \
     --hash=sha256:78e73e19c63f5b20ffa567001531680d939dc042bf7850431877645523c66709 \


### PR DESCRIPTION
Fixes #4244 

* Don't add coverage locally (CI is unaffected, since there is an explicit test in the workflow).
* Use pytest-xdist to parallelize the execution.

I didn't want to run this multiple times, but timed my local run after each commit.

Current config: 0,11s user 0,11s system 0% cpu 1:27,59 total
Remove coverage locally: 0,10s user 0,13s system 0% cpu 50,845 total
With pytest-xdist: 0,11s user 0,11s system 0% cpu 36,793 total

For reference, in CI the pytest step was usually in the 4-5 minutes range.
