### PR TITLE
Fix markup option serialization in editablePattern()

### DIFF
--- a/translate/src/utils/message/editablePattern.ts
+++ b/translate/src/utils/message/editablePattern.ts
@@ -42,7 +42,7 @@ function editablePlaceholder(part: Expression | Markup): string {
     if (part.opt) {
       for (const [name, val] of Object.entries(part.opt)) {
         const opt = typeof val === 'string' ? JSON.stringify(val) : '$' + val.$;
-        str += ` ${name}=${opt}}`;
+        str += ` ${name}=${opt}`;
       }
     }
     return str + (part.open ? '>' : ' />');

--- a/translate/src/utils/message/getPlainMessage.test.ts
+++ b/translate/src/utils/message/getPlainMessage.test.ts
@@ -211,7 +211,7 @@ describe('getPlainMessage', () => {
       expect(getPlainMessage(entry)).toEqual('a = {$b}');
     });
 
-    it('open/close tags', () => {
+    it('works with open/close tags', () => {
       const message =
         'Go to {#a href=open-account}Create password{/a} in settings.';
       const entry = parseEntry('android', message)!;

--- a/translate/src/utils/message/getPlainMessage.test.ts
+++ b/translate/src/utils/message/getPlainMessage.test.ts
@@ -202,13 +202,22 @@ describe('getPlainMessage', () => {
       expect(getPlainMessage(entry)).toEqual('%1$s additional settings');
     });
 
-    it('work with a message entry value', () => {
+    it('message entry value with MF2 placeholder fallback', () => {
       const entry: MessageEntry = {
         format: 'android',
         id: '',
         value: ['a = ', { $: 'b' }],
       };
       expect(getPlainMessage(entry)).toEqual('a = {$b}');
+    });
+
+    it('open/close tags', () => {
+      const message =
+        'Go to {#a href=open-account}Create password{/a} in settings.';
+      const entry = parseEntry('android', message)!;
+      expect(getPlainMessage(entry)).toEqual(
+        'Go to <a href="open-account">Create password</a> in settings.',
+      );
     });
   });
 });


### PR DESCRIPTION
Fixes the editor part of #4266.

There was one extra character hiding in the serialization.