### PR TITLE
Don't reject strings with partial files in Upload translations

### DIFF
--- a/pontoon/base/tests/views/test_upload.py
+++ b/pontoon/base/tests/views/test_upload.py
@@ -2,7 +2,10 @@ from tempfile import NamedTemporaryFile
 
 import pytest
 
-from pontoon.base.models import Translation
+from django.contrib.messages import get_messages
+
+from pontoon.base.models import ChangedEntityLocale, Translation
+from pontoon.test.factories import EntityFactory, TranslationFactory
 
 
 @pytest.fixture
@@ -47,6 +50,39 @@ def upload(client, **args):
     )
 
     return response
+
+
+@pytest.fixture
+def approved_po_translation(po_translation):
+    po_translation.approved = True
+    po_translation.active = True
+    po_translation.save()
+
+    yield po_translation
+
+
+@pytest.fixture
+def upload_po(translator_a, project_locale_a, po_translation):
+    """
+    Upload the given contents as a .po file for the `po_translation` resource,
+    returning the list of (tags, message) pairs.
+    """
+
+    def _upload_po(po_contents):
+        with NamedTemporaryFile("w+", suffix=".po") as fp:
+            fp.write(po_contents)
+            fp.flush()
+            response = upload(
+                translator_a.client,
+                slug=project_locale_a.project.slug,
+                code=project_locale_a.locale.code,
+                part=po_translation.entity.resource.path,
+                uploadfile=open(fp.name),
+            )
+        assert response.status_code == 303
+        return [(m.tags, m.message) for m in get_messages(response.wsgi_request)]
+
+    return _upload_po
 
 
 @pytest.mark.django_db
