### PR TITLE
Find plural examples that are zero or a million

### DIFF
--- a/translate/src/hooks/usePluralExamples.test.js
+++ b/translate/src/hooks/usePluralExamples.test.js
@@ -32,7 +32,46 @@ describe('usePluralExamples', () => {
       pluralRule: '(n != 1)',
     });
 
-    expect(res).toEqual({ 0: 1, 1: 2 });
+    expect(res).toEqual({ 0: 1, 1: 0 });
+    expect(consoleErrorSpy).toHaveBeenCalledOnce();
+  });
+
+  it('uses 0 as an example rather than skipping the category', () => {
+    using consoleErrorSpy = vi.spyOn(console, 'error');
+    // Romanian: `few` covers 0 and 1..19, so its first example is 0
+    const res = usePluralExamples({
+      cldrPlurals: [1, 3, 5],
+      pluralRule: '(n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2)',
+    });
+
+    expect(res).toEqual({ 1: 1, 3: 0, 5: 20 });
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('finds an example for the CLDR many category of millions', () => {
+    using consoleErrorSpy = vi.spyOn(console, 'error');
+    // Breton: `many` only matches non-zero multiples of a million
+    const res = usePluralExamples({
+      cldrPlurals: [1, 2, 3, 4, 5],
+      pluralRule:
+        '(n % 10 == 1 && n % 100 != 11 && n % 100 != 71 && n % 100 != 91) ? 0 : ((n % 10 == 2 && n % 100 != 12 && n % 100 != 72 && n % 100 != 92) ? 1 : ((((n % 10 == 3 || n % 10 == 4) || n % 10 == 9) && (n % 100 < 10 || n % 100 > 19) && (n % 100 < 70 || n % 100 > 79) && (n % 100 < 90 || n % 100 > 99)) ? 2 : ((n != 0 && n % 1000000 == 0) ? 3 : 4)))',
+    });
+
+    expect(res).toEqual({ 1: 1, 2: 2, 3: 3, 4: 1000000, 5: 0 });
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('reports a locale whose plural rule yields fewer forms than it declares', () => {
+    using consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    // A rule that can only ever return 0 or 1 cannot fill three categories
+    const res = usePluralExamples({
+      cldrPlurals: [0, 1, 5],
+      pluralRule: '(n != 1)',
+    });
+
+    expect(res).toEqual({ 0: 1, 1: 0 });
     expect(consoleErrorSpy).toHaveBeenCalledOnce();
   });
 });

--- a/translate/src/hooks/usePluralExamples.ts
+++ b/translate/src/hooks/usePluralExamples.ts
@@ -25,16 +25,23 @@ export function usePluralExamples(locale: Locale): Record<number, number> {
     const fnBody = `return Number(${pluralRule})`;
     const getRule = new Function('n', fnBody) as (n: number) => number;
 
+    // The CLDR `many` category of languages such as Breton only matches
+    // multiples of a million, which a 0..999 scan can never reach.
+    const candidates = [...Array(1000).keys(), 1_000_000];
+
     let found = 0;
     const examples: Record<number, number> = {};
-    for (let n = 0; n < 1000; ++n) {
-      if (found >= cldrPlurals.length) {
-        return examples;
-      }
+    for (const n of candidates) {
       const rule = cldrPlurals[getRule(n)];
-      if (!examples[rule]) {
+      // `rule in examples` rather than a truthiness check, as 0 is a valid
+      // example and would otherwise be treated as "not yet found".
+      if (!(rule in examples)) {
         examples[rule] = n;
-        found += 1;
+        // Checked here rather than at the top of the loop, so that a set
+        // completed by the last candidate is not reported as a failure.
+        if (++found >= cldrPlurals.length) {
+          return examples;
+        }
       }
     }
 


### PR DESCRIPTION
Refs #2784. Partially addresses #3850.

**What is the issue?** `usePluralExamples()` records a category's example with `if (!examples[rule])`. When a category's first match is `n = 0`, `0` is falsy, so it reads as "not found yet": the next `n` in that category overwrites the example *and* increments `found` a second time, so the loop exits with one category never assigned. `getExample()` in `TranslationForm` then returns `undefined` and that plural tab shows no example number.

I ran the current implementation over all 489 locales from `/api/v2/locales/` on pontoon.mozilla.org. Of the 35 with three or more categories, **6 come out differently**:

| locale | category with no example today |
|---|---|
| ro Romanian | `other` |
| shi Tashlhiyt | `other` |
| ga-IE Irish | `other` |
| mt Maltese | `many` |
| br Breton | `many` |
| vmw Emakhuwa | `other` |

`vmw` is the interesting one: its stored rule is `(n != 1)`, which can only ever return two values for three declared categories. That is exactly what the "Unable to generate plural examples" warning is for, and the double increment was suppressing it. It now fires.

Separately, #2784 notes the search stops at 1000, so Breton's `many` — non-zero multiples of a million — was unreachable; adding `1000000` to the candidates fixes it. The rest of the exhaustive list in that issue does nothing: `0.0` is `0` once passed to the rule, and `0.1` changes nothing for any of the 489 locales, because the stored rules are integer Gettext expressions with no `v` operand. So this does **not** close #2784, and #3850 needs more than a search-space change: Czech's `cldr_plurals` is `1,3,5`, so `many` has no slot in the map regardless of what is searched.

Worth checking on review: completion is now tested after recording an example rather than at the top of the next iteration, otherwise a set completed by the final candidate is reported as a failure.

**Testing.** `npm test` in `translate/`: 710 → 713 passing, 101 files. The expected value in the existing misconfigured-locale test encoded the overwrite (`{0: 1, 1: 2}`, correctly `{0: 1, 1: 0}`) and is corrected. Reverting the source fails all four; keeping only the presence check fails the Breton case; keeping only the new candidate fails all four. `npm run types`, `eslint` and `prettier` are clean.

**Steps to reproduce.** Open a Romanian plural string in the editor: the `other` tab has no example number, while `one` and `few` do.
