### PR TITLE
API: Change order_by to use locale code over name

### DIFF
--- a/pontoon/api/views.py
+++ b/pontoon/api/views.py
@@ -317,7 +317,7 @@ class EntityIndividualView(RequestFieldsMixin, generics.RetrieveAPIView):
                     "translation_set",
                     queryset=Translation.objects.filter(approved=True)
                     .select_related("locale")
-                    .order_by("locale__name"),
+                    .order_by("locale__code"),
                     to_attr="filtered_translations",
                 )
             )


### PR DESCRIPTION
This quick fix allows the Entity Translation page of Search to display entity translations in a sorted form, ascended alphabetically based on locale code.

### Screenshots
<img width="979" height="699" alt="image" src="https://github.com/user-attachments/assets/d161d186-8fb7-4e7e-af20-d6e3c06c9dbd" />
