### PR TITLE
Autofill editor from composed Machinery matches

### DIFF
--- a/translate/src/context/Editor.test.jsx
+++ b/translate/src/context/Editor.test.jsx
@@ -111,7 +111,8 @@ function mountSpy(
     fetching: false,
     source: '',
     composed: [],
-    translations: machinery ?? [],
+    translations: [],
+    ...(Array.isArray(machinery) ? { translations: machinery } : machinery),
   };
 
   const Wrapper = () => (
@@ -865,5 +866,93 @@ describe('<EditorProvider>', () => {
     act(() => editor.fields[0].handle.current.setValue('manual_change'));
     act(() => actions.setResultFromInput());
     expect(unsaved.check()).toBe(true);
+  });
+
+  it('reports pending changes for a manually copied translation', () => {
+    let editor, actions, unsaved;
+    const Spy = () => {
+      editor = useContext(EditorData);
+      actions = useContext(EditorActions);
+      unsaved = useContext(UnsavedChanges);
+      return null;
+    };
+    mountSpy(Spy, 'simple', undefined, 'message');
+
+    act(() =>
+      actions.setEditorFromHelpers(
+        'messaggio_it',
+        ['translation-memory'],
+        true,
+      ),
+    );
+
+    expect(editor.autofilled).toBeNull();
+    act(() => actions.setResultFromInput());
+    expect(unsaved.check()).toBe(true);
+  });
+
+  it('autofills a multi-field entry from a composed 100% match', () => {
+    let editor, actions, unsaved;
+    const Spy = () => {
+      editor = useContext(EditorData);
+      actions = useContext(EditorActions);
+      unsaved = useContext(UnsavedChanges);
+      return null;
+    };
+    mountSpy(
+      Spy,
+      'fluent',
+      undefined,
+      ftl`
+      key = Value
+          .label = Label
+      `,
+      {
+        composed: [
+          {
+            sources: ['translation-memory'],
+            quality: 100,
+            value: ['Valeur'],
+            properties: { label: ['Étiquette'] },
+          },
+        ],
+      },
+    );
+
+    expect(editor.fields.map((f) => f.handle.current.value)).toEqual([
+      'Valeur',
+      'Étiquette',
+    ]);
+
+    act(() => actions.setResultFromInput());
+    expect(unsaved.check()).toBe(false);
+  });
+
+  it('does not autofill a multi-field entry without a perfect composed match', () => {
+    let editor;
+    const Spy = () => {
+      editor = useContext(EditorData);
+      return null;
+    };
+    mountSpy(
+      Spy,
+      'fluent',
+      undefined,
+      ftl`
+      key = Value
+          .label = Label
+      `,
+      {
+        composed: [
+          {
+            sources: ['google-translate'],
+            value: ['Valeur'],
+            properties: { label: ['Étiquette'] },
+          },
+        ],
+      },
+    );
+
+    expect(editor.fields.map((f) => f.handle.current.value)).toEqual(['', '']);
   });
 });

