### PR TITLE
Automate release process based on deployment

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,5 @@
+changelog:
+  categories:
+    - title: Features
+      labels:
+        - '*'

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,5 +1,8 @@
 changelog:
   categories:
-    - title: Features
+    - title: Dependencies
+      labels:
+        - dependencies
+    - title: Changes
       labels:
         - '*'

--- a/.github/workflows/release_actions.yml
+++ b/.github/workflows/release_actions.yml
@@ -1,0 +1,65 @@
+name: Automated Release
+on:
+  schedule:
+    - cron: "0 23 * * *"
+permissions: {}
+
+jobs:
+  release:
+    name: New release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Fetch deployed revision
+        id: revision
+        run: |
+          SHA=$(curl -fsS --max-time 10 \
+            https://pontoon.mozilla.org/static/revision.txt | tr -d '[:space:]')
+          
+          if ! printf '%s' "$SHA" | grep -qE '^[0-9a-f]{40}$'; then
+            echo "::error::Expected a 40-character commit hash, got: ${SHA:-<empty>}"
+            exit 1
+          fi
+
+          echo "Deployed revision: $SHA"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+      - name: Check for an existing release tag
+        id: check
+        env:
+          SHA: ${{ steps.revision.outputs.sha }}
+        run: |
+          if ! git cat-file -e "${SHA}^{commit}" 2>/dev/null; then
+            echo "::error::Commit $SHA is not in this repository."
+            exit 1
+          fi
+
+          COMMIT_EXISTS=$(git tag --points-at "$SHA" | grep '^v202' || true)
+
+          if [ -n "$COMMIT_EXISTS" ]; then
+            echo "Already released as ${COMMIT_EXISTS}."
+            exit 1
+          fi
+
+          VERSION="v$(date -u +%Y.%m.%d)"
+
+          if [ -n "$(git tag -l "$VERSION")" ]; then
+            echo "::error::Tag $VERSION already exists. Delete it or this deploy must wait for tomorrow's date."
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        with:
+          tag_name: "${{ steps.check.outputs.version }}"
+          target_commitish: "${{ steps.revision.outputs.sha }}"
+          name: "Release ${{ steps.check.outputs.version }}"
+          generate_release_notes: true
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_actions.yml
+++ b/.github/workflows/release_actions.yml
@@ -48,7 +48,7 @@ jobs:
             exit 0
           fi
 
-          VERSION="v$(date -u +%Y.%m.%d)"
+          VERSION="$(date -u +v%Y.%m.%d)"
 
           if [ -n "$(git tag -l "$VERSION")" ]; then
             echo "::error::Tag $VERSION already exists."

--- a/.github/workflows/release_actions.yml
+++ b/.github/workflows/release_actions.yml
@@ -9,8 +9,7 @@ jobs:
     name: New release
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: read
+      contents: read
     steps:
       - name: Clone repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -59,10 +58,12 @@ jobs:
           echo "release=true" >> "$GITHUB_OUTPUT"
       - name: Create GitHub Release
         if: steps.check.outputs.release == 'true'
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          tag_name: "${{ steps.check.outputs.version }}"
-          target_commitish: "${{ steps.revision.outputs.sha }}"
-          name: "Release ${{ steps.check.outputs.version }}"
-          generate_release_notes: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          VERSION: ${{ steps.check.outputs.version }}
+          SHA: ${{ steps.revision.outputs.sha }}
+        run: |
+          gh release create "$VERSION" \
+            --target "$SHA" \
+            --title "Release $VERSION" \
+            --generate-notes

--- a/.github/workflows/release_actions.yml
+++ b/.github/workflows/release_actions.yml
@@ -9,7 +9,8 @@ jobs:
     name: New release
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
+      pull-requests: read
     steps:
       - name: Clone repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -59,7 +60,7 @@ jobs:
       - name: Create GitHub Release
         if: steps.check.outputs.release == 'true'
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.check.outputs.version }}
           SHA: ${{ steps.revision.outputs.sha }}
         run: |

--- a/.github/workflows/release_actions.yml
+++ b/.github/workflows/release_actions.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Clone repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -40,22 +40,25 @@ jobs:
             exit 1
           fi
 
-          COMMIT_EXISTS=$(git tag --points-at "$SHA" | grep '^v202' || true)
+          TAG_EXISTS=$(git tag --points-at "$SHA" | grep '^v202' || true)
 
-          if [ -n "$COMMIT_EXISTS" ]; then
-            echo "Already released as ${COMMIT_EXISTS}."
-            exit 1
+          if [ -n "$TAG_EXISTS" ]; then
+            echo "Already released as ${TAG_EXISTS}."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           VERSION="v$(date -u +%Y.%m.%d)"
 
           if [ -n "$(git tag -l "$VERSION")" ]; then
-            echo "::error::Tag $VERSION already exists. Delete it or this deploy must wait for tomorrow's date."
+            echo "::error::Tag $VERSION already exists."
             exit 1
           fi
 
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "release=true" >> "$GITHUB_OUTPUT"
       - name: Create GitHub Release
+        if: steps.check.outputs.release == 'true'
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           tag_name: "${{ steps.check.outputs.version }}"

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,6 +1,8 @@
 name: SSDLC SBOM
 
 on:
+  push:
+    branches: [main]
   release:
     types: [published]
 

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,8 +1,6 @@
 name: SSDLC SBOM
 
 on:
-  push:
-    branches: [main]
   release:
     types: [published]
 


### PR DESCRIPTION
As discussed in #2402, we want to be able to have an automated release structure so contributors and non-contributors can better keep track of our work. This is not to function as fully fledged release notes - rather it is a way of tracking work deployed onto the production Pontoon instance on a daily basis. See [this comment](https://github.com/mozilla/pontoon/issues/2402#issuecomment-5181237452) for more information.