### PR TITLE
Copy batch action: show only locales available in current project

### DIFF
--- a/translate/src/api/other-locales.test.ts
+++ b/translate/src/api/other-locales.test.ts
@@ -10,65 +10,15 @@ describe('fetchAllLocales', () => {
     vi.mocked(GET).mockReset();
   });
 
-  describe('single project', () => {
-    it('fetches the project detail endpoint with the correct slug and fields param', async () => {
-      vi.mocked(GET).mockResolvedValueOnce({ localizations: [] });
-
-      await fetchAllLocales('terminology');
-
-      expect(GET).toHaveBeenCalledTimes(1);
-      expect(GET).toHaveBeenCalledWith(
-        expect.stringMatching(/^\/api\/v2\/projects\/terminology\/\?/),
-      );
-      expect(GET).toHaveBeenCalledWith(
-        expect.stringContaining('fields=localizations'),
-      );
-    });
-
-    it('extracts locale from the nested localizations shape, not the raw locales field', async () => {
-      vi.mocked(GET).mockResolvedValueOnce({
-        localizations: [
-          { locale: { code: 'de', name: 'German' }, total_strings: 100 },
-          { locale: { code: 'fr', name: 'French' }, total_strings: 50 },
-        ],
-      });
-
-      const result = await fetchAllLocales('terminology');
-
-      expect(result).toEqual([
-        { code: 'de', name: 'German' },
-        { code: 'fr', name: 'French' },
-      ]);
-      expect(result[0]).toHaveProperty('name');
-    });
-
-    it('returns an empty array if localizations is missing entirely', async () => {
-      vi.mocked(GET).mockResolvedValueOnce({});
-      const result = await fetchAllLocales('terminology');
-      expect(result).toEqual([]);
-    });
-
-    it('does not paginate for a single project (only calls GET once)', async () => {
-      vi.mocked(GET).mockResolvedValueOnce({
-        localizations: [{ locale: { code: 'de', name: 'German' } }],
-        next: '/api/v2/projects/terminology/?page=2',
-      });
-
-      await fetchAllLocales('terminology');
-      expect(GET).toHaveBeenCalledTimes(1);
-    });
-  });
-
   describe('all-projects', () => {
     it('hits the global locale list endpoint, not a project endpoint', async () => {
       vi.mocked(GET).mockResolvedValueOnce({ results: [], next: null });
 
-      await fetchAllLocales('all-projects');
+      await fetchAllLocales();
 
       expect(GET).toHaveBeenCalledWith(
         expect.stringMatching(/^\/api\/v2\/locales\/\?/),
       );
-
       expect(GET).not.toHaveBeenCalledWith(
         expect.stringContaining('/api/v2/projects/'),
       );
@@ -85,7 +35,7 @@ describe('fetchAllLocales', () => {
           next: null,
         });
 
-      const result = await fetchAllLocales('all-projects');
+      const result = await fetchAllLocales();
 
       expect(GET).toHaveBeenCalledTimes(2);
       expect(result).toEqual([
@@ -98,7 +48,7 @@ describe('fetchAllLocales', () => {
       vi.mocked(GET).mockResolvedValueOnce({
         results: [{ code: 'a', name: 'A' }],
       });
-      const result = await fetchAllLocales('all-projects');
+      const result = await fetchAllLocales();
       expect(result).toEqual([{ code: 'a', name: 'A' }]);
     });
   });

--- a/translate/src/api/other-locales.test.ts
+++ b/translate/src/api/other-locales.test.ts
@@ -1,0 +1,106 @@
+import { fetchAllLocales } from './other-locales';
+import { GET } from './utils/base';
+
+vi.mock('./utils/base', () => ({
+  GET: vi.fn(),
+}));
+
+describe('fetchAllLocales', () => {
+  afterEach(() => {
+    vi.mocked(GET).mockReset();
+  });
+
+  describe('single project', () => {
+    it('fetches the project detail endpoint with the correct slug and fields param', async () => {
+      vi.mocked(GET).mockResolvedValueOnce({ localizations: [] });
+
+      await fetchAllLocales('terminology');
+
+      expect(GET).toHaveBeenCalledTimes(1);
+      expect(GET).toHaveBeenCalledWith(
+        expect.stringMatching(/^\/api\/v2\/projects\/terminology\/\?/),
+      );
+      expect(GET).toHaveBeenCalledWith(
+        expect.stringContaining('fields=localizations'),
+      );
+    });
+
+    it('extracts locale from the nested localizations shape, not the raw locales field', async () => {
+      vi.mocked(GET).mockResolvedValueOnce({
+        localizations: [
+          { locale: { code: 'de', name: 'German' }, total_strings: 100 },
+          { locale: { code: 'fr', name: 'French' }, total_strings: 50 },
+        ],
+      });
+
+      const result = await fetchAllLocales('terminology');
+
+      expect(result).toEqual([
+        { code: 'de', name: 'German' },
+        { code: 'fr', name: 'French' },
+      ]);
+      expect(result[0]).toHaveProperty('name');
+    });
+
+    it('returns an empty array if localizations is missing entirely', async () => {
+      vi.mocked(GET).mockResolvedValueOnce({});
+      const result = await fetchAllLocales('terminology');
+      expect(result).toEqual([]);
+    });
+
+    it('does not paginate for a single project (only calls GET once)', async () => {
+      vi.mocked(GET).mockResolvedValueOnce({
+        localizations: [{ locale: { code: 'de', name: 'German' } }],
+        next: '/api/v2/projects/terminology/?page=2', 
+      });
+
+      await fetchAllLocales('terminology');
+      expect(GET).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('all-projects', () => {
+    it('hits the global locale list endpoint, not a project endpoint', async () => {
+      vi.mocked(GET).mockResolvedValueOnce({ results: [], next: null });
+
+      await fetchAllLocales('all-projects');
+
+      expect(GET).toHaveBeenCalledWith(
+        expect.stringMatching(/^\/api\/v2\/locales\/\?/),
+      );
+
+      expect(GET).not.toHaveBeenCalledWith(
+        expect.stringContaining('/api/v2/projects/'),
+      );
+    });
+
+    it('follows pagination until next is null', async () => {
+      vi.mocked(GET)
+        .mockResolvedValueOnce({
+          results: [{ code: 'a', name: 'Locale A' }],
+          next: '/api/v2/locales/?page=2',
+        })
+        .mockResolvedValueOnce({
+          results: [{ code: 'b', name: 'Locale B' }],
+          next: null,
+        });
+
+      const result = await fetchAllLocales('all-projects');
+
+      expect(GET).toHaveBeenCalledTimes(2);
+      expect(result).toEqual([
+        { code: 'a', name: 'Locale A' },
+        { code: 'b', name: 'Locale B' },
+      ]);
+    });
+
+    it('stops looping and does not hang if next is missing rather than null', async () => {
+      vi.mocked(GET).mockResolvedValueOnce({
+        results: [{ code: 'a', name: 'A' }],
+      });
+      const result = await fetchAllLocales('all-projects');
+      expect(result).toEqual([{ code: 'a', name: 'A' }]);
+    });
+  });
+});
+

--- a/translate/src/api/other-locales.test.ts
+++ b/translate/src/api/other-locales.test.ts
@@ -51,7 +51,7 @@ describe('fetchAllLocales', () => {
     it('does not paginate for a single project (only calls GET once)', async () => {
       vi.mocked(GET).mockResolvedValueOnce({
         localizations: [{ locale: { code: 'de', name: 'German' } }],
-        next: '/api/v2/projects/terminology/?page=2', 
+        next: '/api/v2/projects/terminology/?page=2',
       });
 
       await fetchAllLocales('terminology');
@@ -103,4 +103,3 @@ describe('fetchAllLocales', () => {
     });
   });
 });
-

--- a/translate/src/api/other-locales.ts
+++ b/translate/src/api/other-locales.ts
@@ -29,25 +29,16 @@ export async function fetchOtherLocales(
   return Array.isArray(results) ? results : [];
 }
 
-export async function fetchAllLocales(slug: string): Promise<LocaleOption[]> {
-  if (slug === 'all-projects') {
-    const locales: LocaleOption[] = [];
-    let url: string | null = '/api/v2/locales/?fields=code,name&ordering=name';
-    while (url) {
-      const result = await GET(url);
-      if (Array.isArray(result?.results)) {
-        locales.push(...result.results);
-      }
-      url = result?.next ?? null;
+export async function fetchAllLocales(): Promise<LocaleOption[]> {
+  const search = new URLSearchParams({ fields: 'code,name', ordering: 'name' });
+  const locales: LocaleOption[] = [];
+  let url: string | null = `/api/v2/locales/?${search}`;
+  while (url) {
+    const result = await GET(url);
+    if (Array.isArray(result?.results)) {
+      locales.push(...result.results);
     }
-    return locales;
+    url = result?.next ?? null;
   }
-
-  const search = new URLSearchParams({ fields: 'localizations' });
-  const url = `/api/v2/projects/${slug}/?${search}`;
-  const result = await GET(url);
-  const locales: LocaleOption[] = (result?.localizations ?? []).map(
-    (l: { locale: LocaleOption }) => l.locale,
-  );
   return locales;
 }

--- a/translate/src/api/other-locales.ts
+++ b/translate/src/api/other-locales.ts
@@ -30,9 +30,14 @@ export async function fetchOtherLocales(
 }
 
 export async function fetchAllLocales(): Promise<LocaleOption[]> {
-  const search = new URLSearchParams({ fields: 'code,name', ordering: 'name' });
+  const search = new URLSearchParams({
+    fields: 'code,name',
+    ordering: 'name',
+  });
+
   const locales: LocaleOption[] = [];
   let url: string | null = `/api/v2/locales/?${search}`;
+
   while (url) {
     const result = await GET(url);
     if (Array.isArray(result?.results)) {
@@ -40,5 +45,6 @@ export async function fetchAllLocales(): Promise<LocaleOption[]> {
     }
     url = result?.next ?? null;
   }
+
   return locales;
 }

--- a/translate/src/api/other-locales.ts
+++ b/translate/src/api/other-locales.ts
@@ -29,22 +29,25 @@ export async function fetchOtherLocales(
   return Array.isArray(results) ? results : [];
 }
 
-export async function fetchAllLocales(): Promise<LocaleOption[]> {
-  const search = new URLSearchParams({
-    fields: 'code,name',
-    ordering: 'name',
-  });
-
-  const locales: LocaleOption[] = [];
-  let url: string | null = `/api/v2/locales/?${search}`;
-
-  while (url) {
-    const result = await GET(url);
-    if (Array.isArray(result?.results)) {
-      locales.push(...result.results);
+export async function fetchAllLocales(slug: string): Promise<LocaleOption[]> {
+  if (slug === 'all-projects') {
+    const locales: LocaleOption[] = [];
+    let url: string | null = '/api/v2/locales/?fields=code,name&ordering=name';
+    while (url) {
+      const result = await GET(url);
+      if (Array.isArray(result?.results)) {
+        locales.push(...result.results);
+      }
+      url = result?.next ?? null;
     }
-    url = result?.next ?? null;
+    return locales;
   }
 
+  const search = new URLSearchParams({ fields: 'localizations' });
+  const url = `/api/v2/projects/${slug}/?${search}`;
+  const result = await GET(url);
+  const locales: LocaleOption[] = (result?.localizations ?? []).map(
+    (l: { locale: LocaleOption }) => l.locale,
+  );
   return locales;
 }

--- a/translate/src/api/project.ts
+++ b/translate/src/api/project.ts
@@ -1,4 +1,5 @@
 import { GET } from './utils/base';
+import type { LocaleOption } from './other-locales';
 
 export type Tag = {
   readonly slug: string;
@@ -11,8 +12,16 @@ export type Project = {
   name: string;
   info: string;
   tags: Tag[];
+  locales: LocaleOption[];
 };
 
 export async function fetchProject(slug: string): Promise<Project> {
-  return await GET(`/api/v2/projects/${slug}`);
+  const result = await GET(`/api/v2/projects/${slug}`);
+
+  return {
+    ...result,
+    locales: (result?.localizations ?? []).map(
+      (l: { locale: LocaleOption }) => l.locale,
+    ),
+  };
 }

--- a/translate/src/modules/batchactions/components/BatchActions.test.jsx
+++ b/translate/src/modules/batchactions/components/BatchActions.test.jsx
@@ -17,13 +17,6 @@ const DEFAULT_BATCH_ACTIONS = {
   response: null,
 };
 
-vi.mock('~/hooks', () => ({
-  useAppDispatch: vi.fn(() => vi.fn()),
-  useAppSelector: vi.fn((selector) =>
-    selector({ [BATCHACTIONS]: DEFAULT_BATCH_ACTIONS }),
-  ),
-}));
-
 vi.mock('../actions', () => ({
   resetSelection: vi.fn(() => ({ type: 'whatever' })),
   selectAll: vi.fn(() => ({ type: 'whatever' })),

--- a/translate/src/modules/batchactions/components/BatchActions.test.jsx
+++ b/translate/src/modules/batchactions/components/BatchActions.test.jsx
@@ -2,13 +2,13 @@ import React from 'react';
 
 import * as Hooks from '~/hooks';
 import * as Actions from '../actions';
-import * as OtherLocales from '~/api/other-locales';
 import { BATCHACTIONS } from '../reducer';
 
 import { BatchActions } from './BatchActions';
 import { vi } from 'vitest';
 import { fireEvent, render } from '@testing-library/react';
 import { MockLocalizationProvider } from '~/test/utils';
+import { PROJECT } from '~/modules/project';
 
 const DEFAULT_BATCH_ACTIONS = {
   entities: [],
@@ -29,8 +29,23 @@ vi.mock('../actions', () => ({
   selectAll: vi.fn(() => ({ type: 'whatever' })),
 }));
 
-vi.mock('~/api/other-locales', () => ({
-  fetchAllLocales: vi.fn(() => Promise.resolve([])),
+const DEFAULT_PROJECT_STATE = {
+  fetching: false,
+  slug: '',
+  name: '',
+  info: '',
+  tags: [],
+  locales: [],
+};
+
+vi.mock('~/hooks', () => ({
+  useAppDispatch: vi.fn(() => vi.fn()),
+  useAppSelector: vi.fn((selector) =>
+    selector({
+      [BATCHACTIONS]: DEFAULT_BATCH_ACTIONS,
+      [PROJECT]: DEFAULT_PROJECT_STATE,
+    }),
+  ),
 }));
 
 describe('<BatchActions>', () => {
@@ -39,7 +54,6 @@ describe('<BatchActions>', () => {
     Hooks.useAppSelector.mockRestore();
     Actions.resetSelection.mockRestore();
     Actions.selectAll.mockRestore();
-    OtherLocales.fetchAllLocales.mockClear();
   });
 
   const WrapBatchAction = () => {

--- a/translate/src/modules/batchactions/components/BatchActions.tsx
+++ b/translate/src/modules/batchactions/components/BatchActions.tsx
@@ -21,6 +21,8 @@ import { ReplaceAll } from './ReplaceAll';
 import { CopyFromLocale } from './CopyFromLocale';
 import LocaleMenu from '~/modules/locale/components/LocaleMenu';
 import { useProject } from '~/modules/project';
+import { fetchAllLocales, LocaleOption } from '~/api/other-locales';
+
 /**
  * Renders batch editor, used for performing mass actions on translations.
  */
@@ -35,7 +37,16 @@ export function BatchActions(): React.ReactElement<'div'> {
 
   const [otherLocale, setOtherLocale] = useState('');
 
-  const { locales } = useProject();
+  const { slug, locales: projectLocales } = useProject();
+  const [locales, setLocales] = useState<LocaleOption[]>([]);
+
+  useEffect(() => {
+    if (slug === 'all-projects') {
+      fetchAllLocales().then(setLocales);
+    } else {
+      setLocales(projectLocales);
+    }
+  }, [slug, projectLocales]);
 
   const quitBatchActions = useCallback(() => dispatch(resetSelection()), []);
 

--- a/translate/src/modules/batchactions/components/BatchActions.tsx
+++ b/translate/src/modules/batchactions/components/BatchActions.tsx
@@ -41,11 +41,20 @@ export function BatchActions(): React.ReactElement<'div'> {
   const [locales, setLocales] = useState<LocaleOption[]>([]);
 
   useEffect(() => {
+    let cancelled = false;
+
     if (slug === 'all-projects') {
-      fetchAllLocales().then(setLocales);
+      fetchAllLocales().then((result) => {
+        if (!cancelled) {
+          setLocales(result);
+        }
+      });
     } else {
       setLocales(projectLocales);
     }
+    return () => {
+      cancelled = true;
+    };
   }, [slug, projectLocales]);
 
   const quitBatchActions = useCallback(() => dispatch(resetSelection()), []);

--- a/translate/src/modules/batchactions/components/BatchActions.tsx
+++ b/translate/src/modules/batchactions/components/BatchActions.tsx
@@ -51,10 +51,10 @@ export function BatchActions(): React.ReactElement<'div'> {
   }, []);
 
   useEffect(() => {
-    fetchAllLocales().then((all) => {
+    fetchAllLocales(location.project).then((all) => {
       setLocales(all);
     });
-  }, []);
+  }, [location.project]);
 
   const selectAllEntities = useCallback(
     () => dispatch(selectAll(location)),

--- a/translate/src/modules/batchactions/components/BatchActions.tsx
+++ b/translate/src/modules/batchactions/components/BatchActions.tsx
@@ -19,9 +19,8 @@ import './BatchActions.css';
 import { RejectAll } from './RejectAll';
 import { ReplaceAll } from './ReplaceAll';
 import { CopyFromLocale } from './CopyFromLocale';
-import { fetchAllLocales } from '~/api/other-locales';
-import type { LocaleOption } from '~/api/other-locales';
 import LocaleMenu from '~/modules/locale/components/LocaleMenu';
+import { useProject } from '~/modules/project';
 /**
  * Renders batch editor, used for performing mass actions on translations.
  */
@@ -35,7 +34,8 @@ export function BatchActions(): React.ReactElement<'div'> {
   const replace = useRef<HTMLInputElement>(null);
 
   const [otherLocale, setOtherLocale] = useState('');
-  const [locales, setLocales] = useState<LocaleOption[]>([]);
+
+  const { locales } = useProject();
 
   const quitBatchActions = useCallback(() => dispatch(resetSelection()), []);
 
@@ -49,12 +49,6 @@ export function BatchActions(): React.ReactElement<'div'> {
     document.addEventListener('keydown', handleShortcuts);
     return () => document.removeEventListener('keydown', handleShortcuts);
   }, []);
-
-  useEffect(() => {
-    fetchAllLocales(location.project).then((all) => {
-      setLocales(all);
-    });
-  }, [location.project]);
 
   const selectAllEntities = useCallback(
     () => dispatch(selectAll(location)),

--- a/translate/src/modules/project/actions.ts
+++ b/translate/src/modules/project/actions.ts
@@ -4,13 +4,13 @@ import type { AppDispatch } from '~/store';
 
 export const RECEIVE = 'project/RECEIVE';
 export const REQUEST = 'project/REQUEST';
-export const RESET = 'project/RESET';
 
-export type Action = ReceiveAction | RequestAction | ResetAction;
+export type Action = ReceiveAction | RequestAction;
 
 /** Notify that project data is being fetched.  */
 type RequestAction = {
   readonly type: typeof REQUEST;
+  readonly slug: string;
 };
 
 /** Receive project data.  */
@@ -23,18 +23,13 @@ type ReceiveAction = {
   readonly locales: LocaleOption[];
 };
 
-/** Reset project data.  */
-type ResetAction = {
-  readonly type: typeof RESET;
-};
-
 /**
  * Get data about the current project.
  */
 export const getProject = (slug: string) => async (dispatch: AppDispatch) => {
   // When 'all-projects' are selected, we do not fetch data.
+  dispatch({ type: REQUEST, slug });
   if (slug !== 'all-projects') {
-    dispatch({ type: REQUEST });
     const { info, name, slug: slug_, tags, locales } = await fetchProject(slug);
     dispatch({
       type: RECEIVE,
@@ -44,11 +39,5 @@ export const getProject = (slug: string) => async (dispatch: AppDispatch) => {
       tags: tags.sort((a, b) => b.priority - a.priority),
       locales: locales,
     });
-  } else {
-    dispatch(resetProject());
   }
 };
-
-export const resetProject = () => ({
-  type: RESET,
-});

--- a/translate/src/modules/project/actions.ts
+++ b/translate/src/modules/project/actions.ts
@@ -1,3 +1,4 @@
+import { LocaleOption } from '~/api/other-locales';
 import { fetchProject, Tag } from '~/api/project';
 import type { AppDispatch } from '~/store';
 
@@ -18,6 +19,7 @@ type ReceiveAction = {
   readonly name: string;
   readonly info: string;
   readonly tags: Tag[];
+  readonly locales: LocaleOption[];
 };
 
 /**
@@ -27,13 +29,14 @@ export const getProject = (slug: string) => async (dispatch: AppDispatch) => {
   // When 'all-projects' are selected, we do not fetch data.
   if (slug !== 'all-projects') {
     dispatch({ type: REQUEST });
-    const { info, name, slug: slug_, tags } = await fetchProject(slug);
+    const { info, name, slug: slug_, tags, locales } = await fetchProject(slug);
     dispatch({
       type: RECEIVE,
       slug: slug_,
       name: name,
       info: info,
       tags: tags.sort((a, b) => b.priority - a.priority),
+      locales: locales,
     });
   }
 };

--- a/translate/src/modules/project/actions.ts
+++ b/translate/src/modules/project/actions.ts
@@ -4,8 +4,9 @@ import type { AppDispatch } from '~/store';
 
 export const RECEIVE = 'project/RECEIVE';
 export const REQUEST = 'project/REQUEST';
+export const RESET = 'project/RESET';
 
-export type Action = ReceiveAction | RequestAction;
+export type Action = ReceiveAction | RequestAction | ResetAction;
 
 /** Notify that project data is being fetched.  */
 type RequestAction = {
@@ -20,6 +21,11 @@ type ReceiveAction = {
   readonly info: string;
   readonly tags: Tag[];
   readonly locales: LocaleOption[];
+};
+
+/** Reset project data.  */
+type ResetAction = {
+  readonly type: typeof RESET;
 };
 
 /**
@@ -38,5 +44,11 @@ export const getProject = (slug: string) => async (dispatch: AppDispatch) => {
       tags: tags.sort((a, b) => b.priority - a.priority),
       locales: locales,
     });
+  } else {
+    dispatch(resetProject());
   }
 };
+
+export const resetProject = () => ({
+  type: RESET,
+});

--- a/translate/src/modules/project/reducer.ts
+++ b/translate/src/modules/project/reducer.ts
@@ -1,6 +1,7 @@
 import type { Tag } from '~/api/project';
 
 import { Action, RECEIVE, REQUEST } from './actions';
+import { LocaleOption } from '~/api/other-locales';
 
 // Name of this module.
 // Used as the key to store this module's reducer.
@@ -12,6 +13,7 @@ export type ProjectState = {
   readonly name: string;
   readonly info: string;
   readonly tags: Tag[];
+  readonly locales: LocaleOption[];
 };
 
 const initial: ProjectState = {
@@ -20,6 +22,7 @@ const initial: ProjectState = {
   name: '',
   info: '',
   tags: [],
+  locales: [],
 };
 
 export function reducer(
@@ -40,6 +43,7 @@ export function reducer(
         name: action.name,
         info: action.info,
         tags: action.tags,
+        locales: action.locales,
       };
     default:
       return state;

--- a/translate/src/modules/project/reducer.ts
+++ b/translate/src/modules/project/reducer.ts
@@ -31,6 +31,13 @@ export function reducer(
 ): ProjectState {
   switch (action.type) {
     case REQUEST:
+      if (action.slug === 'all-projects') {
+        return {
+          ...initial,
+          slug: action.slug,
+        };
+      }
+
       return {
         ...state,
         fetching: true,

--- a/translate/src/modules/project/reducer.ts
+++ b/translate/src/modules/project/reducer.ts
@@ -1,6 +1,6 @@
 import type { Tag } from '~/api/project';
 
-import { Action, RECEIVE, REQUEST } from './actions';
+import { Action, RECEIVE, REQUEST, RESET } from './actions';
 import { LocaleOption } from '~/api/other-locales';
 
 // Name of this module.
@@ -34,6 +34,7 @@ export function reducer(
       return {
         ...state,
         fetching: true,
+        locales: [],
       };
     case RECEIVE:
       return {
@@ -45,6 +46,8 @@ export function reducer(
         tags: action.tags,
         locales: action.locales,
       };
+    case RESET:
+      return initial;
     default:
       return state;
   }

--- a/translate/src/modules/project/reducer.ts
+++ b/translate/src/modules/project/reducer.ts
@@ -1,6 +1,6 @@
 import type { Tag } from '~/api/project';
 
-import { Action, RECEIVE, REQUEST, RESET } from './actions';
+import { Action, RECEIVE, REQUEST } from './actions';
 import { LocaleOption } from '~/api/other-locales';
 
 // Name of this module.
@@ -34,6 +34,7 @@ export function reducer(
       return {
         ...state,
         fetching: true,
+        slug: action.slug,
         locales: [],
       };
     case RECEIVE:
@@ -46,8 +47,6 @@ export function reducer(
         tags: action.tags,
         locales: action.locales,
       };
-    case RESET:
-      return initial;
     default:
       return state;
   }


### PR DESCRIPTION
Fixes #4424 

Fall back to the global locale list when in the All Projects view. 