### PR TITLE
Redirect renamed project slugs in API v2 project endpoint (fixes #4182)

### DIFF
--- a/pontoon/api/tests/test_views.py
+++ b/pontoon/api/tests/test_views.py
@@ -182,14 +182,6 @@ def test_locale_renamed_code_redirects():
 
 
 @pytest.mark.django_db
-def test_locale_unknown_code_404s():
-    response = APIClient().get(
-        "/api/v2/locales/does-not-exist/", HTTP_ACCEPT="application/json"
-    )
-    assert response.status_code == 404
-
-
-@pytest.mark.django_db
 def test_locales(django_assert_num_queries):
     project_a = ProjectFactory(
         slug="project_a",
@@ -1062,14 +1054,6 @@ def test_project_renamed_slug_redirects():
 
     assert response.status_code == 302
     assert response["Location"] == "/api/v2/projects/terminology-renamed/"
-
-
-@pytest.mark.django_db
-def test_project_unknown_slug_404s():
-    response = APIClient().get(
-        "/api/v2/projects/does-not-exist/", HTTP_ACCEPT="application/json"
-    )
-    assert response.status_code == 404
 
 
 @pytest.mark.django_db

--- a/pontoon/api/tests/test_views.py
+++ b/pontoon/api/tests/test_views.py
@@ -1012,7 +1012,7 @@ def test_project_locale(django_assert_num_queries):
 
 @pytest.mark.django_db
 def test_project_renamed_slug_redirects():
-    """Requesting a project by its old slug redirects to the new slug (#4182)."""
+    """Requesting a project by its old slug redirects to the new slug."""
     project = Project.objects.get(slug="terminology")
     project.slug = "terminology-renamed"
     project.save()

--- a/pontoon/api/tests/test_views.py
+++ b/pontoon/api/tests/test_views.py
@@ -169,6 +169,27 @@ def test_locale(django_assert_num_queries):
 
 
 @pytest.mark.django_db
+def test_locale_renamed_code_redirects():
+    """Requesting a locale by its old code redirects to the new code."""
+    locale = Locale.objects.get(code="af")
+    locale.code = "af-renamed"
+    locale.save()
+
+    response = APIClient().get("/api/v2/locales/af/", HTTP_ACCEPT="application/json")
+
+    assert response.status_code == 302
+    assert response["Location"] == "/api/v2/locales/af-renamed/"
+
+
+@pytest.mark.django_db
+def test_locale_unknown_code_404s():
+    response = APIClient().get(
+        "/api/v2/locales/does-not-exist/", HTTP_ACCEPT="application/json"
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
 def test_locales(django_assert_num_queries):
     project_a = ProjectFactory(
         slug="project_a",
@@ -475,6 +496,24 @@ def test_project(django_assert_num_queries):
         "completed_strings": 12,
         "complete": False,
     } in localizations
+
+
+@pytest.mark.django_db
+def test_project_locale_renamed_redirects():
+    """Requesting a project locale by an old code and old slug redirects to the new URL."""
+    locale = Locale.objects.get(code="af")
+    locale.code = "af-renamed"
+    locale.save()
+    project = Project.objects.get(slug="terminology")
+    project.slug = "terminology-renamed"
+    project.save()
+
+    response = APIClient().get(
+        "/api/v2/af/terminology/", HTTP_ACCEPT="application/json"
+    )
+
+    assert response.status_code == 302
+    assert response["Location"] == "/api/v2/af-renamed/terminology-renamed/"
 
 
 @pytest.mark.django_db

--- a/pontoon/api/tests/test_views.py
+++ b/pontoon/api/tests/test_views.py
@@ -495,8 +495,8 @@ def test_system_project(django_assert_num_queries):
 @pytest.mark.django_db
 def test_disabled_project(django_assert_num_queries):
     project = ProjectFactory.create(slug="disabled-1", disabled=True)
-
-    with django_assert_num_queries(1):
+    # 1 project lookup + 1 ProjectSlugHistory fallback lookup on the 404 path
+    with django_assert_num_queries(2):
         response = APIClient().get(
             f"/api/v2/projects/{project.slug}/", HTTP_ACCEPT="application/json"
         )
@@ -1008,6 +1008,29 @@ def test_project_locale(django_assert_num_queries):
             "complete": False,
         },
     }
+
+
+@pytest.mark.django_db
+def test_project_renamed_slug_redirects():
+    """Requesting a project by its old slug redirects to the new slug (#4182)."""
+    project = Project.objects.get(slug="terminology")
+    project.slug = "terminology-renamed"
+    project.save()
+
+    response = APIClient().get(
+        "/api/v2/projects/terminology/", HTTP_ACCEPT="application/json"
+    )
+
+    assert response.status_code == 302
+    assert response["Location"] == "/api/v2/projects/terminology-renamed/"
+
+
+@pytest.mark.django_db
+def test_project_unknown_slug_404s():
+    response = APIClient().get(
+        "/api/v2/projects/does-not-exist/", HTTP_ACCEPT="application/json"
+    )
+    assert response.status_code == 404
 
 
 @pytest.mark.django_db

--- a/pontoon/api/views.py
+++ b/pontoon/api/views.py
@@ -24,6 +24,7 @@ from pontoon.base.get_entities import get_entities_for_project_locale
 from pontoon.base.models import (
     Entity,
     Locale,
+    LocaleCodeHistory,
     Project,
     ProjectLocale,
     ProjectSlugHistory,
@@ -199,6 +200,19 @@ class LocaleIndividualView(RequestFieldsMixin, generics.RetrieveAPIView):
             qs = qs.stats_data()
 
         return qs
+
+    def retrieve(self, request, *args, **kwargs):
+        try:
+            return super().retrieve(request, *args, **kwargs)
+        except Http404:
+            code_history = (
+                LocaleCodeHistory.objects.filter(old_code=self.kwargs["code"])
+                .order_by("-created_at")
+                .first()
+            )
+            if code_history is None:
+                raise
+            return redirect("locale-individual", code=code_history.locale.code)
 
 
 class ProjectListView(RequestFieldsMixin, generics.ListAPIView):
@@ -388,6 +402,32 @@ class ProjectLocaleIndividualView(RequestFieldsMixin, generics.RetrieveAPIView):
         obj = get_object_or_404(queryset, project__slug=slug, locale__code=code)
 
         return obj
+
+    def retrieve(self, request, *args, **kwargs):
+        try:
+            return super().retrieve(request, *args, **kwargs)
+        except Http404:
+            code = self.kwargs["code"]
+            slug = self.kwargs["slug"]
+
+            code_history = (
+                LocaleCodeHistory.objects.filter(old_code=code)
+                .order_by("-created_at")
+                .first()
+            )
+            slug_history = (
+                ProjectSlugHistory.objects.filter(old_slug=slug)
+                .order_by("-created_at")
+                .first()
+            )
+            if code_history is None and slug_history is None:
+                raise
+
+            if code_history is not None:
+                code = code_history.locale.code
+            if slug_history is not None:
+                slug = slug_history.project.slug
+            return redirect("project-locale-individual", code=code, slug=slug)
 
 
 class TermSearchListView(RequestFieldsMixin, generics.ListAPIView):

--- a/pontoon/api/views.py
+++ b/pontoon/api/views.py
@@ -9,7 +9,8 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from django.db.models import Prefetch, Q
-from django.shortcuts import get_object_or_404
+from django.http import Http404
+from django.shortcuts import get_object_or_404, redirect
 from django.utils.timezone import make_aware
 
 from pontoon.actionlog.models import ActionLog
@@ -25,6 +26,7 @@ from pontoon.base.models import (
     Locale,
     Project,
     ProjectLocale,
+    ProjectSlugHistory,
     Resource,
     Translation,
     TranslationMemoryEntry,
@@ -281,6 +283,19 @@ class ProjectIndividualView(RequestFieldsMixin, generics.RetrieveAPIView):
             qs = qs.stats_data()
 
         return qs.distinct()
+
+    def retrieve(self, request, *args, **kwargs):
+        try:
+            return super().retrieve(request, *args, **kwargs)
+        except Http404:
+            slug_history = (
+                ProjectSlugHistory.objects.filter(old_slug=self.kwargs["slug"])
+                .order_by("-created_at")
+                .first()
+            )
+            if slug_history is None:
+                raise
+            return redirect("project-individual", slug=slug_history.project.slug)
 
 
 class EntityListView(RequestFieldsMixin, generics.ListAPIView):


### PR DESCRIPTION
`/api/v2/projects/<old-slug>/` returned a 404 for renamed projects, while the
web UI redirects to the new slug. This adds a `retrieve()` override to
`ProjectIndividualView` with the same `ProjectSlugHistory` fallback: on a
failed lookup, respond with a 302 to the current slug's URL. Unknown slugs
still return 404.

The fallback logic mirrors `get_project_or_redirect()` in
`pontoon/base/services.py`. The 404 path now runs one extra history query,
hence the query-count update in `test_disabled_project`.

Tests: `test_project_renamed_slug_redirects` (old slug returns a 302 with the
correct `Location`) and `test_project_unknown_slug_404s`.

Note: other slug-based endpoints and locale endpoints (via `LocaleCodeHistory`)
have the same gap. This PR only covers the endpoint from the issue; happy to
follow up on the rest.
