### PR TITLE
404 when resource path in the URL path doesn't exist

### DIFF
--- a/pontoon/base/tests/test_utils.py
+++ b/pontoon/base/tests/test_utils.py
@@ -13,6 +13,7 @@ from pontoon.test.factories import (
     ProjectLocaleFactory,
     ProjectSlugHistoryFactory,
     ResourceFactory,
+    TranslatedResourceFactory,
 )
 
 
@@ -255,8 +256,11 @@ def project_d():
     project = ProjectFactory.create(
         name="Project D", slug="project-d", disabled=False, system_project=False
     )
-    ResourceFactory.create(project=project, path="resource_d.po", format="gettext")
+    resource = ResourceFactory.create(
+        project=project, path="resource_d.po", format="gettext"
+    )
     ProjectLocaleFactory.create(project=project, locale=locale)
+    TranslatedResourceFactory.create(resource=resource, locale=locale)
     return project
 
 

--- a/pontoon/translate/tests/test_views.py
+++ b/pontoon/translate/tests/test_views.py
@@ -2,7 +2,14 @@ import pytest
 
 from django.urls import reverse
 
+from pontoon.base.models import Resource
+from pontoon.test.factories import TranslatedResourceFactory
 from pontoon.translate.views import get_preferred_locale
+
+
+@pytest.fixture
+def translated_resource_a(resource_a, locale_a):
+    return TranslatedResourceFactory.create(resource=resource_a, locale=locale_a)
 
 
 @pytest.fixture
@@ -28,7 +35,9 @@ def test_translate_template(client, project_locale_a, resource_a):
 
 
 @pytest.mark.django_db
-def test_translate_validate_parameters(client, project_locale_a, resource_a):
+def test_translate_validate_parameters(
+    client, project_locale_a, resource_a, translated_resource_a
+):
     url_invalid = reverse(
         "pontoon.translate",
         kwargs={"locale": "locale", "project": "project", "resource": "resource"},
@@ -39,7 +48,7 @@ def test_translate_validate_parameters(client, project_locale_a, resource_a):
         kwargs={
             "locale": project_locale_a.locale.code,
             "project": project_locale_a.project.slug,
-            "resource": "resource",
+            "resource": resource_a.path,
         },
     )
 
@@ -111,4 +120,43 @@ def test_translate_invalid_pl(
     """
     # this doesnt seem to redirect as the comment suggests
     response = client.get(f"/{locale_a.code}/{project_b.slug}/path/")
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_translate_invalid_resource(client, project_locale_a, resource_a):
+    """
+    A path that is not a resource of the project is a 404.
+    """
+    response = client.get(
+        f"/{project_locale_a.locale.code}/{project_locale_a.project.slug}/no/such/path.ftl/"
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_translate_resource_not_translated_for_locale(
+    client, project_locale_a, resource_a
+):
+    """
+    A resource the locale has no TranslatedResource for is a 404 too.
+    """
+    response = client.get(
+        f"/{project_locale_a.locale.code}/{project_locale_a.project.slug}/{resource_a.path}/"
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_translate_obsolete_resource(
+    client, project_locale_a, resource_a, translated_resource_a
+):
+    """
+    A resource that is gone from the repository is a 404 as well.
+    """
+    Resource.objects.filter(pk=resource_a.pk).mark_as_obsolete()
+
+    response = client.get(
+        f"/{project_locale_a.locale.code}/{project_locale_a.project.slug}/{resource_a.path}/"
+    )
     assert response.status_code == 404

--- a/pontoon/translate/tests/test_views.py
+++ b/pontoon/translate/tests/test_views.py
@@ -160,3 +160,20 @@ def test_translate_obsolete_resource(
         f"/{project_locale_a.locale.code}/{project_locale_a.project.slug}/{resource_a.path}/"
     )
     assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_translate_all_projects_path(client, project_locale_a, resource_a):
+    """
+    In the All Projects view, only `all-resources` is allowed.
+    """
+    locale = project_locale_a.locale.code
+
+    response = client.get(f"/{locale}/all-projects/all-resources/")
+    assert response.status_code == 200
+
+    response = client.get(f"/{locale}/all-projects/{resource_a.path}/")
+    assert response.status_code == 404
+
+    response = client.get(f"/{locale}/all-projects/no/such/path.ftl/")
+    assert response.status_code == 404

--- a/pontoon/translate/views.py
+++ b/pontoon/translate/views.py
@@ -74,6 +74,11 @@ def translate(request, locale, project, resource):
         ):
             raise Http404
 
+    # The All Projects view does not support single resource paths,
+    # because path names are not unique across projects.
+    elif resource.lower() != "all-resources":
+        raise Http404
+
     context = {
         "is_google_translate_supported": bool(settings.GOOGLE_TRANSLATE_API_KEY),
         "is_microsoft_translator_supported": bool(

--- a/pontoon/translate/views.py
+++ b/pontoon/translate/views.py
@@ -9,6 +9,7 @@ from django.views.decorators.csrf import (
     ensure_csrf_cookie,
 )
 
+from pontoon.base.models import TranslatedResource
 from pontoon.base.services import get_locale_or_redirect, get_project_or_redirect
 
 
@@ -62,6 +63,15 @@ def translate(request, locale, project, resource):
 
         # Validate ProjectLocale
         if locale not in project.locales.all():
+            raise Http404
+
+        # Validate TranslatedResource
+        if (
+            resource.lower() != "all-resources"
+            and not TranslatedResource.objects.filter(
+                locale=locale, resource__project=project, resource__path=resource
+            ).exists()
+        ):
             raise Http404
 
     context = {


### PR DESCRIPTION
Fix #4353.

The translate view validated the locale, the project and the ProjectLocale, but took the resource straight from the URL. A path that the locale has no resource for rendered the view with the path in the navigation and an empty string list, which reads as an empty resource rather than as a wrong URL.

Require the path to name a resource the locale has a TranslatedResource for, unless it is `all-resources` — the same set the paths menu offers. A resource that is obsolete is a 404 too, and so is one belonging to a locale still waiting for its first sync, which has nothing to translate..