### PR TITLE
Remove warning on SECRET_KEY for MozCloud Docker build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -37,6 +37,7 @@ jobs:
           file: docker/Dockerfile-mozcloud
           build-args: |
             GIT_REVISION=${{ github.sha }}
+            BUILDKIT_DOCKERFILE_CHECK=skip=SecretsUsedInArgOrEnv
           push: false
           load: true
           tags: pontoon:latest


### PR DESCRIPTION
Per comment, the value is a dummy.