### PR TITLE
Fix asterisk overlapping text in heading info title

### DIFF
--- a/pontoon/base/static/css/heading_info.css
+++ b/pontoon/base/static/css/heading_info.css
@@ -48,7 +48,6 @@ ul {
 #heading .details .title sup {
   position: absolute;
   top: -5px;
-  margin-left: -3px;
 }
 
 #heading .details .value {


### PR DESCRIPTION
Fixes #4239

Investigation: I tested the hypothesis that this regressed from the CSS boilerplate update (#4154) by reverting boilerplate.css to its pre-#4154 version on a local instance — the rendering was identical. I also reverted the prettier template reformat from #3959 (heading_info.html), alone and combined with the old boilerplate — identical in every combination, and all match current production. So this doesn't appear to be a recent regression from either change: the overlap comes from the rule itself, where margin-left: -3px pulls the asterisk into the last glyph of the title.

Fix: remove the margin-left: -3px. The superscript keeps its absolute positioning and top: -5px raise (so it doesn't affect the title's layout), but now starts where the text ends instead of overlapping it.

Before: 
<img width="396" height="109" alt="01-current-broken copy" src="https://github.com/user-attachments/assets/f55d44df-4ca8-4f48-bec1-6270dc140c8a" />

After: 
<img width="390" height="116" alt="05-fixed copy 2" src="https://github.com/user-attachments/assets/7e6e24e4-a632-4d8b-bc74-8500a572804e" />


Verified on the team page, project page, and listing pages that share the heading_info widget.