### PR TITLE
CHS Snapshots: tweak count to match google sheet formulas

### DIFF
--- a/pontoon/insights/chs.py
+++ b/pontoon/insights/chs.py
@@ -180,11 +180,11 @@ def get_contributor_metrics_by_locale(locales, end_date: datetime) -> dict[int, 
         else:
             if is_superuser:
                 continue
-            if approved > ACTIVE_CONTRIBUTOR_STRING_THRESHOLD:
+            if approved >= ACTIVE_CONTRIBUTOR_STRING_THRESHOLD:
                 locale_contributors[locale_id]["active_contributors"] += 1
-            if total > ALL_CONTRIBUTOR_STRING_THRESHOLD:
+            if total >= ALL_CONTRIBUTOR_STRING_THRESHOLD:
                 locale_contributors[locale_id]["all_contributors"] += 1
-            if approved > NEW_SIGNUP_STRING_THRESHOLD and joined >= start_date:
+            if approved >= NEW_SIGNUP_STRING_THRESHOLD and joined >= start_date:
                 locale_contributors[locale_id]["new_signups"] += 1
 
     return locale_contributors


### PR DESCRIPTION
This PR sets the people count for snapshot calculation to `>=` the string thresholds, which solves the edge case of a contributor who has exactly 200 contributions as measured in 2026-06 google sheet.