--- a/translate/src/context/Editor.tsx
+++ b/translate/src/context/Editor.tsx
@@ -418,12 +418,14 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
   const status = useTranslationStatus(entity);
   useEffect(() => {
     if (
-      status === 'missing' &&
-      state.machinery === null &&
-      !state.sourceView &&
-      state.fields.length === 1 &&
-      state.fields[0].handle.current.value === ''
+      status !== 'missing' ||
+      state.machinery !== null ||
+      state.sourceView ||
+      state.fields.some((field) => field.handle.current.value !== '')
     ) {
+      return;
+    }
+    if (state.fields.length === 1) {
       const perfect = machinery.translations.find((tx) => tx.quality === 100);
       if (perfect) {
         actions.setEditorFromHelpers(
@@ -432,8 +434,18 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
           false,
         );
       }
+    } else if (state.fields.length > 1) {
+      const perfect = machinery.composed.find((tx) => tx.quality === 100);
+      if (perfect) {
+        actions.setEditorFromComposed(
+          perfect.value,
+          perfect.properties,
+          perfect.sources,
+          false,
+        );
+      }
     }
-  }, [state, actions, status, machinery.translations]);
+  }, [state, actions, status, machinery.translations, machinery.composed]);
 
   useEffect(() => {
     // Changes in `result` need to be reflected in `UnsavedChanges`,

--- a/translate/src/modules/editor/components/MachinerySourceIndicator.test.jsx
+++ b/translate/src/modules/editor/components/MachinerySourceIndicator.test.jsx
@@ -9,7 +9,11 @@ import { MachinerySourceIndicator } from './MachinerySourceIndicator';
 
 const entry = (value) => ({ format: 'plain', id: 'key', value: [value] });
 
-const mount = ({ autofilled = entry('Bonjour'), result = entry('Bonjour') }) =>
+const mount = ({
+  autofilled = entry('Bonjour'),
+  result = entry('Bonjour'),
+  sourceView = false,
+}) =>
   render(
     <MockLocalizationProvider
       resources={[
@@ -17,7 +21,7 @@ const mount = ({ autofilled = entry('Bonjour'), result = entry('Bonjour') }) =>
     .title = 100% Translation Memory match`,
       ]}
     >
-      <EditorData.Provider value={{ autofilled, sourceView: false }}>
+      <EditorData.Provider value={{ autofilled, sourceView }}>
         <EditorResult.Provider value={result}>
           <MachinerySourceIndicator />
         </EditorResult.Provider>
@@ -43,6 +47,12 @@ describe('<MachinerySourceIndicator>', () => {
       attributes: new Map([['label', ['Étiquette']]]),
     };
     const { container } = mount({ autofilled: composed, result: composed });
+
+    expect(container.querySelector('.tm-source')).not.toBeNull();
+  });
+
+  it('shows in the source view as well', () => {
+    const { container } = mount({ sourceView: true });
 
     expect(container.querySelector('.tm-source')).not.toBeNull();
   });

--- a/translate/src/modules/editor/components/MachinerySourceIndicator.test.jsx
+++ b/translate/src/modules/editor/components/MachinerySourceIndicator.test.jsx
@@ -2,20 +2,14 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
-import { EditorData } from '~/context/Editor';
+import { EditorData, EditorResult } from '~/context/Editor';
 import { MockLocalizationProvider } from '~/test/utils';
 
 import { MachinerySourceIndicator } from './MachinerySourceIndicator';
 
-const field = (value) => ({
-  id: '',
-  name: '',
-  keys: [],
-  labels: [],
-  handle: { current: { value } },
-});
+const entry = (value) => ({ format: 'plain', id: 'key', value: [value] });
 
-const mount = (editor) =>
+const mount = ({ autofilled = entry('Bonjour'), result = entry('Bonjour') }) =>
   render(
     <MockLocalizationProvider
       resources={[
@@ -23,22 +17,17 @@ const mount = (editor) =>
     .title = 100% Translation Memory match`,
       ]}
     >
-      <EditorData.Provider
-        value={{
-          fields: [field('Bonjour')],
-          machinery: { manual: false, sources: [], translation: 'Bonjour' },
-          sourceView: false,
-          ...editor,
-        }}
-      >
-        <MachinerySourceIndicator />
+      <EditorData.Provider value={{ autofilled, sourceView: false }}>
+        <EditorResult.Provider value={result}>
+          <MachinerySourceIndicator />
+        </EditorResult.Provider>
       </EditorData.Provider>
     </MockLocalizationProvider>,
   );
 
 describe('<MachinerySourceIndicator>', () => {
   it('shows for content that was filled in automatically', () => {
-    const { container } = mount();
+    const { container } = mount({});
 
     const indicator = container.querySelector('.tm-source');
     expect(indicator).not.toBeNull();
@@ -46,16 +35,26 @@ describe('<MachinerySourceIndicator>', () => {
     expect(indicator.getAttribute('title')).toBeTruthy();
   });
 
-  it('shows nothing for a manual copy', () => {
-    const { container } = mount({
-      machinery: { manual: true, sources: [], translation: 'Bonjour' },
-    });
+  it('shows for a multi-field entry filled in from a composed match', () => {
+    const composed = {
+      format: 'fluent',
+      id: 'key',
+      value: ['Valeur'],
+      attributes: new Map([['label', ['Étiquette']]]),
+    };
+    const { container } = mount({ autofilled: composed, result: composed });
+
+    expect(container.querySelector('.tm-source')).not.toBeNull();
+  });
+
+  it('shows nothing when nothing was filled in', () => {
+    const { container } = mount({ autofilled: null });
 
     expect(container.querySelector('.tm-source')).toBeNull();
   });
 
   it('shows nothing once the filled-in content has been edited', () => {
-    const { container } = mount({ fields: [field('Bonjour !')] });
+    const { container } = mount({ result: entry('Bonjour !') });
 
     expect(container.querySelector('.tm-source')).toBeNull();
   });

--- a/translate/src/modules/editor/components/MachinerySourceIndicator.tsx
+++ b/translate/src/modules/editor/components/MachinerySourceIndicator.tsx
@@ -7,10 +7,10 @@ import { pojoEquals } from '~/utils/pojo';
 import './MachinerySourceIndicator.css';
 
 export function MachinerySourceIndicator() {
-  const { autofilled, sourceView } = useContext(EditorData);
+  const { autofilled } = useContext(EditorData);
   const result = useContext(EditorResult);
 
-  if (sourceView || !autofilled || !pojoEquals(autofilled, result)) {
+  if (!autofilled || !pojoEquals(autofilled, result)) {
     return null;
   }
 

--- a/translate/src/modules/editor/components/MachinerySourceIndicator.tsx
+++ b/translate/src/modules/editor/components/MachinerySourceIndicator.tsx
@@ -2,21 +2,15 @@ import { Localized } from '@fluent/react';
 import React, { useContext } from 'react';
 
 import { EditorData, EditorResult } from '~/context/Editor';
+import { pojoEquals } from '~/utils/pojo';
 
 import './MachinerySourceIndicator.css';
 
 export function MachinerySourceIndicator() {
-  const { fields, machinery, sourceView } = useContext(EditorData);
-  // Included to re-render on input changes
-  useContext(EditorResult);
+  const { autofilled, sourceView } = useContext(EditorData);
+  const result = useContext(EditorResult);
 
-  if (
-    !machinery ||
-    machinery.manual ||
-    sourceView ||
-    fields.length !== 1 ||
-    machinery.translation !== fields[0].handle.current.value
-  ) {
+  if (sourceView || !autofilled || !pojoEquals(autofilled, result)) {
     return null;
   }
 


### PR DESCRIPTION
Fix #4403.

Expand autofilling of untranslated string editor with a perfect TM match to composed (multi-field) Machinery suggestions. Composed Machinery suggestions are perfect matches only when every one of its fields comes from TM.

I don't see a good reason to hide the 100% match indicator when switching to the source editor, so I dropped that requirement in a 2nd commit.