### PR TITLE
Set target-language on `<file>` instead of `<xliff>` when missing

### DIFF
--- a/pontoon/sync/core/translations_to_repo.py
+++ b/pontoon/sync/core/translations_to_repo.py
@@ -301,7 +301,7 @@ def set_translations(
                     else locale.code
                 )
                 if prev_tgt is None:
-                    res.meta.append(Metadata("@target-language", lc))
+                    section.meta.append(Metadata("@target-language", lc))
                 else:
                     prev_tgt.value = lc
 

--- a/pontoon/sync/tests/test_e2e.py
+++ b/pontoon/sync/tests/test_e2e.py
@@ -313,7 +313,7 @@ def test_xliff_html_translation():
         makedirs(repo.checkout_path)
         file_xliff = dedent("""\
             <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-              <file original="file.txt" source-language="en" target-language="en" datatype="plaintext">
+              <file original="file.txt" source-language="en" datatype="plaintext">
                 <body>
                   <trans-unit id="key">
                     <source>Hello &lt;b&gt;world&lt;/b&gt;!</source>
@@ -348,7 +348,7 @@ def test_xliff_html_translation():
             assert file.read() == dedent("""\
                 <?xml version="1.0" encoding="utf-8"?>
                 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-                  <file original="file.txt" source-language="en" target-language="de-Test" datatype="plaintext">
+                  <file original="file.txt" source-language="en" datatype="plaintext" target-language="de-Test">
                     <body>
                       <trans-unit id="key">
                         <source>Hello &lt;b&gt;world&lt;/b&gt;!</source>


### PR DESCRIPTION
Fixes a bug introduced in #3587