### PR TITLE
Docs: Fix link to pretranslation guidelines

### DIFF
--- a/documentation/docs/localizer/teams-projects.md
+++ b/documentation/docs/localizer/teams-projects.md
@@ -71,7 +71,7 @@ Click on `REQUEST PRETRANSLATION`, select the projects to add and then click `RE
 An email will be sent to Pontoon’s administrators, and they will act on the request. Please note that:
 
 * If a locale doesn’t have pretranslation enabled for any projects yet, it’s necessary to set up and train a new custom model, and this operation requires several hours.
-* For `pontoon.mozilla.org`, each request will be evaluated against specific [opt-in guidelines](https://mozilla-l10n.github.io/documentation/tools/pontoon/managing_pretranslation.html#opt-in-guidelines-to-enable-new-locales).
+* For `pontoon.mozilla.org`, each request will be evaluated against specific [opt-in guidelines](https://mozilla-l10n.github.io/localizer-documentation/tools/pretranslation.html#opt-in-guidelines).
 
 ### Translation memory management
 


### PR DESCRIPTION
## Summary

Per #4458: the "Requesting pretranslation" section links to the opt-in guidelines in the admin documentation (`managing_pretranslation.html`), which redirects to admin docs about enabling pretranslation.

## Changes

- `documentation/docs/localizer/teams-projects.md`: updated the opt-in guidelines link from `https://mozilla-l10n.github.io/documentation/tools/pontoon/managing_pretranslation.html#opt-in-guidelines-to-enable-new-locales` to `https://mozilla-l10n.github.io/localizer-documentation/tools/pretranslation.html#opt-in-guidelines` as suggested in the issue.

## Verification

- Single link replacement; no other content touched