### PR TITLE
Fix Entity.order and Entity.section updates during sync

### DIFF
--- a/pontoon/base/migrations/0127_add_missing_sections.py
+++ b/pontoon/base/migrations/0127_add_missing_sections.py
@@ -1,0 +1,60 @@
+from collections import defaultdict
+from itertools import groupby
+
+from django.db import migrations
+from django.db.models import F
+
+
+section_key_formats = {"ini", "xcode", "xliff"}
+
+
+def add_missing_sections(apps, schema_editor):
+    Entity = apps.get_model("base", "Entity")
+    Section = apps.get_model("base", "Section")
+
+    entities = list(
+        Entity.objects.filter(section_id=None, obsolete=False)
+        .only("id", "key", "resource_id")
+        .annotate(format=F("resource__format"))
+    )
+    prev_sections = defaultdict(
+        list,
+        (
+            (res_id, list(res_sections))
+            for res_id, res_sections in groupby(
+                Section.objects.filter(
+                    resource_id__in={e.resource_id for e in entities}
+                ).order_by("resource_id"),
+                key=lambda s: s.resource_id,
+            )
+        ),
+    )
+    new_sections = []
+    for e in entities:
+        section_key = e.key[:1] if e.format in section_key_formats else []
+        res_sections = prev_sections[e.resource_id]
+        section = next((s for s in res_sections if s.key == section_key), None)
+        if section is None:
+            section = Section(resource_id=e.resource_id, key=section_key)
+            new_sections.append(section)
+            res_sections.append(section)
+        e.section = section
+
+    print(
+        f"\n    Adding {len(new_sections)} sections, updating {len(entities)} entities...\n   ",
+        end="",
+        flush=True,
+    )
+    Section.objects.bulk_create(new_sections)
+    Entity.objects.bulk_update(entities, ["section"], batch_size=10_000)
+
+
+class Migration(migrations.Migration):
+    dependencies = [("base", "0126_set_system_user_roles")]
+
+    operations = [
+        migrations.RunPython(
+            add_missing_sections,
+            reverse_code=migrations.RunPython.noop,
+        )
+    ]

--- a/pontoon/base/models/entity.py
+++ b/pontoon/base/models/entity.py
@@ -21,9 +21,11 @@ class Entity(DirtyFieldsMixin, models.Model):
     resource: models.ForeignKey["Resource"] = models.ForeignKey(
         Resource, models.CASCADE, related_name="entities"
     )
+    resource_id: int
     section: models.ForeignKey[Section | None] = models.ForeignKey(
         Section, models.SET_NULL, related_name="entities", null=True, blank=True
     )
+    section_id: int | None
     string = models.TextField()
     key = ArrayField(models.TextField(), default=list)
     value = models.JSONField(default=list)

--- a/pontoon/sync/core/entities.py
+++ b/pontoon/sync/core/entities.py
@@ -276,8 +276,15 @@ def update_resources(
         mod_entities, ["value", "properties", "string", "comment", "meta", "section"]
     )
 
-    # FIXME: Entity order should be updated on insertion
-    # https://github.com/mozilla/pontoon/issues/2115
+    reorder_entities: list[Entity] = []
+    for key, next_ent in next_entities.items():
+        prev_ent = prev_entities.get(key, None)
+        if prev_ent is not None and prev_ent.order != next_ent.order:
+            prev_ent.order = next_ent.order
+            reorder_entities.append(prev_ent)
+    if reorder_entities:
+        Entity.objects.bulk_update(reorder_entities, ["order"])
+
     added_entities = Entity.objects.bulk_create(added_entities)
     add_count = len(added_entities)
 

