### PR TITLE
Editor: change editor background in dark mode

### DIFF
--- a/pontoon/base/static/css/dark-theme.css
+++ b/pontoon/base/static/css/dark-theme.css
@@ -61,7 +61,7 @@
   --translation-secondary-color: #aaaaaa;
   --translation-main-button-color: #272a2f;
   --translation-subtitle-color: #888888;
-  --editor-background: #1a1d22;
+  --editor-background: #333941;
   --editor-color: #e6e6e6;
   --editor-form-background: #272a2f;
   --editor-menu-background: #272a2f;


### PR DESCRIPTION
Fix #4293 

Change editor background from `1a1d22` to `333941`, matches other inputs in dark theme.