### PR TITLE
Follow up to #4494: Add regression test for uppercase terms popup

### DIFF
--- a/translate/src/modules/originalstring/components/OriginalString.test.jsx
+++ b/translate/src/modules/originalstring/components/OriginalString.test.jsx
@@ -14,18 +14,33 @@ const ENTITY = {
   properties: { 'page-title': ['Hello\nSimple\nString'] },
 };
 
-function mountOriginalString(spy) {
+function mountOriginalString(spy, { entity = ENTITY, terms = {} } = {}) {
   const store = createReduxStore({ user: { isAuthenticated: true } });
   return mountComponentWithStore(
     () => (
-      <EntityView.Provider value={{ entity: ENTITY }}>
+      <EntityView.Provider value={{ entity }}>
         <EditorActions.Provider value={{ setEditorSelection: spy }}>
-          <OriginalString terms={{}} />
+          <OriginalString terms={terms} />
         </EditorActions.Provider>
       </EntityView.Provider>
     ),
     store,
   );
+}
+
+function plainEntity(value) {
+  return { format: 'plain', key: ['key'], value: [value] };
+}
+
+function term(text) {
+  return {
+    text,
+    partOfSpeech: 'noun',
+    definition: `Definition of ${text}`,
+    usage: '',
+    translation: `Translation of ${text}`,
+    entityId: 1,
+  };
 }
 
 describe('<OriginalString>', () => {
@@ -46,5 +61,31 @@ describe('<OriginalString>', () => {
 
     fireEvent.click(container.querySelector('.original mark'));
     expect(spy).toHaveBeenCalled();
+  });
+
+  it('shows the terms popup for a term stored with an uppercase letter', () => {
+    const { container } = mountOriginalString(vi.fn(), {
+      entity: plainEntity('Report an Issue here.'),
+      terms: { fetching: false, terms: [term('Issue')] },
+    });
+
+    fireEvent.click(container.querySelector('.original mark.term'));
+
+    const popup = container.querySelector('.terms-popup');
+    expect(popup).not.toBeNull();
+    expect(popup.querySelector('.text').textContent).toBe('Issue');
+  });
+
+  it('shows the terms popup for a lowercase term used capitalized', () => {
+    const { container } = mountOriginalString(vi.fn(), {
+      entity: plainEntity('Issue reported.'),
+      terms: { fetching: false, terms: [term('issue')] },
+    });
+
+    fireEvent.click(container.querySelector('.original mark.term'));
+
+    const popup = container.querySelector('.terms-popup');
+    expect(popup).not.toBeNull();
+    expect(popup.querySelector('.text').textContent).toBe('issue');
   });
 });


### PR DESCRIPTION
As requested in (https://github.com/mozilla/pontoon/issues/4474#issuecomment-5495611963), adding the regression test that should have come with #4494.

The test fails without the fix from #4494 and passes with it. 