### PR TITLE
Insights: contributor tooltip & LocaleHealthSnapshot model changes

### DIFF
--- a/pontoon/insights/chs.py
+++ b/pontoon/insights/chs.py
@@ -90,9 +90,11 @@ def get_key_projects_enabled_by_locale(
     return {pl_count["locale_id"]: pl_count["count"] for pl_count in pl_counts}
 
 
-def get_contributor_metrics_by_locale(locales, end_date: datetime) -> dict[int, dict]:
+def get_contributor_classification_by_locale(
+    locales, end_date: datetime
+) -> dict[int, dict]:
     """
-    Per-locale active-contributor counts over the 12-month window ending at end_date.
+    Per-locale active-contributor lists over the 12-month window ending at end_date.
     """
     start_date = end_date - relativedelta(months=13)
 
@@ -152,11 +154,11 @@ def get_contributor_metrics_by_locale(locales, end_date: datetime) -> dict[int, 
 
     locale_contributors = {
         locale.pk: {
-            "active_managers": 0,
-            "active_translators": 0,
-            "active_contributors": 0,
-            "all_contributors": 0,
-            "new_signups": 0,
+            "active_managers": set(),
+            "active_translators": set(),
+            "active_contributors": set(),
+            "all_contributors": set(),
+            "new_signups": set(),
         }
         for locale in locales
     }
@@ -176,21 +178,35 @@ def get_contributor_metrics_by_locale(locales, end_date: datetime) -> dict[int, 
 
         if user_id in managers[locale_id]:
             if action_count + approved > MANAGER_STRING_THRESHOLD:
-                locale_contributors[locale_id]["active_managers"] += 1
+                locale_contributors[locale_id]["active_managers"].add(user_id)
         elif user_id in translators[locale_id]:
             if action_count + approved > TRANSLATOR_STRING_THRESHOLD:
-                locale_contributors[locale_id]["active_translators"] += 1
+                locale_contributors[locale_id]["active_translators"].add(user_id)
         else:
             if is_superuser:
                 continue
             if approved >= ACTIVE_CONTRIBUTOR_STRING_THRESHOLD:
-                locale_contributors[locale_id]["active_contributors"] += 1
+                locale_contributors[locale_id]["active_contributors"].add(user_id)
             if total >= ALL_CONTRIBUTOR_STRING_THRESHOLD:
-                locale_contributors[locale_id]["all_contributors"] += 1
+                locale_contributors[locale_id]["all_contributors"].add(user_id)
             if approved >= NEW_SIGNUP_STRING_THRESHOLD and joined >= start_date:
-                locale_contributors[locale_id]["new_signups"] += 1
+                locale_contributors[locale_id]["new_signups"].add(user_id)
 
     return locale_contributors
+
+
+def get_contributor_metrics_by_locale(locales, end_date: datetime) -> dict[int, dict]:
+    """
+    Per-locale active-contributor counts over the 12-month window ending at end_date.
+    """
+    locale_contributors = get_contributor_classification_by_locale(locales, end_date)
+
+    locale_contributor_counts = {
+        loc_id: {metric: len(contributors) for metric, contributors in counts.items()}
+        for loc_id, counts in locale_contributors.items()
+    }
+
+    return locale_contributor_counts
 
 
 def scaled_points(count, points) -> float:

--- a/pontoon/insights/static/css/insights.css
+++ b/pontoon/insights/static/css/insights.css
@@ -111,10 +111,57 @@
 
         .info {
           align-self: center;
+          position: relative;
 
           &.met {
             color: var(--status-translated);
             font-weight: bold;
+          }
+
+          .metric-tooltip {
+            position: absolute;
+            bottom: 100%;
+            left: 50%;
+            transform: translateX(-50%);
+            z-index: 20;
+            min-width: 140px;
+            margin-bottom: 10px;
+            padding: 10px;
+            background: var(--tooltip-background);
+            border-radius: 10px;
+            color: var(--tooltip-color);
+            font-weight: normal;
+            text-align: left;
+
+            &:after {
+              content: '';
+              position: absolute;
+              bottom: -20px;
+              left: 50%;
+              transform: translateX(-50%);
+              border: 10px solid;
+              border-color: var(--tooltip-background) transparent transparent
+                transparent;
+              clip-path: polygon(0 0, 100% 0, 100% 50%, 0 50%);
+            }
+
+            ul {
+              margin: 0;
+              padding: 0;
+              list-style: none;
+            }
+
+            li {
+              list-style: none;
+            }
+
+            a {
+              display: flex;
+              align-items: center;
+              gap: 6px;
+              color: var(--tooltip-color);
+              white-space: nowrap;
+            }
           }
         }
 

--- a/pontoon/insights/static/js/insights.js
+++ b/pontoon/insights/static/js/insights.js
@@ -56,6 +56,61 @@ function renderCommunityHealthPanel() {
   });
 }
 
+let contributorTooltipTimer = null;
+let activeContributorInfo = null;
+
+$('body')
+  .on('mouseenter', '.community-health-table .info[data-metric]', function () {
+    const info = $(this);
+    activeContributorInfo = this;
+
+    contributorTooltipTimer = setTimeout(function () {
+      $.ajax({
+        url: '/insights/ajax/locale-contributors/',
+        global: false,
+        data: {
+          locale: info.data('locale'),
+          metric: info.data('metric'),
+        },
+        success(response) {
+          if (activeContributorInfo !== info[0] || !response.users) {
+            return;
+          }
+
+          const list = $('<ul>');
+
+          if (response.users.length === 0) {
+            list.append($('<li class="empty">').text('No contributors'));
+          } else {
+            response.users.forEach(function (user) {
+              const link = $('<a>').attr(
+                'href',
+                '/contributors/' + user.username + '/',
+              );
+              link.append(
+                $('<img class="rounded">')
+                  .attr('width', 24)
+                  .attr('height', 24)
+                  .attr('src', user.avatar),
+              );
+              link.append($('<span>').text(user.name));
+              list.append($('<li>').append(link));
+            });
+          }
+
+          info.append($('<div class="metric-tooltip">').append(list));
+        },
+      });
+    }, 500);
+  })
+  .on('mouseleave', '.community-health-table .info[data-metric]', function () {
+    clearTimeout(contributorTooltipTimer);
+    if (activeContributorInfo === this) {
+      activeContributorInfo = null;
+    }
+    $(this).find('.metric-tooltip').remove();
+  });
+
 $('#edit-locales').on('click', function (e) {
   e.preventDefault();
 

--- a/pontoon/insights/templates/insights/widgets/community_health_table.html
+++ b/pontoon/insights/templates/insights/widgets/community_health_table.html
@@ -48,7 +48,7 @@
 
 {% macro value_cell(base_value, base_delta=None, base_threshold=None,
                     score_value=None, score_delta=None, score_threshold=None,
-                    percent=False, single=False) %}
+                    percent=False, single=False, locale_id=None, metric=None) %}
   <td class="cell" data-sort="{{ base_value }}"
       {% if not single %} data-base-sort="{{ base_value }}" data-score-sort="{{ score_value }}"{% endif %}>
     {% if single %}
@@ -61,13 +61,13 @@
     {% else %}
       <div class="info-container base-view">
         {{ delta_span(base_delta, percent) }}
-        <span class="info {% if base_threshold and base_value >= base_threshold %}met{% endif %}">
+        <span class="info {% if base_threshold and base_value >= base_threshold %}met{% endif %}"{% if metric and base_value > 0 %} data-locale="{{ locale_id }}" data-metric="{{ metric }}"{% endif %}>
           {{ base_value }}{{ '%' if percent }}
         </span>
       </div>
       <div class="info-container score-view">
         {{ delta_span(score_delta, false) }}
-        <span class="info {% if score_threshold and score_value >= score_threshold %}met{% endif %}">
+        <span class="info {% if score_threshold and score_value >= score_threshold %}met{% endif %}"{% if metric and base_value > 0 %} data-locale="{{ locale_id }}" data-metric="{{ metric }}"{% endif %}>
           {{ score_value }}
         </span>
       </div>
@@ -76,6 +76,7 @@
 {% endmacro %}
 
 {% macro item(locale, main_link, curr_snapshot=None, base_deltas=None, score_deltas=None, columns=None, class='limited') %}
+  {% set contributor_columns = ['active_managers', 'active_translators', 'active_contributors', 'all_contributors', 'new_signups'] %}
   <tr class="{{ class }}">
     <td class="code">
       <div>
@@ -98,7 +99,9 @@
                score_value=curr_snapshot[field + '_score'],
                score_delta=score_deltas[field + '_score'] if score_deltas else None,
                score_threshold=column.score_threshold,
-               percent=column.percent) }}
+               percent=column.percent,
+               locale_id=locale.id,
+               metric=field if field in contributor_columns else none) }}
         {% endif %}
       {% endfor %}
     {% else %}

