### PR TITLE
Check translator rights per string in All Projects

### DIFF
--- a/translate/src/hooks/useTranslator.test.js
+++ b/translate/src/hooks/useTranslator.test.js
@@ -6,20 +6,28 @@ import { useTranslator } from './useTranslator';
 import { vi } from 'vitest';
 
 vi.spyOn(Hooks, 'useAppSelector');
+
+const ctx = vi.hoisted(() => ({ code: 'mylocale', entity: { project: {} } }));
 vi.mock('react', async (importOriginal) => {
   const actual = await importOriginal();
-  return { ...actual, useContext: () => ({ code: 'mylocale' }) };
+  return { ...actual, useContext: () => ctx };
+});
+
+beforeEach(() => {
+  ctx.entity = { project: {} };
 });
 
 afterAll(() => {
   vi.restoreAllMocks();
 });
 
-const fakeSelector = (user) => (sel) =>
-  sel({
-    [PROJECT]: { slug: 'myproject' },
-    [USER]: user,
-  });
+const fakeSelector =
+  (user, slug = 'myproject') =>
+  (sel) =>
+    sel({
+      [PROJECT]: { slug },
+      [USER]: user,
+    });
 
 describe('useTranslator', () => {
   it('returns false for non-authenticated users', () => {
@@ -61,6 +69,53 @@ describe('useTranslator', () => {
         canTranslateLocales: ['localeB'],
         translatorForProjects: { 'mylocale-myproject': true },
       }),
+    );
+    expect(useTranslator()).toBeTruthy();
+  });
+
+  it('returns true for a project the user translates, in the All Projects view', () => {
+    ctx.entity = { project: { slug: 'myproject' } };
+    Hooks.useAppSelector.mockImplementation(
+      fakeSelector(
+        {
+          isAuthenticated: true,
+          canManageLocales: [],
+          canTranslateLocales: [],
+          translatorForProjects: { 'mylocale-myproject': true },
+        },
+        'all-projects',
+      ),
+    );
+    expect(useTranslator()).toBeTruthy();
+  });
+
+  it('uses the given entity rather than the selected one', () => {
+    ctx.entity = { project: { slug: 'myproject' } };
+    Hooks.useAppSelector.mockImplementation(
+      fakeSelector(
+        {
+          isAuthenticated: true,
+          canManageLocales: [],
+          canTranslateLocales: [],
+          translatorForProjects: { 'mylocale-myproject': true },
+        },
+        'all-projects',
+      ),
+    );
+    expect(useTranslator({ project: { slug: 'otherproject' } })).toBeFalsy();
+  });
+
+  it('falls back to the locale permission with no string in hand', () => {
+    Hooks.useAppSelector.mockImplementation(
+      fakeSelector(
+        {
+          isAuthenticated: true,
+          canManageLocales: [],
+          canTranslateLocales: ['mylocale'],
+          translatorForProjects: { 'mylocale-myproject': false },
+        },
+        'all-projects',
+      ),
     );
     expect(useTranslator()).toBeTruthy();
   });

--- a/translate/src/hooks/useTranslator.ts
+++ b/translate/src/hooks/useTranslator.ts
@@ -1,5 +1,7 @@
 import { useContext } from 'react';
 
+import type { Entity } from '~/api/entity';
+import { EntityView } from '~/context/EntityView';
 import { Locale } from '~/context/Locale';
 import { useProject } from '~/modules/project';
 import { USER } from '~/modules/user';
@@ -8,10 +10,13 @@ import { useAppSelector } from '~/hooks';
 /**
  * Return true if the user has translator permission for the current project
  * and locale.
+ *
+ * @param entity Used in the All Projects view to check the permission.
  */
-export function useTranslator(): boolean {
+export function useTranslator(entity?: Entity): boolean {
   const { code } = useContext(Locale);
   const { slug } = useProject();
+  const selected = useContext(EntityView)?.entity;
   const {
     isAuthenticated,
     canManageLocales,
@@ -27,7 +32,10 @@ export function useTranslator(): boolean {
     return true;
   }
 
-  const localeProject = `${code}-${slug}`;
+  const projectSlug =
+    slug === 'all-projects' ? (entity ?? selected)?.project?.slug : slug;
+
+  const localeProject = `${code}-${projectSlug}`;
   if (Object.hasOwnProperty.call(translatorForProjects, localeProject)) {
     return translatorForProjects[localeProject];
   }

--- a/translate/src/hooks/useTranslator.ts
+++ b/translate/src/hooks/useTranslator.ts
@@ -16,7 +16,7 @@ import { useAppSelector } from '~/hooks';
 export function useTranslator(entity?: Entity): boolean {
   const { code } = useContext(Locale);
   const { slug } = useProject();
-  const selected = useContext(EntityView)?.entity;
+  const selected = useContext(EntityView).entity;
   const {
     isAuthenticated,
     canManageLocales,
@@ -33,7 +33,7 @@ export function useTranslator(entity?: Entity): boolean {
   }
 
   const projectSlug =
-    slug === 'all-projects' ? (entity ?? selected)?.project?.slug : slug;
+    slug === 'all-projects' ? (entity ?? selected).project.slug : slug;
 
   const localeProject = `${code}-${projectSlug}`;
   if (Object.hasOwnProperty.call(translatorForProjects, localeProject)) {

--- a/translate/src/modules/entitieslist/components/Entity.tsx
+++ b/translate/src/modules/entitieslist/components/Entity.tsx
@@ -54,7 +54,7 @@ export function Entity({
   selectEntity,
   toggleForBatchEditing,
 }: Props): React.ReactElement<'li'> {
-  const isTranslator = useTranslator();
+  const isTranslator = useTranslator(entity);
   const [areSiblingsActive, setSiblingsActive] = useState(false);
   const entitiesList = useContext(EntitiesList);
 


### PR DESCRIPTION
Fix #4395.

`useTranslator()` builds its key from the URL:

```js
const localeProject = `${code}-${slug}`;
if (Object.hasOwnProperty.call(translatorForProjects, localeProject)) { … }
```

In the All Projects view slug is "all-projects", and e.g. "uk-all-projects" is never a key in `translatorForProjects`, so it falls through to the locale-wide check, which is false for a per-project translator. Hence "Suggest".

The fix is to take the project from the entity instead.

Note that even today the submit approves, because the server already checks permissions against the entity's own project.