--- a/pontoon/sync/core/entities.py
+++ b/pontoon/sync/core/entities.py
@@ -247,7 +247,7 @@ def update_resources(
         Section.objects.filter(pk__in=del_section_ids).delete()
         for prev_ent in prev_entities.values():
             if prev_ent.section_id in del_section_ids:
-                prev_ent.refresh_from_db(fields=["section"])
+                prev_ent.section = None
 
     # The Section.pk values need to be set before we modify or create Entities.
     Section.objects.bulk_create(new_sections)

--- a/pontoon/sync/core/entities.py
+++ b/pontoon/sync/core/entities.py
@@ -158,6 +158,7 @@ def update_resources(
     changed_res_paths: set[str] = {res.path for res in changed_resources.values()}
     log.info(f"[{project.slug}] Changed source files: {', '.join(changed_res_paths)}")
 
+    # Most Entity.section fields are deferred; use prev_sections instead when required.
     prev_entities: dict[tuple[str, L10nId], Entity] = {
         (changed_resources[e.resource_id].path, tuple(e.key)): e
         for e in Entity.objects.filter(resource__in=changed_resources, obsolete=False)

--- a/pontoon/sync/core/entities.py
+++ b/pontoon/sync/core/entities.py
@@ -227,6 +227,7 @@ def update_resources(
         if key not in next_entities:
             prev_ent.obsolete = True
             prev_ent.date_obsoleted = now
+            # Avoids a separate later update if/once the section is removed
             prev_ent.section = None
             obsolete_entities.append(prev_ent)
             key_path, key_entity = key
@@ -239,11 +240,14 @@ def update_resources(
 
     # Order matters here: Sections can be simultaneously modified and deleted.
     Section.objects.bulk_update(mod_sections, ["meta"])
-    del_section_ids = [
+    del_section_ids = {
         section.pk for section in prev_sections.values() if section not in keep_sections
-    ]
+    }
     if del_section_ids:
         Section.objects.filter(pk__in=del_section_ids).delete()
+        for prev_ent in prev_entities.values():
+            if prev_ent.section_id in del_section_ids:
+                prev_ent.refresh_from_db(fields=["section"])
 
     # The Section.pk values need to be set before we modify or create Entities.
     Section.objects.bulk_create(new_sections)
@@ -264,11 +268,12 @@ def update_resources(
             + model_update(prev_ent, "string", next_ent.string)
             + model_update(prev_ent, "comment", next_ent.comment)
             + model_update(prev_ent, "meta", next_ent.meta)
+            + model_update(prev_ent, "section", next_ent.section)
         ):
             mod_entities.append(prev_ent)
             log_mod[key_path].append("/".join(key_entity))
     Entity.objects.bulk_update(
-        mod_entities, ["value", "properties", "string", "comment", "meta"]
+        mod_entities, ["value", "properties", "string", "comment", "meta", "section"]
     )
 
     # FIXME: Entity order should be updated on insertion

--- a/pontoon/sync/core/entities.py
+++ b/pontoon/sync/core/entities.py
@@ -160,9 +160,12 @@ def update_resources(
 
     prev_entities: dict[tuple[str, L10nId], Entity] = {
         (changed_resources[e.resource_id].path, tuple(e.key)): e
-        for e in Entity.objects.filter(
-            resource__in=changed_resources, obsolete=False
-        ).iterator()
+        for e in Entity.objects.filter(resource__in=changed_resources, obsolete=False)
+        .select_related("section")
+        .defer(
+            "section__key", "section__comment", "section__meta", "section__resource_id"
+        )
+        .iterator()
     }
     prev_sections: dict[tuple[str, L10nId, str], Section] = {
         (changed_resources[s.resource_id].path, tuple(s.key), s.comment): s

--- a/pontoon/sync/tests/test_entities.py
+++ b/pontoon/sync/tests/test_entities.py
@@ -483,6 +483,8 @@ def test_change_entities():
         # Filesystem setup
         res_ftl = dedent(
             """
+            key-4 = New message 4
+            key-5 = New message 5
             key-2 = Fixed message 2
             # New comment
             key-3 = Message 3
@@ -511,20 +513,22 @@ def test_change_entities():
         # Test sync
         assert sync_resources_from_repo(
             project, locale_map, mock_checkout, paths, now
-        ) == (0, {"res.ftl"}, set())
+        ) == (2, {"res.ftl"}, set())
         assert {
             tuple(ent.key): (ent.order, ent.value, ent.section, ent.comment)
             for ent in Entity.objects.filter(resource=res)
         } == {
-            ("key-1",): (2, ["Message 1"], section, ""),
-            ("key-2",): (0, ["Fixed message 2"], section, ""),
-            ("key-3",): (1, ["Message 3"], section, "New comment"),
+            ("key-4",): (0, ["New message 4"], section, ""),
+            ("key-5",): (1, ["New message 5"], section, ""),
+            ("key-2",): (2, ["Fixed message 2"], section, ""),
+            ("key-3",): (3, ["Message 3"], section, "New comment"),
+            ("key-1",): (4, ["Message 1"], section, ""),
         }
 
         # Test stats
         update_stats(project)
         project.refresh_from_db()
-        assert (project.total_strings, project.approved_strings) == (3, 3)
+        assert (project.total_strings, project.approved_strings) == (5, 3)
 
 
 @pytest.mark.django_db

--- a/pontoon/sync/tests/test_entities.py
+++ b/pontoon/sync/tests/test_entities.py
@@ -11,7 +11,7 @@ from moz.l10n.paths import L10nDiscoverPaths
 from django.conf import settings
 from django.utils import timezone
 
-from pontoon.base.models import Entity, Project, TranslatedResource
+from pontoon.base.models import Entity, Project, Section, TranslatedResource
 from pontoon.base.models.translation import Translation
 from pontoon.sync.core.checkout import Checkout, Checkouts
 from pontoon.sync.core.entities import sync_resources_from_repo
@@ -24,6 +24,7 @@ from pontoon.test.factories import (
     ProjectFactory,
     RepositoryFactory,
     ResourceFactory,
+    SectionFactory,
     TranslationFactory,
 )
 
@@ -292,10 +293,14 @@ def test_add_resource():
         ) == (3, {"c.ftl"}, set())
         res_c = project.resources.get(path="c.ftl")
         TranslatedResource.objects.get(resource=res_c)
-        assert {tuple(ent.key) for ent in Entity.objects.filter(resource=res_c)} == {
-            ("key-1",),
-            ("key-2",),
-            ("key-3",),
+        section = Section.objects.get(resource=res_c)
+        assert {
+            (*ent.key, ent.section == section)
+            for ent in Entity.objects.filter(resource=res_c)
+        } == {
+            ("key-1", True),
+            ("key-2", True),
+            ("key-3", True),
         }
 
 
@@ -379,9 +384,11 @@ def test_update_resource():
             res[n] = ResourceFactory.create(
                 project=project, path=f"{n}.ftl", format="fluent", total_strings=3
             )
+            section = SectionFactory(resource=res[n], key=[])
             for i in (1, 2, 3):
                 entity = EntityFactory.create(
                     resource=res[n],
+                    section=section,
                     key=[f"key-{n}-{i}"],
                     string=f"key-{n}-{i} = Message {i}\n",
                 )
@@ -423,13 +430,19 @@ def test_update_resource():
         assert sync_resources_from_repo(
             project, locale_map, mock_checkout, paths, now
         ) == (1, {"c.ftl"}, set())
+        section = Section.objects.get(resource=res["c"])
         assert {
-            (*ent.key, ent.obsolete) for ent in Entity.objects.filter(resource=res["c"])
+            (
+                *ent.key,
+                1 if ent.section == section else -1 if ent.section is None else 0,
+                ent.obsolete,
+            )
+            for ent in Entity.objects.filter(resource=res["c"])
         } == {
-            ("key-c-1", True),
-            ("key-c-2", False),
-            ("key-c-3", True),
-            ("key-c-4", False),
+            ("key-c-1", -1, True),
+            ("key-c-2", 1, False),
+            ("key-c-3", -1, True),
+            ("key-c-4", 1, False),
         }
 
         # Test stats
@@ -455,9 +468,11 @@ def test_change_entities():
         res = ResourceFactory.create(
             project=project, path="res.ftl", format="fluent", total_strings=3
         )
+        section = SectionFactory(resource=res, key=[])
         for i in (1, 2, 3):
             entity = EntityFactory.create(
                 resource=res,
+                section=section,
                 key=[f"key-{i}"],
                 string=f"key-{i} = Message {i}\n",
             )
@@ -502,15 +517,90 @@ def test_change_entities():
             project, locale_map, mock_checkout, paths, now
         ) == (0, {"res.ftl"}, set())
         assert {
-            tuple(ent.key): (ent.value, ent.comment)
+            tuple(ent.key): (ent.value, ent.section, ent.comment)
             for ent in Entity.objects.filter(resource=res)
         } == {
-            ("key-1",): (["Message 1"], ""),
-            ("key-2",): (["Fixed message 2"], ""),
-            ("key-3",): (["Message 3"], "New comment"),
+            ("key-1",): (["Message 1"], section, ""),
+            ("key-2",): (["Fixed message 2"], section, ""),
+            ("key-3",): (["Message 3"], section, "New comment"),
         }
 
         # Test stats
         update_stats(project)
         project.refresh_from_db()
         assert (project.total_strings, project.approved_strings) == (3, 3)
+
+
+@pytest.mark.django_db
+def test_fluent_group_comment_change():
+    with TemporaryDirectory() as root:
+        # Database setup
+        settings.MEDIA_ROOT = root
+        locale = LocaleFactory.create(code="fr-Test")
+        locale_map = {locale.code: locale}
+        repo = RepositoryFactory(url="http://example.com/repo")
+        project = ProjectFactory.create(
+            name="test-gc", locales=[locale], repositories=[repo], visibility="public"
+        )
+        res = ResourceFactory.create(project=project, path="file.ftl", format="fluent")
+        old_section = SectionFactory(resource=res, key=[], comment="Old comment")
+        EntityFactory.create(
+            resource=res,
+            section=old_section,
+            key=["key-1"],
+            string="key-1 = Message 1\n",
+        )
+        EntityFactory.create(
+            resource=res,
+            section=old_section,
+            key=["key-2"],
+            string="key-2 = Message 2\n",
+        )
+
+        # Filesystem setup
+        file_ftl = dedent(
+            """
+            ## New comment
+
+            key-2 = Message 2
+            key-3 = Message 3
+            """
+        )
+        makedirs(repo.checkout_path)
+        build_file_tree(
+            repo.checkout_path,
+            {
+                "en-US": {"file.ftl": file_ftl},
+                "fr-Test": {"file.ftl": ""},
+            },
+        )
+
+        # Paths setup
+        mock_checkout = Mock(
+            Checkout,
+            path=repo.checkout_path,
+            changed=[join("en-US", "file.ftl")],
+            removed=[],
+            renamed=[],
+        )
+        paths = find_paths(project, Checkouts(mock_checkout, mock_checkout))
+
+        # Test sync
+        assert sync_resources_from_repo(
+            project, locale_map, mock_checkout, paths, now
+        ) == (1, {"file.ftl"}, set())
+        sections = Section.objects.filter(resource=res)
+        assert len(sections) == 1
+        assert sections[0].comment == "New comment"
+        assert {
+            (
+                *ent.key,
+                ent.section.comment if ent.section is not None else None,
+                ent.obsolete,
+            )
+            for ent in Entity.objects.filter(resource=res)
+        } == {
+            ("key-1", None, True),
+            ("key-2", "New comment", False),
+            ("key-3", "New comment", False),
+        }

--- a/pontoon/sync/tests/test_entities.py
+++ b/pontoon/sync/tests/test_entities.py
@@ -294,14 +294,10 @@ def test_add_resource():
         res_c = project.resources.get(path="c.ftl")
         TranslatedResource.objects.get(resource=res_c)
         section = Section.objects.get(resource=res_c)
-        assert {
+        assert [
             (*ent.key, ent.section == section)
-            for ent in Entity.objects.filter(resource=res_c)
-        } == {
-            ("key-1", True),
-            ("key-2", True),
-            ("key-3", True),
-        }
+            for ent in Entity.objects.filter(resource=res_c).order_by("order")
+        ] == [("key-1", True), ("key-2", True), ("key-3", True)]
 
 
 @pytest.mark.django_db
@@ -487,10 +483,10 @@ def test_change_entities():
         # Filesystem setup
         res_ftl = dedent(
             """
-            key-1 = Message 1
             key-2 = Fixed message 2
             # New comment
             key-3 = Message 3
+            key-1 = Message 1
             """
         )
         makedirs(repo.checkout_path)
@@ -517,12 +513,12 @@ def test_change_entities():
             project, locale_map, mock_checkout, paths, now
         ) == (0, {"res.ftl"}, set())
         assert {
-            tuple(ent.key): (ent.value, ent.section, ent.comment)
+            tuple(ent.key): (ent.order, ent.value, ent.section, ent.comment)
             for ent in Entity.objects.filter(resource=res)
         } == {
-            ("key-1",): (["Message 1"], section, ""),
-            ("key-2",): (["Fixed message 2"], section, ""),
-            ("key-3",): (["Message 3"], section, "New comment"),
+            ("key-1",): (2, ["Message 1"], section, ""),
+            ("key-2",): (0, ["Fixed message 2"], section, ""),
+            ("key-3",): (1, ["Message 3"], section, "New comment"),
         }
 
         # Test stats
@@ -548,6 +544,7 @@ def test_fluent_group_comment_change():
             resource=res,
             section=old_section,
             key=["key-1"],
+            order=13,
             string="key-1 = Message 1\n",
         )
         EntityFactory.create(
@@ -593,14 +590,14 @@ def test_fluent_group_comment_change():
         assert len(sections) == 1
         assert sections[0].comment == "New comment"
         assert {
-            (
-                *ent.key,
+            tuple(ent.key): (
+                ent.order,
                 ent.section.comment if ent.section is not None else None,
                 ent.obsolete,
             )
             for ent in Entity.objects.filter(resource=res)
         } == {
-            ("key-1", None, True),
-            ("key-2", "New comment", False),
-            ("key-3", "New comment", False),
+            ("key-1",): (13, None, True),
+            ("key-2",): (0, "New comment", False),
+            ("key-3",): (1, "New comment", False),
         }

--- a/pontoon/test/factories.py
+++ b/pontoon/test/factories.py
@@ -94,6 +94,7 @@ class ResourceFactory(DjangoModelFactory):
 
 
 class SectionFactory(DjangoModelFactory):
+    key = Sequence(lambda n: [f"Section {n}"])
     resource = SubFactory(ResourceFactory)
 
     class Meta:
@@ -118,6 +119,7 @@ class ProjectLocaleFactory(DjangoModelFactory):
 
 class EntityFactory(DjangoModelFactory):
     resource = SubFactory(ResourceFactory)
+    section = SubFactory(SectionFactory, resource=SelfAttribute("..resource"))
     string = Sequence(lambda n: f"string {n}")
     order = Sequence(lambda n: n)
 


### PR DESCRIPTION
Fixes #2115 
Prerequisite for #4212

We currently don't have data for the correct order & section-level comments, so those won't be fixes in all cases until the relevant resources are sync'd (at which point they'll be fixed using data from the source repo), so we may want to do a force-sync for all projects at some point.

The data migration took about 20 seconds on my machine.