### PR TITLE
Add role field to system users, centralize helper functions

### DIFF
--- a/pontoon/base/migrations/0125_userprofile_system_user_role.py
+++ b/pontoon/base/migrations/0125_userprofile_system_user_role.py
@@ -1,0 +1,53 @@
+from django.db import migrations, models
+
+
+# Match both email variants, just in case something went wrong
+# with previous migrations.
+system_user_roles = {
+    "pontoon-sync@example.com": "sync",
+    "pontoon-sync@mozilla.com": "sync",
+    "pontoon-gt@example.com": "gt",
+    "pontoon-gt@mozilla.com": "gt",
+    "pontoon-tm@example.com": "tm",
+    "pontoon-tm@mozilla.com": "tm",
+}
+
+
+def set_system_user_roles(apps, schema_editor):
+    UserProfile = apps.get_model("base", "UserProfile")
+    for email, role in system_user_roles.items():
+        UserProfile.objects.filter(user__email=email).update(
+            system_user=True, system_user_role=role
+        )
+
+
+def unset_system_user_roles(apps, schema_editor):
+    UserProfile = apps.get_model("base", "UserProfile")
+    UserProfile.objects.exclude(system_user_role="").update(system_user_role="")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("base", "0124_project_is_chs_project"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="userprofile",
+            name="system_user_role",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("sync", "Sync"),
+                    ("gt", "Google Translate"),
+                    ("tm", "Translation Memory"),
+                ],
+                default="",
+                max_length=20,
+            ),
+        ),
+        migrations.RunPython(
+            code=set_system_user_roles,
+            reverse_code=unset_system_user_roles,
+        ),
+    ]

--- a/pontoon/base/migrations/0125_userprofile_system_user_role.py
+++ b/pontoon/base/migrations/0125_userprofile_system_user_role.py
@@ -1,31 +1,6 @@
 from django.db import migrations, models
 
 
-# Match both email variants, just in case something went wrong
-# with previous migrations.
-system_user_roles = {
-    "pontoon-sync@example.com": "sync",
-    "pontoon-sync@mozilla.com": "sync",
-    "pontoon-gt@example.com": "gt",
-    "pontoon-gt@mozilla.com": "gt",
-    "pontoon-tm@example.com": "tm",
-    "pontoon-tm@mozilla.com": "tm",
-}
-
-
-def set_system_user_roles(apps, schema_editor):
-    UserProfile = apps.get_model("base", "UserProfile")
-    for email, role in system_user_roles.items():
-        UserProfile.objects.filter(user__email=email).update(
-            system_user=True, system_user_role=role
-        )
-
-
-def unset_system_user_roles(apps, schema_editor):
-    UserProfile = apps.get_model("base", "UserProfile")
-    UserProfile.objects.exclude(system_user_role="").update(system_user_role="")
-
-
 class Migration(migrations.Migration):
     dependencies = [
         ("base", "0124_project_is_chs_project"),
@@ -42,12 +17,17 @@ class Migration(migrations.Migration):
                     ("gt", "Google Translate"),
                     ("tm", "Translation Memory"),
                 ],
-                default="",
+                default=None,
                 max_length=20,
+                null=True,
             ),
         ),
-        migrations.RunPython(
-            code=set_system_user_roles,
-            reverse_code=unset_system_user_roles,
+        migrations.AddConstraint(
+            model_name="userprofile",
+            constraint=models.UniqueConstraint(
+                models.F("system_user_role"),
+                condition=models.Q(("system_user_role__isnull", False)),
+                name="base_userprofile_system_user_role_uniq",
+            ),
         ),
     ]

