### PR TITLE
Insights: lock 2 decimal places for CHS charts

### DIFF
--- a/pontoon/insights/static/js/insights.js
+++ b/pontoon/insights/static/js/insights.js
@@ -3,6 +3,7 @@ const nf = new Intl.NumberFormat('en', {
 });
 
 const scoreFormat = new Intl.NumberFormat('en', {
+  minimumFractionDigits: 2,
   maximumFractionDigits: 2,
 });
 

--- a/pontoon/insights/static/js/insights.js
+++ b/pontoon/insights/static/js/insights.js
@@ -2,7 +2,7 @@ const nf = new Intl.NumberFormat('en', {
   style: 'percent',
 });
 
-const scoreFormat = new Intl.NumberFormat('en', {
+const sf = new Intl.NumberFormat('en', {
   minimumFractionDigits: 2,
   maximumFractionDigits: 2,
 });
@@ -206,9 +206,7 @@ var Pontoon = (function (my) {
                   maxTicksLimit: 3,
                   precision: 0,
                   callback: function (value) {
-                    return isScore
-                      ? scoreFormat.format(value)
-                      : nf.format(value / 100);
+                    return isScore ? sf.format(value) : nf.format(value / 100);
                   },
                 },
                 beginAtZero: true,
@@ -241,7 +239,7 @@ var Pontoon = (function (my) {
 
                     const label = chart.data.datasets[datasetIndex].label;
                     const value = isScore
-                      ? scoreFormat.format(parsed.y)
+                      ? sf.format(parsed.y)
                       : nf.format(parsed.y / 100);
                     return `${label}: ${value}`;
                   },

--- a/pontoon/insights/static/js/insights_tab.js
+++ b/pontoon/insights/static/js/insights_tab.js
@@ -1,3 +1,8 @@
+const scoreFormat = new Intl.NumberFormat('en', {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
 // eslint-disable-next-line no-var
 var Pontoon = (function (my) {
   const nf = new Intl.NumberFormat('en');
@@ -1053,7 +1058,7 @@ var Pontoon = (function (my) {
                 },
                 displayColors: false,
                 callbacks: {
-                  label: (context) => nf.format(context.parsed.y),
+                  label: (context) => scoreFormat.format(context.parsed.y),
                 },
               },
             },

--- a/pontoon/insights/static/js/insights_tab.js
+++ b/pontoon/insights/static/js/insights_tab.js
@@ -1,11 +1,10 @@
-const scoreFormat = new Intl.NumberFormat('en', {
-  minimumFractionDigits: 2,
-  maximumFractionDigits: 2,
-});
-
 // eslint-disable-next-line no-var
 var Pontoon = (function (my) {
   const nf = new Intl.NumberFormat('en');
+  const sf = new Intl.NumberFormat('en', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
   const pf = new Intl.NumberFormat('en', {
     style: 'percent',
     maximumFractionDigits: 2,
@@ -1058,7 +1057,7 @@ var Pontoon = (function (my) {
                 },
                 displayColors: false,
                 callbacks: {
-                  label: (context) => scoreFormat.format(context.parsed.y),
+                  label: (context) => sf.format(context.parsed.y),
                 },
               },
             },


### PR DESCRIPTION
Forces CHS charts in /insights and /<locale>/insights to display with exactly 2 decimal places.