### PR TITLE
Unifying search box styling across Settings and Search pages

### DIFF
--- a/pontoon/administration/static/css/admin_project.css
+++ b/pontoon/administration/static/css/admin_project.css
@@ -145,6 +145,10 @@ form .controls .button.manage-resources[disabled]:hover {
   width: 150px;
 }
 
+.admin-project .search-wrapper {
+  background: var(--input-background-1);
+}
+
 #admin-strings-form .controls .add-inline {
   float: left;
   margin-left: 0;

--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -1306,7 +1306,7 @@ body > form,
 }
 
 .controls > .search-wrapper input {
-  background: var(--black-3);
+  background: var(--dark-grey-1);
   border: 1px solid var(--main-border-1);
   color: var(--input-color-2);
   font-size: 13px;

--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -494,16 +494,18 @@ time {
 }
 
 .search-wrapper {
-  border-bottom: 1px solid var(--main-border-1);
+  border: 1px solid var(--main-border-1);
   margin-bottom: 10px;
   position: relative;
+  border-radius: 3px;
+  background: var(--dark-grey-2);
 }
 
 .search-wrapper .icon {
   color: var(--light-grey-7);
   font-size: 1.2em;
   position: absolute;
-  left: 3px;
+  left: 6px;
   top: 5px;
 }
 

--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -498,7 +498,6 @@ time {
   margin-bottom: 10px;
   position: relative;
   border-radius: 3px;
-  background: var(--dark-grey-2);
 }
 
 .search-wrapper .icon {

--- a/pontoon/base/static/css/style.css
+++ b/pontoon/base/static/css/style.css
@@ -303,6 +303,10 @@ time {
   z-index: 19; /* Must be lower than for the (popup) .menu */
 }
 
+.select.opened .menu .search-wrapper {
+  background: var(--black-3);
+}
+
 .project.select,
 .locale.select,
 .part.select,
@@ -1302,7 +1306,7 @@ body > form,
 }
 
 .controls > .search-wrapper input {
-  background: var(--dark-grey-1);
+  background: var(--black-3);
   border: 1px solid var(--main-border-1);
   color: var(--input-color-2);
   font-size: 13px;

--- a/pontoon/contributors/static/css/settings.css
+++ b/pontoon/contributors/static/css/settings.css
@@ -29,10 +29,6 @@ form a:visited {
   margin-top: 10px;
 }
 
-#preferred-locale .search-wrapper {
-  background: var(--black-3);
-}
-
 #locale-settings .label,
 #account-settings .label,
 .double-check-box > .label,

--- a/pontoon/contributors/static/css/settings.css
+++ b/pontoon/contributors/static/css/settings.css
@@ -29,6 +29,10 @@ form a:visited {
   margin-top: 10px;
 }
 
+#preferred-locale .search-wrapper {
+  background: var(--black-3);
+}
+
 #locale-settings .label,
 #account-settings .label,
 .double-check-box > .label,

--- a/pontoon/contributors/static/css/settings.css
+++ b/pontoon/contributors/static/css/settings.css
@@ -6,6 +6,10 @@ form.user-locales-settings div {
   text-align: right;
 }
 
+form.user-locales-settings .search-wrapper {
+  background: var(--input-background-1);
+}
+
 form a:link,
 form a:visited {
   color: var(--status-translated-alt);

--- a/pontoon/messaging/static/css/messaging.css
+++ b/pontoon/messaging/static/css/messaging.css
@@ -9,6 +9,9 @@
     section {
       padding: 20px;
     }
+    .search-wrapper {
+      background: var(--black-3);
+    }
   }
 
   .controls {

--- a/pontoon/search/static/css/search.css
+++ b/pontoon/search/static/css/search.css
@@ -59,6 +59,9 @@
         #project-selector {
           margin-right: 10px;
         }
+        .search-wrapper {
+          background: var(--black-3);
+        }
 
         .check-list {
           display: inline-block;

--- a/pontoon/search/static/css/search.css
+++ b/pontoon/search/static/css/search.css
@@ -59,9 +59,6 @@
         #project-selector {
           margin-right: 10px;
         }
-        .search-wrapper {
-          background: var(--black-3);
-        }
 
         .check-list {
           display: inline-block;

--- a/pontoon/teams/static/css/team.css
+++ b/pontoon/teams/static/css/team.css
@@ -300,3 +300,7 @@
 #project-selector .menu li:not(.limited) {
   display: none;
 }
+
+#project-selector.select.opened .menu .search-wrapper {
+  background: var(--black-3);
+}

--- a/pontoon/teams/static/css/team.css
+++ b/pontoon/teams/static/css/team.css
@@ -230,6 +230,10 @@
   width: 100%;
 }
 
+#permissions-form .search-wrapper {
+  background: var(--dark-grey-1);
+}
+
 #permissions-form .user.select .menu ul {
   height: 168px;
   margin-bottom: 0;


### PR DESCRIPTION
Fixes #4264

Unifies search box styling in the search page and settings page, so that it's similar to the search box on the resource page drop down and copy from locale batch action drop down.
<img width="1154" height="245" alt="Screenshot 2026-07-10 at 00 37 48" src="https://github.com/user-attachments/assets/a5cd7e61-1d72-427a-9631-f30beae0a47c" />
<img width="950" height="352" alt="Screenshot 2026-07-10 at 00 37 30" src="https://github.com/user-attachments/assets/05ae6610-3f50-44d3-a9ad-271164a80941" />

To test:
- Check if the changes apply to all the search boxes.