### PR TITLE
Fix progress chart growing on resource switch when browser is zoomed

### DIFF
--- a/translate/src/modules/resourceprogress/components/ProgressChart.tsx
+++ b/translate/src/modules/resourceprogress/components/ProgressChart.tsx
@@ -18,7 +18,6 @@ export function ProgressChart({
 }: Props): React.ReactElement<'canvas'> {
   const canvas = useRef<HTMLCanvasElement>(null);
   const dpr = window.devicePixelRatio || 1;
-  const style = getComputedStyle(document.body);
 
   useEffect(() => {
     const { approved, pretranslated, warnings, errors, missing, total } = stats;
@@ -26,6 +25,8 @@ export function ProgressChart({
     if (!canvas.current || !total) {
       return;
     }
+
+    const style = getComputedStyle(document.body);
 
     // Set up canvas to be HiDPI display ready.
     canvas.current.style.width = size + 'px';

--- a/translate/src/modules/resourceprogress/components/ProgressChart.tsx
+++ b/translate/src/modules/resourceprogress/components/ProgressChart.tsx
@@ -21,22 +21,18 @@ export function ProgressChart({
   const style = getComputedStyle(document.body);
 
   useEffect(() => {
-    if (canvas.current) {
-      const { height, width } = canvas.current;
-      // Set up canvas to be HiDPI display ready
-      canvas.current.style.width = width + 'px';
-      canvas.current.style.height = height + 'px';
-      canvas.current.width = width * dpr;
-      canvas.current.height = height * dpr;
-    }
-  }, [dpr]);
-
-  useEffect(() => {
     const { approved, pretranslated, warnings, errors, missing, total } = stats;
 
     if (!canvas.current || !total) {
       return;
     }
+
+    // Set up canvas to be HiDPI display ready.
+    canvas.current.style.width = size + 'px';
+    canvas.current.style.height = size + 'px';
+    canvas.current.width = size * dpr;
+    canvas.current.height = size * dpr;
+
     const { height, width } = canvas.current;
     const context = canvas.current.getContext('2d');
     if (!context) {
@@ -77,7 +73,7 @@ export function ProgressChart({
       context.strokeStyle = color;
       context.stroke();
     }
-  }, [stats]);
+  }, [stats, dpr, size]);
 
   return <canvas ref={canvas} height={size} width={size} />;
 }


### PR DESCRIPTION
Fixes #4291

The resource progress chart is drawn on a `<canvas>` sized for HiDPI displays. The setup effect read the canvas's current drawing area dimensions and multiplied them by `window.devicePixelRatio` at each resource change, increasing the chart's size.