### PR TITLE
Translate: ability to save long translations

### DIFF
--- a/translate/src/modules/translationform/utils/editFieldModes.test.ts
+++ b/translate/src/modules/translationform/utils/editFieldModes.test.ts
@@ -1,0 +1,39 @@
+import {
+  ensureSyntaxTree,
+  StreamLanguage,
+  type StreamParser,
+  syntaxTree,
+} from '@codemirror/language';
+import { EditorState } from '@codemirror/state';
+
+import { commonMode, fluentMode, webextMode } from './editFieldModes';
+
+const LONG_DOC = `<a ${'x '.repeat(300)}\n${'y '.repeat(30)}>`;
+
+function fullyParsed(mode: StreamParser<any>, doc: string): EditorState {
+  const state = EditorState.create({
+    doc,
+    extensions: [StreamLanguage.define(mode)],
+  });
+  ensureSyntaxTree(state, state.doc.length, 5000);
+  return state;
+}
+
+describe.each([
+  ['fluent', fluentMode],
+  ['common', commonMode],
+  ['webext', webextMode],
+])('%s mode', (_name, mode: StreamParser<any>) => {
+  test('applies an edit resuming from a parser state snapshot (#4438)', () => {
+    let state = fullyParsed(mode, LONG_DOC);
+    state = state.update({
+      changes: { from: state.doc.length, insert: 'X' },
+    }).state;
+    ensureSyntaxTree(state, state.doc.length, 5000);
+
+    expect(state.doc.toString()).toBe(`${LONG_DOC}X`);
+    expect(syntaxTree(state).toString()).toBe(
+      syntaxTree(fullyParsed(mode, `${LONG_DOC}X`)).toString(),
+    );
+  });
+});

--- a/translate/src/modules/translationform/utils/editFieldModes.ts
+++ b/translate/src/modules/translationform/utils/editFieldModes.ts
@@ -1,9 +1,5 @@
 import { StreamParser } from '@codemirror/language';
 
-// Avoids saving {} for snapshots.
-// https://github.com/mozilla/pontoon/issues/4438
-const copyStack = <T>(state: T[]): T[] => state.slice();
-
 export const fluentMode: StreamParser<Array<'expression' | 'literal' | 'tag'>> =
   {
     name: 'fluent',
@@ -100,7 +96,7 @@ export const commonMode: StreamParser<Array<'literal' | 'tag'>> = {
   name: 'common',
   languageData: { closeBrackets: { brackets: ['(', '[', '{', '"', '<'] } },
   startState: () => [],
-  copyState: copyStack,
+  copyState: (state) => [...state],
   token(stream, state) {
     if (
       stream.match(printf) ||

--- a/translate/src/modules/translationform/utils/editFieldModes.ts
+++ b/translate/src/modules/translationform/utils/editFieldModes.ts
@@ -9,7 +9,7 @@ export const fluentMode: StreamParser<Array<'expression' | 'literal' | 'tag'>> =
     name: 'fluent',
     languageData: { closeBrackets: { brackets: ['(', '[', '{', '"', '<'] } },
     startState: () => [],
-    copyState: copyStack,
+    copyState: (state) => [...state],
     token(stream, state) {
       const ch = stream.next();
       switch (state.at(-1)) {

--- a/translate/src/modules/translationform/utils/editFieldModes.ts
+++ b/translate/src/modules/translationform/utils/editFieldModes.ts
@@ -1,10 +1,15 @@
 import { StreamParser } from '@codemirror/language';
 
+// Avoids saving {} for snapshots.
+// https://github.com/mozilla/pontoon/issues/4438
+const copyStack = <T>(state: T[]): T[] => state.slice();
+
 export const fluentMode: StreamParser<Array<'expression' | 'literal' | 'tag'>> =
   {
     name: 'fluent',
     languageData: { closeBrackets: { brackets: ['(', '[', '{', '"', '<'] } },
     startState: () => [],
+    copyState: copyStack,
     token(stream, state) {
       const ch = stream.next();
       switch (state.at(-1)) {
@@ -95,6 +100,7 @@ export const commonMode: StreamParser<Array<'literal' | 'tag'>> = {
   name: 'common',
   languageData: { closeBrackets: { brackets: ['(', '[', '{', '"', '<'] } },
   startState: () => [],
+  copyState: copyStack,
   token(stream, state) {
     if (
       stream.match(printf) ||


### PR DESCRIPTION
Fix #4438

The bug is in CodeMirror’s parser state handling:
- `fluentMode` and `commonMode` store tokenizer state as an array stack.
- CodeMirror’s default `copyState()` incorrectly copies that array into a plain object.
- When parsing resumes from that copied state, `state.at()` / `push()` / `pop()` no longer exist, causing `TypeError: state.at is not a function.`
- This only occurs for sufficiently long, multi-line values when editing near the end, because that’s when CodeMirror resumes from a saved parser snapshot. After `512 + 25` characters.

Fix:
- Add custom `copyState` for `fluentMode` and `commonMode`.
- Add tests that resume typing from a parser state snapshot.