### PR TITLE
Update moz-l10n & properly parse escaped characters in .properties strings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2570,9 +2570,9 @@
       "license": "MIT"
     },
     "node_modules/@mozilla/l10n": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/@mozilla/l10n/-/l10n-0.11.3.tgz",
-      "integrity": "sha512-s+rI4SZjFrCkmvgQiXtPbydiWwUkqEf2AcOFUJY8GRXvPKs0czAa5b7fAH1Y/lKh6hEbrQJa2CKVVY47PhAvAA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@mozilla/l10n/-/l10n-0.12.0.tgz",
+      "integrity": "sha512-COQKXmv2NlLWcjxrPgpxf8X99fpLm5ZFVhiRuvaAyYrwx6NCjyrc6Q+MdFuCV3ZI31eBN/9j8UVhXFrQGSQ43Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fluent/syntax": "^0.19.0",
@@ -10654,7 +10654,7 @@
         "@fluent/langneg": "^0.7.0",
         "@fluent/react": "^0.15.1",
         "@lezer/highlight": "^1.1.6",
-        "@mozilla/l10n": "^0.11.3",
+        "@mozilla/l10n": "^0.12.0",
         "@reduxjs/toolkit": "^1.6.1",
         "classnames": "^2.3.1",
         "date-and-time": "^0.14.2",

