### PR TITLE
Translate: Follow up for avoiding faulty redirection

### DIFF
--- a/translate/src/modules/entitieslist/components/EntitiesList.test.js
+++ b/translate/src/modules/entitieslist/components/EntitiesList.test.js
@@ -13,7 +13,7 @@ import {
 
 import { EntitiesList } from './EntitiesList';
 import { expect, vi } from 'vitest';
-import { fireEvent } from '@testing-library/react';
+import { act, fireEvent } from '@testing-library/react';
 
 // Entities shared between tests
 const ENTITIES = [
@@ -25,6 +25,14 @@ describe('<EntitiesList>', () => {
   let mockLogUXAction;
 
   beforeAll(() => {
+    vi.stubGlobal(
+      'IntersectionObserver',
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
     vi.spyOn(BatchActions, 'resetSelection').mockReturnValue({
       type: 'whatever',
     });
@@ -50,6 +58,7 @@ describe('<EntitiesList>', () => {
 
   afterAll(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
   // FIXME: https://github.com/mozilla/pontoon/issues/3883
   it.skip('shows a loading animation when there are more entities to load', () => {
@@ -154,6 +163,33 @@ describe('<EntitiesList>', () => {
         'REPLACE',
       ],
     ]);
+  });
+
+  it('does not redirect to a stale entity when the entity list changes', () => {
+    const history = createMemoryHistory({
+      initialEntries: ['/kg/firefox/all-resources/?string=2'],
+    });
+
+    const store = createReduxStore();
+    store.dispatch({
+      type: EntitiesActions.RECEIVE_ENTITIES,
+      entities: ENTITIES,
+      hasMore: false,
+    });
+
+    mountComponentWithStore(EntitiesList, store, {}, history);
+
+    const spy = vi.fn();
+    history.listen(spy);
+
+    act(() => {
+      history.push('/kg/firefox/all-resources/?status=missing');
+    });
+
+    const redirected = spy.mock.calls.some(
+      ([, action]) => action === 'REPLACE',
+    );
+    expect(redirected).toBe(false);
   });
 
   it('toggles entity for batch editing', () => {

--- a/translate/src/modules/entitieslist/components/EntitiesList.test.js
+++ b/translate/src/modules/entitieslist/components/EntitiesList.test.js
@@ -179,16 +179,11 @@ describe('<EntitiesList>', () => {
 
     mountComponentWithStore(EntitiesList, store, {}, history);
 
-    const spy = vi.fn();
-    history.listen(spy);
-
     act(() => {
       history.push('/kg/firefox/all-resources/?status=missing');
     });
 
-    const redirected = spy.mock.calls.some(
-      ([, action]) => action === 'REPLACE',
-    );
+    expect(history.location.search).toBe('?status=missing');
     expect(redirected).toBe(false);
   });
 

--- a/translate/src/modules/entitieslist/components/EntitiesList.test.js
+++ b/translate/src/modules/entitieslist/components/EntitiesList.test.js
@@ -184,7 +184,6 @@ describe('<EntitiesList>', () => {
     });
 
     expect(history.location.search).toBe('?status=missing');
-    expect(redirected).toBe(false);
   });
 
   it('toggles entity for batch editing', () => {

--- a/translate/src/modules/entitieslist/components/EntitiesList.tsx
+++ b/translate/src/modules/entitieslist/components/EntitiesList.tsx
@@ -244,7 +244,9 @@ export function EntitiesList(): React.ReactElement<'div'> {
   //    is possible that going for another possible solutions will make
   //    testing easier, which would be very desirable.
   //
-  // `listKey` holds all of these parameters, explicitly not selected entity
+  // `listKey` covers the same location fields as the dependency list it
+  // replaced, deliberately not the selected entity. It is unused in the body:
+  // it is a dependency so that changing any of those fields triggers the reset.
   useEffect(() => {
     if (mounted.current) {
       dispatch(resetEntities());

--- a/translate/src/modules/entitieslist/components/EntitiesList.tsx
+++ b/translate/src/modules/entitieslist/components/EntitiesList.tsx
@@ -167,6 +167,9 @@ export function EntitiesList(): React.ReactElement<'div'> {
    *
    * Exception: a `string` that is valid and viewable but doesn't match the
    * current query is handled by the "string not found" page
+   *
+   * A stale list (query params just changed, so is about to be reset) is
+   * skipped, else would drag old `string` into new URL. See #4371.
    */
   useEffect(() => {
     if (entitiesAreStale) {

--- a/translate/src/modules/entitieslist/components/EntitiesList.tsx
+++ b/translate/src/modules/entitieslist/components/EntitiesList.tsx
@@ -239,23 +239,13 @@ export function EntitiesList(): React.ReactElement<'div'> {
   //  * I haven't been able to figure out how to test this feature. It
   //    is possible that going for another possible solutions will make
   //    testing easier, which would be very desirable.
+  //
+  // `listKey` holds all of these parameters, explicitly not selected entity
   useEffect(() => {
     if (mounted.current) {
       dispatch(resetEntities());
     }
-  }, [
-    dispatch,
-    // Note: location.entity is explicitly not included here
-    location.locale,
-    location.project,
-    location.resource,
-    location.search,
-    location.status,
-    location.extra,
-    location.tag,
-    location.author,
-    location.time,
-  ]);
+  }, [dispatch, listKey]);
 
   const scrollToSelected = useCallback(() => {
     if (!mounted.current) {

--- a/translate/src/modules/entitieslist/components/EntitiesList.tsx
+++ b/translate/src/modules/entitieslist/components/EntitiesList.tsx
@@ -168,8 +168,9 @@ export function EntitiesList(): React.ReactElement<'div'> {
    * Exception: a `string` that is valid and viewable but doesn't match the
    * current query is handled by the "string not found" page
    *
-   * A stale list (query params just changed, so is about to be reset) is
-   * skipped, else would drag old `string` into new URL. See #4371.
+   * Skipped while the list is stale, i.e. the query params just changed and the
+   * entities are about to be reset. Selecting from the previous result set
+   * would write its first entity into the new URL. See #4371.
    */
   useEffect(() => {
     if (entitiesAreStale) {


### PR DESCRIPTION
Fix #4371 

- Add regression test (not redirecting to stale entity).
- Dedup field list (using `listKey`).
- Add comments for code (from #4373).