### PR TITLE
Return `None` from `reset_active_translation()` for no active translation

### DIFF
--- a/pontoon/base/models/entity.py
+++ b/pontoon/base/models/entity.py
@@ -13,7 +13,7 @@ from pontoon.base.models.section import Section
 
 if TYPE_CHECKING:
     from pontoon.base.models.comment import Comment
-    from pontoon.base.models.translation import Translation, TranslationQuerySet
+    from pontoon.base.models.translation import TranslationQuerySet
     from pontoon.terminology.models import Term
 
 
@@ -62,10 +62,11 @@ class Entity(DirtyFieldsMixin, models.Model):
         """
         return locale in self.changed_locales.all()
 
-    def reset_active_translation(self, locale: Locale) -> "Translation":
+    def reset_active_translation(self, locale: Locale) -> dict[str, Any] | None:
         """
         Reset active translation for given entity and locale.
-        Return active translation if exists or empty Translation instance.
+
+        Return data for the active translation if it exists, or None otherwise.
         """
         from pontoon.base.models.translation import Translation
 
@@ -83,9 +84,9 @@ class Entity(DirtyFieldsMixin, models.Model):
             # Do not trigger the overridden Translation.save() method
             super(Translation, active_translation).save(update_fields=["active"])
 
-            return active_translation
+            return active_translation.serialize()
         else:
-            return Translation()
+            return None
 
     def reset_term_translation(self, locale):
         """

--- a/pontoon/base/tests/models/test_entity.py
+++ b/pontoon/base/tests/models/test_entity.py
@@ -84,7 +84,7 @@ def test_reset_active_translation_single_unreviewed(translation_a):
     entity = translation_a.entity
     locale = translation_a.locale
 
-    assert entity.reset_active_translation(locale) == translation_a
+    assert entity.reset_active_translation(locale) == translation_a.serialize()
 
 
 @pytest.mark.django_db
@@ -99,7 +99,7 @@ def test_reset_active_translation_single_approved(translation_a):
     translation_a.approved = True
     translation_a.save()
 
-    assert entity.reset_active_translation(locale) == translation_a
+    assert entity.reset_active_translation(locale) == translation_a.serialize()
 
 
 @pytest.mark.django_db
@@ -114,7 +114,7 @@ def test_reset_active_translation_single_pretranslated(translation_a):
     translation_a.pretranslated = True
     translation_a.save()
 
-    assert entity.reset_active_translation(locale) == translation_a
+    assert entity.reset_active_translation(locale) == translation_a.serialize()
 
 
 @pytest.mark.django_db
@@ -129,7 +129,7 @@ def test_reset_active_translation_single_fuzzy(translation_a):
     translation_a.fuzzy = True
     translation_a.save()
 
-    assert entity.reset_active_translation(locale) == translation_a
+    assert entity.reset_active_translation(locale) == translation_a.serialize()
 
 
 @pytest.mark.django_db
@@ -144,7 +144,7 @@ def test_reset_active_translation_single_rejected(translation_a):
     translation_a.rejected = True
     translation_a.save()
 
-    assert entity.reset_active_translation(locale).pk is None
+    assert entity.reset_active_translation(locale) is None
 
 
 @pytest.mark.django_db
@@ -159,7 +159,7 @@ def test_reset_active_translation_two_unreviewed(
     entity = translation_a.entity
     locale = translation_a.locale
 
-    assert entity.reset_active_translation(locale) == translation_b
+    assert entity.reset_active_translation(locale) == translation_b.serialize()
 
 
 @pytest.mark.django_db
@@ -177,7 +177,7 @@ def test_reset_active_translation_unreviewed_and_approved(
     translation_b.approved = True
     translation_b.save()
 
-    assert entity.reset_active_translation(locale) == translation_b
+    assert entity.reset_active_translation(locale) == translation_b.serialize()
 
 
 @pytest.mark.django_db
@@ -195,7 +195,7 @@ def test_reset_active_translation_fuzzy_and_unreviewed(
     translation_a.fuzzy = True
     translation_a.save()
 
-    assert entity.reset_active_translation(locale) == translation_a
+    assert entity.reset_active_translation(locale) == translation_a.serialize()
 
 
 @pytest.mark.django_db

--- a/pontoon/translations/views.py
+++ b/pontoon/translations/views.py
@@ -168,7 +168,7 @@ def create_translation(request):
 
     log_action(ActionLog.ActionType.TRANSLATION_CREATED, user, translation=translation)
 
-    translation = entity.reset_active_translation(locale=locale)
+    active_translation = entity.reset_active_translation(locale=locale)
 
     # When user makes their first contribution to the team, notify team managers
     first_contribution = (
@@ -203,7 +203,7 @@ def create_translation(request):
                 category="new_contributor",
             )
 
-    response_data = {"status": True, "translation": translation.serialize()}
+    response_data = {"status": True, "translation": active_translation}
     _add_stats(response_data, resource, locale, req_data["stats"])
 
     # Send Translation Champion Badge notification information
@@ -343,8 +343,7 @@ def approve_translation(request):
     log_action(ActionLog.ActionType.TRANSLATION_APPROVED, user, translation=translation)
 
     active_translation = entity.reset_active_translation(locale=locale)
-
-    response_data = {"translation": active_translation.serialize()}
+    response_data = {"status": True, "translation": active_translation}
     _add_stats(response_data, resource, locale, stats)
 
     # Send Review Master Badge notification information
@@ -408,8 +407,7 @@ def unapprove_translation(request):
     )
 
     active_translation = entity.reset_active_translation(locale=locale)
-
-    response_data = {"translation": active_translation.serialize()}
+    response_data = {"status": True, "translation": active_translation}
     _add_stats(response_data, resource, locale, stats)
     return JsonResponse(response_data)
 
@@ -471,8 +469,7 @@ def reject_translation(request):
     )
 
     active_translation = entity.reset_active_translation(locale=locale)
-
-    response_data = {"translation": active_translation.serialize()}
+    response_data = {"status": True, "translation": active_translation}
     _add_stats(response_data, resource, locale, stats)
 
     # Send Review Master Badge notification information
@@ -536,7 +533,6 @@ def unreject_translation(request):
     )
 
     active_translation = translation.entity.reset_active_translation(locale=locale)