--- a/pontoon/base/migrations/0126_set_system_user_roles.py
+++ b/pontoon/base/migrations/0126_set_system_user_roles.py
@@ -1,0 +1,41 @@
+from django.db import migrations
+
+
+# Match both email variants, just in case something went wrong
+# with previous migrations.
+system_user_roles = {
+    "pontoon-sync@example.com": "sync",
+    "pontoon-sync@mozilla.com": "sync",
+    "pontoon-gt@example.com": "gt",
+    "pontoon-gt@mozilla.com": "gt",
+    "pontoon-tm@example.com": "tm",
+    "pontoon-tm@mozilla.com": "tm",
+}
+
+
+def set_system_user_roles(apps, schema_editor):
+    UserProfile = apps.get_model("base", "UserProfile")
+    for email, role in system_user_roles.items():
+        UserProfile.objects.filter(user__email=email).update(
+            system_user=True, system_user_role=role
+        )
+
+
+def unset_system_user_roles(apps, schema_editor):
+    UserProfile = apps.get_model("base", "UserProfile")
+    UserProfile.objects.exclude(system_user_role=None).update(system_user_role=None)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("base", "0125_userprofile_system_user_role"),
+        # Ensures the sync user exists before we try to give it a role.
+        ("sync", "0002_change_pontoon_sync_email"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=set_system_user_roles,
+            reverse_code=unset_system_user_roles,
+        ),
+    ]

--- a/pontoon/base/models/user_profile.py
+++ b/pontoon/base/models/user_profile.py
@@ -169,6 +169,21 @@ class UserProfile(models.Model):
     # Used to mark users as system users.
     system_user = models.BooleanField(default=False)
 
+    # Used to identify the system user responsible for a specific feature.
+    # Not every system user has a role: generic bots (e.g. scripts or agents
+    # interacting with Pontoon) are only marked with system_user.
+    class SystemUserRole(models.TextChoices):
+        SYNC = "sync", "Sync"
+        GOOGLE_TRANSLATE = "gt", "Google Translate"
+        TRANSLATION_MEMORY = "tm", "Translation Memory"
+
+    system_user_role = models.CharField(
+        max_length=20,
+        choices=SystemUserRole.choices,
+        blank=True,
+        default="",
+    )
+
     @property
     def preferred_locales(self):
         return Locale.objects.filter(pk__in=self.locales_order)

--- a/pontoon/base/models/user_profile.py
+++ b/pontoon/base/models/user_profile.py
@@ -180,8 +180,9 @@ class UserProfile(models.Model):
     system_user_role = models.CharField(
         max_length=20,
         choices=SystemUserRole.choices,
+        null=True,
         blank=True,
-        default="",
+        default=None,
     )
 
     @property
@@ -194,7 +195,13 @@ class UserProfile(models.Model):
                 Lower("username"),
                 name="base_userprofile_username_lower_uniq",
                 condition=models.Q(username__isnull=False),
-            )
+            ),
+            # Allow only one system user for each role.
+            models.UniqueConstraint(
+                "system_user_role",
+                name="base_userprofile_system_user_role_uniq",
+                condition=models.Q(system_user_role__isnull=False),
+            ),
         ]
 
     @property

--- a/pontoon/base/tests/test_user_utils.py
+++ b/pontoon/base/tests/test_user_utils.py
@@ -2,6 +2,8 @@ import pytest
 
 from allauth.socialaccount.models import SocialAccount
 
