### PR TITLE
Insights: fix test_get_global_locale_health_insights_shape()

### DIFF
--- a/pontoon/insights/tests/test_views.py
+++ b/pontoon/insights/tests/test_views.py
@@ -280,56 +280,54 @@ def test_get_global_locale_health_insights_shape():
         convert_to_unix_time(date(2024, 2, 1), anchor_noon=True)
     ]
     assert len(insights["dataset"]) == 3
-    assert insights["dataset"] == [
-        {
-            "name": f"{locale_a.name} · {locale_a.code}",
-            "chs": [
-                10.0,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-            ],
-        },
-        {
-            "name": f"{locale_b.name} · {locale_b.code}",
-            "chs": [
-                20.0,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-            ],
-        },
-        {
-            "name": "Average (all locales)",
-            "chs": [
-                15.0,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-            ],
-        },
-    ]
+    assert {
+        "name": f"{locale_a.name} · {locale_a.code}",
+        "chs": [
+            10.0,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+    } in insights["dataset"]
+    assert {
+        "name": f"{locale_b.name} · {locale_b.code}",
+        "chs": [
+            20.0,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+    } in insights["dataset"]
+    assert {
+        "name": "Average (all locales)",
+        "chs": [
+            15.0,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ],
+    } in insights["dataset"]


### PR DESCRIPTION
Fixed test_get_global_locale_health_insights_shape(), which was flaky based on test objects having `created_at` assigned the same time and displayed in an ordered list, which is not deterministic.

Fixes #4341. 