### PR TITLE
Use moz-l10n `parsePattern` with options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2570,9 +2570,9 @@
       "license": "MIT"
     },
     "node_modules/@mozilla/l10n": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@mozilla/l10n/-/l10n-0.13.0.tgz",
-      "integrity": "sha512-Fkspk3svlFPEY/gbyv1+3xLGAMoROoUNXWczIpVx+c/1E9h84zt1Md+bPFPLGi3so2USKl97vhjH1jkNYwu3Aw==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@mozilla/l10n/-/l10n-0.14.0.tgz",
+      "integrity": "sha512-07aqvhPiUQrMrQMmAqdZh7UNKaNwkPS7PSaNdcBlHv401HD3tAWdlDLfv4smslMeU7Aqa2qvO9nhnF3/+kI2ng==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fluent/syntax": "^0.19.0",
@@ -10654,7 +10654,7 @@
         "@fluent/langneg": "^0.7.0",
         "@fluent/react": "^0.15.1",
         "@lezer/highlight": "^1.1.6",
-        "@mozilla/l10n": "^0.13.0",
+        "@mozilla/l10n": "^0.14.0",
         "@reduxjs/toolkit": "^1.6.1",
         "classnames": "^2.3.1",
         "date-and-time": "^0.14.2",

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -37,7 +37,7 @@ drf-spectacular[sidecar]==0.29.0
 google-cloud-translate==3.16.0
 gunicorn==23.0.0
 markupsafe==2.0.1
-moz.l10n[xml]==0.13.0
+moz.l10n[xml]==0.14.0
 newrelic==9.6.0
 openai==2.43.0
 PyJWT==2.13.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1279,9 +1279,9 @@ markupsafe==2.0.1 \
     #   -c prod.txt
     #   -r base.in
     #   jinja2
-moz-l10n[xml]==0.13.0 \
-    --hash=sha256:c194494e48ce1576907c756096186f24dbdd9669d70f6341dddcbed4465a0b3f \
-    --hash=sha256:c90efd78a2940db57da1fa19307e24f21d27ffb6769a42ca8221f0d3f8aae707
+moz-l10n[xml]==0.14.0 \
+    --hash=sha256:451050fe26ad019f610813e9d9b702484fb0257cf84a6a57d3b9f36c3e99d3ff \
+    --hash=sha256:65225e6781b29369b2aaf1e8c47a52e403252a8bc69e7792ce35a2c4f3762576
     # via
     #   -c prod.txt
     #   -r base.in
@@ -2529,3 +2529,6 @@ zensical==0.0.34 \
     # via
     #   -c prod.txt
     #   -r base.in
+
+# The following packages were excluded from the output:
+# setuptools

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -980,9 +980,9 @@ markupsafe==2.0.1 \
     # via
     #   -r base.in
     #   jinja2
-moz-l10n[xml]==0.13.0 \
-    --hash=sha256:c194494e48ce1576907c756096186f24dbdd9669d70f6341dddcbed4465a0b3f \
-    --hash=sha256:c90efd78a2940db57da1fa19307e24f21d27ffb6769a42ca8221f0d3f8aae707
+moz-l10n[xml]==0.14.0 \
+    --hash=sha256:451050fe26ad019f610813e9d9b702484fb0257cf84a6a57d3b9f36c3e99d3ff \
+    --hash=sha256:65225e6781b29369b2aaf1e8c47a52e403252a8bc69e7792ce35a2c4f3762576
     # via -r base.in
 newrelic==9.6.0 \
     --hash=sha256:01c0eb630bb18261241a37aa0a70cb6f706079a1f58f59f2bb64f26fda54ffc5 \
@@ -1965,3 +1965,6 @@ zensical==0.0.34 \
     --hash=sha256:eb9d880ccb25edba332e1f310b40e65afb0e1072c69530ec02afc6179b33c5ec \
     --hash=sha256:f77cb1152b51ccc5bf0c1055ac06802a6eeeff9cb8b4293919300c0becbd26bd
     # via -r base.in
+
+# The following packages were excluded from the output:
+# setuptools

--- a/translate/package.json
+++ b/translate/package.json
@@ -11,7 +11,7 @@
     "@fluent/langneg": "^0.7.0",
     "@fluent/react": "^0.15.1",
     "@lezer/highlight": "^1.1.6",
-    "@mozilla/l10n": "^0.13.0",
+    "@mozilla/l10n": "^0.14.0",
     "@reduxjs/toolkit": "^1.6.1",
     "classnames": "^2.3.1",
     "date-and-time": "^0.14.2",

--- a/translate/src/utils/message/buildMessageEntry.test.js
+++ b/translate/src/utils/message/buildMessageEntry.test.js
@@ -178,4 +178,36 @@ describe('buildMessageEntry', () => {
       value: ['Bonjour Monde'],
     });
   });
+
+  it('updates standard xliff entry without Xcode printf variables', () => {
+    const base = parseEntry('xliff', 'Hello %@');
+    const result = buildMessageEntry(base, [
+      { name: '', keys: [], handle: { current: { value: 'Bonjour %@' } } },
+    ]);
+    expect(result).toEqual({
+      format: 'xliff',
+      id: '',
+      value: ['Bonjour %@'],
+    });
+  });
+
+  it('properly replaces HTML via escapeHTML option', () => {
+    const base = parseEntry('gettext', 'Hello, World!');
+    const result = buildMessageEntry(
+      base,
+      [
+        {
+          name: '',
+          keys: [],
+          handle: { current: { value: 'Hello, <b>World</b>!' } },
+        },
+      ],
+      { escapeHTML: /<(\/?\w+)/g, trim: false },
+    );
+    expect(result).toEqual({
+      format: 'gettext',
+      id: '',
+      value: ['Hello, &lt;b>World&lt;/b>!'],
+    });
+  });
 });