+from django.db.utils import IntegrityError
+
 from pontoon.base.models.user import User
 from pontoon.base.models.user_profile import UserProfile
 from pontoon.base.user_utils import (
@@ -40,6 +42,16 @@ def test_system_users(user_a, sync_user, gt_user, tm_user):
 
 
 @pytest.mark.django_db
+def test_system_user_role_is_unique(user_a, sync_user):
+    """Two profiles can't share a role."""
+    profile = user_a.profile
+    profile.system_user = True
+    profile.system_user_role = UserProfile.SystemUserRole.SYNC
+    with pytest.raises(IntegrityError):
+        profile.save()
+
+
+@pytest.mark.django_db
 def test_get_system_user(sync_user, gt_user, tm_user):
     assert get_system_user(UserProfile.SystemUserRole.SYNC) == sync_user
     assert get_system_user(UserProfile.SystemUserRole.GOOGLE_TRANSLATE) == gt_user
@@ -55,7 +67,7 @@ def test_get_pretranslation_authors(sync_user, gt_user, tm_user):
 def test_get_pretranslation_authors_missing(gt_user, tm_user):
     """An incomplete set of authors is an error."""
     profile = gt_user.profile
-    profile.system_user_role = ""
+    profile.system_user_role = None
     profile.save()
 
     with pytest.raises(User.DoesNotExist, match="pretranslation roles: gt"):

--- a/pontoon/base/tests/test_user_utils.py
+++ b/pontoon/base/tests/test_user_utils.py
@@ -3,13 +3,63 @@ import pytest
 from allauth.socialaccount.models import SocialAccount
 
 from pontoon.base.models.user import User
+from pontoon.base.models.user_profile import UserProfile
 from pontoon.base.user_utils import (
     avatar_url,
     fxa_avatar_url,
+    get_pretranslation_authors,
+    get_system_user,
+    human_users,
+    system_users,
     user_banner,
     user_locale_role,
     user_role,
 )
+
+
+@pytest.mark.django_db
+def test_human_users(user_a, sync_user, gt_user, tm_user):
+    users = human_users()
+    assert user_a in users
+    assert not any(user in users for user in (sync_user, gt_user, tm_user))
+
+
+@pytest.mark.django_db
+def test_system_users(user_a, sync_user, gt_user, tm_user):
+    assert set(system_users()) == {sync_user, gt_user, tm_user}
+    assert user_a not in system_users()
+
+    # Filtered by role
+    assert set(system_users(UserProfile.SystemUserRole.SYNC)) == {sync_user}
+
+    # Bots without a role are still system users
+    user_a.profile.system_user = True
+    user_a.profile.save()
+    assert user_a in system_users()
+    assert user_a not in system_users(UserProfile.SystemUserRole.SYNC)
+
+
+@pytest.mark.django_db
+def test_get_system_user(sync_user, gt_user, tm_user):
+    assert get_system_user(UserProfile.SystemUserRole.SYNC) == sync_user
+    assert get_system_user(UserProfile.SystemUserRole.GOOGLE_TRANSLATE) == gt_user
+    assert get_system_user(UserProfile.SystemUserRole.TRANSLATION_MEMORY) == tm_user
+
+
+@pytest.mark.django_db
+def test_get_pretranslation_authors(sync_user, gt_user, tm_user):
+    assert get_pretranslation_authors() == {"gt": gt_user, "tm": tm_user}
+
+
+@pytest.mark.django_db
+def test_get_pretranslation_authors_missing(gt_user, tm_user):
+    """An incomplete set of authors is an error."""
+    profile = gt_user.profile
+    profile.system_user_role = ""
+    profile.save()
+
+    with pytest.raises(User.DoesNotExist, match="pretranslation roles: gt"):
+        get_pretranslation_authors()
 
 
 @pytest.mark.django_db

--- a/pontoon/base/user_utils.py
+++ b/pontoon/base/user_utils.py
@@ -13,12 +13,57 @@ from django.utils import timezone
 
 if TYPE_CHECKING:
     from pontoon.base.models import Locale, Project, User
+    from pontoon.base.models.user_profile import UserProfile
+
+    SystemUserRole = UserProfile.SystemUserRole
 else:
     from django.contrib.auth.models import User
 
 
 def is_system_user(user: User) -> bool:
     return user.pk is None or user.profile.system_user
+
+
+def human_users() -> QuerySet[Any]:
+    """All users that are not system users."""
+    return User.objects.filter(profile__system_user=False)
+
+
+def system_users(role: "SystemUserRole | None" = None) -> QuerySet[Any]:
+    """All system users, optionally limited to those serving a specific role."""
+    users = User.objects.filter(profile__system_user=True)
+    return users.filter(profile__system_user_role=role) if role else users
+
+
+def get_system_user(role: "SystemUserRole") -> User:
+    """The system user serving the given role."""
+    return system_users(role).get()
+
+
+def get_pretranslation_authors() -> dict[str, User]:
+    """System users used as authors of pretranslations, keyed by role.
+
+    Raises User.DoesNotExist if any of them is missing. Callers use the authors
+    both to attribute new pretranslations and to recognize existing ones, and
+    neither works with an incomplete set.
+    """
+    from pontoon.base.models.user_profile import UserProfile
+
+    roles = [
+        UserProfile.SystemUserRole.TRANSLATION_MEMORY,
+        UserProfile.SystemUserRole.GOOGLE_TRANSLATE,
+    ]
+    authors = {
+        user.profile.system_user_role: user
+        for user in system_users()
+        .filter(profile__system_user_role__in=roles)
+        .select_related("profile")
+    }
+    if missing := set(roles) - authors.keys():
+        raise User.DoesNotExist(
+            f"No system user found for pretranslation roles: {', '.join(sorted(missing))}"
+        )
+    return authors
 
 
 def fxa_avatar_url(user: User) -> str | None:

--- a/pontoon/base/user_utils.py
+++ b/pontoon/base/user_utils.py
@@ -32,7 +32,7 @@ def human_users() -> QuerySet[Any]:
 def system_users(role: "SystemUserRole | None" = None) -> QuerySet[Any]:
     """All system users, optionally limited to those serving a specific role."""
     users = User.objects.filter(profile__system_user=True)
-    return users.filter(profile__system_user_role=role) if role else users
+    return users.filter(profile__system_user_role=role) if role is not None else users
 
 
 def get_system_user(role: "SystemUserRole") -> User:

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -62,6 +62,7 @@ from pontoon.base.user_utils import (
     can_manage_locales,
     can_translate,
     can_translate_locales,
+    human_users,
     manager_for_locales,
     profile_url,
     translated_projects,
@@ -930,9 +931,8 @@ def get_users(request):
         project_id = int(project_id)
 
     users = (
-        User.objects
         # Exclude system users
-        .exclude(profile__system_user=True)
+        human_users()
         # Exclude deleted users
         .exclude(email__regex=r"^deleted-user-(\w+)@example.com$")
         # Prefetch profile for retrieving username

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -724,10 +724,11 @@ def _send_add_comment_notifications(user, comment, entity, locale, translation):
         User.objects.filter(username__in=usernames).values_list("pk", flat=True)
     )
 
-    for recipient in User.objects.filter(
-        pk__in=recipients,
-        profile__comment_notifications=True,
-    ).exclude(pk=user.pk):
+    for recipient in (
+        human_users()
+        .filter(pk__in=recipients, profile__comment_notifications=True)
+        .exclude(pk=user.pk)
+    ):
         send_notification(
             user,
             recipient=recipient,
@@ -758,8 +759,8 @@ def _send_pin_comment_notifications(user, comment):
             if u:
                 recipient_data[u.pk].append(t.locale.pk)
 
-    for recipient in User.objects.filter(pk__in=recipient_data.keys()).exclude(
-        pk=user.pk
+    for recipient in (
+        human_users().filter(pk__in=recipient_data.keys()).exclude(pk=user.pk)
     ):
         # Send separate notification for each locale (which results in links to corresponding translate views)
         for locale in Locale.objects.filter(pk__in=recipient_data[recipient.pk]):

--- a/pontoon/insights/tasks.py
+++ b/pontoon/insights/tasks.py
@@ -11,13 +11,23 @@ from celery import shared_task
 from dateutil.relativedelta import relativedelta
 from sacrebleu.metrics import CHRF
 
-from django.contrib.auth.models import User
 from django.db.models import Avg, Count, F, Sum
 from django.db.models.functions import Extract, Now
 from django.utils import timezone
 
 from pontoon.actionlog.models import ActionLog
-from pontoon.base.models import Entity, Locale, TranslatedResource, Translation
+from pontoon.base.models import (
+    Entity,
+    Locale,
+    TranslatedResource,
+    Translation,
+    UserProfile,
+)
+from pontoon.base.user_utils import (
+    get_pretranslation_authors,
+    get_system_user,
+    system_users,
+)
 from pontoon.insights.chs import build_chs_snapshots
 from pontoon.insights.models import (
     LocaleHealthSnapshot,
@@ -91,12 +101,10 @@ def count_activities(dt_max: datetime):
     """
     res: dict[int, Activity] = dict()
 
-    sync_user = User.objects.get(email="pontoon-sync@example.com").pk
-    pretranslation_users: set[int] = set(
-        User.objects.filter(
-            email__in=["pontoon-tm@example.com", "pontoon-gt@example.com"]
-        ).values_list("pk", flat=True)
-    )
+    sync_user = get_system_user(UserProfile.SystemUserRole.SYNC).pk
+    pretranslation_users: set[int] = {
+        user.pk for user in get_pretranslation_authors().values()
+    }
 
     actions = query_actions(dt_max)
     approved_translations = get_approved_translations(actions, pretranslation_users)
@@ -414,7 +422,7 @@ def get_contributors() -> dict[int, set[int]]:
     """
     contributors = (
         Translation.objects.filter(user__isnull=False)
-        .exclude(user__in=User.objects.filter(profile__system_user=True))
+        .exclude(user__in=system_users())
         .values("locale", "user")
         .order_by("locale")
         .distinct()

--- a/pontoon/insights/utils.py
+++ b/pontoon/insights/utils.py
@@ -2,12 +2,13 @@ from datetime import timedelta
 
 from dateutil.relativedelta import relativedelta
 
-from django.contrib.auth.models import User
 from django.db.models import Avg, Count, Q, Sum
 from django.db.models.functions import TruncMonth
 from django.utils import timezone
 
 from pontoon.actionlog.models import ActionLog
+from pontoon.base.models import UserProfile
+from pontoon.base.user_utils import get_pretranslation_authors, get_system_user
 from pontoon.base.utils import convert_to_unix_time
 from pontoon.insights.models import (
     LocaleHealthSnapshot,
@@ -453,14 +454,9 @@ def get_insights(locale=None, project=None):
 def get_global_pretranslation_quality(category, id):
     start_date = get_insight_start_date()
 
-    sync_user = User.objects.get(email="pontoon-sync@example.com").pk
+    sync_user = get_system_user(UserProfile.SystemUserRole.SYNC).pk
 
-    pretranslation_users = User.objects.filter(
-        email__in=[
-            "pontoon-tm@example.com",
-            "pontoon-gt@example.com",
-        ]
-    ).values_list("pk", flat=True)
+    pretranslation_users = [user.pk for user in get_pretranslation_authors().values()]
 
     actions = (
         ActionLog.objects.filter(

--- a/pontoon/messaging/emails.py
+++ b/pontoon/messaging/emails.py
@@ -19,6 +19,7 @@ from pontoon.actionlog.models import ActionLog
 from pontoon.base.models import Locale, User, UserProfile
 from pontoon.base.notification_utils import is_subscribed_to_notification
 from pontoon.base.templatetags.helpers import full_url
+from pontoon.base.user_utils import human_users
 from pontoon.insights.models import LocaleInsightsSnapshot
 from pontoon.messaging.models import EmailContent
 from pontoon.messaging.utils import html_to_plain_text_with_links
@@ -198,10 +199,9 @@ def send_monthly_activity_summary():
     log.info("Start sending Monthly activity summary emails.")
 
     # Get user monthly actions
-    users = User.objects.filter(
+    users = human_users().filter(
         is_active=True,
         profile__monthly_activity_summary=True,
-        profile__system_user=False,
     )
     user_month_actions = _get_monthly_user_actions(users, months_ago=1)
     previous_user_month_actions = _get_monthly_user_actions(users, months_ago=2)
@@ -290,7 +290,8 @@ def send_notification_digest(frequency: Literal["Daily", "Weekly"] = "Daily"):
         start_time = timezone.now() - datetime.timedelta(weeks=1)
 
     users = (
-        User.objects.filter(is_active=True, profile__system_user=False)
+        human_users()
+        .filter(is_active=True)
         # Users with the selected notification email frequency
         .filter(profile__notification_email_frequency=frequency)
         # Users subscribed to at least one email notification type

--- a/pontoon/messaging/management/commands/send_deadline_notifications.py
+++ b/pontoon/messaging/management/commands/send_deadline_notifications.py
@@ -1,10 +1,10 @@
 import datetime
 
-from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand
 
 from pontoon.base.models import Project
 from pontoon.base.models.translated_resource import TranslatedResource
+from pontoon.base.user_utils import human_users
 from pontoon.messaging.notifications import send_notification
 
 
@@ -43,11 +43,15 @@ class Command(BaseCommand):
                 if pl_stats["approved"] < pl_stats["total"]:
                     locales.append(project_locale.locale)
 
-            contributors = User.objects.filter(
-                translation__entity__resource__project=project,
-                translation__locale__in=locales,
-                profile__project_deadline_notifications=True,
-            ).distinct()
+            contributors = (
+                human_users()
+                .filter(
+                    translation__entity__resource__project=project,
+                    translation__locale__in=locales,
+                    profile__project_deadline_notifications=True,
+                )
+                .distinct()
+            )
 
             for contributor in contributors:
                 if is_project_public or contributor.is_superuser:

--- a/pontoon/messaging/management/commands/send_inactive_account_emails.py
+++ b/pontoon/messaging/management/commands/send_inactive_account_emails.py
@@ -2,13 +2,13 @@ from collections import defaultdict
 from datetime import timedelta
 
 from django.conf import settings
-from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand
 from django.db.models import Prefetch
 from django.utils.timezone import now
 
 from pontoon.actionlog.models import ActionLog
 from pontoon.base.models import Locale
+from pontoon.base.user_utils import human_users
 from pontoon.messaging.emails import (
     send_inactive_contributor_emails,
     send_inactive_manager_emails,
@@ -20,7 +20,7 @@ class Command(BaseCommand):
     help = "Send inactive account reminder emails based on user role and activity."
 
     def handle(self, *args, **options):
-        users = User.objects.filter(
+        users = human_users().filter(
             profile__last_inactive_reminder_sent__isnull=True,
         )
 

--- a/pontoon/messaging/management/commands/send_suggestion_notifications.py
+++ b/pontoon/messaging/management/commands/send_suggestion_notifications.py
@@ -12,6 +12,7 @@ from django.template.loader import render_to_string
 from django.utils import timezone
 
 from pontoon.base.models import Comment, Locale, ProjectLocale, Translation
+from pontoon.base.user_utils import human_users
 from pontoon.messaging.notifications import send_notification
 
 
@@ -56,17 +57,19 @@ class Command(BaseCommand):
         recipients = recipients.union(self.locale_reviewers[locale])
 
         # Authors of previous translations of the same string
-        recipients = recipients.union(User.objects.filter(translation__in=translations))
+        recipients = recipients.union(
+            human_users().filter(translation__in=translations)
+        )
 
         # Authors of comments of previous translations
         translations_comments = Comment.objects.filter(translation__in=translations)
         recipients = recipients.union(
-            User.objects.filter(comment__in=translations_comments)
+            human_users().filter(comment__in=translations_comments)
         )
 
         # Authors of team comments of the same string
         team_comments = Comment.objects.filter(entity=entity, locale=locale)
-        recipients = recipients.union(User.objects.filter(comment__in=team_comments))
+        recipients = recipients.union(human_users().filter(comment__in=team_comments))
 
         for recipient in recipients:
             data[recipient].add(project_locale)

--- a/pontoon/messaging/tests/test_views.py
+++ b/pontoon/messaging/tests/test_views.py
@@ -1,6 +1,9 @@
 import pytest
 
 from pontoon.base.models import User
+from pontoon.messaging.forms import MessageForm
+from pontoon.messaging.views import get_recipients
+from pontoon.test.factories import TranslationFactory
 
 
 @pytest.mark.django_db
@@ -28,3 +31,59 @@ def test_dismiss_email_consent(member):
     assert profile.email_communications_enabled is True
     assert profile.email_consent_dismissed_at is not None
     assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_get_recipients_excludes_system_users(locale_a, entity_a, user_a, tm_user):
+    """System users must not show up among the contributors of a message."""
+    for user in (user_a, tm_user):
+        TranslationFactory.create(locale=locale_a, entity=entity_a, user=user)
+
+    form = MessageForm(
+        {
+            "subject": "Subject",
+            "body": "Body",
+            "notification": True,
+            "contributors": True,
+            "locale_toggle": True,
+            "locales": str(locale_a.pk),
+        }
+    )
+    assert form.is_valid()
+
+    recipients = get_recipients(form)
+    assert user_a in recipients
+    assert tm_user not in recipients
+
+
+@pytest.mark.django_db
+def test_get_recipients_excludes_system_users_with_permissions(
+    locale_a, entity_a, user_a, tm_user
+):
+    """System users must be left out of the manager and translator groups too.
+
+    Those groups are combined with the contributors using `|`, which ORs the
+    conditions of both querysets, so each one has to exclude system users.
+    """
+    for user in (user_a, tm_user):
+        TranslationFactory.create(locale=locale_a, entity=entity_a, user=user)
+
+    locale_a.managers_group.user_set.add(user_a)
+    locale_a.translators_group.user_set.add(tm_user)
+
+    form = MessageForm(
+        {
+            "subject": "Subject",
+            "body": "Body",
+            "notification": True,
+            "managers": True,
+            "translators": True,
+            "locale_toggle": True,
+            "locales": str(locale_a.pk),
+        }
+    )
+    assert form.is_valid()
+
+    recipients = get_recipients(form)
+    assert user_a in recipients
+    assert tm_user not in recipients

--- a/pontoon/messaging/views.py
+++ b/pontoon/messaging/views.py
@@ -127,7 +127,7 @@ def get_recipients(form):
     translations = Translation.objects.all()
     if form.cleaned_data.get("contributors"):
         recipients = human_users().exclude(
-            Q(pk__in=manager_ids) | Q(pk__in=translator_ids)
+            Q(pk__in=manager_ids) | Q(pk__in=translator_ids) | Q(pk=-1)
         )
 
     if form.cleaned_data.get("managers"):

--- a/pontoon/messaging/views.py
+++ b/pontoon/messaging/views.py
@@ -15,6 +15,7 @@ from django.utils import timezone
 from django.views.decorators.http import require_POST
 
 from pontoon.base.models import Locale, Project, Translation, UserProfile
+from pontoon.base.user_utils import human_users
 from pontoon.base.utils import require_AJAX, split_ints
 from pontoon.messaging import forms
 from pontoon.messaging.emails import send_manual_emails
@@ -125,15 +126,15 @@ def get_recipients(form):
 
     translations = Translation.objects.all()
     if form.cleaned_data.get("contributors"):
-        recipients = User.objects.exclude(
-            Q(pk__in=manager_ids) | Q(pk__in=translator_ids) | Q(pk=-1)
+        recipients = human_users().exclude(
+            Q(pk__in=manager_ids) | Q(pk__in=translator_ids)
         )
 
     if form.cleaned_data.get("managers"):
-        recipients = recipients | User.objects.filter(pk__in=manager_ids)
+        recipients = recipients | human_users().filter(pk__in=manager_ids)
 
     if form.cleaned_data.get("translators"):
-        recipients = recipients | User.objects.filter(pk__in=translator_ids)
+        recipients = recipients | human_users().filter(pk__in=translator_ids)
 
     if form.cleaned_data.get("locale_toggle"):
         translations = translations.filter(

--- a/pontoon/pretranslation/__init__.py
+++ b/pontoon/pretranslation/__init__.py
@@ -1,7 +1,0 @@
-from typing import Literal
-
-
-AUTHORS: dict[Literal["gt", "tm"], str] = {
-    "tm": "pontoon-tm@example.com",
-    "gt": "pontoon-gt@example.com",
-}

--- a/pontoon/pretranslation/tasks.py
+++ b/pontoon/pretranslation/tasks.py
@@ -16,14 +16,13 @@ from pontoon.base.models import (
     Project,
     TranslatedResource,
     Translation,
-    User,
 )
 from pontoon.base.tasks import PontoonTask
+from pontoon.base.user_utils import get_pretranslation_authors
 from pontoon.checks.libraries import run_checks
 from pontoon.checks.utils import bulk_run_checks
 from pontoon.translations.utils import parse_source_string_to_json
 
-from . import AUTHORS
 from .pretranslate import get_pretranslation
 
 
@@ -80,7 +79,7 @@ def pretranslate(project: Project, paths: set[str] | None):
     )
 
     # Fetch all locale-entity pairs with non-rejected or pretranslated translations
-    pt_authors = {key: User.objects.get(email=email) for key, email in AUTHORS.items()}
+    pt_authors = get_pretranslation_authors()
     translated_entities = (
         Translation.objects.filter(
             locale__in=locales,

--- a/pontoon/sync/core/__init__.py
+++ b/pontoon/sync/core/__init__.py
@@ -14,8 +14,8 @@ from pontoon.base.models import (
     ProjectLocale,
     TranslatedResource,
     Translation,
-    User,
 )
+from pontoon.base.user_utils import human_users
 from pontoon.messaging.notifications import send_notification
 from pontoon.pretranslation.tasks import pretranslate
 from pontoon.sync.core.checkout import checkout_repos
@@ -172,7 +172,7 @@ def notify_users(project: Project, now: datetime) -> None:
     # the user's homepage locale: report that locale's count when the user
     # contributes to it, otherwise fall back to the largest count among the
     # locales they contributed to.
-    users = User.objects.filter(id__in=user_locales.keys()).select_related("profile")
+    users = human_users().filter(id__in=user_locales.keys()).select_related("profile")
     for user in users:
         locale_ids = user_locales[user.id]
         homepage_id = locale_id_by_code.get(user.profile.custom_homepage)
@@ -188,4 +188,4 @@ def notify_users(project: Project, now: datetime) -> None:
             category="new_string",
             created_time=created_time,
         )
-    log.info(f"[{project.slug}] Notifying {len(user_locales)} users about new strings")
+    log.info(f"[{project.slug}] Notifying {len(users)} users about new strings")

--- a/pontoon/sync/core/translations_from_repo.py
+++ b/pontoon/sync/core/translations_from_repo.py
@@ -28,7 +28,9 @@ from pontoon.base.models import (
     Translation,
     TranslationMemoryEntry,
     User,
+    UserProfile,
 )
+from pontoon.base.user_utils import get_system_user
 from pontoon.checks import DB_FORMATS
 from pontoon.checks.utils import bulk_run_checks
 from pontoon.sync.core.checkout import Checkout, Checkouts
@@ -304,7 +306,7 @@ def update_db_translations(
     scope = f"[{project.slug}]"
     log.debug(f"{scope} Syncing translations from repo...")
 
-    log_user = user or User.objects.get(username="pontoon-sync")
+    log_user = user or get_system_user(UserProfile.SystemUserRole.SYNC)
     translations_to_reject = Q()
     actions: list[ActionLog] = []
 

--- a/pontoon/teams/views.py
+++ b/pontoon/teams/views.py
@@ -48,6 +48,7 @@ from pontoon.base.models.translation import Translation
 from pontoon.base.services import get_locale_or_redirect
 from pontoon.base.user_utils import (
     can_translate_locales,
+    human_users,
     profile_url,
     user_locale_role,
     user_role,
@@ -283,9 +284,8 @@ def ajax_permissions(request, locale):
     )
 
     locale_contributors = (
-        User.objects.filter(
-            translation__locale=locale, profile__system_user=False, is_active=True
-        )
+        human_users()
+        .filter(translation__locale=locale, is_active=True)
         .distinct()
         .order_by("email")
     )

--- a/pontoon/test/fixtures/base.py
+++ b/pontoon/test/fixtures/base.py
@@ -1,7 +1,7 @@
 import pytest
 
-from django.contrib.auth.models import User
-
+from pontoon.base.models import UserProfile
+from pontoon.base.user_utils import get_system_user
 from pontoon.test import factories
 
 
@@ -24,17 +24,17 @@ def client_superuser(client, admin):
 
 @pytest.fixture
 def sync_user():
-    return User.objects.get(email="pontoon-sync@example.com")
+    return get_system_user(UserProfile.SystemUserRole.SYNC)
 
 
 @pytest.fixture
 def gt_user():
-    return User.objects.get(email="pontoon-gt@example.com")
+    return get_system_user(UserProfile.SystemUserRole.GOOGLE_TRANSLATE)
 
 
 @pytest.fixture
 def tm_user():
-    return User.objects.get(email="pontoon-tm@example.com")
+    return get_system_user(UserProfile.SystemUserRole.TRANSLATION_MEMORY)
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes #4340 

I have two commits in the PR: one is adding a `system_user_role` field to UserProfile and centralizing helpers, the other is filtering system users in another couple of places where filtering was a side effect (e.g. filtering users by last login).