@@ -144,33 +180,155 @@ def test_upload_project_locale_is_readonly(
 
 
 @pytest.mark.django_db
-def test_upload_file(
-    translator_a,
-    project_locale_a,
-    po_translation,
-):
+def test_upload_file(upload_po, po_translation):
     """
     Test a positive upload which changes the translation.
     """
-    po_contents = 'msgid "test_key"\nmsgstr "new translation"'
-    with NamedTemporaryFile("w+", suffix=".po") as fp:
-        fp.write(po_contents)
-        fp.flush()
-        response = upload(
-            translator_a.client,
-            slug=project_locale_a.project.slug,
-            code=project_locale_a.locale.code,
-            part=po_translation.entity.resource.path,
-            uploadfile=open(fp.name),
-        )
-
-    assert response.status_code == 303
+    messages = upload_po('msgid "test_key"\nmsgstr "new translation"')
+    assert messages == [
+        ("upload success", "Translations from uploaded file: 1 updated, 0 unchanged.")
+    ]
 
     translation = Translation.objects.get(string="new translation")
-
-    assert translation.entity.key == ["test_key"]
-    assert translation.entity.resource.path == "resource_a.po"
+    assert translation.entity == po_translation.entity
     assert translation.approved
     assert translation.user
     assert not translation.warnings.exists()
     assert not translation.errors.exists()
+
+
+@pytest.mark.django_db
+def test_upload_is_additive(upload_po, approved_po_translation, locale_a):
+    """
+    Approved translations missing from the uploaded file are left untouched.
+    """
+    resource = approved_po_translation.entity.resource
+    other_translation = TranslationFactory(
+        entity=EntityFactory(resource=resource, string="other", key=["other_key"]),
+        locale=locale_a,
+        string="other translation",
+        value=["other translation"],
+        approved=True,
+        active=True,
+    )
+
+    messages = upload_po('msgid "test_key"\nmsgstr "new translation"')
+    assert messages == [
+        ("upload success", "Translations from uploaded file: 1 updated, 0 unchanged.")
+    ]
+
+    approved_po_translation.refresh_from_db()
+    assert not approved_po_translation.approved
+    assert approved_po_translation.rejected
+    assert (
+        Translation.objects.get(
+            entity=approved_po_translation.entity, approved=True
+        ).string
+        == "new translation"
+    )
+
+    other_translation.refresh_from_db()
+    assert other_translation.approved
+    assert other_translation.active
+    assert not other_translation.rejected
+
+
+@pytest.mark.django_db
+def test_upload_approves_matching_suggestion(upload_po, po_translation, locale_a):
+    """
+    An uploaded translation matching an existing suggestion approves it,
+    and the entity is still marked as changed for the next sync.
+    """
+    assert not po_translation.approved
+
+    messages = upload_po(f'msgid "test_key"\nmsgstr "{po_translation.string}"')
+    assert messages == [
+        ("upload success", "Translations from uploaded file: 1 updated, 0 unchanged.")
+    ]
+
+    assert Translation.objects.filter(entity=po_translation.entity).count() == 1
+    po_translation.refresh_from_db()
+    assert po_translation.approved
+    assert ChangedEntityLocale.objects.filter(
+        entity=po_translation.entity, locale=locale_a
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_upload_identical_translation_is_ignored(upload_po, approved_po_translation):
+    messages = upload_po(f'msgid "test_key"\nmsgstr "{approved_po_translation.string}"')
+    assert messages == [
+        ("upload info", "Translations from uploaded file: 0 updated, 1 unchanged.")
+    ]
+
+    assert (
+        Translation.objects.filter(entity=approved_po_translation.entity).count() == 1
+    )
+    approved_po_translation.refresh_from_db()
+    assert approved_po_translation.approved
+
+
+@pytest.mark.django_db
+def test_upload_undefined_keys_are_reported(upload_po, po_translation):
+    """
+    Translations for keys that are missing or obsolete in Pontoon are ignored.
+    """
+    resource = po_translation.entity.resource
+    EntityFactory(resource=resource, string="old", key=["obsolete_key"], obsolete=True)
+
+    messages = upload_po(
+        'msgid "test_key"\nmsgstr "new translation"\n\n'
+        'msgid "obsolete_key"\nmsgstr "obsolete translation"\n\n'
+        'msgid "missing_key"\nmsgstr "missing translation"\n'
+    )
+    assert messages == [
+        (
+            "upload success",
+            "Translations from uploaded file: 1 updated, 0 unchanged, "
+            "2 not found in Pontoon.",
+        )
+    ]
+    assert set(
+        Translation.objects.filter(entity__resource=resource).values_list(
+            "string", flat=True
+        )
+    ) == {po_translation.string, "new translation"}
+
+
+@pytest.mark.django_db
+def test_upload_ignores_translations_of_obsolete_entities(
+    upload_po, po_translation, locale_a
+):
+    """
+    A key removed and later re-added leaves an obsolete entity with the same key.
+    If the new key is untranslated, the upload should fill it and be counted as
+    translated, even if that matches the original translation in the obsolete key.
+    """
+    TranslationFactory(
+        entity=EntityFactory(
+            resource=po_translation.entity.resource,
+            string="entity a",
+            key=["test_key"],
+            obsolete=True,
+        ),
+        locale=locale_a,
+        string="new translation",
+        value=["new translation"],
+        approved=True,
+        active=True,
+    )
+
+    messages = upload_po('msgid "test_key"\nmsgstr "new translation"')
+    assert messages == [
+        ("upload success", "Translations from uploaded file: 1 updated, 0 unchanged.")
+    ]
+    assert (
+        Translation.objects.get(entity=po_translation.entity, approved=True).string
+        == "new translation"
+    )
+
+
+@pytest.mark.django_db
+def test_upload_file_without_translations(upload_po):
+    messages = upload_po("# Just a comment\n")
+    assert messages == [("error", "No translations found in uploaded file.")]

--- a/pontoon/base/views.py
+++ b/pontoon/base/views.py
@@ -1058,7 +1058,7 @@ def upload(request):
         project, locale
     ):
         return HttpResponseForbidden("You don't have permission to upload files.")
-    get_object_or_404(Resource, project=project, path=res_path)
+    resource = get_object_or_404(Resource, project=project, path=res_path)
 
     form = forms.UploadFileForm(request.POST, request.FILES)
     if form.is_valid():
@@ -1066,15 +1066,22 @@ def upload(request):
 
         upload = request.FILES["uploadfile"]
         try:
-            badge_name, badge_level = import_uploaded_file(
-                project, locale, res_path, upload, request.user
+            result = import_uploaded_file(
+                project, locale, resource, upload, request.user
             )
-            messages.success(request, "Translations updated from uploaded file.")
-            if badge_name:
+            summary = [f"{result.updated} updated", f"{result.unchanged} unchanged"]
+            if result.undefined_keys:
+                summary.append(f"{len(result.undefined_keys)} not found in Pontoon")
+            message = f"Translations from uploaded file: {', '.join(summary)}."
+            if result.updated:
+                messages.success(request, message, extra_tags="upload")
+            else:
+                messages.info(request, message, extra_tags="upload")
+            if result.badge_name:
                 message = json.dumps(
                     {
-                        "name": badge_name,
-                        "level": badge_level,
+                        "name": result.badge_name,
+                        "level": result.badge_level,
                     }
                 )
                 messages.info(request, message, extra_tags="badge")

--- a/pontoon/sync/core/paths.py
+++ b/pontoon/sync/core/paths.py
@@ -48,24 +48,3 @@ def find_paths(
     log.debug(f"[{project.slug}] Paths({name}): ref_root={rel_root} base={rel_base}")
 
     return paths
-
-
-class UploadPaths:
-    """
-    moz.l10n.paths -like interface for sync'ing content from a single file.
-    Implements minimal functionality required by `find_db_updates()`.
-    """
-
-    ref_root = ""
-
-    def __init__(self, ref_path: str, locale_code: str, file_path: str):
-        self._ref_path = ref_path
-        self._locale_code = locale_code
-        self._file_path = file_path
-
-    def find_reference(self, target_path: str):
-        return (
-            (self._ref_path, {"locale": self._locale_code})
-            if target_path == self._file_path
-            else None
-        )

--- a/pontoon/sync/core/translations_from_repo.py
+++ b/pontoon/sync/core/translations_from_repo.py
@@ -34,7 +34,6 @@ from pontoon.base.user_utils import get_system_user
 from pontoon.checks import DB_FORMATS
 from pontoon.checks.utils import bulk_run_checks
 from pontoon.sync.core.checkout import Checkout, Checkouts
-from pontoon.sync.core.paths import UploadPaths
 from pontoon.sync.formats import RepoTranslation, as_repo_translations
 
 
@@ -136,7 +135,7 @@ def find_db_updates(
     project: Project,
     locale_map: dict[str, Locale],
     changed_target_paths: Iterable[str],
-    paths: L10nConfigPaths | L10nDiscoverPaths | UploadPaths,
+    paths: L10nConfigPaths | L10nDiscoverPaths,
     db_changes: Iterable[ChangedEntityLocale],
 ) -> Updates | None:
     """
@@ -178,9 +177,7 @@ def find_db_updates(
                 except Exception as error:
                     scope = f"[{project.slug}:{db_path}, {locale.code}]"
                     log.warning(f"{scope} Skipping resource with parse error: {error}")
-        elif splitext(target_path)[1] in l10n_extensions and not isinstance(
-            paths, UploadPaths
-        ):
+        elif splitext(target_path)[1] in l10n_extensions:
             log.debug(
                 f"[{project.slug}:{relpath(target_path, paths.base)}] Not an L10n target path"
             )

--- a/pontoon/sync/utils.py
+++ b/pontoon/sync/utils.py
@@ -1,7 +1,9 @@
+from dataclasses import dataclass, field
 from os.path import basename, join
 from tempfile import TemporaryDirectory
 
-from moz.l10n.resource import serialize_resource
+from moz.l10n.model import Id as L10nId
+from moz.l10n.resource import parse_resource, serialize_resource
 
 from django.core.files import File
 from django.db.models import Q
@@ -10,6 +12,7 @@ from django.utils import timezone
 from pontoon.base.badge_utils import badges_review_level, badges_translation_level
 from pontoon.base.models import (
     ChangedEntityLocale,
+    Entity,
     Locale,
     Project,
     Resource as DbResource,
@@ -17,13 +20,17 @@ from pontoon.base.models import (
     User,
 )
 from pontoon.messaging.notifications import send_badge_notification
-from pontoon.sync.core.paths import UploadPaths
 from pontoon.sync.core.stats import update_stats
-from pontoon.sync.core.translations_from_repo import find_db_updates, write_db_updates
+from pontoon.sync.core.translations_from_repo import (
+    Updates,
+    translations_equal,
+    write_db_updates,
+)
 from pontoon.sync.core.translations_to_repo import (
     build_moz_l10n_resource,
     build_translated_resource,
 )
+from pontoon.sync.formats import as_repo_translations
 
 
 def serialize_translated_resource(db_res: DbResource, locale: Locale) -> str:
@@ -50,44 +57,100 @@ def serialize_translated_resource(db_res: DbResource, locale: Locale) -> str:
     return "".join(serialize_resource(tr_res, gettext_plurals=lc_plurals))
 
 
-def import_uploaded_file(
-    project: Project, locale: Locale, res_path: str, upload: File, user: User
-):
-    """Update translations in the database from an uploaded file."""
+@dataclass
+class UploadResult:
+    """
+    Summary of an uploaded file import:
+    - `updated`: translations added or replaced
+    - `unchanged`: translations identical to the current approved or pretranslated one
+    - `undefined_keys`: keys of translations with no matching entity in Pontoon
+    """
 
+    updated: int = 0
+    unchanged: int = 0
+    undefined_keys: list[L10nId] = field(default_factory=list)
+    badge_name: str = ""
+    badge_level: int = 0
+
+
+def import_uploaded_file(
+    project: Project,
+    locale: Locale,
+    db_res: DbResource,
+    upload: File,
+    user: User,
+) -> UploadResult:
+    """Update translations in the database from an uploaded file."""
     with TemporaryDirectory() as root:
-        file_path = join(root, basename(res_path))
+        file_path = join(root, basename(db_res.path))
         with open(file_path, "wb") as file:
             for chunk in upload.chunks():
                 file.write(chunk)
-        paths = UploadPaths(res_path, locale.code, file_path)
-        updates = find_db_updates(
-            project, {locale.code: locale}, [file_path], paths, []
+        try:
+            l10n_res = parse_resource(
+                file_path,
+                gettext_plurals=locale.cldr_plurals_list(),
+                gettext_skip_obsolete=True,
+            )
+        except Exception as error:
+            raise Exception(f"Could not parse uploaded file: {error}") from error
+    upload_translations = {rt.key: rt for rt in as_repo_translations(l10n_res)}
+    if not upload_translations:
+        raise Exception("No translations found in uploaded file.")
+
+    result = UploadResult()
+    entities: dict[L10nId, int] = {
+        tuple(key): id
+        for id, key in Entity.objects.filter(resource=db_res, obsolete=False)
+        .values_list("id", "key")
+        .iterator()
+    }
+    result.undefined_keys = [key for key in upload_translations if key not in entities]
+    for key in result.undefined_keys:
+        del upload_translations[key]
+
+    current_translations = (
+        Translation.objects.filter(
+            entity__resource=db_res, entity__obsolete=False, locale=locale
         )
+        .filter(Q(approved=True) | Q(pretranslated=True))
+        .values_list("entity__key", "value", "properties")
+        .iterator()
+    )
+    for key, value, properties in current_translations:
+        rt = upload_translations.get(tuple(key), None)
+        if rt is not None and translations_equal(
+            rt.value, rt.properties, value, properties
+        ):
+            del upload_translations[rt.key]
+            result.unchanged += 1
+
+    updates: Updates = {
+        (entities[key], locale.pk): rt for key, rt in upload_translations.items()
+    }
+    result.updated = len(updates)
     if updates:
         now = timezone.now()
         translation_before_level = badges_translation_level(user)
         review_before_level = badges_review_level(user)
+        # write_db_updates() removes entries from `updates` as it processes them
+        update_keys = list(updates)
         write_db_updates(project, updates, user, now)
         update_stats(project)
         ChangedEntityLocale.objects.bulk_create(
             (
                 ChangedEntityLocale(entity_id=entity_id, locale_id=locale_id, when=now)
-                for entity_id, locale_id in updates
+                for entity_id, locale_id in update_keys
             ),
             ignore_conflicts=True,
         )
 
-        badge_name = ""
-        badge_level = 0
         if badges_translation_level(user) > translation_before_level:
-            badge_name = "Translation Champion"
-            badge_level = badges_translation_level(user)
-            send_badge_notification(user, badge_name, badge_level)
+            result.badge_name = "Translation Champion"
+            result.badge_level = badges_translation_level(user)
+            send_badge_notification(user, result.badge_name, result.badge_level)
         if badges_review_level(user) > review_before_level:
-            badge_name = "Review Master"
-            badge_level = badges_review_level(user)
-            send_badge_notification(user, badge_name, badge_level)
-        return badge_name, badge_level
-    else:
-        raise Exception("Upload failed.")
+            result.badge_name = "Review Master"
+            result.badge_level = badges_review_level(user)
+            send_badge_notification(user, result.badge_name, result.badge_level)
+    return result

--- a/translate/src/context/Notification.tsx
+++ b/translate/src/context/Notification.tsx
@@ -6,6 +6,8 @@ type NotificationType = 'debug' | 'error' | 'info' | 'success' | 'warning';
 export type NotificationMessage = Readonly<{
   type: NotificationType;
   content: string | React.ReactElement;
+  /** How long to show the message, in milliseconds. */
+  duration?: number;
 }>;
 
 export const NotificationMessage = createContext<NotificationMessage | null>(

--- a/translate/src/hooks/useNotifications.ts
+++ b/translate/src/hooks/useNotifications.ts
@@ -2,6 +2,10 @@ import { useState, useEffect } from 'react';
 import { NotificationMessage } from '~/context/Notification';
 import { BadgeTooltipMessage } from '~/context/BadgeTooltip';
 
+/** Display summaries for longer than standard (2s), since they carry
+ * more information than a status message. */
+const UPLOAD_MESSAGE_DURATION = 6000;
+
 export function useNotifications() {
   const [message, setMessage] = useState<NotificationMessage | null>(null);
   const [badgeMessage, setBadgeMessage] = useState<BadgeTooltipMessage | null>(
@@ -28,9 +32,13 @@ export function useNotifications() {
         );
 
         if (generalNotification) {
+          const tags: string[] = generalNotification.type.split(' ');
           setMessage({
-            type: generalNotification.type,
+            type: tags[tags.length - 1] as NotificationMessage['type'],
             content: generalNotification.content,
+            duration: tags.includes('upload')
+              ? UPLOAD_MESSAGE_DURATION
+              : undefined,
           });
         }
 

--- a/translate/src/modules/notification/components/NotificationPanel.test.jsx
+++ b/translate/src/modules/notification/components/NotificationPanel.test.jsx
@@ -55,6 +55,19 @@ describe('<NotificationPanel>', () => {
     expect(container.querySelectorAll('.showing')).toHaveLength(0);
   });
 
+  it('honors a custom duration', () => {
+    vi.useFakeTimers();
+    const { container } = render(
+      <ComponentWithProvider initialMessage={{ ...NOTIF, duration: 5000 }} />,
+    );
+
+    vi.advanceTimersByTime(2500);
+    expect(container.querySelectorAll('.showing')).toHaveLength(1);
+
+    vi.advanceTimersByTime(2500);
+    expect(container.querySelectorAll('.showing')).toHaveLength(0);
+  });
+
   it('hides a message on click', () => {
     const { container } = render(
       <ComponentWithProvider initialMessage={NOTIF} />,

--- a/translate/src/modules/notification/components/NotificationPanel.tsx
+++ b/translate/src/modules/notification/components/NotificationPanel.tsx
@@ -9,8 +9,8 @@ import './NotificationPanel.css';
  * Show a status notification for a short period of time.
  *
  * This supports showing 'info' (in green) or 'error' (in red) notifications,
- * once at a time. The notification will hide after a 2s timeout, or when
- * clicked.
+ * once at a time. The notification will hide after a timeout (default 2 seconds,
+ * if not defined explicitly by the message), or when clicked.
  */
 export function NotificationPanel(): React.ReactElement<'div'> {
   const message = useContext(NotificationMessage);
@@ -25,7 +25,7 @@ export function NotificationPanel(): React.ReactElement<'div'> {
   useEffect(() => {
     window.clearTimeout(timeout.current);
     if (message) {
-      timeout.current = window.setTimeout(hide, 2000);
+      timeout.current = window.setTimeout(hide, message.duration ?? 2000);
     }
   }, [message]);
 


### PR DESCRIPTION
This also fixes a bug in the current implementation leading to approved existing suggestions not being synced to the repo, because of `write_db_updates()` mutating the list passed as argument (hence the explicit test).

This is using the existing infobar implementation, but adding a parameter to show it for longer than 2s.

Fixes #4481 