### PR TITLE
Label plural catchall with the locale's category

### DIFF
--- a/pontoon/base/migrations/0131_fix_gettext_plural_catchall.py
+++ b/pontoon/base/migrations/0131_fix_gettext_plural_catchall.py
@@ -1,0 +1,81 @@
+from django.db import migrations
+
+
+batch_size = 1000
+
+CLDR_PLURALS = ("zero", "one", "two", "few", "many", "other")
+
+
+def plural_categories(cldr_plurals: str) -> list[str]:
+    """Matches Locale.cldr_plurals_list(), which is unavailable to migrations."""
+    if cldr_plurals == "":
+        return ["other"]
+    res: list[str] = []
+    for p in cldr_plurals.split(","):
+        try:
+            res.append(CLDR_PLURALS[int(p)])
+        except (ValueError, IndexError):
+            pass
+    return res
+
+
+def fix_plural_catchall(apps, schema_editor):
+    """Label the catchall variant of gettext plurals with the locale's own category.
+
+    gettext addresses plural forms by category, so a catchall labelled `other`
+    in a locale whose categories are `one, few, many` matches no form and is
+    serialized as an empty msgstr. Only gettext is affected.
+    """
+    Locale = apps.get_model("base", "Locale")
+    Translation = apps.get_model("base", "Translation")
+
+    catchalls = {}
+
+    for pk, code, cldr_plurals in Locale.objects.values_list(
+        "pk", "code", "cldr_plurals"
+    ):
+        categories = plural_categories(cldr_plurals)
+        if len(categories) > 1 and categories[-1] != "other":
+            catchalls[pk] = categories[-1]
+
+    if not catchalls:
+        return
+
+    updates = []
+    fixed = 0
+    translations = Translation.objects.filter(
+        locale_id__in=catchalls,
+        entity__resource__format="gettext",
+        value__has_key="alt",
+    ).iterator()
+
+    for tx in translations:
+        catchall = catchalls[tx.locale_id]
+        changed = False
+
+        for variant in tx.value["alt"]:
+            for i, key in enumerate(variant["keys"]):
+                if isinstance(key, dict) and key.get("*") != catchall:
+                    variant["keys"][i] = {"*": catchall}
+                    changed = True
+
+        if changed:
+            updates.append(tx)
+            fixed += 1
+
+        if len(updates) == batch_size:
+            Translation.objects.bulk_update(updates, ["value"])
+            updates.clear()
+
+    if updates:
+        Translation.objects.bulk_update(updates, ["value"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [("base", "0130_userprofile_monthly_health_report")]
+
+    operations = [
+        migrations.RunPython(
+            fix_plural_catchall, reverse_code=migrations.RunPython.noop
+        ),
+    ]

--- a/pontoon/base/migrations/0131_fix_gettext_plural_catchall.py
+++ b/pontoon/base/migrations/0131_fix_gettext_plural_catchall.py
@@ -42,7 +42,7 @@ def fix_plural_catchall(apps, schema_editor):
         locale_id__in=catchalls,
         entity__resource__format="gettext",
         value__has_key="alt",
-    )
+    ).iterator()
 
     for tx in translations:
         catchall = catchalls[tx.locale_id]

--- a/pontoon/base/migrations/0131_fix_gettext_plural_catchall.py
+++ b/pontoon/base/migrations/0131_fix_gettext_plural_catchall.py
@@ -1,8 +1,6 @@
 from django.db import migrations
 
 
-batch_size = 1000
-
 CLDR_PLURALS = ("zero", "one", "two", "few", "many", "other")
 
 
@@ -31,9 +29,7 @@ def fix_plural_catchall(apps, schema_editor):
 
     catchalls = {}
 
-    for pk, code, cldr_plurals in Locale.objects.values_list(
-        "pk", "code", "cldr_plurals"
-    ):
+    for pk, cldr_plurals in Locale.objects.values_list("pk", "cldr_plurals"):
         categories = plural_categories(cldr_plurals)
         if len(categories) > 1 and categories[-1] != "other":
             catchalls[pk] = categories[-1]
@@ -42,12 +38,11 @@ def fix_plural_catchall(apps, schema_editor):
         return
 
     updates = []
-    fixed = 0
     translations = Translation.objects.filter(
         locale_id__in=catchalls,
         entity__resource__format="gettext",
         value__has_key="alt",
-    ).iterator()
+    )
 
     for tx in translations:
         catchall = catchalls[tx.locale_id]
@@ -61,14 +56,14 @@ def fix_plural_catchall(apps, schema_editor):
 
         if changed:
             updates.append(tx)
-            fixed += 1
 
-        if len(updates) == batch_size:
-            Translation.objects.bulk_update(updates, ["value"])
-            updates.clear()
-
-    if updates:
-        Translation.objects.bulk_update(updates, ["value"])
+    print(
+        f"\n    Re-labelling plural catchalls in {len(updates)} translations"
+        f" across {len(catchalls)} locales...\n   ",
+        end="",
+        flush=True,
+    )
+    Translation.objects.bulk_update(updates, ["value"], batch_size=10_000)
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
Migration 0111 restored the catchall label as `other` for every locale. 

Gettext addresses plural forms by category, so in a locale whose categories are `one, few, many` a catchall labelled `other` matches no form and is serialized as an empty msgstr, dropping the translation from the repository.

This affects be, pl, ru, szl and uk, and surfaced only once #4391 began writing resources from the data model rather than the previous path.

This PR only fixes the data part of #4453, so that syncing can resume. The code paths that reintroduce the wrong label, and sync-time reporting of unmatched variant keys, should follow separately.