### PR TITLE
Unify vertical and horizontal space between accesskey candidate buttons

### DIFF
--- a/translate/src/modules/translationform/components/TranslationForm.css
+++ b/translate/src/modules/translationform/components/TranslationForm.css
@@ -57,7 +57,7 @@
 
 .translationform .accesskeys {
   float: right;
-  margin: 2px 0;
+  margin: 2px 0 -1px;
   width: calc(100% - 27px);
 }
 
@@ -68,6 +68,7 @@
   cursor: pointer;
   display: inline-block;
   line-height: 24px;
+  margin-bottom: 3px;
   margin-right: 3px;
   padding: 0;
   text-align: center;


### PR DESCRIPTION
Before:
<img width="1456" height="314" alt="Posnetek zaslona 2026-08-27 ob 23 13 13" src="https://github.com/user-attachments/assets/6af08e4a-cb5e-4ebe-a4f3-7dacf6493a29" />

After:
<img width="1456" height="320" alt="Posnetek zaslona 2026-08-27 ob 23 12 40" src="https://github.com/user-attachments/assets/c3dfe71b-ae45-4e6a-b1d3-85a1dcd7e6c5" />
