### PR TITLE
Fix copying translations naming its plural catchall after the source into the editor

### DIFF
--- a/translate/src/context/Editor.test.jsx
+++ b/translate/src/context/Editor.test.jsx
@@ -582,9 +582,7 @@ describe('<EditorProvider>', () => {
       cldrPlurals: [1, 3, 4],
     });
 
-    // The fields already rendered, i.e. what the translator is looking at
-    const live = editor.fields;
-    expect(live.map((f) => f.id)).toEqual(['|one', '|few', '|*']);
+    expect(editor.fields.map((f) => f.id)).toEqual(['|one', '|few', '|*']);
 
     act(() =>
       actions.setEditorFromHistory(ftl`
@@ -597,17 +595,16 @@ describe('<EditorProvider>', () => {
         `),
     );
 
-    expect(live.map(({ id, handle }) => [id, handle.current.value])).toEqual([
-      ['|one', 'ОДИН'],
-      ['|few', 'КІЛЬКА'],
-      ['|*', 'БАГАТО'],
-    ]);
-
-    // The entry is still adopted with its own catchall name
-    expect(editor.fields.map((f) => f.labels.at(-1).label)).toEqual([
-      'one',
-      'few',
-      'other',
+    expect(
+      editor.fields.map(({ id, labels, handle }) => [
+        id,
+        labels.at(-1).label,
+        handle.current.value,
+      ]),
+    ).toEqual([
+      ['|one', 'one', 'ОДИН'],
+      ['|few', 'few', 'КІЛЬКА'],
+      ['|*', 'other', 'БАГАТО'],
     ]);
   });
 

--- a/translate/src/context/Editor.test.jsx
+++ b/translate/src/context/Editor.test.jsx
@@ -19,7 +19,13 @@ import { Location, LocationProvider } from './Location';
 import { UnsavedChanges, UnsavedChangesProvider } from './UnsavedChanges';
 import { fluentParseEntry, mf2ParseMessage } from '@mozilla/l10n';
 
