### PR TITLE
Send Google Translate API key in a header

### DIFF
--- a/pontoon/machinery/tests/test_views.py
+++ b/pontoon/machinery/tests/test_views.py
@@ -159,8 +159,8 @@ def test_view_google_translate(
         "source": ["en"],
         "target": ["google-translate"],
         "format": ["text"],
-        "key": ["2fffff"],
     }
+    assert req.headers["X-Goog-Api-Key"] == "2fffff"
 
 
 @pytest.mark.django_db

--- a/pontoon/machinery/utils.py
+++ b/pontoon/machinery/utils.py
@@ -97,10 +97,11 @@ def get_google_generic_translation(text, locale_code, format="text"):
         "source": "en",
         "target": locale_code,
         "format": format,
-        "key": api_key,
     }
 
-    r = requests.post(url, params=payload)
+    headers = {"X-Goog-Api-Key": api_key}
+
+    r = requests.post(url, params=payload, headers=headers)
     r.raise_for_status()
     root = json.loads(r.content)
 


### PR DESCRIPTION
https://docs.cloud.google.com/docs/authentication/api-keys-use#using-with-rest

The underlying issue was reported reported by @timhaines. Thank you!