### PR TITLE
Translate: add CodeMirror editor theme inheritance

### DIFF
--- a/translate/src/context/Theme.tsx
+++ b/translate/src/context/Theme.tsx
@@ -8,6 +8,12 @@ type ThemeContextType = {
   setEditorTheme: (editorTheme: string) => void;
 };
 
+export function editorThemeClass(editorTheme: string | null): string {
+  return editorTheme === 'dark' || editorTheme === 'light'
+    ? `${editorTheme}-theme`
+    : '';
+}
+
 export const ThemeContext = createContext<ThemeContextType>({
   theme: 'dark',
   editorTheme: 'match',

--- a/translate/src/modules/translationform/components/EditField.tsx
+++ b/translate/src/modules/translationform/components/EditField.tsx
@@ -14,7 +14,7 @@ import React, {
 
 import { EditFieldHandle, EditorActions } from '~/context/Editor';
 import { Locale } from '~/context/Locale';
-import { ThemeContext } from '~/context/Theme';
+import { editorThemeClass, ThemeContext } from '~/context/Theme';
 import { useReadonlyEditor } from '~/hooks/useReadonlyEditor';
 
 import { getExtensions, useKeyHandlers } from '../utils/editFieldExtensions';
@@ -127,15 +127,10 @@ export const EditField = memo(
         [view],
       );
 
-      const editorThemeClass =
-        editorTheme === 'dark' || editorTheme === 'light'
-          ? `${editorTheme}-theme`
-          : '';
-
       return (
         <div
           className={
-            [readOnly && 'readonly', editorThemeClass]
+            [readOnly && 'readonly', editorThemeClass(editorTheme)]
               .filter(Boolean)
               .join(' ') || undefined
           }

--- a/translate/src/modules/translationform/utils/editFieldExtensions.ts
+++ b/translate/src/modules/translationform/utils/editFieldExtensions.ts
@@ -22,6 +22,7 @@ import { tags } from '@lezer/highlight';
 import { useContext, useEffect, useRef } from 'react';
 
 import { EditorActions } from '~/context/Editor';
+import { editorThemeClass } from '~/context/Theme';
 import { useCopyOriginalIntoEditor } from '~/modules/editor';
 import { placeholder } from '~/modules/placeable/placeholder';
 import type { MessageEntry } from '~/utils/message';
@@ -167,7 +168,13 @@ function autocompletePlaceholders(entry: MessageEntry) {
       override.push(completePlaceholder(edit, ...hl));
     }
   }
-  return override.length ? autocompletion({ override }) : null;
+  return override.length
+    ? autocompletion({
+        override,
+        tooltipClass: () =>
+          editorThemeClass(document.body.getAttribute('data-editor-theme')),
+      })
+    : null;
 }
 
 function completePlaceholder(


### PR DESCRIPTION
Fix #4252 

Use single source of truth for CodeMirror inheritance to editor theme.

<img height="200" alt="image" src="https://github.com/user-attachments/assets/a1e25b81-1c76-420b-aa15-489fbf7676e5" />
<img height="200" alt="image" src="https://github.com/user-attachments/assets/4f1374c6-920e-4207-a348-9f9f42fdfe66" />