--- a/translate/src/utils/message/buildMessageEntry.test.js
+++ b/translate/src/utils/message/buildMessageEntry.test.js
@@ -190,24 +190,4 @@ describe('buildMessageEntry', () => {
       value: ['Bonjour %@'],
     });
   });
-
-  it('properly replaces HTML via escapeHTML option', () => {
-    const base = parseEntry('gettext', 'Hello, World!');
-    const result = buildMessageEntry(
-      base,
-      [
-        {
-          name: '',
-          keys: [],
-          handle: { current: { value: 'Hello, <b>World</b>!' } },
-        },
-      ],
-      { escapeHTML: /<(\/?\w+)/g, trim: false },
-    );
-    expect(result).toEqual({
-      format: 'gettext',
-      id: '',
-      value: ['Hello, &lt;b>World&lt;/b>!'],
-    });
-  });
 });

--- a/translate/src/utils/message/buildMessageEntry.ts
+++ b/translate/src/utils/message/buildMessageEntry.ts
@@ -47,7 +47,10 @@ export function buildMessageEntry(
     if (options.trim) {
       src = src.trim();
     }
-    return parsePattern(format, src, { webextBaseMsg: msg, xliffIsXcode: xliffIsXcode });
+    return parsePattern(format, src, {
+      webextBaseMsg: msg,
+      xliffIsXcode: xliffIsXcode,
+    });
   };
 
   try {

--- a/translate/src/utils/message/buildMessageEntry.ts
+++ b/translate/src/utils/message/buildMessageEntry.ts
@@ -15,19 +15,26 @@ import type { MessageEntry } from '.';
 export function buildMessageEntry(
   base: MessageEntry,
   fields: EditorField[],
-  options: { escapeHTML: RegExp | null; trim: boolean } = {
+  options: {
+    escapeHTML: RegExp | null;
+    trim: boolean;
+    xliffIsXcode: boolean;
+  } = {
     escapeHTML: null,
     trim: false,
+    xliffIsXcode: false,
   },
 ): MessageEntry | null {
   const res = structuredClone(base);
   let format: FormatKey;
+  let xliffIsXcode = options.xliffIsXcode ?? false;
   switch (res.format) {
     case 'gettext':
       format = 'plain';
       break;
     case 'xcode':
       format = 'xliff';
+      xliffIsXcode = true;
       break;
     default:
       format = res.format ?? 'plain';
@@ -40,7 +47,7 @@ export function buildMessageEntry(
     if (options.trim) {
       src = src.trim();
     }
-    return parsePattern(format, src, msg);
+    return parsePattern(format, src, { baseMsg: msg, xliffIsXcode });
   };
 
   try {

--- a/translate/src/utils/message/buildMessageEntry.ts
+++ b/translate/src/utils/message/buildMessageEntry.ts
@@ -47,7 +47,7 @@ export function buildMessageEntry(
     if (options.trim) {
       src = src.trim();
     }
-    return parsePattern(format, src, { baseMsg: msg, xliffIsXcode });
+    return parsePattern(format, src, { webextBaseMsg: msg, xliffIsXcode: xliffIsXcode });
   };
 
   try {

--- a/translate/src/utils/message/buildMessageEntry.ts
+++ b/translate/src/utils/message/buildMessageEntry.ts
@@ -18,15 +18,11 @@ export function buildMessageEntry(
   options: {
     escapeHTML: RegExp | null;
     trim: boolean;
-  } = {
-    escapeHTML: null,
-    trim: false,
-    xliffIsXcode: false,
-  },
+  } = { escapeHTML: null, trim: false },
 ): MessageEntry | null {
   const res = structuredClone(base);
   let format: FormatKey;
-  let xliffIsXcode = false;
+  let xliffIsXcode: boolean = false;
   switch (res.format) {
     case 'gettext':
       format = 'plain';

--- a/translate/src/utils/message/buildMessageEntry.ts
+++ b/translate/src/utils/message/buildMessageEntry.ts
@@ -18,7 +18,7 @@ export function buildMessageEntry(
   options: {
     escapeHTML: RegExp | null;
     trim: boolean;
-    xliffIsXcode: boolean;
+    xliffIsXcode?: boolean;
   } = {
     escapeHTML: null,
     trim: false,

--- a/translate/src/utils/message/buildMessageEntry.ts
+++ b/translate/src/utils/message/buildMessageEntry.ts
@@ -18,7 +18,6 @@ export function buildMessageEntry(
   options: {
     escapeHTML: RegExp | null;
     trim: boolean;
-    xliffIsXcode?: boolean;
   } = {
     escapeHTML: null,
     trim: false,
@@ -27,7 +26,7 @@ export function buildMessageEntry(
 ): MessageEntry | null {
   const res = structuredClone(base);
   let format: FormatKey;
-  let xliffIsXcode = options.xliffIsXcode ?? false;
+  let xliffIsXcode = false;
   switch (res.format) {
     case 'gettext':
       format = 'plain';


### PR DESCRIPTION
fix #4362.
- [x] make `parsePattern` use options bag with `xliffIsXcode` flag
- [x] update moz-l10n requirement

The TypeScript check was failing as long as the fixed `moz-l10n` package was not yet published and the new version put into the [`translate/package.json`](https://github.com/mozilla/pontoon/blob/fe225295a9aacd6b329dfc459c79adf6fc25838b/translate/package.json#L14).
That's done now :)