### PR TITLE
Documentation: add insights documentation for admins

### DIFF
--- a/documentation/docs/admin/index.md
+++ b/documentation/docs/admin/index.md
@@ -30,6 +30,10 @@ This guide covers administrative tasks in Pontoon — managing projects, locales
 
     How to enable automated pretranslation for a project and train custom Google AutoML models.
 
+- :material-eye: **[Insights](insights.md)**
+
+    Resources for analyzing locale & project health.
+
 - :material-message-text: **[Messaging Center](messaging-center.md)**
 
     How to send targeted emails and in-app notifications to contributors.

--- a/documentation/docs/admin/insights.md
+++ b/documentation/docs/admin/insights.md
@@ -10,9 +10,9 @@ This section presents a table of the monthly `Community health score` and its un
 
 Each cell also displays the month-over-month change, making it possible to compare the current values against the previous month. Use the `Filter teams` search box to narrow the table down to specific locales.
 
-### Edit configuration
+### Edit locales
 
-The `Edit Configuration` button opens a page where you select which locales are displayed in the dashboard and its charts. Move one or more locales into the target list and click `Save Configuration`. If no locales are selected, the dashboard prompts you to choose at least one before any data is shown.
+The `Edit Locales` button toggles a view where the user selects which locales are displayed in the dashboard and its charts. Move one or more locales into the target list to save preferred locales for display. If no locales are selected, the dashboard prompts the user to choose at least one before any data is shown. Press `Back` to toggle back to the dashboard view.
 
 ### Show scores
 

--- a/documentation/docs/admin/insights.md
+++ b/documentation/docs/admin/insights.md
@@ -1,0 +1,35 @@
+# Insights
+
+Pontoon provides a global **Insights** dashboard for analyzing the health of localization communities and the quality of pretranslations across all locales and projects.
+
+The dashboard is restricted to staff and is available at [https://pontoon.mozilla.org/insights/](https://pontoon.mozilla.org/insights/) when logged in as an administrator.
+
+## Community health activity
+
+This section presents a table of the monthly `Community health score` and its underlying metrics for each selected locale. For every team it shows the number of managers, translators, active contributors, all contributors and new signups, along with the number of enabled projects, project completion, and the resulting `Community health score`.
+
+Each cell also displays the month-over-month change, making it possible to compare the current values against the previous month. Use the `Filter teams` search box to narrow the table down to specific locales.
+
+### Edit configuration
+
+The `Edit Configuration` button opens a page where you select which locales are displayed in the dashboard and its charts. Move one or more locales into the target list and click `Save Configuration`. If no locales are selected, the dashboard prompts you to choose at least one before any data is shown.
+
+### Show scores
+
+By default the table shows the raw value of each metric. Click the `Show scores` button to switch to the score view, which instead displays the individual component scores that add up to the `Community health score`. Click the button again (now labeled `Show default`) to return to the raw values.
+
+## Community health score chart
+
+This chart plots the monthly `Community health scores` of all selected locales for the most recent 12 months, along with the 12-month average. Hover over a data point in the graph to see all selected locale scores for that month along with the 12-month average.
+
+## Pretranslation quality
+
+Two charts track the quality of [pretranslations](../localizer/glossary.md#pretranslation) over time, measured as the approval rate of pretranslated strings (the share of pretranslations that reviewers approve rather than reject).
+
+### Team pretranslation quality
+
+Plots the approval rate of pretranslations for each team, making it possible to compare pretranslation quality across locales and spot teams whose custom machine translation models may need attention.
+
+### Project pretranslation quality
+
+Plots the approval rate of pretranslations for each project, highlighting which projects produce the most and least reliable pretranslations.

--- a/documentation/docs/admin/insights.md
+++ b/documentation/docs/admin/insights.md
@@ -20,7 +20,7 @@ By default the table shows the raw value of each metric. Click the `Show scores`
 
 ## Community health score chart
 
-This chart plots the monthly `Community health scores` of all selected locales for the most recent 12 months, along with the 12-month average. Hover over a data point in the graph to see all selected locale scores for that month along with the 12-month average.
+This chart plots the monthly `Community health scores` of each selected locale for the most recent 12 months, along with the average of all selected locales. Hover over a data point in the graph to see each selected locale's score for that month along with the average.
 
 ## Pretranslation quality
 

--- a/documentation/docs/admin/insights.md
+++ b/documentation/docs/admin/insights.md
@@ -6,7 +6,7 @@ The dashboard is restricted to staff and is available at `/insights` when logged
 
 ## Community health activity
 
-This section presents a table of the monthly `Community health score` and its underlying metrics for each selected locale. For every team it shows the number of managers, translators, active contributors, all contributors and new signups, along with the number of enabled projects, project completion, and the resulting `Community health score`.
+This section presents a table of the monthly `Community health score` and its underlying metrics for each selected locale. For every team it shows the number of users in different roles — managers, translators, contributors — above a certain threshold of submitted translations, all contributors independently of the number of approved translations, and new signups, along with the number of enabled projects, project completion, and the resulting `Community health score`.
 
 Each cell also displays the month-over-month change, making it possible to compare the current values against the previous month. Use the `Filter teams` search box to narrow the table down to specific locales.
 

--- a/documentation/docs/admin/insights.md
+++ b/documentation/docs/admin/insights.md
@@ -2,7 +2,7 @@
 
 Pontoon provides a global **Insights** dashboard for analyzing the health of localization communities and the quality of pretranslations across all locales and projects.
 
-The dashboard is restricted to staff and is available at [https://pontoon.mozilla.org/insights/](https://pontoon.mozilla.org/insights/) when logged in as an administrator.
+The dashboard is restricted to staff and is available at `/insights` when logged in as an administrator (e.g. [https://pontoon.mozilla.org/insights/](https://pontoon.mozilla.org/insights/) for the instance hosted by Mozilla).
 
 ## Community health activity
 

--- a/documentation/docs/localizer/teams-projects.md
+++ b/documentation/docs/localizer/teams-projects.md
@@ -161,5 +161,7 @@ The following insights only appear on Team pages:
 * **Active users**: shows the ratio of active versus total for each [user role](users.md#user-roles): managers (Team managers), reviewers (Team managers and Translators), and contributors, filterable by time period (last 12/6/3/1 months).
 * **Time to review suggestions**: shows the average age of [suggestions](glossary.md#translation) reviewed for a particular month, and the 12 month average. Hover over a data point in the graph to see the exact age in days for that month’s current and 12 month average.
 * **Age of unreviewed suggestions**: this can be accessed by clicking `Age of unreviewed` on the bottom of the Time to review suggestions graph. Shows the average age of unreviewed suggestions at a particular point in time. Hover over a data point in the graph to see the exact age in days for unreviewed suggestions for that month.
+* **Community health score**: shows the community health score calculated for a particular
+month. Hover over a data point in the graph to see the exact score for that month.
 
 Note: clicking on the `i` icon in the top right of each insight will provide detailed definitions for the data shown.

--- a/documentation/zensical.toml
+++ b/documentation/zensical.toml
@@ -33,7 +33,8 @@ nav = [
     { "Renaming a Localization File" = "admin/renaming-file.md" },
     { "Renaming a Project" = "admin/renaming-project.md" },
     { "Managing Users" = "admin/managing-users.md" },
-    { "Adding Terminology" = "admin/adding-terminology.md" }
+    { "Adding Terminology" = "admin/adding-terminology.md" },
+    { "Insights" = "admin/insights.md" }
   ]},
 
   { "Developer Guide" = [


### PR DESCRIPTION
This PR add documentation for the `/insights` page and edits the `/<code>/insights` page as well.

Fixes #4278.