### PR TITLE
Ignore many plural rule for cs, lt, sk

### DIFF
--- a/translate/src/utils/message/getEmptyMessage.test.js
+++ b/translate/src/utils/message/getEmptyMessage.test.js
@@ -214,4 +214,29 @@ describe('getEmptyMessage', () => {
 
       `);
   });
+
+  for (const code of ['cs', 'lt', 'sk']) {
+    it(`handles plural messages for locales with a decimal-only many (${code})`, () => {
+      const source = parseEntry(
+        'fluent',
+        ftl`
+      selector-multi =
+        { $num ->
+            [one] ONE
+           *[other] OTHER
+        }
+      `,
+      );
+      const entry = getEmptyMessageEntry(source, { code });
+      expect(serializeEntry(entry)).toBe(ftl`
+      selector-multi =
+          { $num ->
+              [one] { "" }
+              [few] { "" }
+             *[other] { "" }
+          }
+
+      `);
+    });
+  }
 });

--- a/translate/src/utils/message/getPluralCategories.ts
+++ b/translate/src/utils/message/getPluralCategories.ts
@@ -22,6 +22,12 @@ export function getPluralCategories(code: string): Intl.LDMLPluralRule[] {
     case 'uk': // Ukrainian
       return ['one', 'few', 'many'];
 
+    // For the following, deliberately ignore the `many` rule for decimals.
+    case 'cs': // Czech
+    case 'lt': // Lithuanian
+    case 'sk': // Slovak
+      return ['one', 'few', 'other'];
+
     // For the following Romance languages,
     // deliberately ignore the `many` rule for millions.
     case 'ca': // Catalan

--- a/translate/src/utils/message/getPluralCategories.ts
+++ b/translate/src/utils/message/getPluralCategories.ts
@@ -22,7 +22,7 @@ export function getPluralCategories(code: string): Intl.LDMLPluralRule[] {
     case 'uk': // Ukrainian
       return ['one', 'few', 'many'];
 
-    // For the following, deliberately ignore the `many` rule for decimals.
+    // For the following, deliberately ignore the `many` rule for fractions
     case 'cs': // Czech
     case 'lt': // Lithuanian
     case 'sk': // Slovak


### PR DESCRIPTION
Fix #4441.
Fix #3850.