### PR TITLE
Translate: Log StringNotFound UX events for experimentation

### DIFF
--- a/translate/src/modules/entities/components/StringNotFound.test.jsx
+++ b/translate/src/modules/entities/components/StringNotFound.test.jsx
@@ -2,7 +2,12 @@ import { createMemoryHistory } from 'history';
 import { fireEvent } from '@testing-library/react';
 import { expect, vi } from 'vitest';
 
-import { createReduxStore, mountComponentWithStore } from '~/test/store';
+import * as uxaction from '~/api/uxaction';
+import {
+  createDefaultUser,
+  createReduxStore,
+  mountComponentWithStore,
+} from '~/test/store';
 
 import { StringNotFound } from './StringNotFound';
 
@@ -33,11 +38,15 @@ entities-StringNotFound--all-resources = All Resources
 function mount(
   entityLocation,
   url = '/kg/firefox/all-resources/?status=missing&string=99',
+  { authenticated = false } = {},
 ) {
   const history = createMemoryHistory({ initialEntries: [url] });
   const spy = vi.fn();
   history.listen(spy);
   const store = createReduxStore();
+  if (authenticated) {
+    createDefaultUser(store);
+  }
   const result = mountComponentWithStore(
     StringNotFound,
     store,
@@ -49,6 +58,18 @@ function mount(
 }
 
 describe('<StringNotFound>', () => {
+  let mockLogUXAction;
+
+  beforeAll(() => {
+    mockLogUXAction = vi
+      .spyOn(uxaction, 'logUXAction')
+      .mockImplementation(() => {});
+  });
+
+  beforeEach(() => mockLogUXAction.mockClear());
+
+  afterAll(() => vi.restoreAllMocks());
+
   it('lays out where the requested string lives', () => {
     const { getByText } = mount(ENTITY_LOCATION);
 
@@ -115,5 +136,74 @@ describe('<StringNotFound>', () => {
   it('renders nothing without a string location', () => {
     const { container } = mount(null);
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it('logs a UX action when an authenticated user is shown the panel', () => {
+    mount(ENTITY_LOCATION, undefined, { authenticated: true });
+
+    expect(mockLogUXAction).toHaveBeenCalledTimes(1);
+    expect(mockLogUXAction).toHaveBeenCalledWith(
+      'Render: String not found',
+      'String Not Found 1.0',
+      {
+        all_projects: false,
+        same_project: false,
+        same_resource: true,
+        filtered_out: false,
+      },
+    );
+  });
+
+  it('logs a UX action for each of the two panel actions', () => {
+    const { getByRole } = mount(ENTITY_LOCATION, undefined, {
+      authenticated: true,
+    });
+
+    fireEvent.click(getByRole('link', { name: 'Show the string' }));
+    expect(mockLogUXAction).toHaveBeenLastCalledWith(
+      'Click: String not found, go to string',
+      'String Not Found 1.0',
+      expect.anything(),
+    );
+
+    fireEvent.click(getByRole('link', { name: 'Keep the parameters' }));
+    expect(mockLogUXAction).toHaveBeenLastCalledWith(
+      'Click: String not found, show matching',
+      'String Not Found 1.0',
+      expect.anything(),
+    );
+  });
+
+  it('logs why the string was filtered out', () => {
+    mount(
+      {
+        pk: 99,
+        project: 'firefox',
+        project_name: 'Firefox',
+        resource: 'foo.ftl',
+        filters: ['missing'],
+      },
+      '/kg/firefox/all-resources/?status=warnings&string=99',
+      { authenticated: true },
+    );
+
+    expect(mockLogUXAction).toHaveBeenCalledWith(
+      'Render: String not found',
+      'String Not Found 1.0',
+      {
+        all_projects: false,
+        same_project: true,
+        same_resource: true,
+        filtered_out: true,
+      },
+    );
+  });
+
+  it('logs nothing for anonymous users', () => {
+    const { getByRole } = mount(ENTITY_LOCATION);
+
+    fireEvent.click(getByRole('link', { name: 'Show the string' }));
+
+    expect(mockLogUXAction).not.toHaveBeenCalled();
   });
 });

--- a/translate/src/modules/entities/components/StringNotFound.test.jsx
+++ b/translate/src/modules/entities/components/StringNotFound.test.jsx
@@ -19,12 +19,6 @@ const ENTITY_LOCATION = {
   filters: [],
 };
 
-const UX_DATA = {
-  all_projects: false,
-  same_project: false,
-  same_resource: true,
-};
-
 const FTL = `
 entities-StringNotFound--title = String not found
 entities-StringNotFound--description = doesn’t match
@@ -151,32 +145,29 @@ describe('<StringNotFound>', () => {
     expect(mockLogUXAction).toHaveBeenCalledWith(
       'Render: String not found',
       'String Not Found 1.0',
-      UX_DATA,
+      { panel: 'project' },
     );
   });
 
   it.each([
     ['Show the string', 'Click: String not found, go to string'],
     ['Keep the parameters', 'Click: String not found, show matching'],
-  ])(
-    'logs %s with the dimensions of the panel it was shown on',
-    (label, action) => {
-      const { getByRole } = mount(ENTITY_LOCATION, undefined, {
-        authenticated: true,
-      });
+  ])('logs %s against the panel it was shown on', (label, action) => {
+    const { getByRole } = mount(ENTITY_LOCATION, undefined, {
+      authenticated: true,
+    });
 
-      fireEvent.click(getByRole('link', { name: label }));
+    fireEvent.click(getByRole('link', { name: label }));
 
-      expect(mockLogUXAction).toHaveBeenLastCalledWith(
-        action,
-        'String Not Found 1.0',
-        UX_DATA,
-      );
-    },
-  );
+    expect(mockLogUXAction).toHaveBeenLastCalledWith(
+      action,
+      'String Not Found 1.0',
+      { panel: 'project' },
+    );
+  });
 
-  it('logs a string hidden by filters as living in the current view', () => {
-    mount(
+  it('logs the filters panel when it names the filters that hid the string', () => {
+    const { getByText } = mount(
       {
         pk: 99,
         project: 'firefox',
@@ -188,10 +179,33 @@ describe('<StringNotFound>', () => {
       { authenticated: true },
     );
 
+    getByText('missing');
     expect(mockLogUXAction).toHaveBeenCalledWith(
       'Render: String not found',
       'String Not Found 1.0',
-      { all_projects: false, same_project: true, same_resource: true },
+      { panel: 'filters' },
+    );
+  });
+
+  it('logs the resource panel when no filter can be named', () => {
+    const { getByText, queryByText } = mount(
+      {
+        pk: 99,
+        project: 'firefox',
+        project_name: 'Firefox',
+        resource: 'foo.ftl',
+        filters: [],
+      },
+      '/kg/firefox/all-resources/?tag=ui&string=99',
+      { authenticated: true },
+    );
+
+    getByText('foo.ftl');
+    expect(queryByText('Firefox')).not.toBeInTheDocument();
+    expect(mockLogUXAction).toHaveBeenCalledWith(
+      'Render: String not found',
+      'String Not Found 1.0',
+      { panel: 'resource' },
     );
   });
 

--- a/translate/src/modules/entities/components/StringNotFound.test.jsx
+++ b/translate/src/modules/entities/components/StringNotFound.test.jsx
@@ -19,6 +19,12 @@ const ENTITY_LOCATION = {
   filters: [],
 };
 
+const UX_DATA = {
+  all_projects: false,
+  same_project: false,
+  same_resource: true,
+};
+
 const FTL = `
 entities-StringNotFound--title = String not found
 entities-StringNotFound--description = doesn’t match
@@ -145,36 +151,31 @@ describe('<StringNotFound>', () => {
     expect(mockLogUXAction).toHaveBeenCalledWith(
       'Render: String not found',
       'String Not Found 1.0',
-      {
-        all_projects: false,
-        same_project: false,
-        same_resource: true,
-        filtered_out: false,
-      },
+      UX_DATA,
     );
   });
 
-  it('logs a UX action for each of the two panel actions', () => {
-    const { getByRole } = mount(ENTITY_LOCATION, undefined, {
-      authenticated: true,
-    });
+  it.each([
+    ['Show the string', 'Click: String not found, go to string'],
+    ['Keep the parameters', 'Click: String not found, show matching'],
+  ])(
+    'logs %s with the dimensions of the panel it was shown on',
+    (label, action) => {
+      const { getByRole } = mount(ENTITY_LOCATION, undefined, {
+        authenticated: true,
+      });
 
-    fireEvent.click(getByRole('link', { name: 'Show the string' }));
-    expect(mockLogUXAction).toHaveBeenLastCalledWith(
-      'Click: String not found, go to string',
-      'String Not Found 1.0',
-      expect.anything(),
-    );
+      fireEvent.click(getByRole('link', { name: label }));
 
-    fireEvent.click(getByRole('link', { name: 'Keep the parameters' }));
-    expect(mockLogUXAction).toHaveBeenLastCalledWith(
-      'Click: String not found, show matching',
-      'String Not Found 1.0',
-      expect.anything(),
-    );
-  });
+      expect(mockLogUXAction).toHaveBeenLastCalledWith(
+        action,
+        'String Not Found 1.0',
+        UX_DATA,
+      );
+    },
+  );
 
-  it('logs why the string was filtered out', () => {
+  it('logs a string hidden by filters as living in the current view', () => {
     mount(
       {
         pk: 99,
@@ -190,12 +191,7 @@ describe('<StringNotFound>', () => {
     expect(mockLogUXAction).toHaveBeenCalledWith(
       'Render: String not found',
       'String Not Found 1.0',
-      {
-        all_projects: false,
-        same_project: true,
-        same_resource: true,
-        filtered_out: true,
-      },
+      { all_projects: false, same_project: true, same_resource: true },
     );
   });
 

--- a/translate/src/modules/entities/components/StringNotFound.tsx
+++ b/translate/src/modules/entities/components/StringNotFound.tsx
@@ -49,15 +49,15 @@ export function StringNotFound({
   const sameProject = entityLocation?.project === location.project;
   const sameResource =
     allResources || entityLocation?.resource === location.resource;
-  const filteredOut = allProjects || (sameProject && sameResource);
+  const stringFilters = entityLocation?.filters ?? [];
+  const filteredOut =
+    (allProjects || (sameProject && sameResource)) && stringFilters.length > 0;
+
+  const panel = filteredOut ? 'filters' : !sameProject ? 'project' : 'resource';
 
   const logAction = (action: string) => {
     if (isAuthUser) {
-      logUXAction(action, 'String Not Found 1.0', {
-        all_projects: allProjects,
-        same_project: sameProject,
-        same_resource: sameResource,
-      });
+      logUXAction(action, 'String Not Found 1.0', { panel });
     }
   };
 
@@ -119,7 +119,7 @@ export function StringNotFound({
   ).flatMap((key) => location[key]?.split(',') ?? []);
   const filterList = formatFilters(filters);
 
-  const stringFilterList = formatFilters(entityLocation.filters);
+  const stringFilterList = formatFilters(stringFilters);
 
   return (
     <section id='string-not-found'>
@@ -184,13 +184,13 @@ export function StringNotFound({
               <h3 />
             </Localized>
             <div className='fields'>
-              {filteredOut && entityLocation.filters.length > 0 ? (
+              {panel === 'filters' ? (
                 <Detail labelId='entities-StringNotFound--label-filters'>
                   {stringFilterList}
                 </Detail>
               ) : (
                 <>
-                  {!sameProject && (
+                  {panel === 'project' && (
                     <Detail labelId='entities-StringNotFound--label-project'>
                       {entityLocation.project_name}
                     </Detail>

--- a/translate/src/modules/entities/components/StringNotFound.tsx
+++ b/translate/src/modules/entities/components/StringNotFound.tsx
@@ -11,11 +11,6 @@ import { USER } from '~/modules/user';
 
 import './StringNotFound.css';
 
-const UX_EXPERIMENT = 'String Not Found 1.0';
-const UX_RENDER = 'Render: String not found';
-const UX_GO_TO_STRING = 'Click: String not found, go to string';
-const UX_SHOW_MATCHING = 'Click: String not found, show matching';
-
 function Detail({
   labelId,
   children,
@@ -56,19 +51,21 @@ export function StringNotFound({
     allResources || entityLocation?.resource === location.resource;
   const filteredOut = allProjects || (sameProject && sameResource);
 
-  const uxData = {
-    all_projects: allProjects,
-    same_project: sameProject,
-    same_resource: sameResource,
-    filtered_out: filteredOut,
+  const logAction = (action: string) => {
+    if (isAuthUser) {
+      logUXAction(action, 'String Not Found 1.0', {
+        all_projects: allProjects,
+        same_project: sameProject,
+        same_resource: sameResource,
+      });
+    }
   };
 
-  const requestedPk = entityLocation?.pk;
   useEffect(() => {
-    if (isAuthUser && requestedPk) {
-      logUXAction(UX_RENDER, UX_EXPERIMENT, uxData);
+    if (entityLocation) {
+      logAction('Render: String not found');
     }
-  }, [isAuthUser, requestedPk]);
+  }, [isAuthUser, entityLocation?.pk]);
 
   if (!entityLocation) {
     return null;
@@ -76,29 +73,27 @@ export function StringNotFound({
 
   const { push } = location;
 
-  const goToString = () =>
+  const goToString = (ev: React.MouseEvent) => {
+    ev.preventDefault();
+    logAction('Click: String not found, go to string');
     push({
       ...emptyParams,
       project: entityLocation.project,
       resource: entityLocation.resource,
       entity: entityLocation.pk,
     });
+  };
 
-  const showMatching = () => push({ entity: 0 });
+  const showMatching = (ev: React.MouseEvent) => {
+    ev.preventDefault();
+    logAction('Click: String not found, show matching');
+    push({ entity: 0 });
+  };
 
   const goToStringHref = `/${location.locale}/${entityLocation.project}/${entityLocation.resource}/?string=${entityLocation.pk}`;
   const showMatchingUrl = new URL(window.location.href);
   showMatchingUrl.searchParams.delete('string');
   const showMatchingHref = showMatchingUrl.pathname + showMatchingUrl.search;
-
-  const onClick =
-    (actionType: string, navigate: () => void) => (ev: React.MouseEvent) => {
-      ev.preventDefault();
-      if (isAuthUser) {
-        logUXAction(actionType, UX_EXPERIMENT, uxData);
-      }
-      navigate();
-    };
 
   const requestProject = allProjects
     ? l10n.getString(
@@ -142,7 +137,7 @@ export function StringNotFound({
               className='primary'
               href={goToStringHref}
               title={goToStringHref}
-              onClick={onClick(UX_GO_TO_STRING, goToString)}
+              onClick={goToString}
             />
           </Localized>
           <Localized id='entities-StringNotFound--show-matching'>
@@ -150,7 +145,7 @@ export function StringNotFound({
               className='secondary'
               href={showMatchingHref}
               title={showMatchingHref}
-              onClick={onClick(UX_SHOW_MATCHING, showMatching)}
+              onClick={showMatching}
             />
           </Localized>
         </div>

--- a/translate/src/modules/entities/components/StringNotFound.tsx
+++ b/translate/src/modules/entities/components/StringNotFound.tsx
@@ -1,12 +1,20 @@
 import { Localized, useLocalization } from '@fluent/react';
-import React, { useContext } from 'react';
+import React, { useContext, useEffect } from 'react';
 
 import type { RequestedEntityLocation } from '~/api/entity';
+import { logUXAction } from '~/api/uxaction';
 import { Locale } from '~/context/Locale';
 import { emptyParams, Location } from '~/context/Location';
+import { useAppSelector } from '~/hooks';
 import { useProject } from '~/modules/project';
+import { USER } from '~/modules/user';
 
 import './StringNotFound.css';
+
+const UX_EXPERIMENT = 'String Not Found 1.0';
+const UX_RENDER = 'Render: String not found';
+const UX_GO_TO_STRING = 'Click: String not found, go to string';
+const UX_SHOW_MATCHING = 'Click: String not found, show matching';
 
 function Detail({
   labelId,
@@ -38,19 +46,35 @@ export function StringNotFound({
   const locale = useContext(Locale);
   const { name: viewProjectName } = useProject();
   const { l10n } = useLocalization();
+  const isAuthUser = useAppSelector((state) => state[USER].isAuthenticated);
+
+  const allProjects = location.project === 'all-projects';
+  const allResources =
+    !location.resource || location.resource === 'all-resources';
+  const sameProject = entityLocation?.project === location.project;
+  const sameResource =
+    allResources || entityLocation?.resource === location.resource;
+  const filteredOut = allProjects || (sameProject && sameResource);
+
+  const uxData = {
+    all_projects: allProjects,
+    same_project: sameProject,
+    same_resource: sameResource,
+    filtered_out: filteredOut,
+  };
+
+  const requestedPk = entityLocation?.pk;
+  useEffect(() => {
+    if (isAuthUser && requestedPk) {
+      logUXAction(UX_RENDER, UX_EXPERIMENT, uxData);
+    }
+  }, [isAuthUser, requestedPk]);
 
   if (!entityLocation) {
     return null;
   }
 
   const { push } = location;
-  const allProjects = location.project === 'all-projects';
-  const allResources =
-    !location.resource || location.resource === 'all-resources';
-  const sameProject = entityLocation.project === location.project;
-  const sameResource =
-    allResources || entityLocation.resource === location.resource;
-  const filteredOut = allProjects || (sameProject && sameResource);
 
   const goToString = () =>
     push({
@@ -67,10 +91,14 @@ export function StringNotFound({
   showMatchingUrl.searchParams.delete('string');
   const showMatchingHref = showMatchingUrl.pathname + showMatchingUrl.search;
 
-  const onClick = (navigate: () => void) => (ev: React.MouseEvent) => {
-    ev.preventDefault();
-    navigate();
-  };
+  const onClick =
+    (actionType: string, navigate: () => void) => (ev: React.MouseEvent) => {
+      ev.preventDefault();
+      if (isAuthUser) {
+        logUXAction(actionType, UX_EXPERIMENT, uxData);
+      }
+      navigate();
+    };
 
   const requestProject = allProjects
     ? l10n.getString(
@@ -114,7 +142,7 @@ export function StringNotFound({
               className='primary'
               href={goToStringHref}
               title={goToStringHref}
-              onClick={onClick(goToString)}
+              onClick={onClick(UX_GO_TO_STRING, goToString)}
             />
           </Localized>
           <Localized id='entities-StringNotFound--show-matching'>
@@ -122,7 +150,7 @@ export function StringNotFound({
               className='secondary'
               href={showMatchingHref}
               title={showMatchingHref}
-              onClick={onClick(showMatching)}
+              onClick={onClick(UX_SHOW_MATCHING, showMatching)}
             />
           </Localized>
         </div>


### PR DESCRIPTION
Fix #4360 

Log the 2 buttons for all 3 panels:
- `filters`: the active filters the string doesn't match
- `project`: the project and resource the string lives in
- `resource`: only the resource, the string being in the current project

Changes:
- Log StringNotFound UX events, similar to how it's done for Notifications.
- Add tests to log cases for different panel load cases.