### PR TITLE
Fix approve button hover state

### DIFF
--- a/translate/src/modules/editor/components/EditorMenu.css
+++ b/translate/src/modules/editor/components/EditorMenu.css
@@ -55,7 +55,7 @@
   background: var(--status-missing);
 }
 
-.editor-menu .actions .action-approve:hover,
+.editor-menu .actions .action-approve:not(.has-error):hover,
 .editor-menu .actions .action-save:not(.has-error):hover,
 .editor-menu .actions .action-suggest:not(.has-error):hover {
   color: var(--white-1);


### PR DESCRIPTION
Fixes #4306.

**Problem:**
Hovering over the Approve button in the translation editor makes the button label unreadable. The text color becomes the same as the background color.

**Root cause:**
CSS specificity regression introduced in #4187. Commit `1f271423` changed `.editor-menu .actions button:hover` to `.editor-menu .actions button:not(.has-error):hover`, raising its specificity from 0,2,1 to 0,3,2. This generic selector now overrides `.action-approve:hover` (specificity 0,3,1), causing the hover text to use `var(--status-translated)` instead of the intended `var(--white-1)`. Since the button background is also `var(--status-translated)`, the text becomes invisible.

The save and suggest hover selectors were correctly updated in that commit to include `:not(.has-error)`, but the approve selector was missed.

**Fix:**
Add `:not(.has-error)` to `.action-approve:hover` in `EditorMenu.css`, matching the existing pattern and restoring the intended hover text color.

**How to review:**
- `translate/src/modules/editor/components/EditorMenu.css` — verify the approve button hover selector now includes `:not(.has-error)`.

**How to test:**
1. Start Pontoon locally.
2. Sign in as a user with approve permission.
3. Open an entity with an existing unapproved translation.
4. Hover over the **Approve** button.
5. Confirm the button label is readable while hovered (text should be white in dark theme, or the `--white-1` value for the current theme).