### PR TITLE
Preserve editor focus after copying a helper

### DIFF
--- a/translate/src/context/Editor.tsx
+++ b/translate/src/context/Editor.tsx
@@ -196,6 +196,12 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
             focusField.current = next.fields[0];
             setResult(result);
           }
+          // Keep focus in the editor after a manual copy (click or shortcut),
+          // regardless of where in the helper the click landed. The automatic
+          // perfect-match prefill (manual = false) must not steal focus.
+          if (manual) {
+            (focusField.current ?? field).handle.current.focus();
+          }
           return next;
         }),
 

--- a/translate/src/context/Editor.tsx
+++ b/translate/src/context/Editor.tsx
@@ -184,7 +184,7 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
       setEditorFromHelpers: (str, sources, manual) =>
         setState((prev) => {
           const { fields, focusField, sourceView } = prev;
-          const field = focusField.current ?? fields[0];
+          let field = focusField.current ?? fields[0];
           field.handle.current.setValue(str);
           const next = {
             ...prev,
@@ -193,14 +193,11 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
           if (sourceView) {
             const result = buildMessageEntry(prev.base, prev.fields, buildOpts);
             next.fields = editSource(result ?? str);
-            focusField.current = next.fields[0];
+            field = focusField.current = next.fields[0];
             setResult(result);
           }
-          // Keep focus in the editor after a manual copy (click or shortcut),
-          // regardless of where in the helper the click landed. The automatic
-          // perfect-match prefill (manual = false) must not steal focus.
           if (manual) {
-            (focusField.current ?? field).handle.current.focus();
+            field.handle.current.focus();
           }
           return next;
         }),


### PR DESCRIPTION
Fix #4314.

Clicking a Machinery/TM match copied the value into the editor via setValue() but never focused the field, so focus retention depended on the browser's default mousedown behavior. Clicking a placeable (user-select: none) kept focus; clicking plain suggestion text started a text selection and blurred CodeMirror, making the behavior inconsistent depending on where in the match the click landed.

The copy path has never focused the editor explicitly, but the position-dependent behavior traces back to #2866, which replaced the native `<textarea>` with CodeMirror's `contenteditable` and changed the focus/selection dynamics.

Explicitly focus the target field on a manual copy (click or shortcut). The automatic perfect-match prefill (`manual = false`) is excluded so it does not steal focus during navigation.