### PR TITLE
Name catchall plural variants after target locale

### DIFF
--- a/pontoon/machinery/tests/test_composed.py
+++ b/pontoon/machinery/tests/test_composed.py
@@ -257,6 +257,45 @@ def test_composed_expands_source_plural_for_target_locale(
 
 
 @pytest.mark.django_db
+def test_composed_names_catchall_for_target_locale(client, fluent_resource, entity_a):
+    """The catchall is named after the target locale's own last category.
+
+    en-US declares `*[other]`, but a locale with one/few/many needs `*[many]`.
+    """
+    locale = LocaleFactory(code="uk-test", name="Plural many", cldr_plurals="1,3,4")
+
+    fluent_string = dedent(
+        """\
+        popup =
+            { $count ->
+               *[other] Many popups.
+            }
+        """
+    )
+    fluent_entity = EntityFactory(resource=fluent_resource, string=fluent_string)
+
+    TranslationMemoryFactory.create(
+        entity=entity_a, source="Many popups.", target="TM_popups", locale=locale
+    )
+
+    url = reverse("pontoon.machinery_composed")
+    response = client.get(
+        url,
+        {
+            "entity": str(fluent_entity.pk),
+            "locale": locale.code,
+            "service": "translation-memory",
+        },
+    )
+    assert response.status_code == 200
+    assert json.loads(response.content)["value"]["alt"] == [
+        {"keys": ["one"], "pat": ["TM_popups"]},
+        {"keys": ["few"], "pat": ["TM_popups"]},
+        {"keys": [{"*": "many"}], "pat": ["TM_popups"]},
+    ]
+
+
+@pytest.mark.django_db
 def test_composed_tm_only_partial_returns_empty(
     client, fluent_resource, entity_a, locale_a
 ):

--- a/pontoon/pretranslation/pretranslate.py
+++ b/pontoon/pretranslation/pretranslate.py
@@ -190,7 +190,8 @@ class Pretranslation:
             msg.pattern = self.pattern(msg.pattern)
         else:
             # catchall category is always last, and is always included
-            plurals = self.locale.cldr_plurals_list()[:-1]
+            locale_plurals = self.locale.cldr_plurals_list()
+            plurals = locale_plurals[:-1]
 
             # Plural selectors need special attention
             plural_selectors = [
@@ -225,6 +226,16 @@ class Pretranslation:
                                     tgt_variants[pc_keys] = deepcopy(pattern)
                         tgt_variants[keys] = pattern
                     msg.variants = tgt_variants
+
+            # The catchall carries the source's category name, e.g. `other` from
+            # en-US. Name it after the target locale's own catchall category.
+            catchall = locale_plurals[-1] if locale_plurals else None
+            if catchall:
+                for idx in plural_selectors:
+                    for keys in msg.variants:
+                        key = keys[idx]
+                        if isinstance(key, CatchallKey):
+                            key.value = catchall
 
     def pattern(self, pattern: Pattern) -> Pattern:
         # First try to get a 100% match from Translation Memory

--- a/pontoon/pretranslation/tests/test_pretranslate.py
+++ b/pontoon/pretranslation/tests/test_pretranslate.py
@@ -683,6 +683,45 @@ def test_get_pretranslations_fluent_plural(
 
 @patch("pontoon.pretranslation.pretranslate.get_google_translate_data")
 @pytest.mark.django_db
+def test_get_pretranslations_fluent_plural_catchall_named_for_locale(
+    gt_mock, fluent_resource, google_translate_locale
+):
+    gt_mock.return_value = "GT"
+
+    # one, few, many — as in uk, ru, pl, be
+    google_translate_locale.cldr_plurals = "1,3,4"
+
+    input_string = dedent(
+        """
+        plural =
+            { $count ->
+                [one] One match found.
+                *[other] { $count } matches found.
+            }
+    """
+    )
+    fluent_entity = EntityFactory(resource=fluent_resource, string=input_string)
+
+    expected = dedent(
+        """
+        plural =
+            { $count ->
+                [one] GT
+                [few] GT
+                *[many] GT
+            }
+    """
+    )
+
+    # Re-serialize to match whitespace
+    pretranslated_string = serializer.serialize_entry(parser.parse_entry(expected))
+
+    response = get_pretranslation(fluent_entity, google_translate_locale)
+    assert response == (pretranslated_string, "gt")
+
+
+@patch("pontoon.pretranslation.pretranslate.get_google_translate_data")
+@pytest.mark.django_db
 def test_get_pretranslations_fluent_complex(
     gt_mock, entity_a, fluent_resource, google_translate_locale
 ):


### PR DESCRIPTION
Fix #4397.

The patch fixes an issue surfaced by #4236, although it was caused by older code.

Pretranslation expands a plural selector to the target locale's categories, but left the catchall carrying the source's name, e.g. `other` from en-US. For a locale whose last category is not `other` (uk, ru, pl, be) that puts the variants out of sync with the plural fields in the editor.

Check out an example string on DEV:
https://pontoon.allizom.org/uk/firefox/all-resources/?string=317622

Same string on PROD:
https://pontoon.mozilla.org/uk/firefox/all-resources/?string=317622
