### PR TITLE
add regex testing for non-alpha characters

### DIFF
--- a/translate/src/modules/placeable/components/Highlight.test.jsx
+++ b/translate/src/modules/placeable/components/Highlight.test.jsx
@@ -60,6 +60,33 @@ describe('mark terms', () => {
     expect(container.querySelector('mark')).toBeNull();
   });
 
+  it('does not mark a term followed by _', () => {
+    const string = 'foo_bar text';
+    const terms = {
+      terms: [{ text: 'foo' }],
+    };
+
+    const { container } = mountMarker(string, terms);
+
+    expect(container.querySelector('mark')).toBeNull();
+  });
+
+  it.each(['[', '\\', ']', '^', '`'])(
+    'does not extend a term match past %s',
+    (char) => {
+      const string = `foo${char}bar text`;
+      const terms = {
+        terms: [{ text: 'foo' }],
+      };
+
+      const { container } = mountMarker(string, terms);
+      const marks = container.querySelectorAll('mark.term');
+
+      expect(marks).toHaveLength(1);
+      expect(marks[0].textContent).toBe('foo');
+    },
+  );
+
   it('marks longer terms first', () => {
     const string = 'This is a translation tool.';
     const terms = {

--- a/translate/src/modules/placeable/components/Highlight.tsx
+++ b/translate/src/modules/placeable/components/Highlight.tsx
@@ -112,7 +112,7 @@ export function Highlight({
       .map((t) => t.text)
       .sort((a, b) => (a.length < b.length ? 1 : -1));
     for (const term of sourceTerms) {
-      const re = new RegExp(`\\b${escapeRegExp(term)}[a-zA-z]*\\b`, 'gi');
+      const re = new RegExp(`\\b${escapeRegExp(term)}[a-zA-Z]*\\b`, 'gi');
       for (const match of source.matchAll(re)) {
         marks.push({
           index: match.index ?? -1,


### PR DESCRIPTION
Fixes #4497

`[a-zA-z]` in the term-matching regex is a typo: the range runs from `A` (65)
to `z` (122), so it also covers the six characters that sit between the two
alphabets, which are `[`, `\`, `]`, `^`, `_` and `` ` ``.  And terms were matched across
them as if they were letters.
### example
`foo` and the source string `foo_bar text`:

- before: `\bfoo[a-zA-z]*\b` matches `foo_bar`, highlighting the whole
  identifier as the term
- after: `\bfoo[a-zA-Z]*\b` does not match. In fact, `_` is a word character, so there
  is no word boundary after `foo`

For the other five characters the old pattern didn't invent a match, it just
made an existing one too long: `foo[bar]` highlighted `foo[bar` instead of
`foo`.

The old suffix matching on actual letters is the same, so `add-on` still highlights
`Add-Ons`.

### Tests

Added regression coverage for all non-alpha characters in `Highlight.test.jsx`, 
I split them into two because the two groups behave differently: 
`_` is word character no mark at all, while the five non-word characters yield 
exactly one mark equal to the term. Both cases fail against the old pattern.


`make test-translate` ran successfully after changes.