--- a/pontoon/insights/urls.py
+++ b/pontoon/insights/urls.py
@@ -1,6 +1,11 @@
 from django.urls import include, path
 
-from pontoon.insights.views import edit_locales, insights, render_panel
+from pontoon.insights.views import (
+    edit_locales,
+    get_locale_contributors,
+    insights,
+    render_panel,
+)
 
 
 urlpatterns = [
@@ -25,9 +30,14 @@ urlpatterns = [
                                 name="pontoon.insights.edit_locales",
                             ),
                             path(
-                                "render-panel/",
+                                "render-table/",
                                 render_panel,
-                                name="pontoon.insights.render_panel",
+                                name="pontoon.insights.render_table",
+                            ),
+                            path(
+                                "locale-contributors/",
+                                get_locale_contributors,
+                                name="pontoon.insights.locale_contributors",
                             ),
                         ]
                     ),

--- a/pontoon/insights/urls.py
+++ b/pontoon/insights/urls.py
@@ -30,9 +30,9 @@ urlpatterns = [
                                 name="pontoon.insights.edit_locales",
                             ),
                             path(
-                                "render-table/",
+                                "render-panel/",
                                 render_panel,
-                                name="pontoon.insights.render_table",
+                                name="pontoon.insights.render_panel",
                             ),
                             path(
                                 "locale-contributors/",

--- a/pontoon/insights/views.py
+++ b/pontoon/insights/views.py
@@ -4,18 +4,23 @@ from dateutil.relativedelta import relativedelta
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.models import User
 from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured, PermissionDenied
 from django.db import transaction
 from django.http import JsonResponse
-from django.shortcuts import render
+from django.shortcuts import get_object_or_404, render
 from django.template.loader import render_to_string
 from django.utils import timezone
+from django.utils.datastructures import MultiValueDictKeyError
 from django.views.decorators.http import require_POST
 
 from pontoon.base.models.locale import Locale
 from pontoon.base.utils import require_AJAX
-from pontoon.insights.chs import KEY_PROJECT_SLUGS
+from pontoon.insights.chs import (
+    KEY_PROJECT_SLUGS,
+    get_contributor_classification_by_locale,
+)
 from pontoon.insights.forms import CommunityHealthLocalesForm
 from pontoon.insights.models import LocaleHealthSnapshot
 from pontoon.insights.utils import (
@@ -136,10 +141,21 @@ def _community_health_context(profile):
     locales = Locale.objects.visible()
     display_locales = locales.filter(pk__in=community_health_locales).order_by("code")
 
-    current_anchor = timezone.now().date()
+    current_tz = timezone.now()
+    current_anchor = current_tz.date()
     previous_anchor = current_anchor.replace(day=1) - relativedelta(days=1)
     current_snapshots = get_monthly_snapshots(display_locales, current_anchor)
     previous_snapshots = get_monthly_snapshots(display_locales, previous_anchor)
+
+    locale_contributor_key = f"/{__name__}/locale_contributors"
+    locale_contributors = cache.get(locale_contributor_key)
+    if locale_contributors is None:
+        locale_contributors = get_contributor_classification_by_locale(
+            locales, current_tz
+        )
+        cache.set(
+            locale_contributor_key, locale_contributors, settings.VIEW_CACHE_TIMEOUT
+        )
 
     return {
         "display_locales": display_locales,
@@ -154,11 +170,13 @@ def _community_health_context(profile):
         "global_locale_health_insights": get_global_locale_health_insights(
             display_locales
         ),
+        "locale_contributors": locale_contributors,
     }
 
 
 @login_required(redirect_field_name="", login_url="/403")
 @require_POST
+@require_AJAX
 @transaction.atomic
 @require_AJAX
 def edit_locales(request):
@@ -170,7 +188,13 @@ def edit_locales(request):
     profile = user.profile
 
     if not user.is_staff:
-        raise PermissionDenied
+        return JsonResponse(
+            {
+                "status": False,
+                "message": "Forbidden: You don't have permission to submit this form.",
+            },
+            status=403,
+        )
 
     community_health_locales_form = CommunityHealthLocalesForm(
         request.POST, instance=profile
@@ -212,6 +236,58 @@ def render_panel(request):
     )
 
     return JsonResponse({"status": True, "html": html})
+
+
+@login_required(redirect_field_name="", login_url="/403")
+@require_AJAX
+def get_locale_contributors(request):
+    if not settings.ENABLE_INSIGHTS:
+        raise ImproperlyConfigured("ENABLE_INSIGHTS variable not set in settings.")
+
+    if not request.user.is_staff:
+        raise PermissionDenied
+
+    try:
+        locale_id = int(request.GET["locale"])
+        metric = request.GET["metric"]
+    except (MultiValueDictKeyError, ValueError) as e:
+        return JsonResponse(
+            {"status": False, "message": f"Bad Request: {e}"},
+            status=400,
+        )
+
+    locale = get_object_or_404(Locale, id=locale_id)
+
+    key = f"/{__name__}/locale_contributors"
+    classification = cache.get(key)
+    if classification is None:
+        classification = get_contributor_classification_by_locale(
+            Locale.objects.visible(), timezone.now()
+        )
+        cache.set(key, classification, settings.VIEW_CACHE_TIMEOUT)
+
+    contributors = classification.get(locale.pk, {})
+    if metric not in contributors:
+        return JsonResponse(
+            {"status": False, "message": f"Bad Request: unknown metric '{metric}'"},
+            status=400,
+        )
+
+    users = User.objects.filter(pk__in=contributors[metric]).order_by("first_name")
+
+    return JsonResponse(
+        {
+            "status": True,
+            "users": [
+                {
+                    "name": user.name_or_email,
+                    "username": user.username,
+                    "avatar": user.avatar_url(),
+                }
+                for user in users
+            ],
+        }
+    )
 
 
 @login_required(redirect_field_name="", login_url="/403")


### PR DESCRIPTION
This PR adds a contributor tooltip, displaying corresponding managers/translators/contributors upon hovering over a locales user metric.

<img width="951" height="261" alt="image" src="https://github.com/user-attachments/assets/5add9010-fd15-4b7d-ac88-7f816cec2080" />


Also changes the currently displayed month on the dashboard to represent live statistics rather than potentially stale CHS metrics while maintaining `LocaleHealthSnapshot` historicity for graphs + MoM comparison. This results are cached daily.


Fixes #4312.