### PR TITLE
Fix opt-in typo: "Locales can opt-in" should read "opt in"

### DIFF
--- a/documentation/docs/admin/adding-new-db-project.md
+++ b/documentation/docs/admin/adding-new-db-project.md
@@ -15,7 +15,7 @@ Access Pontoon’s [admin console](https://pontoon.allizom.org/admin/) on the **
 * Locales:
 
   * Select at least one locale. To make things faster it’s possible to copy supported locales from an existing project.
-  * You can uncheck the `Locales can opt-in` checkbox to prevent localizers from requesting this specific project.
+  * You can uncheck the `Locales can opt in` checkbox to prevent localizers from requesting this specific project.
 
 * Data Source: select `Database` in the list of options. This will hide the *Repositories* section and show a *Strings* section instead.
 * Strings: you can enter the initial set of strings here. Strings must be separated by new lines. If you leave this empty, you’ll be able to enter strings as a batch again after creating the project. Strings must be in `en-US`, and they will become the entities on that project. A resource named `database` will automatically be created.

--- a/documentation/docs/admin/adding-new-project.md
+++ b/documentation/docs/admin/adding-new-project.md
@@ -62,7 +62,7 @@ The new project will appear in the [public list of Projects](https://pontoon.moz
 
   * Select at least one locale. To make things faster it’s possible to copy supported locales from an existing project.
   * The *Read-only* column can be used to add languages in read-only mode. In this way, their translations will be available to other languages in the LOCALES tab when translating, but it won’t be possible to change or submit translations directly in Pontoon.
-  * You can uncheck the `Locales can opt-in` checkbox to prevent localizers from requesting this specific project.
+  * You can uncheck the `Locales can opt in` checkbox to prevent localizers from requesting this specific project.
 
 * Repositories: select the type of repository and URL. Make sure to use SSH to allow write access. For example, if the repository is `https://github.com/meandavejustice/min-vid`, the URL should be `git@github.com:meandavejustice/min-vid.git`. You can use the *Clone or download* button in the repository page on GitHub, making sure that *Clone with SSH* is selected.
 * Leave the `Branch` field empty, unless developers asked to commit translations in a specific branch instead of the default one (usually `main` or `master`).

--- a/pontoon/administration/templates/admin_project.html
+++ b/pontoon/administration/templates/admin_project.html
@@ -66,7 +66,7 @@
     <div class="locales-toolbar clearfix">
       <section class="can-be-requested checkbox clearfix">
         <label for="id_can_be_requested">
-          {{ form.can_be_requested }}Locales can opt-in
+          {{ form.can_be_requested }}Locales can opt in
         </label>
       </section>
       <section class="copy-locales clearfix">


### PR DESCRIPTION
## Summary
- \`opt-in\` is a noun/adjective; used as a verb after "can" it should be "opt in" (no hyphen)
- Fixes the admin UI checkbox label in `admin_project.html`
- Updates the two docs pages that quote that label to match

## Test plan
- Searched the codebase for other instances of "can opt-in" — none remain
- Text-only change, no functional/behavioral change

Fixes #4285