### PR TITLE
Serve system projects to translate endpoints

### DIFF
--- a/pontoon/base/tests/views/test_ajax.py
+++ b/pontoon/base/tests/views/test_ajax.py
@@ -302,3 +302,32 @@ def test_get_team_comments_authentication(rf, user_a, admin):
     response = get_team_comments(request_b)
 
     assert response.status_code == 200
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "view",
+    [
+        get_translations_from_other_locales,
+        get_sibling_entities,
+        get_translation_history,
+        get_team_comments,
+    ],
+)
+def test_translate_view_endpoints_reach_system_projects(rf, user_a, view):
+    """The tutorial is a system project: kept off the dashboards, but translated
+    in the same UI as any other project, so these endpoints have to serve it."""
+    project = ProjectFactory(
+        name="System Project", slug="system-project", system_project=True
+    )
+    resource = ResourceFactory(project=project)
+    entity = EntityFactory(string="Entity", resource=resource)
+    locale = LocaleFactory(code="gs", name="Geonosian")
+
+    request = rf.get(
+        f"/?entity={entity.id}&locale={locale.code}",
+        HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+    )
+    request.user = user_a
+
+    assert view(request).status_code == 200

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -442,7 +442,7 @@ def get_translations_from_other_locales(request):
             status=400,
         )
 
-    visible_projects = Project.objects.visible().visible_for(request.user)
+    visible_projects = Project.objects.available().visible_for(request.user)
     entities = Entity.objects.filter(resource__project__in=visible_projects)
 
     entity = get_object_or_404(entities, pk=entity)
@@ -487,7 +487,7 @@ def get_sibling_entities(request):
             status=400,
         )
 
-    visible_projects = Project.objects.visible().visible_for(request.user)
+    visible_projects = Project.objects.available().visible_for(request.user)
     entities = Entity.objects.filter(resource__project__in=visible_projects)
 
     entity = get_object_or_404(entities, pk=entity)
@@ -533,7 +533,7 @@ def get_translation_history(request):
             status=400,
         )
 
-    visible_projects = Project.objects.visible().visible_for(request.user)
+    visible_projects = Project.objects.available().visible_for(request.user)
     entities = Entity.objects.filter(resource__project__in=visible_projects)
 
     entity = get_object_or_404(entities, pk=entity)
@@ -615,7 +615,7 @@ def get_team_comments(request):
             status=400,
         )
 
-    visible_projects = Project.objects.visible().visible_for(request.user)
+    visible_projects = Project.objects.available().visible_for(request.user)
     entities = Entity.objects.filter(resource__project__in=visible_projects)
 
     entity = get_object_or_404(entities, pk=entity)


### PR DESCRIPTION
Fix #4354.

The History, Comments, Locales and Sibling strings endpoints looked the entity up in `Project.objects.visible()`, which is `available().filter(system_project=False)`. The tutorial is a system project, so all four returned 404 for every user, and the panels showed nothing rather than reporting a failure.

What these endpoints need to know is whether the user can reach the project, not whether it is listed on the dashboards. `available()` still excludes disabled and resource-less projects, and `visible_for` still hides private ones from non-superusers.