### PR TITLE
Fix tutorial entity values

### DIFF
--- a/pontoon/tour/migrations/0003_fix_tutorial_entity_value.py
+++ b/pontoon/tour/migrations/0003_fix_tutorial_entity_value.py
@@ -1,0 +1,26 @@
+from django.db import migrations
+
+
+def set_tutorial_entity_value(apps, schema_editor):
+    """
+    Backfill the message data model `value` for Tutorial entities that were
+    created without it.
+    """
+    Entity = apps.get_model("base", "Entity")
+
+    entities = Entity.objects.filter(resource__project__slug="tutorial", value=[])
+    for entity in entities:
+        entity.value = [entity.string]
+    Entity.objects.bulk_update(entities, ["value"], batch_size=10_000)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tour", "0002_make_tutorial_public"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            set_tutorial_entity_value, reverse_code=migrations.RunPython.noop
+        ),
+    ]


### PR DESCRIPTION
Fixes #4445.

Similar to the regression with terminology fixed in 6727ff3, the same problem affected the tutorial project in which `entity.value`s were not populated.

We add a new data migration to backfill tutorial project's `entity.value` rows from `entity.string`.