### PR TITLE
Authentication: fix local standalone logout

### DIFF
--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -960,6 +960,22 @@ header .right .select .menu {
   line-height: 22px;
 }
 
+#profile .menu li#standalone-sign-out form {
+  display: flex;
+}
+
+#profile .menu li#standalone-sign-out button {
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: 22px;
+  padding: 0;
+  text-align: left;
+}
+
 #profile .menu li i.fas,
 #profile .menu li i.fab {
   margin: 0 8px 0 -2px;

--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -965,6 +965,7 @@ header .right .select .menu {
 }
 
 #profile .menu li#standalone-sign-out button {
+  flex: 1;
   background: transparent;
   border: none;
   color: inherit;

--- a/pontoon/base/templates/allauth/layouts/base.html
+++ b/pontoon/base/templates/allauth/layouts/base.html
@@ -169,11 +169,15 @@
                   {% if settings.AUTHENTICATION_METHOD == 'django' %}
                     {% if user.is_authenticated %}
                       <li id="standalone-sign-out">
-                        <a
-                          href="{% url 'standalone_logout' %}"
-                          title="{{ user.email|nospam }}"
-                          ><i class="fas fa-sign-out-alt fa-fw"></i>Sign out</a
+                        <form
+                          action="{% url 'standalone_logout' %}"
+                          method="post"
                         >
+                          {% csrf_token %}
+                          <button type="submit" title="{{ user.email|nospam }}">
+                            <i class="fas fa-sign-out-alt fa-fw"></i>Sign out
+                          </button>
+                        </form>
                       </li>
                     {% else %}
                       <li id="standalone-signin">

--- a/pontoon/base/templates/header.html
+++ b/pontoon/base/templates/header.html
@@ -118,11 +118,12 @@
 
                 {% if settings.AUTHENTICATION_METHOD == 'django' %}
                   <li id="standalone-sign-out">
-                    <a
-                      href="{{ url('standalone_logout') }}"
-                      title="{{ user.email|nospam }}"
-                      ><i class="fas fa-sign-out-alt fa-fw"></i>Sign out</a
-                    >
+                    <form action="{{ url('standalone_logout') }}" method="post">
+                      {% csrf_token %}
+                      <button type="submit" title="{{ user.email|nospam }}">
+                        <i class="fas fa-sign-out-alt fa-fw"></i>Sign out
+                      </button>
+                    </form>
                   </li>
                 {% else %}
                   <li id="sign-out">


### PR DESCRIPTION
This PR fixes the `405: Method Not Allowed` error that occurs locally when attempting to logout. The reason this was happening was due to our upgrade from Django 4.2 -> Django 5.2, which completely removed GET request ability to logout directly due to malicious logout attack vector. This prevents `<a>` tags from being able to logout users, as clicking a link counts as a GET request.

The `<a>` tag has been replaced with a submitt-able button, which fixes this issue.
Fixes #4169.