### PR TITLE
Source locale dropdown in Batch actions to open upwards instead of downwards

### DIFF
--- a/translate/src/modules/batchactions/components/BatchActions.css
+++ b/translate/src/modules/batchactions/components/BatchActions.css
@@ -172,7 +172,7 @@
 }
 
 #copy-locale-form .locale-menu button.is-open {
-  border-radius: 3px 3px 0 0;
+  border-radius: 0 0 3px 3px;
 }
 
 .batch-actions .actions-panel .locale-menu-search input {

--- a/translate/src/modules/batchactions/components/BatchActions.css
+++ b/translate/src/modules/batchactions/components/BatchActions.css
@@ -153,7 +153,8 @@
   border-radius: 3px;
   appearance: none;
   -webkit-appearance: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath fill='%23ffffff' d='M0 6l5-6 5 6z'/%3E%3C/svg%3E");  background-repeat: no-repeat;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath fill='%23ffffff' d='M0 6l5-6 5 6z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
   background-position: right 12px center;
   color: var(--white-1);
   background-color: var(--dark-grey-1);

--- a/translate/src/modules/batchactions/components/BatchActions.css
+++ b/translate/src/modules/batchactions/components/BatchActions.css
@@ -153,8 +153,7 @@
   border-radius: 3px;
   appearance: none;
   -webkit-appearance: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath fill='%23ffffff' d='M0 0l5 6 5-6z'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath fill='%23ffffff' d='M0 6l5-6 5 6z'/%3E%3C/svg%3E");  background-repeat: no-repeat;
   background-position: right 12px center;
   color: var(--white-1);
   background-color: var(--dark-grey-1);

--- a/translate/src/modules/locale/components/LocaleMenu.css
+++ b/translate/src/modules/locale/components/LocaleMenu.css
@@ -7,12 +7,13 @@
 
 .locale-menu-dropdown {
   position: absolute;
-  top: 100%;
+  /* top: 100%; */
+  bottom: 100%;
   left: 0;
   width: 100%;
   z-index: 100;
   background-color: var(--dark-grey-1);
-  padding: 0 12px 12px;
+  padding: 12px 12px 0px;
   box-sizing: border-box;
 }
 

--- a/translate/src/modules/locale/components/LocaleMenu.css
+++ b/translate/src/modules/locale/components/LocaleMenu.css
@@ -7,7 +7,6 @@
 
 .locale-menu-dropdown {
   position: absolute;
-  /* top: 100%; */
   bottom: 100%;
   left: 0;
   width: 100%;


### PR DESCRIPTION
closes: #4488 

The Source locale dropdown in the "Copy from another locale" section of Batch actions now opens upwards.

Changes:
- Position the dropdown above the button instead of below it.
- Flip the caret to point up, matching the new direction.
- Adjust the dropdown padding for the new orientation.

### Before
[dropdown_before.webm](https://github.com/user-attachments/assets/f45f61b9-172b-470b-9b35-76fd138c6a9e)


### After 
With many locales (simulated by duplicating list items in DevTools), the list gets a scrollbar and the dropdown stays within the viewport.

[dropdown_after.webm](https://github.com/user-attachments/assets/2dac5af5-2b64-4b31-a6f3-1bcbe6db7951)