-function mountSpy(Spy, format, formatTranslation, formatSource = 'key = test') {
+function mountSpy(
+  Spy,
+  format,
+  formatTranslation,
+  formatSource = 'key = test',
+  locale = { code: 'sl', cldrPlurals: [1, 2, 3, 5] },
+) {
   const history = createMemoryHistory({
     initialEntries: [`/sl/pro/all/?string=42`],
   });
@@ -102,7 +108,7 @@ function mountSpy(Spy, format, formatTranslation, formatSource = 'key = test') {
 
   const Wrapper = () => (
     <LocationProvider history={history}>
-      <Locale.Provider value={{ code: 'sl', cldrPlurals: [1, 2, 3, 5] }}>
+      <Locale.Provider value={locale}>
         <EntityViewProvider>
           <UnsavedChangesProvider>
             <EditorProvider>
@@ -511,7 +517,7 @@ describe('<EditorProvider>', () => {
         },
         {
           handle: { current: { value: '' } },
-          id: '|other',
+          id: '|*',
           keys: [{ '*': 'other' }],
           labels: [{ label: 'other', plural: true }],
           name: '',
@@ -557,6 +563,54 @@ describe('<EditorProvider>', () => {
     });
   });
 
+  it('sets editor from a history entry whose catchall is named for the source', () => {
+    let editor, actions;
+    const Spy = () => {
+      editor = useContext(EditorData);
+      actions = useContext(EditorActions);
+      return null;
+    };
+    const source = ftl`
+      key =
+          { $count ->
+              [one] ONE
+             *[other] OTHER
+          }
+      `;
+    mountSpy(Spy, 'fluent', undefined, source, {
+      code: 'uk',
+      cldrPlurals: [1, 3, 4],
+    });
+
+    // The fields already rendered, i.e. what the translator is looking at
+    const live = editor.fields;
+    expect(live.map((f) => f.id)).toEqual(['|one', '|few', '|*']);
+
+    act(() =>
+      actions.setEditorFromHistory(ftl`
+        key =
+            { $count ->
+                [one] ОДИН
+                [few] КІЛЬКА
+               *[other] БАГАТО
+            }
+        `),
+    );
+
+    expect(live.map(({ id, handle }) => [id, handle.current.value])).toEqual([
+      ['|one', 'ОДИН'],
+      ['|few', 'КІЛЬКА'],
+      ['|*', 'БАГАТО'],
+    ]);
+
+    // The entry is still adopted with its own catchall name
+    expect(editor.fields.map((f) => f.labels.at(-1).label)).toEqual([
+      'one',
+      'few',
+      'other',
+    ]);
+  });
+
   it('sets editor from history', () => {
     let editor, result, actions;
     const Spy = () => {
@@ -588,7 +642,7 @@ describe('<EditorProvider>', () => {
         },
         {
           handle: { current: { value: 'OTHER' } },
-          id: '|other',
+          id: '|*',
           keys: [{ '*': 'other' }],
           labels: [{ label: 'other', plural: true }],
           name: '',

--- a/translate/src/context/Editor.tsx
+++ b/translate/src/context/Editor.tsx
@@ -4,6 +4,7 @@ import React, {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 
@@ -220,6 +221,7 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
   const { resetFailedChecks } = useContext(FailedChecksData);
 
   const [state, setState] = useState(initEditorData);
+  const pendingValues = useRef<Array<[string, string]> | null>(null);
   const [result, setResult] = useState<MessageEntry | null>(null);
 
   const actions = useMemo<EditorActions>(() => {
@@ -231,17 +233,11 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
       trim: !hasOuterWhitespace(sourceEntry),
     };
 
-    // HACK: Without this code, re-applying a composed Machinery suggestion
-    // (or restoring history) after editing a field takes two clicks:
-    // the first does nothing.
-    // Changing the `fields` changes the `defaultValue` of each field,
-    // but then for some reason the `fields` changes a second time,
-    // and we end up re-rendering the `TranslationForm` with the old field values.
-    const resetFields = (prev: EditorData, next: EditorData): EditorData => {
-      for (const field of next.fields) {
-        const live = prev.fields.find((f) => f.id === field.id);
-        live?.handle.current.setValue(field.handle.current.value);
-      }
+    const resetFields = (next: EditorData): EditorData => {
+      pendingValues.current = next.fields.map(({ id, handle }) => [
+        id,
+        handle.current.value,
+      ]);
       next.focusField.current = next.fields[0];
       setResult(buildMessageEntry(next.base, next.fields, buildOpts));
       return next;
@@ -300,7 +296,7 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
               : editMessageEntry(sourceEntry, entry);
           }
           return {
-            ...resetFields(prev, next),
+            ...resetFields(next),
             machinery: {
               manual,
               translation: getPlainMessage(entry),
@@ -331,7 +327,7 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
             next.fields = editMessageEntry(sourceEntry, prev.initial);
             next.fields[0].handle.current.setValue(str);
           }
-          return resetFields(prev, next);
+          return resetFields(next);
         }),
 
       setEditorSelection: (content) =>
@@ -398,6 +394,20 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
     }));
     setResult(base);
   }, [locale, entity, activeTranslation]);
+
+  // Write the values recorded by `resetFields` into the fields that are now
+  // on screen. After the commit, so that the editor changes this dispatches
+  // don't land in React's render phase.
+  useEffect(() => {
+    const pending = pendingValues.current;
+    if (pending) {
+      pendingValues.current = null;
+      for (const [id, value] of pending) {
+        const field = state.fields.find((f) => f.id === id);
+        field?.handle.current.setValue(value);
+      }
+    }
+  }, [state.fields]);
 
   // For missing entries, fill editor initially with a perfect match from
   // translation memory, if available.

--- a/translate/src/context/Editor.tsx
+++ b/translate/src/context/Editor.tsx
@@ -227,7 +227,7 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
   const { resetFailedChecks } = useContext(FailedChecksData);
 
   const [state, setState] = useState(initEditorData);
-  const pendingValues = useRef<Array<[string, string]> | null>(null);
+  const pendingFieldValues = useRef<Array<[string, string]> | null>(null);
   const [result, setResult] = useState<MessageEntry | null>(null);
 
   const actions = useMemo<EditorActions>(() => {
@@ -240,7 +240,7 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
     };
 
     const resetFields = (next: EditorData): EditorData => {
-      pendingValues.current = next.fields.map(({ id, handle }) => [
+      pendingFieldValues.current = next.fields.map(({ id, handle }) => [
         id,
         handle.current.value,
       ]);
@@ -413,9 +413,9 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
   // on screen. After the commit, so that the editor changes this dispatches
   // don't land in React's render phase.
   useEffect(() => {
-    const pending = pendingValues.current;
+    const pending = pendingFieldValues.current;
     if (pending) {
-      pendingValues.current = null;
+      pendingFieldValues.current = null;
       for (const [id, value] of pending) {
         const field = state.fields.find((f) => f.id === id);
         field?.handle.current.setValue(value);

--- a/translate/src/modules/translationform/components/TranslationForm-multiple.test.jsx
+++ b/translate/src/modules/translationform/components/TranslationForm-multiple.test.jsx
@@ -26,7 +26,7 @@ const DEFAULT_LOCALE = {
   cldrPlurals: [1, 5],
 };
 
-function mountForm(source, target = null) {
+function mountForm(source, target = null, locale = DEFAULT_LOCALE) {
   target ??= source;
   const store = createReduxStore();
   createDefaultUser(store);
@@ -56,7 +56,7 @@ function mountForm(source, target = null) {
 
   const wrapper = mountComponentWithStore(
     () => (
-      <Locale.Provider value={DEFAULT_LOCALE}>
+      <Locale.Provider value={locale}>
         <MockLocalizationProvider>
           <EntityView.Provider value={{ entity }}>
             <EditorProvider>
@@ -432,5 +432,54 @@ describe('<TranslationForm> with multiple fields', () => {
     // Same suggestion, same values: the edited field must still be reset.
     applyComposed();
     expect(docs()).toEqual(['COMPOSED', 'COMPOSED_LABEL']);
+  });
+
+  it('copies a translation naming its catchall after the source, on one click', () => {
+    const source = ftl`
+      key =
+          { $count ->
+              [one] ONE
+             *[other] OTHER
+          }
+      `;
+    const inLocale = ftl`
+      key =
+          { $count ->
+              [one] ОДИН
+              [few] КІЛЬКА
+             *[many] БАГАТО
+          }
+      `;
+    const fromSource = ftl`
+      key =
+          { $count ->
+              [one] ОДИН2
+              [few] КІЛЬКА2
+             *[other] БАГАТО2
+          }
+      `;
+    const { actions, views, wrapper } = mountForm(source, inLocale, {
+      direction: 'ltr',
+      code: 'uk',
+      script: 'Cyrillic',
+      cldrPlurals: [1, 3, 4],
+    });
+    const labels = () =>
+      Array.from(
+        wrapper.container.querySelectorAll('.translationform label'),
+      ).map((el) => el.textContent.trim());
+    const docs = () => views.map((view) => view.state.doc.toString());
+
+    expect(labels()).toEqual(['one', 'few', 'many']);
+
+    act(() => actions.setEditorFromHistory(fromSource));
+
+    expect(docs()).toEqual(['ОДИН2', 'КІЛЬКА2', 'БАГАТО2']);
+    expect(labels()).toEqual(['one', 'few', 'other']);
+
+    act(() => actions.setEditorFromHistory(inLocale));
+
+    expect(docs()).toEqual(['ОДИН', 'КІЛЬКА', 'БАГАТО']);
+    expect(labels()).toEqual(['one', 'few', 'many']);
   });
 });

--- a/translate/src/utils/message/editMessageEntry.ts
+++ b/translate/src/utils/message/editMessageEntry.ts
@@ -106,6 +106,6 @@ function* genPatterns(
 function getId(name: string, keys: (string | CatchallKey)[]) {
   return [
     name,
-    ...keys.map((key) => (typeof key === 'string' ? key : key['*'] || '*')),
+    ...keys.map((key) => (typeof key === 'string' ? key : '*')),
   ].join('|');
 }


### PR DESCRIPTION
Fix #4398.

Copying a translation into the editor matches its fields against the ones on screen by id, and the id carries the catchall's name. A translation naming its plural catchall after the source, e.g. `*[other]` where this locale's categories are one/few/many, therefore matched nothing, and the locale's own catchall field stayed empty until a second click.

Reduce the catchall to `*` in the id instead of using its name. It is the same field either way.

The alternatives would be:
- to name catchall after the locale (as we do for pretranslation and Machinery in #4405), at the cost of rewriting what is copied
- to prevent such translations from being saved in the first place

Check out the example string on DEV:
https://pontoon.allizom.org/uk/firefox/all-resources/?string=317622

Same string on PROD:
https://pontoon.mozilla.org/uk/firefox/all-resources/?string=317622

The 1st commit fixes the problem with the input field staying empty after 1st click, and 2nd commit fixes the problem with the right catchall name being used as the label.