-
-    response = {"translation": active_translation.serialize()}
+    response = {"status": True, "translation": active_translation}
     _add_stats(response, resource, locale, stats)
     return JsonResponse(response)

--- a/translate/src/api/translation.ts
+++ b/translate/src/api/translation.ts
@@ -116,10 +116,15 @@ export function createTranslation(
   return POST('/translations/create/', payload, { headers });
 }
 
-type SetTranslationResponse =
-  | { failedChecks: ApiFailedChecks; string: string } // indicates failed approve
+type SetTranslationStatusResponse =
   | {
-      translation: EntityTranslation;
+      failedChecks: ApiFailedChecks;
+      status?: never;
+      string: string;
+    } // indicates failed approve
+  | {
+      status: true;
+      translation: EntityTranslation | null;
       stats: APIStats;
       badge_update?: BadgeInfo;
       failedChecks?: never;
@@ -130,7 +135,7 @@ export function setTranslationStatus(
   id: number,
   resource: string,
   ignoreWarnings: boolean,
-): Promise<SetTranslationResponse> {
+): Promise<SetTranslationStatusResponse> {
   const url = `/translations/${change}/`;
 
   const payload = new URLSearchParams({

--- a/translate/src/modules/editor/hooks/useUpdateTranslationStatus.ts
+++ b/translate/src/modules/editor/hooks/useUpdateTranslationStatus.ts
@@ -77,7 +77,7 @@ export function useUpdateTranslationStatus(
       setTimeout(() => setFailedChecks(results.failedChecks, translationId));
     } else {
       // Show a notification to explain what happened.
-      const notif = getNotification(change, !!results.translation);
+      const notif = getNotification(change, results.status);
       showNotification(notif);
 
       if (results.translation && change === 'approve') {
@@ -113,7 +113,9 @@ export function useUpdateTranslationStatus(
       }
 
       // Update entity translation data now that it has changed on the server.
-      dispatch(updateEntityTranslation(entity.pk, results.translation));
+      dispatch(
+        updateEntityTranslation(entity.pk, results.translation ?? undefined),
+      );
     }
 
     NProgress.done();

--- a/translate/src/modules/entities/actions.ts
+++ b/translate/src/modules/entities/actions.ts
@@ -42,7 +42,7 @@ type ResetAction = {
 type UpdateAction = {
   type: typeof UPDATE_ENTITIES;
   entity: number;
-  translation: EntityTranslation;
+  translation: EntityTranslation | undefined;
 };
 
 export type Action =
@@ -56,7 +56,7 @@ export const resetEntities = (): ResetAction => ({ type: RESET_ENTITIES });
 
 export const updateEntityTranslation = (
   entity: number,
-  translation: EntityTranslation,
+  translation: EntityTranslation | undefined,
 ): UpdateAction => ({ type: UPDATE_ENTITIES, entity, translation });
 
 /** Fetch entities and their translation.  */

--- a/translate/src/modules/entities/reducer.ts
+++ b/translate/src/modules/entities/reducer.ts
@@ -25,7 +25,7 @@ type EntitiesState = {
 function updateEntityTranslation(
   state: EntitiesState,
   entity: number,
-  translation: EntityTranslation,
+  translation: EntityTranslation | undefined,
 ): Entity[] {
   return state.entities.map((item) => {
     if (item.pk !== entity) {


### PR DESCRIPTION
Fixes #4317

Previously, we were returning a fake empty translation that sort of worked only by accident.