### PR TITLE
Drop linkify-it dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "@types/escape-html": "^1.0.1",
         "@types/history": "^4.7.8",
         "@types/javascript-time-ago": "^2.0.3",
-        "@types/linkify-it": "^3.0.1",
         "@types/lodash.escaperegexp": "^4.1.6",
         "@types/lodash.isempty": "^4.4.6",
         "@types/node": "^24.12.4",
@@ -3394,13 +3393,6 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/linkify-it": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.5.tgz",
-      "integrity": "sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==",
       "dev": true,
       "license": "MIT"
     },
@@ -10673,7 +10665,6 @@
         "history": "^4.10.1",
         "html-react-parser": "^5.2.6",
         "javascript-time-ago": "^2.3.9",
-        "linkify-it": "^2.1.0",
         "lodash.escaperegexp": "^4.1.2",
         "nprogress": "^0.2.0",
         "react": "^16.14.0",
@@ -10689,8 +10680,7 @@
         "redux-thunk": "^2.3.0",
         "slate": "^0.78.0",
         "slate-react": "^0.77.4",
-        "styled-components": "^5.3.3",
-        "tlds": "^1.218.0"
+        "styled-components": "^5.3.3"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "@types/escape-html": "^1.0.1",
     "@types/history": "^4.7.8",
     "@types/javascript-time-ago": "^2.0.3",
-    "@types/linkify-it": "^3.0.1",
     "@types/lodash.escaperegexp": "^4.1.6",
     "@types/lodash.isempty": "^4.4.6",
     "@types/node": "^24.12.4",

--- a/translate/package.json
+++ b/translate/package.json
@@ -22,7 +22,6 @@
     "history": "^4.10.1",
     "html-react-parser": "^5.2.6",
     "javascript-time-ago": "^2.3.9",
-    "linkify-it": "^2.1.0",
     "lodash.escaperegexp": "^4.1.2",
     "nprogress": "^0.2.0",
     "react": "^16.14.0",
@@ -38,8 +37,7 @@
     "redux-thunk": "^2.3.0",
     "slate": "^0.78.0",
     "slate-react": "^0.77.4",
-    "styled-components": "^5.3.3",
-    "tlds": "^1.218.0"
+    "styled-components": "^5.3.3"
   },
   "scripts": {
     "start": "rollup -c --watch",

--- a/translate/src/modules/entitydetails/components/Screenshots.test.jsx
+++ b/translate/src/modules/entitydetails/components/Screenshots.test.jsx
@@ -40,6 +40,24 @@ describe('<Screenshots>', () => {
     );
   });
 
+  it('strips trailing sentence punctuation from the image URL', () => {
+    const source =
+      'See http://link.to/image.png?size=large, then https://example.org/en-US/test.jpg#preview.';
+    const { getAllByRole } = render(
+      <Screenshots locale='kg' source={source} />,
+    );
+    const images = getAllByRole('img');
+    expect(images).toHaveLength(2);
+    expect(images[0]).toHaveAttribute(
+      'src',
+      'http://link.to/image.png?size=large',
+    );
+    expect(images[1]).toHaveAttribute(
+      'src',
+      'https://example.org/kg/test.jpg#preview',
+    );
+  });
+
   it('does not find non PNG or JPG images', () => {
     const source =
       'That is a non-supported image URL: http://link.to/image.bmp';

--- a/translate/src/modules/entitydetails/components/Screenshots.test.jsx
+++ b/translate/src/modules/entitydetails/components/Screenshots.test.jsx
@@ -20,6 +20,26 @@ describe('<Screenshots>', () => {
     expect(images[1]).toHaveAttribute('src', 'https://example.org/kg/test.jpg');
   });
 
+  it('keeps query strings and fragments on the image URL', () => {
+    const source = `
+      http://link.to/image.png?size=large
+      https://example.org/en-US/test.jpg#preview
+    `;
+    const { getAllByRole } = render(
+      <Screenshots locale='kg' source={source} />,
+    );
+    const images = getAllByRole('img');
+    expect(images).toHaveLength(2);
+    expect(images[0]).toHaveAttribute(
+      'src',
+      'http://link.to/image.png?size=large',
+    );
+    expect(images[1]).toHaveAttribute(
+      'src',
+      'https://example.org/kg/test.jpg#preview',
+    );
+  });
+
   it('does not find non PNG or JPG images', () => {
     const source =
       'That is a non-supported image URL: http://link.to/image.bmp';

--- a/translate/src/modules/entitydetails/components/Screenshots.tsx
+++ b/translate/src/modules/entitydetails/components/Screenshots.tsx
@@ -4,7 +4,9 @@ import './Screenshots.css';
 
 // Matches http(s) URLs pointing at a PNG or JPG image, including any
 // trailing query string or fragment (e.g. .../image.jpg?size=large).
-const IMAGE_URL_RE = /https?:\/\/[^\s"'<>]+?\.(?:png|jpg)(?:[?#][^\s"'<>]*)?/gi;
+// Trailing sentence punctuation is excluded so a URL can appear mid-sentence.
+const IMAGE_URL_RE =
+  /https?:\/\/[^\s"'<>]+?\.(?:png|jpg)(?:[?#][^\s"'<>]*(?<![,.;!?]))?/gi;
 
 function getImageURLs(source: string, locale: string) {
   const matches = source.match(IMAGE_URL_RE);

--- a/translate/src/modules/entitydetails/components/Screenshots.tsx
+++ b/translate/src/modules/entitydetails/components/Screenshots.tsx
@@ -2,8 +2,9 @@ import React, { useEffect, useState } from 'react';
 
 import './Screenshots.css';
 
-// Matches http(s) URLs pointing at a PNG or JPG image.
-const IMAGE_URL_RE = /https?:\/\/[^\s"'<>]+?\.(?:png|jpg)/gi;
+// Matches http(s) URLs pointing at a PNG or JPG image, including any
+// trailing query string or fragment (e.g. .../image.jpg?size=large).
+const IMAGE_URL_RE = /https?:\/\/[^\s"'<>]+?\.(?:png|jpg)(?:[?#][^\s"'<>]*)?/gi;
 
 function getImageURLs(source: string, locale: string) {
   const matches = source.match(IMAGE_URL_RE);

--- a/translate/src/modules/entitydetails/components/Screenshots.tsx
+++ b/translate/src/modules/entitydetails/components/Screenshots.tsx
@@ -1,21 +1,16 @@
-import LinkifyIt from 'linkify-it';
 import React, { useEffect, useState } from 'react';
-import tlds from 'tlds';
 
 import './Screenshots.css';
 
-// Create and configure a URLs matcher.
-const linkify = new LinkifyIt();
-linkify.tlds(tlds);
+// Matches http(s) URLs pointing at a PNG or JPG image.
+const IMAGE_URL_RE = /https?:\/\/[^\s"'<>]+?\.(?:png|jpg)/gi;
 
 function getImageURLs(source: string, locale: string) {
-  const matches = linkify.match(source);
+  const matches = source.match(IMAGE_URL_RE);
   if (!matches) {
     return [];
   }
-  return matches
-    .filter((match) => /(https?:\/\/.*\.(?:png|jpg))/im.test(match.url))
-    .map((match) => match.url.replace(/en-US\//gi, locale + '/'));
+  return matches.map((url) => url.replace(/en-US\//gi, locale + '/'));
 }
 
 type Props = {


### PR DESCRIPTION
Fix #4310.

Screenshots was the only consumer. Its match results were already filtered down to http(s) PNG/JPG URLs, so linkify-it's TLD-aware matching (and the tlds list feeding it) added nothing a plain regex can't do.