### PR TITLE
add explicit `escapeHTML` test for `buildMessageEntry`

### DIFF
--- a/translate/src/utils/message/buildMessageEntry.test.js
+++ b/translate/src/utils/message/buildMessageEntry.test.js
@@ -191,27 +191,37 @@ describe('buildMessageEntry', () => {
     });
   });
 
-  it('properly replaces HTML via escapeHTML option', () => {
-    let base = parseEntry('xliff', 'Hello, World!');
-    const testValue = 'Hello, <b>World</b>!';
-    const fields = [
-      { name: '', keys: [], handle: { current: { value: testValue } } },
-    ];
-    let unescaped = [
-      'Hello, ',
-      { open: 'b', opt: undefined },
-      'World',
-      { close: 'b' },
-      '!',
-    ];
+  it('properly replaces HTML in xliff via escapeHTML option', () => {
+    const result = buildMessageEntry(
+      parseEntry('xliff', 'Hello, World!'),
+      [
+        {
+          name: '',
+          keys: [],
+          handle: { current: { value: 'Hello, <b>World</b>!' } },
+        },
+      ],
+      { escapeHTML: /<(\/?b)/g },
+    );
+    expect(result).toEqual({
+      format: 'xliff',
+      id: '',
+      value: ['Hello, <b>World</b>!'],
+    });
+  });
 
-    let result = buildMessageEntry(base, fields, { escapeHTML: /<(\/?b)/g });
-    expect(result).toEqual({ format: 'xliff', id: '', value: [testValue] });
-    result = buildMessageEntry(base, fields);
-    expect(result).toEqual({ format: 'xliff', id: '', value: unescaped });
-
-    base = parseEntry('android', 'Hello, World!');
-    result = buildMessageEntry(base, fields, { escapeHTML: /<(\/?b)/g });
+  it('properly replaces HTML in android via escapeHTML option', () => {
+    const result = buildMessageEntry(
+      parseEntry('android', 'Hello, World!'),
+      [
+        {
+          name: '',
+          keys: [],
+          handle: { current: { value: 'Hello, <b>World</b>!' } },
+        },
+      ],
+      { escapeHTML: /<(\/?b)/g },
+    );
     expect(result).toEqual({
       format: 'android',
       id: '',
@@ -223,8 +233,29 @@ describe('buildMessageEntry', () => {
         '!',
       ],
     });
-
-    result = buildMessageEntry(base, fields);
-    expect(result).toEqual({ format: 'android', id: '', value: unescaped });
   });
+
+  it.each(['xliff', 'android'])(
+    'replaces HTML in %s without escapeHTML option',
+    (format) => {
+      const result = buildMessageEntry(parseEntry(format, 'Hello, World!'), [
+        {
+          name: '',
+          keys: [],
+          handle: { current: { value: 'Hello, <b>World</b>!' } },
+        },
+      ]);
+      expect(result).toEqual({
+        format: format,
+        id: '',
+        value: [
+          'Hello, ',
+          { open: 'b', opt: undefined },
+          'World',
+          { close: 'b' },
+          '!',
+        ],
+      });
+    },
+  );
 });

--- a/translate/src/utils/message/buildMessageEntry.test.js
+++ b/translate/src/utils/message/buildMessageEntry.test.js
@@ -190,4 +190,41 @@ describe('buildMessageEntry', () => {
       value: ['Bonjour %@'],
     });
   });
+
+  it('properly replaces HTML via escapeHTML option', () => {
+    let base = parseEntry('xliff', 'Hello, World!');
+    const testValue = 'Hello, <b>World</b>!';
+    const fields = [
+      { name: '', keys: [], handle: { current: { value: testValue } } },
+    ];
+    let unescaped = [
+      'Hello, ',
+      { open: 'b', opt: undefined },
+      'World',
+      { close: 'b' },
+      '!',
+    ];
+
+    let result = buildMessageEntry(base, fields, { escapeHTML: /<(\/?b)/g });
+    expect(result).toEqual({ format: 'xliff', id: '', value: [testValue] });
+    result = buildMessageEntry(base, fields);
+    expect(result).toEqual({ format: 'xliff', id: '', value: unescaped });
+
+    base = parseEntry('android', 'Hello, World!');
+    result = buildMessageEntry(base, fields, { escapeHTML: /<(\/?b)/g });
+    expect(result).toEqual({
+      format: 'android',
+      id: '',
+      value: [
+        'Hello, ',
+        { _: '<b>', fn: 'html' },
+        'World',
+        { _: '</b>', fn: 'html' },
+        '!',
+      ],
+    });
+
+    result = buildMessageEntry(base, fields);
+    expect(result).toEqual({ format: 'android', id: '', value: unescaped });
+  });
 });

--- a/translate/src/utils/message/buildMessageEntry.test.js
+++ b/translate/src/utils/message/buildMessageEntry.test.js
@@ -191,7 +191,7 @@ describe('buildMessageEntry', () => {
     });
   });
 
-  it('properly replaces HTML in xliff via escapeHTML option', () => {
+  it('parses HTML as text in Xliff with escapeHTML option', () => {
     const result = buildMessageEntry(
       parseEntry('xliff', 'Hello, World!'),
       [
@@ -210,7 +210,7 @@ describe('buildMessageEntry', () => {
     });
   });
 
-  it('properly replaces HTML in android via escapeHTML option', () => {
+  it('parses HTML as expressions in Android with escapeHTML option', () => {
     const result = buildMessageEntry(
       parseEntry('android', 'Hello, World!'),
       [
@@ -236,7 +236,7 @@ describe('buildMessageEntry', () => {
   });
 
   it.each(['xliff', 'android'])(
-    'replaces HTML in %s without escapeHTML option',
+    'parses XML as markup in %s without escapeHTML option',
     (format) => {
       const result = buildMessageEntry(parseEntry(format, 'Hello, World!'), [
         {


### PR DESCRIPTION
Fix #4380

Adding true/false tests for the `escapeHTML` option for both XML formats `android` and `xliff`.

Based on @eemeli's [comment](https://github.com/mozilla/pontoon/pull/4370#discussion_r3748588316) I moved these here although we have implicit test coverage already.
This one is explicitly for `buildMessageEntry` since we test `trim` already but not yet this option.