--- a/pontoon/base/migrations/0120_fix_properties.py
+++ b/pontoon/base/migrations/0120_fix_properties.py
@@ -1,0 +1,114 @@
+import json
+import re
+
+from moz.l10n.formats.properties import (
+    properties_parse_message,
+    properties_serialize_message,
+)
+from moz.l10n.message import message_from_json, message_to_json
+from moz.l10n.model import PatternMessage
+
+from django.db import migrations
+from django.db.models import Q
+
+
+_esc_nul = re.compile(r"\\u(?:0|00|000)(?![0-9a-fA-F])|\\u0000")
+
+
+def _clean_and_parse(src: str):
+    clean = src.strip("\n").replace("\n", "\\n")
+    clean = _esc_nul.sub(r"\\uFFFD", clean)
+    return properties_parse_message(clean)
+
+
+def fix_properties(apps, schema_editor):
+    Entity = apps.get_model("base", "Entity")
+    entities = Entity.objects.filter(
+        resource__format="properties", string__contains="\\"
+    )
+    for e in entities:
+        msg = properties_parse_message(e.string)
+        e.value = message_to_json(msg)
+        e.string = properties_serialize_message(msg)
+    Entity.objects.bulk_update(entities, ["string", "value"])
+
+    Translation = apps.get_model("base", "Translation")
+    translations = Translation.objects.filter(
+        entity__resource__format="properties", string__contains="\\"
+    )
+    for t in translations:
+        try:
+            msg = _clean_and_parse(t.string)
+            t.value = message_to_json(msg)
+            t.string = properties_serialize_message(msg)
+        except ValueError:
+            print(t.entity_id, t.locale.code, json.dumps(t.string))
+            raise
+    Translation.objects.bulk_update(
+        translations, ["string", "value"], batch_size=10_000
+    )
+
+    TranslationMemoryEntry = apps.get_model("base", "TranslationMemoryEntry")
+    tm_entries = TranslationMemoryEntry.objects.filter(
+        entity__resource__format="properties"
+    ).filter(Q(source__contains="\\") | Q(target__contains="\\"))
+    for tm in tm_entries:
+        src_msg = properties_parse_message(tm.source)
+        (tm.source,) = src_msg.pattern if src_msg.pattern else [""]
+        tgt_msg = _clean_and_parse(tm.target)
+        (tm.target,) = tgt_msg.pattern if tgt_msg.pattern else [""]
+    TranslationMemoryEntry.objects.bulk_update(tm_entries, ["source", "target"])
+
+
+_prop_esc_u = re.compile(r"(?<!\\)\\u(?!0000)[0-9A-Fa-f]{4}")
+_prop_esc_ws = re.compile(r"(?<!\\)\\([^\S\n])")
+
+
+def _unicode_unescape(m: re.Match[str]):
+    return m[0].encode("utf-8").decode("unicode_escape")
+
+
+def _unfix_string(msg):
+    string = properties_serialize_message(msg)
+    string = _prop_esc_u.sub(_unicode_unescape, string)
+    string = _prop_esc_ws.sub(r"\1", string)
+    return string
+
+
+def unfix_properties(apps, schema_editor):
+    Entity = apps.get_model("base", "Entity")
+    entities = Entity.objects.filter(
+        resource__format="properties", string__contains="\\"
+    )
+    for e in entities:
+        e.string = _unfix_string(message_from_json(e.value))
+        e.value = PatternMessage([e.string])
+    Entity.objects.bulk_update(entities, ["string", "value"])
+
+    Translation = apps.get_model("base", "Translation")
+    translations = Translation.objects.filter(
+        entity__resource__format="properties", string__contains="\\"
+    )
+    for t in translations:
+        t.string = _unfix_string(message_from_json(t.value))
+        t.value = PatternMessage([t.string])
+    Translation.objects.bulk_update(
+        translations, ["string", "value"], batch_size=10_000
+    )
+
+    TranslationMemoryEntry = apps.get_model("base", "TranslationMemoryEntry")
+    tm_entries = TranslationMemoryEntry.objects.filter(
+        entity__resource__format="properties"
+    ).filter(Q(source__contains="\n") | Q(target__contains="\n"))
+    for tm in tm_entries:
+        tm.source = _unfix_string(PatternMessage([tm.source] if tm.source else []))
+        tm.target = _unfix_string(PatternMessage([tm.target] if tm.target else []))
+    TranslationMemoryEntry.objects.bulk_update(tm_entries, ["source", "target"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [("base", "0119_userprofile_community_health_locales")]
+
+    operations = [
+        migrations.RunPython(fix_properties, reverse_code=unfix_properties),
+    ]

--- a/pontoon/base/migrations/0120_fix_properties.py
+++ b/pontoon/base/migrations/0120_fix_properties.py
@@ -23,8 +23,8 @@ def _clean_and_parse(src: str):
 
 def fix_properties(apps, schema_editor):
     Entity = apps.get_model("base", "Entity")
-    entities = Entity.objects.filter(
-        resource__format="properties", string__contains="\\"
+    entities = Entity.objects.filter(resource__format="properties").filter(
+        Q(string__contains="\\") | Q(string__contains="\n")
     )
     for e in entities:
         msg = properties_parse_message(e.string)
@@ -34,8 +34,8 @@ def fix_properties(apps, schema_editor):
 
     Translation = apps.get_model("base", "Translation")
     translations = Translation.objects.filter(
-        entity__resource__format="properties", string__contains="\\"
-    )
+        entity__resource__format="properties"
+    ).filter(Q(string__contains="\\") | Q(string__contains="\n"))
     for t in translations:
         try:
             msg = _clean_and_parse(t.string)
@@ -82,7 +82,7 @@ def unfix_properties(apps, schema_editor):
     )
     for e in entities:
         e.string = _unfix_string(message_from_json(e.value))
-        e.value = PatternMessage([e.string])
+        e.value = [e.string]
     Entity.objects.bulk_update(entities, ["string", "value"])
 
     Translation = apps.get_model("base", "Translation")
@@ -91,7 +91,7 @@ def unfix_properties(apps, schema_editor):
     )
     for t in translations:
         t.string = _unfix_string(message_from_json(t.value))
-        t.value = PatternMessage([t.string])
+        t.value = [t.string]
     Translation.objects.bulk_update(
         translations, ["string", "value"], batch_size=10_000
     )
@@ -101,8 +101,8 @@ def unfix_properties(apps, schema_editor):
         entity__resource__format="properties"
     ).filter(Q(source__contains="\n") | Q(target__contains="\n"))
     for tm in tm_entries:
-        tm.source = _unfix_string(PatternMessage([tm.source] if tm.source else []))
-        tm.target = _unfix_string(PatternMessage([tm.target] if tm.target else []))
+        tm.source = _unfix_string(PatternMessage([tm.source])) if tm.source else ""
+        tm.target = _unfix_string(PatternMessage([tm.target])) if tm.target else ""
     TranslationMemoryEntry.objects.bulk_update(tm_entries, ["source", "target"])
 
 

--- a/pontoon/sync/formats/__init__.py
+++ b/pontoon/sync/formats/__init__.py
@@ -5,7 +5,6 @@ Parsing resource files.
 from collections.abc import Iterator
 from dataclasses import dataclass
 from os.path import splitext
-from re import Match, compile
 
 from fluent.syntax import FluentSerializer
 from moz.l10n.formats import Format, detect_format, l10n_extensions
@@ -55,27 +54,13 @@ def are_compatible_files(file_a, file_b):
     return False
 
 
-_fluent_serializer = FluentSerializer()
-_prop_esc_u = compile(r"(?<!\\)\\u(?!0000)[0-9A-Fa-f]{4}")
-_prop_esc_ws = compile(r"(?<!\\)\\([^\S\n])")
-
-
-def _unicode_unescape(m: Match[str]):
-    return m[0].encode("utf-8").decode("unicode_escape")
-
-
 def _as_string(format: Format | None, entry: Entry[Message]) -> str:
     match format:
         case Format.fluent:
             fluent_entry = fluent_astify_entry(entry, comment_str=lambda _: "")
-            return _fluent_serializer.serialize_entry(fluent_entry)
+            return FluentSerializer().serialize_entry(fluent_entry)
         case Format.android | Format.gettext | Format.webext | Format.xliff:
             return serialize_message(Format.mf2, entry.value)
-        case Format.properties:
-            string = serialize_message(Format.properties, entry.value)
-            string = _prop_esc_u.sub(_unicode_unescape, string)
-            string = _prop_esc_ws.sub(r"\1", string)
-            return string
         case _:
             return serialize_message(format, entry.value)
 

--- a/pontoon/sync/tests/formats/test_properties.py
+++ b/pontoon/sync/tests/formats/test_properties.py
@@ -3,6 +3,7 @@ from textwrap import dedent
 from unittest import TestCase
 
 from moz.l10n.formats import Format
+from moz.l10n.model import PatternMessage
 from moz.l10n.resource import parse_resource
 
 from pontoon.sync.formats import as_entity, as_repo_translations
@@ -21,23 +22,24 @@ class PropertiesTests(TestCase):
             NoCommentsorSources=Translated No Comments or Sources
 
             EmptyTranslation=
