### PR TITLE
Insights: small tweaks to global charts

### DIFF
--- a/pontoon/insights/static/js/insights.js
+++ b/pontoon/insights/static/js/insights.js
@@ -2,6 +2,10 @@ const nf = new Intl.NumberFormat('en', {
   style: 'percent',
 });
 
+const scoreFormat = new Intl.NumberFormat('en', {
+  maximumFractionDigits: 2,
+});
+
 const longMonthFormat = new Intl.DateTimeFormat('en', {
   month: 'long',
   year: 'numeric',
@@ -51,6 +55,8 @@ var Pontoon = (function (my) {
           return;
         }
 
+        const isScore = key === 'chs';
+
         const colors = [
           style.getPropertyValue('--purple'),
           style.getPropertyValue('--lilac'),
@@ -68,7 +74,7 @@ var Pontoon = (function (my) {
 
         const datasets = chart.data('dataset').map(function (item, index) {
           const color =
-            item.name === 'All'
+            item.name === 'Average (all locales)'
               ? style.getPropertyValue('--white-1')
               : colors[index % colors.length];
           return {
@@ -76,7 +82,7 @@ var Pontoon = (function (my) {
             label: item.name,
             data: item[key],
             borderColor: [color],
-            borderWidth: item.name === 'All' ? 3 : 1,
+            borderWidth: item.name === 'AAverage (all locales)ll' ? 3 : 1,
             pointBackgroundColor: color,
             pointHitRadius: 10,
             pointRadius: 3.25,
@@ -87,7 +93,7 @@ var Pontoon = (function (my) {
             fill: true,
             tension: 0.4,
             order: color.length - index,
-            hidden: item.name === 'All' ? false : true,
+            hidden: item.name === 'Average (all locales)' ? false : true,
           };
         });
 
@@ -125,7 +131,9 @@ var Pontoon = (function (my) {
                   maxTicksLimit: 3,
                   precision: 0,
                   callback: function (value) {
-                    return nf.format(value / 100);
+                    return isScore
+                      ? scoreFormat.format(value)
+                      : nf.format(value / 100);
                   },
                 },
                 beginAtZero: true,
@@ -157,7 +165,9 @@ var Pontoon = (function (my) {
                     const { chart, datasetIndex, parsed } = context;
 
                     const label = chart.data.datasets[datasetIndex].label;
-                    const value = nf.format(parsed.y / 100);
+                    const value = isScore
+                      ? scoreFormat.format(parsed.y)
+                      : nf.format(parsed.y / 100);
                     return `${label}: ${value}`;
                   },
                   title: function (tooltipItems) {

--- a/pontoon/insights/tests/test_views.py
+++ b/pontoon/insights/tests/test_views.py
@@ -63,7 +63,7 @@ def test_default_empty(client_superuser, clear_cache, locale_a, project_a, user_
     team_pretranslation_quality = response_context["team_pretranslation_quality"]
     assert team_pretranslation_quality["dataset"] == [
         {
-            "name": "All",
+            "name": "Average (all locales)",
             "approval_rate": [
                 None,
                 None,
@@ -83,7 +83,7 @@ def test_default_empty(client_superuser, clear_cache, locale_a, project_a, user_
     project_pretranslation_quality = response_context["project_pretranslation_quality"]
     assert project_pretranslation_quality["dataset"] == [
         {
-            "name": "All",
+            "name": "Average (all locales)",
             "approval_rate": [
                 None,
                 None,
@@ -169,7 +169,7 @@ def test_default_with_data(
             ],
         },
         {
-            "name": "All",
+            "name": "Average (all locales)",
             "approval_rate": [
                 None,
                 None,
@@ -206,7 +206,7 @@ def test_default_with_data(
             ],
         },
         {
-            "name": "All",
+            "name": "Average (all locales)",
             "approval_rate": [
                 None,
                 None,
@@ -316,7 +316,7 @@ def test_get_global_locale_health_insights_shape():
             ],
         },
         {
-            "name": "All",
+            "name": "Average (all locales)",
             "chs": [
                 15.0,
                 None,

--- a/pontoon/insights/utils.py
+++ b/pontoon/insights/utils.py
@@ -166,7 +166,7 @@ def get_locale_health_data(locales):
     data.update(
         {
             "all": {
-                "name": "All",
+                "name": "Average (all locales)",
                 "chs": [None] * 12,
             }
         }
@@ -530,7 +530,7 @@ def get_global_pretranslation_quality(category, id):
     data.update(
         {
             "all": {
-                "name": "All",
+                "name": "Average (all locales)",
                 "approval_rate": [None] * 12,
             }
         }


### PR DESCRIPTION
This PR does two things in `/insights`:
1. Replaces percentage datapoints display with 2 decimal datapoints in Community health score chart
2. Replace 'All' in global chart legends with 'Average (all locales)'

Fixes #4279.