### PR TITLE
Always include source attributes & declarations in Editor base value

### DIFF
--- a/translate/src/context/Editor.test.jsx
+++ b/translate/src/context/Editor.test.jsx
@@ -507,6 +507,62 @@ describe('<EditorProvider>', () => {
     });
   });
 
+  it('allows editing an approved webext translation with no placeholder', () => {
+    let actions, editor, result, location;
+    const Spy = () => {
+      actions = useContext(EditorActions);
+      editor = useContext(EditorData);
+      result = useContext(EditorResult);
+      location = useContext(Location);
+      return null;
+    };
+
+    const sourceStr =
+      '.local $ph = {$arg1 @source=|$1|}\n' +
+      '{{source with {$ph @source=|$ph$|}}}';
+    const targetStr = 'target with $ph$';
+
+    mountSpy(Spy, 'plain', 'translated', 'source', {
+      entity: {
+        pk: 13,
+        format: 'webext',
+        key: ['foo'],
+        original: sourceStr,
+        value: mf2ParseMessage(sourceStr),
+        translation: { string: targetStr, value: mf2ParseMessage(targetStr) },
+        project: { contact: '' },
+      },
+    });
+
+    act(() => location.push({ entity: 13 }));
+
+    const targetWithDecl = {
+      format: 'webext',
+      id: 'foo',
+      value: {
+        decl: { ph: { $: 'arg1', attr: { source: '$1' } } },
+        msg: ['target with $ph$'],
+      },
+    };
+
+    expect(editor).toMatchObject({
+      initial: targetWithDecl,
+      fields: [{ handle: { current: { value: 'target with $ph$' } } }],
+    });
+    expect(result).toEqual(targetWithDecl);
+
+    // String value is re-parsed on input
+    act(() => actions.setResultFromInput());
+    expect(result).toEqual({
+      format: 'webext',
+      id: 'foo',
+      value: {
+        decl: { ph: { $: 'arg1', attr: { source: '$1' } } },
+        msg: ['target with ', { $: 'ph', attr: { source: '$ph$' } }],
+      },
+    });
+  });
+
   it('clears a rich Fluent value', () => {
     let editor, actions;
     const Spy = () => {

--- a/translate/src/context/Editor.test.jsx
+++ b/translate/src/context/Editor.test.jsx
@@ -23,10 +23,13 @@ import { fluentParseEntry, mf2ParseMessage } from '@mozilla/l10n';
 function mountSpy(
   Spy,
   format,
-  formatTranslation,
-  formatSource = 'key = test',
-  machinery = null,
-  locale = { code: 'sl', cldrPlurals: [1, 2, 3, 5] },
+  targetStr,
+  sourceStr = 'key = test',
+  {
+    entity = null,
+    locale = { code: 'sl', cldrPlurals: [1, 2, 3, 5] },
+    machinery = null,
+  } = {},
 ) {
   const history = createMemoryHistory({
     initialEntries: [`/sl/pro/all/?string=42`],
@@ -37,14 +40,14 @@ function mountSpy(
   let translation = undefined;
   switch (format) {
     case 'fluent': {
-      const [id, entry] = fluentParseEntry(formatSource);
+      const [id, entry] = fluentParseEntry(sourceStr);
       key = [id];
       value = entry['='];
       properties = entry['+'];
-      if (formatTranslation) {
-        const [, entry] = fluentParseEntry(formatTranslation);
+      if (targetStr) {
+        const [, entry] = fluentParseEntry(targetStr);
         translation = {
-          string: formatTranslation,
+          string: targetStr,
           value: entry['='],
           properties: entry['+'],
         };
@@ -52,53 +55,38 @@ function mountSpy(
       break;
     }
     case 'android':
-      value = mf2ParseMessage(formatSource);
-      if (formatTranslation) {
+      value = mf2ParseMessage(sourceStr);
+      if (targetStr) {
         translation = {
-          string: formatTranslation,
-          value: mf2ParseMessage(formatTranslation),
+          string: targetStr,
+          value: mf2ParseMessage(targetStr),
         };
       }
       break;
     default:
-      value = [formatSource];
-      if (formatTranslation) {
-        translation = { string: formatTranslation, value: [formatTranslation] };
+      value = [sourceStr];
+      if (targetStr) {
+        translation = { string: targetStr, value: [targetStr] };
       }
   }
 
-  const gettextSource =
-    '.input {$n :number}\n.match $n\none {{orig one}}\n* {{orig other}}';
-  const gettextTranslation =
-    '.input {$n :number}\n.match $n\none {{trans one}}\n* {{trans other}}';
-
-  const initialState = {
-    entities: {
-      entities: [
-        {
-          pk: 42,
-          format,
-          key,
-          original: formatSource,
-          value,
-          properties,
-          translation,
-          project: { contact: '' },
-        },
-        {
-          pk: 13,
-          format: 'gettext',
-          key: ['plural'],
-          original: gettextSource,
-          value: mf2ParseMessage(gettextSource),
-          translation: {
-            string: gettextTranslation,
-            value: mf2ParseMessage(gettextTranslation),
-          },
-          project: { contact: '' },
-        },
-      ],
+  const entities = [
+    {
+      pk: 42,
+      format,
+      key,
+      original: sourceStr,
+      value,
+      properties,
+      translation,
+      project: { contact: '' },
     },
+  ];
+  if (entity) {
+    entities.push(entity);
+  }
+  const initialState = {
+    entities: { entities },
     otherlocales: { translations: [] },
     user: {
       isAuthenticated: true,
@@ -472,7 +460,26 @@ describe('<EditorProvider>', () => {
       entity = useContext(EntityView).entity;
       return null;
     };
-    mountSpy(Spy, 'plain', 'translated');
+
+    const gettextSource =
+      '.input {$n :number}\n.match $n\none {{orig one}}\n* {{orig other}}';
+    const gettextTranslation =
+      '.input {$n :number}\n.match $n\none {{trans one}}\n* {{trans other}}';
+
+    mountSpy(Spy, 'plain', 'translated', 'source', {
+      entity: {
+        pk: 13,
+        format: 'gettext',
+        key: ['plural'],
+        original: gettextSource,
+        value: mf2ParseMessage(gettextSource),
+        translation: {
+          string: gettextTranslation,
+          value: mf2ParseMessage(gettextTranslation),
+        },
+        project: { contact: '' },
+      },
+    });
 
     act(() => location.push({ entity: 13 }));
 
@@ -589,9 +596,8 @@ describe('<EditorProvider>', () => {
              *[other] OTHER
           }
       `;
-    mountSpy(Spy, 'fluent', undefined, source, null, {
-      code: 'uk',
-      cldrPlurals: [1, 3, 4],
+    mountSpy(Spy, 'fluent', undefined, source, {
+      locale: { code: 'uk', cldrPlurals: [1, 3, 4] },
     });
 
     expect(editor.fields.map((f) => f.id)).toEqual(['|one', '|few', '|*']);
@@ -892,14 +898,16 @@ describe('<EditorProvider>', () => {
       unsaved = useContext(UnsavedChanges);
       return null;
     };
-    mountSpy(Spy, 'simple', undefined, 'message', [
-      {
-        original: 'message',
-        translation: 'messaggio_it',
-        quality: 100,
-        sources: ['translation-memory'],
-      },
-    ]);
+    mountSpy(Spy, 'simple', undefined, 'message', {
+      machinery: [
+        {
+          original: 'message',
+          translation: 'messaggio_it',
+          quality: 100,
+          sources: ['translation-memory'],
+        },
+      ],
+    });
 
     expect(editor).toMatchObject({
       machinery: { manual: false, translation: 'messaggio_it' },
@@ -954,14 +962,16 @@ describe('<EditorProvider>', () => {
           .label = Label
       `,
       {
-        composed: [
-          {
-            sources: ['translation-memory'],
-            quality: 100,
-            value: ['Valeur'],
-            properties: { label: ['Étiquette'] },
-          },
-        ],
+        machinery: {
+          composed: [
+            {
+              sources: ['translation-memory'],
+              quality: 100,
+              value: ['Valeur'],
+              properties: { label: ['Étiquette'] },
+            },
+          ],
+        },
       },
     );
 
@@ -989,13 +999,15 @@ describe('<EditorProvider>', () => {
           .label = Label
       `,
       {
-        composed: [
-          {
-            sources: ['google-translate'],
-            value: ['Valeur'],
-            properties: { label: ['Étiquette'] },
-          },
-        ],
+        machinery: {
+          composed: [
+            {
+              sources: ['google-translate'],
+              value: ['Valeur'],
+              properties: { label: ['Étiquette'] },
+            },
+          ],
+        },
       },
     );
 

--- a/translate/src/context/Editor.tsx
+++ b/translate/src/context/Editor.tsx
@@ -1,4 +1,4 @@
-import { CatchallKey, type Message } from '@mozilla/l10n';
+import type { CatchallKey, Message } from '@mozilla/l10n';
 import React, {
   createContext,
   useContext,
@@ -21,12 +21,12 @@ import {
   requiresSourceView,
   serializeEntry,
 } from '~/utils/message';
+import { createMessageEntry } from '~/utils/message/createMessageEntry';
 import {
   hasOuterWhitespace,
   htmlElementEscapes,
 } from '~/utils/message/entryInformation';
 import { messageEntryFromEntityTranslation } from '~/utils/message/fromEntity';
-import { createMessageEntry } from '~/utils/message/createMessageEntry';
 import { getMessageEntryFormat } from '~/utils/message/getMessageEntryFormat';
 import { specialFormats } from '~/utils/message/specialFormats';
 import { pojoEquals } from '~/utils/pojo';
@@ -188,6 +188,40 @@ function parseEntryFromFluentSource(
   return entry;
 }
 
+/**
+ * Modifies `base` in-place, ensuring that it contains
+ * the attributes and declarations present on `sourceEntry`.
+ */
+function includeSourceAttributesAndDeclarations(
+  base: MessageEntry,
+  sourceEntry: MessageEntry,
+) {
+  const apply = (source: Message, target: Message): Message => {
+    if (Array.isArray(source)) {
+      return target;
+    }
+    if (Array.isArray(target)) {
+      return { decl: structuredClone(source.decl), msg: target };
+    }
+    for (const [name, expression] of Object.entries(source.decl)) {
+      target.decl[name] ??= structuredClone(expression);
+    }
+    return target;
+  };
+
+  if (sourceEntry.value) {
+    base.value = apply(sourceEntry.value, base.value ?? []);
+  }
+
+  if (sourceEntry.attributes) {
+    base.attributes ??= new Map();
+    for (const [name, message] of sourceEntry.attributes) {
+      const prev = base.attributes.get(name) ?? [];
+      base.attributes.set(name, apply(message, prev));
+    }
+  }
+}
+
 const initEditorData: EditorData = {
   pk: 0,
   busy: false,
@@ -324,6 +358,7 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
           if (specialFormats.has(format)) {
             const entry = parseEntry(format, str);
             if (entry) {
+              includeSourceAttributesAndDeclarations(entry, sourceEntry);
               next.base = entry;
             } else if (format !== 'fluent') {
               return prev;
@@ -369,6 +404,7 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
           if (sourceView) {
             const entry = parseEntryFromFluentSource(sourceEntry, fields);
             if (entry && !requiresSourceView(entry)) {
+              includeSourceAttributesAndDeclarations(entry, sourceEntry);
               const fields = editMessageEntry(sourceEntry, entry);
               state.focusField.current = fields[0];
               setResult(entry);
@@ -391,6 +427,7 @@ export function EditorProvider({ children }: { children: React.ReactElement }) {
 
   useEffect(() => {
     const base = messageEntryFromEntityTranslation(entity, locale);
+    includeSourceAttributesAndDeclarations(base, sourceEntry);
     const sourceView = requiresSourceView(base);
     const fields = sourceView
       ? editSource(serializeEntry(base))


### PR DESCRIPTION
Fixes #4414

Based on https://github.com/mozilla/pontoon/issues/4262#issuecomment-4881690752, I presume that @havarh has submitted the translations we currently have for [`nb-NO`](https://pontoon.mozilla.org/nb-NO/all-projects/all-resources/?search=%2524keyId%2524) and [`nn-NO`](https://pontoon.mozilla.org/nn-NO/all-projects/all-resources/?search=%2524keyId%2524) by manually crafting `POST /translations/create/` requests. These end up rendering as apparently-correct in Pontoon, but don't include the placeholder declaration object that's required (a bit of a web extensions specialty).

The original issue leading to that workaround has since been resolved by #4313. However, now that we do have these not-quite-right approved translations, editing them turns out to not work well, as we've been presuming that approved translations are a valid starting point for further translations, and this is not the case here. Attempting to edit those translations will now fail due to a parsing error.

This PR fixes the front-end's capability to edit partial translations like this, making it more robust in general -- though this particular error case should only have been possible to reach with webext translations, and by manually crafting the POST request.

After this is merged and deployed, it should be possible to edit the invalid translations by e.g. adding and removing a space character to trigger the translation re-parsing, which should enable the Save/Suggest button to submit a valid translation for what appears to be the same translation. Explicitly rejecting the current translations and re-entering them should also work already now, though I've not verified that.