### PR TITLE
Fix term popup not showing for uppercase terms

### DIFF
--- a/translate/src/modules/originalstring/components/OriginalString.tsx
+++ b/translate/src/modules/originalstring/components/OriginalString.tsx
@@ -68,7 +68,7 @@ export function OriginalString({
         const markedTerm = target.dataset['match'];
         if (markedTerm) {
           setPopupTerms(
-            terms.terms?.filter((t) => t.text.toLowerCase() === markedTerm) ??
+            terms.terms?.filter((t) => t.text.toLowerCase() === markedTerm.toLowerCase()) ??
               [],
           );
         }

--- a/translate/src/modules/originalstring/components/OriginalString.tsx
+++ b/translate/src/modules/originalstring/components/OriginalString.tsx
@@ -68,8 +68,9 @@ export function OriginalString({
         const markedTerm = target.dataset['match'];
         if (markedTerm) {
           setPopupTerms(
-            terms.terms?.filter((t) => t.text.toLowerCase() === markedTerm.toLowerCase()) ??
-              [],
+            terms.terms?.filter(
+              (t) => t.text.toLowerCase() === markedTerm.toLowerCase(),
+            ) ?? [],
           );
         }
       }


### PR DESCRIPTION
Fixes #4474

## Problem

Clicking a term in the source string did nothing when the term was stored with an uppercase first letter in the terminology database.

## Cause

`Highlight.tsx` writes the term's stored text into `data-match` on the `<mark>` element. The click handler in `OriginalString.tsx` then looked it up with:

```js
terms.terms?.filter((t) => t.text.toLowerCase() === markedTerm)
```

Only the left side was lowercased, so a term stored as `Issue` produced `"issue" === "Issue"`. This resulted in no match, empty result, no popup. Terms stored lowercase were unaffected, which is why the failure only showed on capitalized entries.

## Fix

Lowercase both sides of the comparison.

## Testing

Created two local terms, one stored capitalized and one lowercase, each with a definition and an Arabic translation. Before the change, only the lowercase term opened its popup; after, both do.

## Visual proof:
 
[PR1.Pontoon.webm](https://github.com/user-attachments/assets/05cf83e7-dfb3-4b46-969d-b90af6322c37)