+            Multiline=Foo\\n\\nbar\\n
             """)
 
         res = parse_resource(Format.properties, src)
-        e0, e1, e2, e3 = (
+        e0, e1, e2, e3, e4 = (
             as_entity(Format.properties, (), entry, date_created=datetime.now())
             for entry in res.all_entries()
         )
-        t0, t1, t2, t3 = as_repo_translations(res)
+        t0, t1, t2, t3, t4 = as_repo_translations(res)
 
         # basic
         assert e0.comment == "Sample comment"
         assert e0.key == ["SourceString"]
-        assert e0.string == "Translated String "
+        assert e0.string == "Translated String\\u0020"
         assert e0.value == ["Translated String "]
 
         assert t0.key == ("SourceString",)
-        assert t0.string == "Translated String "
+        assert t0.string == "Translated String\\u0020"
 
         # multiple comments
         assert e1.comment == "First comment\nSecond comment"
@@ -65,3 +67,9 @@ class PropertiesTests(TestCase):
 
         assert t3.key == ("EmptyTranslation",)
         assert t3.string == ""
+
+        # multiline
+        assert e4.string == "Foo\\n\\nbar\\n"
+        assert e4.value == ["Foo\n\nbar\n"]
+        assert t4.string == "Foo\\n\\nbar\\n"
+        assert t4.value == PatternMessage(["Foo\n\nbar\n"])

--- a/pontoon/translations/tests/test_views.py
+++ b/pontoon/translations/tests/test_views.py
@@ -86,6 +86,46 @@ def test_create_translation_success_mf2(member, project_a, locale_a, project_loc
 
 
 @pytest.mark.django_db
+def test_create_translation_success_properties(
+    member, project_a, locale_a, project_locale_a
+):
+    resource = ResourceFactory(
+        project=project_a, path="file.properties", format="properties"
+    )
+    entity = EntityFactory(resource=resource, key=["key"])
+    response = request_create_translation(
+        member.client,
+        entity=entity.pk,
+        locale=locale_a.code,
+        value=["multiline\nvalue"],
+    )
+    assert response.status_code == 200
+    assert response.json()["status"]
+
+    translation = Translation.objects.get(entity=entity, locale=locale_a)
+    assert translation.string == "multiline\\nvalue"
+
+
+@pytest.mark.django_db
+def test_create_translation_fail_properties(
+    member, project_a, locale_a, project_locale_a
+):
+    resource = ResourceFactory(
+        project=project_a, path="file.properties", format="properties"
+    )
+    entity = EntityFactory(resource=resource, key=["key"])
+    response = request_create_translation(
+        member.client,
+        entity=entity.pk,
+        locale=locale_a.code,
+        value=["\x00value"],
+    )
+    assert response.status_code == 400
+    assert not response.json()["status"]
+    assert response.json()["message"]
+
+
+@pytest.mark.django_db
 def test_create_translation_not_logged_in(client, entity_a, locale_a):
     response = request_create_translation(
         client,
@@ -194,7 +234,7 @@ def test_run_checks_during_translation_update(
         member.client,
         entity=properties_entity.pk,
         locale=locale_a.code,
-        value=["bad suggestion \\q %q"],
+        value=["bad  suggestion %q"],
         ignore_warnings="true",
     )
 
@@ -202,7 +242,7 @@ def test_run_checks_during_translation_update(
     assert response.json() == {
         "failedChecks": {
             "clErrors": ["Found single %"],
-            "clWarnings": ["unknown escape sequence, \\q"],
+            "ttWarnings": ["Double spaces"],
         },
         "status": False,
     }

--- a/pontoon/translations/utils.py
+++ b/pontoon/translations/utils.py
@@ -2,6 +2,10 @@ from typing import Any
 
 from moz.l10n.formats.fluent import fluent_parse_entry, fluent_serialize_entry
 from moz.l10n.formats.mf2 import mf2_parse_message, mf2_serialize_message
+from moz.l10n.formats.properties import (
+    properties_parse_message,
+    properties_serialize_message,
+)
 from moz.l10n.message import message_to_json, serialize_message
 from moz.l10n.model import CatchallKey, Entry, Message, SelectMessage
 
@@ -38,6 +42,9 @@ def parse_db_string_to_json(
                         if isinstance(key, CatchallKey):
                             key.value = "other"
             return message_to_json(msg), None
+        case Resource.Format.PROPERTIES:
+            msg = properties_parse_message(source)
+            return message_to_json(msg), None
         case _:
             return [source] if source else [], None
 
@@ -57,5 +64,7 @@ def serialize_for_db(
             | Resource.Format.XLIFF
         ):
             return mf2_serialize_message(value)
+        case Resource.Format.PROPERTIES:
+            return properties_serialize_message(value)
         case _:
             return serialize_message(None, value)

--- a/pontoon/translations/views.py
+++ b/pontoon/translations/views.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable, Mapping
 from typing import cast
 
 from moz.l10n.message import message_to_json
@@ -54,6 +55,16 @@ def _add_badge_data(response_data, user, badge_name, badge_level):
     )
 
 
+def _contains_null_char(x) -> bool:
+    if isinstance(x, str):
+        return "\x00" in x
+    if isinstance(x, Mapping):
+        return any(_contains_null_char(y) for y in x.items())
+    if isinstance(x, Iterable):
+        return any(_contains_null_char(y) for y in x)
+    return False
+
+
 @require_POST
 @utils.require_AJAX
 @login_required(redirect_field_name="", login_url="/403")
@@ -101,6 +112,12 @@ def create_translation(request):
 
     json_value = message_to_json(value)
     json_properties = {k: message_to_json(v) for k, v in properties.items()} or None
+
+    if _contains_null_char((string, json_value, json_properties)):
+        # PostgreSQL does not support null characters in text or jsonb
+        return JsonResponse(
+            {"status": False, "message": "Unsupported null character"}, status=400
+        )
 
     # If same translation exists in the DB, don't save it again.
     if (

--- a/requirements/default.in
+++ b/requirements/default.in
@@ -36,7 +36,7 @@ drf-spectacular[sidecar]==0.29.0
 google-cloud-translate==3.16.0
 gunicorn==23.0.0
 markupsafe==2.0.1
-moz.l10n[xml]==0.11.3
+moz.l10n[xml]==0.12.0
 newrelic==9.6.0
 openai==2.43.0
 psycopg2==2.9.12

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -275,6 +275,7 @@ click==8.3.1 \
     #   click-didyoumean
     #   click-plugins
     #   click-repl
+    #   moz-l10n
     #   sacremoses
     #   zensical
 click-didyoumean==0.3.1 \
@@ -979,9 +980,9 @@ markupsafe==2.0.1 \
     # via
     #   -r default.in
     #   jinja2
-moz-l10n[xml]==0.11.3 \
-    --hash=sha256:30b2d81aac683fe1c6c8ce17131c177fb10f8bed38f426872da3f52ffa4c1bdf \
-    --hash=sha256:f6e65ee6249b104161dcaf43f8a6b65da6c93d88206fcbdce4986993a03bd77a
+moz-l10n[xml]==0.12.0 \
+    --hash=sha256:1fef7ae191ba1c61cb62c73d3eb482f1c0fea774d7dd2e67bcd057c04ffbfd6b \
+    --hash=sha256:a2340b9540ae4b56ddd85d74528191e06dfb920e6aa8e1c94ca835ee408fbcf5
     # via
     #   -r default.in
     #   moz-l10n

--- a/translate/package.json
+++ b/translate/package.json
@@ -11,7 +11,7 @@
     "@fluent/langneg": "^0.7.0",
     "@fluent/react": "^0.15.1",
     "@lezer/highlight": "^1.1.6",
-    "@mozilla/l10n": "^0.11.3",
+    "@mozilla/l10n": "^0.12.0",
     "@reduxjs/toolkit": "^1.6.1",
     "classnames": "^2.3.1",
     "date-and-time": "^0.14.2",

--- a/translate/src/context/Editor.test.jsx
+++ b/translate/src/context/Editor.test.jsx
@@ -250,6 +250,34 @@ describe('<EditorProvider>', () => {
     });
   });
 
+  it('provides a multiline properties value with CRLF terminators', () => {
+    let editor, result;
+    const Spy = () => {
+      editor = useContext(EditorData);
+      result = useContext(EditorResult);
+      return null;
+    };
+    mountSpy(Spy, 'properties', 'föö\r\nbär\r\n', 'foo\r\nbar\r\n');
+    expect(editor).toMatchObject({
+      sourceView: false,
+      initial: { id: 'key', value: ['föö\r\nbär\r\n'] },
+      fields: [
+        {
+          id: '',
+          keys: [],
+          labels: [],
+          name: '',
+          handle: { current: { value: 'föö\\r\nbär\\r\n' } },
+        },
+      ],
+    });
+    expect(result).toEqual({
+      format: 'properties',
+      id: 'key',
+      value: ['föö\r\nbär\r\n'],
+    });
+  });
+
   it('provides a simple Android value with no translation', () => {
     let editor, result;
     const Spy = () => {

--- a/translate/src/modules/machinery/components/MachineryTranslation.tsx
+++ b/translate/src/modules/machinery/components/MachineryTranslation.tsx
@@ -47,7 +47,11 @@ export function MachineryTranslationComponent({
   const copyTranslationIntoEditor = useCallback(() => {
     if (window.getSelection()?.isCollapsed !== false) {
       setElement(index);
-      const content = llmTranslation || translation.translation;
+      let content = llmTranslation || translation.translation;
+      // FIXME: https://bugzilla.mozilla.org/show_bug.cgi?id=2055465
+      // Should just strip these out;
+      // CodeMirror will throw an error if we leave any CR in the value.
+      content = content.replaceAll('\r', '\\r');
       const sources: SourceType[] = llmTranslation
         ? ['gpt-transform']
         : translation.sources;

--- a/translate/src/utils/message/editablePattern.ts
+++ b/translate/src/utils/message/editablePattern.ts
@@ -1,29 +1,32 @@
 import {
-  Expression,
+  type Expression,
+  type Markup,
+  type Pattern,
+  fluentSerializePattern,
   isExpression,
   mf2SerializePattern,
-  Markup,
-  Pattern,
-  fluentSerializePattern,
 } from '@mozilla/l10n';
+import type { MessageEntry } from '.';
 
-/**
- * @param format - Either a `MessageEntry['format']` or an `Entity.format`;
- *   only the `'fluent'` value gets special consideration.
- */
-export function editablePattern(format: string, pattern: Pattern): string {
+export function editablePattern(
+  format: MessageEntry['format'],
+  pattern: Pattern,
+): string {
   if (format === 'fluent') {
-    return fluentSerializePattern(pattern, {
-      escapeSyntax: false,
-      onError: () => {},
-    });
+    return fluentSerializePattern(
+      // Drop empty literals: { "" }
+      pattern.filter((el) => typeof el === 'string' || el._ !== '' || el.fn),
+      undefined,
+      { escapeSyntax: false, onError: () => {} },
+    );
   }
 
   let str = '';
   for (const part of pattern) {
     str += typeof part === 'string' ? part : editablePlaceholder(part);
   }
-  return str;
+  // FIXME: https://bugzilla.mozilla.org/show_bug.cgi?id=2055465
+  return format === 'properties' ? str.replaceAll('\r', '\\r') : str;
 }
 
 function editablePlaceholder(part: Expression | Markup): string {

--- a/translate/src/utils/message/getMessageEntryFormat.ts
+++ b/translate/src/utils/message/getMessageEntryFormat.ts
@@ -5,6 +5,7 @@ export function getMessageEntryFormat(format: string): MessageEntry['format'] {
     case 'android':
     case 'gettext':
     case 'fluent':
+    case 'properties':
     case 'webext':
     case 'xcode':
     case 'xliff':

--- a/translate/src/utils/message/getPlainMessage.ts
+++ b/translate/src/utils/message/getPlainMessage.ts
@@ -23,7 +23,10 @@ export function getPlainMessage(entry: MessageEntry): string {
   return '';
 }
 
-function previewMessage(format: string, message: Message): string {
+function previewMessage(
+  format: MessageEntry['format'],
+  message: Message,
+): string {
   let pattern: Pattern;
   if (Array.isArray(message)) {
     pattern = message;

--- a/translate/src/utils/message/index.ts
+++ b/translate/src/utils/message/index.ts
@@ -8,6 +8,7 @@ export type MessageEntry =
         | 'fluent'
         | 'gettext'
         | 'plain'
+        | 'properties'
         | 'webext'
         | 'xcode'
         | 'xliff';

--- a/translate/src/utils/message/parseEntry.test.js
+++ b/translate/src/utils/message/parseEntry.test.js
@@ -98,7 +98,7 @@ describe('parseEntry:fluent', () => {
       format: 'fluent',
       id: '-term',
       value: ['My ', { $: 'awesome' }, ' term'],
-      attributes: new Map([['attr', []]]),
+      attributes: new Map([['attr', [{ _: '' }]]]),
     });
   });
 
@@ -154,6 +154,27 @@ describe('parseEntry:fluent', () => {
           },
         ],
       },
+    });
+  });
+});
+
+describe('parseEntry:properties', () => {
+  it('simple value', () => {
+    const res = parseEntry('properties', 'Hello');
+    expect(res).toEqual({ format: 'properties', id: '', value: ['Hello'] });
+  });
+
+  it('empty value', () => {
+    const res = parseEntry('properties', '');
+    expect(res).toEqual({ format: 'properties', id: '', value: [] });
+  });
+
+  it('multiline', () => {
+    const res = parseEntry('properties', 'foo\nbar\\r\nbaz');
+    expect(res).toEqual({
+      format: 'properties',
+      id: '',
+      value: ['foo\nbar\r\nbaz'],
     });
   });
 });

--- a/translate/src/utils/message/parseEntry.ts
+++ b/translate/src/utils/message/parseEntry.ts
@@ -2,6 +2,7 @@ import {
   fluentParseEntry,
   mf2ParseMessage,
   normalizeMessage,
+  propertiesParsePattern,
   type Message,
 } from '@mozilla/l10n';
 import type { MessageEntry } from '.';
@@ -28,6 +29,16 @@ export function parseEntry(
         return { format, id, value, attributes };
       }
       return value ? { format, id, value } : null;
+    } else if (format === 'properties') {
+      return {
+        format: 'properties',
+        id: '',
+        value: propertiesParsePattern(source)
+          // FIXME: https://bugzilla.mozilla.org/show_bug.cgi?id=2055465
+          .map((el) =>
+            typeof el === 'string' ? el.replaceAll('\\r', '\r') : el,
+          ),
+      };
     } else if (specialFormats.has(format)) {
       return {
         format: format as MessageEntry['format'],

--- a/translate/src/utils/message/specialFormats.ts
+++ b/translate/src/utils/message/specialFormats.ts
@@ -2,6 +2,7 @@ export const specialFormats = new Set([
   'android',
   'fluent',
   'gettext',
+  'properties',
   'webext',
   'xcode',
   'xliff',


### PR DESCRIPTION
- Fixes #2058
- Fixes #4261
- Fixes #4262 
- Fixes #4266
- Fixes #4270

This started out as a relatively small bugfix, but then I looked at things more closely. The changes here make us handle the `\n` and other escapes in .properties strings correctly, such that translators are not presented with them as escaped content, but as the actual characters.

The non-.properties fixes are thanks to the moz-l10n update.

After this change, the `.string` value of a .properties Translation is its serialised value, while the value presented to the translator has the escapes (mostly) unescaped. This is a bit messy, as this change is coming in the middle of the work on moving to `.value` based serialization. It's messed up even further by [bug 2055465](https://bugzilla.mozilla.org/show_bug.cgi?id=2055465), due to which we need to treat `\r` CR escapes as special, at least for a little while.

The attached migration is a little bit messy because it needs to clean up a few cases where we have incorrect translations of .properties strings that include an escaped null character, and PostgreSQL does not support null characters in jsonb fields (where JSON string values are parsed and then stored as text). Its reversal is not completely idempotent, as some of the fixing we do is not reversible.

A check is added to `/translations/create` for null characters in incoming translations, so that those are handled as client rather than server errors.

A couple of particular strings to observe:
- [`/ff/firefox/devtools/client/shared.properties/?string=76752`](https://pontoon.mozilla.org/ff/firefox/devtools/client/shared.properties/?string=76752) has a non-approved translation where a null character is replaced by �
- [`/fr/firefox/browser/installer/override.properties/?string=79087`](https://pontoon.mozilla.org/fr/firefox/browser/installer/override.properties/?string=79087) is one of the strings for which `\r` is special-cased.